### PR TITLE
Type-check nab-index and the CLI

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -60,8 +60,13 @@ Lint and format with ruff; type-check with pyright:
 ```bash
 .venv/bin/python -m ruff check .
 .venv/bin/python -m ruff format .
-.venv/bin/python -m pyright nab-resolver/src/
+.venv/bin/python -m pyright
 ```
+
+CI checks the same trees with five checkers rather than one, so a change
+pyright accepts can still fail the matrix. Reproduce a single cell with
+`nox -s "types(checker='mypy')"`; the trees are `TYPED_TREES` in
+`noxfile.py`.
 
 ## Building the docs
 

--- a/nab-index/src/nab_index/_pep503.py
+++ b/nab-index/src/nab_index/_pep503.py
@@ -13,6 +13,8 @@ from dataclasses import dataclass
 from html.parser import HTMLParser
 from urllib.parse import unquote, urljoin, urlsplit
 
+from typing_extensions import override
+
 __all__ = [
     "Anchor",
     "hash_fragment",
@@ -98,6 +100,7 @@ class _ProjectPageParser(HTMLParser):
         self.base_href: str | None = None
         self.declares_repository_version = False
 
+    @override
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         if tag == "meta":
             for name, value in attrs:

--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -318,7 +318,7 @@ class CachedAsyncSimpleClient:
         :func:`_parse_files` raises on it, the same as on the wire path.
         """
         try:
-            return json.loads(body)
+            decoded: object = json.loads(body)
         except ValueError:
             logger.warning(
                 "Corrupt cached Simple-API body for %r from %s: not valid JSON; "
@@ -327,6 +327,7 @@ class CachedAsyncSimpleClient:
                 self._index_url,
             )
             return None
+        return decoded
 
     def _parse_listing(self, body: bytes, package: str) -> list[WheelFile | SdistFile]:
         """Parse a Simple-API listing body.

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -15,9 +15,10 @@ import re
 import sys
 import tarfile
 import zlib
+from collections.abc import Mapping
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin, urlsplit, urlunsplit
 
 from packaging.utils import canonicalize_name, parse_sdist_filename
@@ -50,6 +51,10 @@ __all__ = [
     "is_readable_filename",
     "verify_sdist_hash",
 ]
+
+# One decoded PEP 691 ``files`` entry.  Neither its keys nor its values
+# have been checked, so every field is narrowed where it is read.
+_FileEntry = Mapping[Any, object]
 
 # Verification order; sha256 is pip's hash-checking baseline.
 ACCEPTED_HASH_ALGORITHMS: tuple[str, ...] = ("sha256", "sha384", "sha512")
@@ -505,7 +510,7 @@ def _resolve_file_url(raw_url: str, base_url: str) -> str | None:
 
 
 def _parse_file_entry(
-    file_info: dict,
+    file_info: _FileEntry,
     filename: str,
     raw_url: str,
     base_url: str,
@@ -612,7 +617,7 @@ def _parse_size(value: object) -> int | None:
 _LEGACY_METADATA_KEY = "dist-info-metadata"
 
 
-def _metadata_value(file_info: dict) -> object:
+def _metadata_value(file_info: _FileEntry) -> object:
     """Return the metadata field, applying PEP 714 key precedence.
 
     When ``core-metadata`` is present it wins and the legacy
@@ -626,7 +631,7 @@ def _metadata_value(file_info: dict) -> object:
     return file_info.get(_LEGACY_METADATA_KEY)
 
 
-def _has_metadata(file_info: dict) -> bool:
+def _has_metadata(file_info: _FileEntry) -> bool:
     """Return True when the file entry advertises a PEP 658/714 sidecar.
 
     PEP 691 allows either a ``true`` boolean (sidecar exists but no
@@ -637,7 +642,7 @@ def _has_metadata(file_info: dict) -> bool:
     return value is True or isinstance(value, dict)
 
 
-def _metadata_hash(file_info: dict) -> tuple[str, str] | None:
+def _metadata_hash(file_info: _FileEntry) -> tuple[str, str] | None:
     """Return the sidecar's published ``(algo, hex)`` to verify, or None.
 
     A bare ``true`` (sidecar exists, no hash), an empty digest, or a table with

--- a/nab-index/src/nab_index/lazy_wheel.py
+++ b/nab-index/src/nab_index/lazy_wheel.py
@@ -204,9 +204,10 @@ class _SparseFile:
         """Return the current read position."""
         return self._pos
 
-    def read(self, size: int = -1) -> bytes:
+    def read(self, size: int | None = -1) -> bytes:
         """Return up to ``size`` bytes from the current position.
 
+        ``None`` or a negative ``size`` reads to the end, as on a file object.
         Reads across contiguous spans and stops at the first gap, so a
         short return is the caller's cue that more bytes are needed.
         """
@@ -248,8 +249,12 @@ class _AcqKind(enum.Enum):
     NONE = "none"
 
 
+# The bytes an acquisition carries, read according to its _AcqKind: a whole
+# body, a tail window plus the offset it starts at, or nothing.
+_AcqPayload = bytes | tuple[_SparseFile, int] | None
+
 # A netloc that cannot serve usable ranges and volunteered no full body.
-_UNSUPPORTED_NONE: tuple[RangeCapability, _AcqKind, object] = (
+_UNSUPPORTED_NONE: tuple[RangeCapability, _AcqKind, _AcqPayload] = (
     RangeCapability.UNSUPPORTED,
     _AcqKind.NONE,
     None,
@@ -328,7 +333,7 @@ async def _suffix_attempt(
 
 async def _absolute_attempt(
     transport: AsyncHttpTransport, url: str, tail_size: int
-) -> tuple[RangeCapability, _AcqKind, object]:
+) -> tuple[RangeCapability, _AcqKind, _AcqPayload]:
     """Learn the length with ``bytes=0-0``, then read the tail absolutely.
 
     A probe that is refused, or that reports no usable total, steps down to
@@ -357,7 +362,7 @@ async def _absolute_attempt(
 
 async def _absolute_tail(
     transport: AsyncHttpTransport, url: str, total: int, tail_size: int
-) -> tuple[RangeCapability, _AcqKind, object]:
+) -> tuple[RangeCapability, _AcqKind, _AcqPayload]:
     """Read the tail window with an absolute range once the length is known.
 
     A tail refused after an honoured probe still steps down to the plain GET,
@@ -399,7 +404,7 @@ async def _full_body_fetch(transport: AsyncHttpTransport, url: str) -> bytes | N
 
 async def _fallback_full_body(
     transport: AsyncHttpTransport, url: str, *, latch: bool
-) -> tuple[RangeCapability, _AcqKind, object]:
+) -> tuple[RangeCapability, _AcqKind, _AcqPayload]:
     """Step an unusable range down to the plain GET, choosing what it teaches.
 
     ``latch`` records the netloc ``FULL_BODY_ONLY``, so later wheels skip the
@@ -421,7 +426,7 @@ async def _acquire(
     url: str,
     capability: RangeCapability,
     tail_size: int,
-) -> tuple[RangeCapability, _AcqKind, object]:
+) -> tuple[RangeCapability, _AcqKind, _AcqPayload]:
     """Fetch bytes per the netloc's known capability, learning it if unknown."""
     if capability is RangeCapability.UNSUPPORTED:
         return _UNSUPPORTED_NONE

--- a/nab-index/src/nab_index/retry.py
+++ b/nab-index/src/nab_index/retry.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import random
 
 import urllib3
+from typing_extensions import override
 from urllib3.exceptions import InvalidHeader
 
 __all__ = [
@@ -61,6 +62,7 @@ def _retry_after_seconds(value: str) -> float | None:
 class _BoundedRetry(urllib3.Retry):
     """Retry that bounds the Retry-After wait and ignores a malformed one."""
 
+    @override
     def get_retry_after(self, response: urllib3.BaseHTTPResponse) -> float | None:
         value = response.headers.get("Retry-After")
         return None if value is None else _retry_after_seconds(value)
@@ -91,5 +93,7 @@ def next_delay(failures: int, retry_after: str | None = None) -> float:
             return seconds
     if failures <= 1:
         return 0.0
-    backoff = _BACKOFF_FACTOR * 2 ** (failures - 1)
+    # Annotated because typeshed types int ** int as Any: a negative exponent
+    # yields a float.
+    backoff: float = _BACKOFF_FACTOR * 2 ** (failures - 1)
     return backoff + random.random() * _BACKOFF_JITTER  # noqa: S311

--- a/nab-index/src/nab_index/urllib3_async_transport.py
+++ b/nab-index/src/nab_index/urllib3_async_transport.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any
 
 import truststore
 import urllib3
+from typing_extensions import override
 
 from .retry import GET_RETRY, MAX_RETRIES, next_delay
 from .transport import (
@@ -55,6 +56,7 @@ class _SSLContext(truststore.SSLContext):
     urllib3-future restores the guard.
     """
 
+    @override
     def cert_store_stats(self) -> dict[str, int]:
         return {"x509_ca": 1, "x509": 1, "crl": 0}
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -3,10 +3,10 @@
 ``tests`` runs one workspace's suite and gates each package it owns at 100
 percent. ``fail_under`` and the ``[tool.coverage.paths]`` remaps live in
 ``pyproject.toml``; the per-package ``--include`` globs are built here.
-``types`` runs one type-checker over ``nab-resolver/src``. ``dists`` builds
-every distribution and installs each sdist and wheel to catch packaging
-regressions that building alone misses. All take their pinned dependencies
-from ``.github/requirements``.
+``types`` runs one type-checker over the source trees in ``TYPED_TREES``.
+``dists`` builds every distribution and installs each sdist and wheel to
+catch packaging regressions that building alone misses. All take their
+pinned dependencies from ``.github/requirements``.
 
 The Python version comes from whoever launches nox, so CI drives the matrix
 through ``actions/setup-python`` and stays off the per-OS versioned-binary
@@ -50,14 +50,18 @@ WORKSPACES = {
     ),
 }
 
+# nab-python is left out: it carries the vendored packaging tree, which is
+# rebuilt from upstream and cannot be edited to satisfy a checker.
+TYPED_TREES = ["nab-resolver/src", "nab-index/src", "src"]
+
 # checker -> command; pyright reads its targets from [tool.pyright] in
-# pyproject.toml, the rest take nab-resolver/src on the command line.
+# pyproject.toml, the rest take the trees on the command line.
 TYPE_CHECKERS = {
-    "mypy": ["mypy", "nab-resolver/src"],
+    "mypy": ["mypy", *TYPED_TREES],
     "pyright": ["pyright"],
-    "ty": ["ty", "check", "nab-resolver/src"],
-    "pyrefly": ["pyrefly", "check", "nab-resolver/src"],
-    "zuban": ["zuban", "check", "nab-resolver/src"],
+    "ty": ["ty", "check", *TYPED_TREES],
+    "pyrefly": ["pyrefly", "check", *TYPED_TREES],
+    "zuban": ["zuban", "check", *TYPED_TREES],
 }
 
 
@@ -89,10 +93,10 @@ def tests(session: nox.Session, workspace: str) -> None:
 @nox.session
 @nox.parametrize("checker", list(TYPE_CHECKERS))
 def types(session: nox.Session, checker: str) -> None:
-    """Type-check nab-resolver/src with one checker."""
-    # Only nab-resolver is checked; the checkers reach sibling packages through
-    # their source-path config, not installs.
-    _install(session, TYPES_LOCK, ["nab-resolver"])
+    """Type-check the trees in ``TYPED_TREES`` with one checker."""
+    # Installing the whole workspace resolves every import; TYPED_TREES alone
+    # decides what is reported, which is how nab-python's own errors stay out.
+    _install(session, TYPES_LOCK, ["nab-resolver", "nab-index", "nab-python", "."])
     session.run(*TYPE_CHECKERS[checker])
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "nab-python==0.0.13.dev0",
     "nab-index==0.0.13.dev0",
     "tyro>=1.0",
+    "typing_extensions>=4.6",
 ]
 
 [project.optional-dependencies]
@@ -57,6 +58,7 @@ exclude = [
     "tests/test_classifiers.py",
     "tests/test_contributing_docs.py",
     "tests/test_release.py",
+    "tests/test_type_check_scope.py",
 ]
 
 # Dependency groups feed `nab lock` for CI lockfiles; regenerate via
@@ -327,6 +329,8 @@ typeCheckingMode = "standard"
 include = [
     "nab-resolver/src",
     "nab-resolver/tests",
+    "nab-index/src",
+    "src",
 ]
 # Editable installs hide the workspace packages from pyright's auto-detection;
 # point it at the source trees directly so cross-package imports resolve.
@@ -339,7 +343,7 @@ extraPaths = [
 
 # https://pyrefly.org/en/docs/configuration/
 [tool.pyrefly]
-project-includes = ["nab-resolver/src"]
+project-includes = ["nab-resolver/src", "nab-index/src", "src"]
 
 # https://mypy.readthedocs.io/en/stable/config_file.html#using-a-pyproject-toml-file
 [tool.mypy]
@@ -347,7 +351,10 @@ python_version = "3.10"
 strict = true
 namespace_packages = true
 explicit_package_bases = true
-mypy_path = ["nab-resolver/src"]
+# Each checked tree is a package base. Without "src" the umbrella resolves
+# under two module names ("nab._version" and "src.nab._version") and mypy
+# stops before checking anything.
+mypy_path = ["nab-resolver/src", "nab-index/src", "src"]
 enable_error_code = [
     "redundant-expr",
     "truthy-bool",

--- a/src/nab/_download.py
+++ b/src/nab/_download.py
@@ -5,10 +5,9 @@ archive into a local directory: the union of every target's
 artefacts, deduplicated by URL, which for a declared matrix
 pre-populates a directory for offline deployment across platforms.
 
-External callers (the resolver entry point and the download
-helper) are accessed through :mod:`nab.cli` so the test suite's
-``patch("nab.cli.download_lock")`` style of monkey patches keeps
-working after the per-command split.
+The helpers this shares with :mod:`nab._lock` (config loading, the
+printer, transport selection, the resolve step) live in :mod:`nab.cli`;
+everything else is imported from the module that defines it.
 """
 
 from __future__ import annotations
@@ -19,7 +18,8 @@ from typing import Annotated
 
 import tyro
 
-from nab_python.download import DownloadError
+from nab_python.download import DownloadError, download_lock
+from nab_python.resolve import build_lock_input
 
 from . import cli as _cli
 from ._lock import resolve_extra_selection, resolve_group_selection
@@ -130,7 +130,7 @@ def download(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config 
         resolution_strategy=settings.resolution,
         progress=ProgressReporter(_cli.printer()),
     )
-    lock_input = _cli.build_lock_input(
+    lock_input = build_lock_input(
         result,
         config=config,
         extras=selected_extras,
@@ -139,7 +139,7 @@ def download(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config 
 
     download_transport = _cli._make_transport(settings.http_backend)  # noqa: SLF001
     try:
-        outcome = _cli.download_lock(
+        outcome = download_lock(
             lock_input,
             download_transport,
             output,

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -4,10 +4,9 @@ Wires :func:`resolve_for_targets` to the writers in
 :mod:`nab_python.lockfile`, plus the per-target emission shapes a matrix
 needs (a templated file per tuple, multi-block stdout).
 
-External callers (the resolver entry point, the lockfile writers) are
-accessed through :mod:`nab.cli` so the test suite's
-``patch("nab.cli.resolve_for_targets")`` style of monkey patches keeps
-working after the per-command split.
+The helpers this shares with :mod:`nab._download` (config loading, the
+printer, transport selection, the resolve step) live in :mod:`nab.cli`;
+everything else is imported from the module that defines it.
 """
 
 from __future__ import annotations
@@ -37,9 +36,12 @@ from nab_python.config import (
     with_python_override,
 )
 from nab_python.lockfile import (
+    DisjointnessError,
+    DivergentBaseDependencyError,
     InvalidLockfileError,
     LockfileSyntaxError,
     LockInput,
+    MissingHashError,
     Provenance,
     RootRequirement,
     TargetLock,
@@ -49,7 +51,11 @@ from nab_python.lockfile import (
     package_metadata_override_records,
     read_lockfile_anchor,
     read_lockfile_packages,
+    render_lock,
     summarize_lock,
+    write_lock,
+    write_requirements_with_hashes,
+    write_requirements_without_hashes,
 )
 from nab_python.paths import PathState, path_state
 from nab_python.requirements_file import (
@@ -62,6 +68,7 @@ from nab_python.requirements_file import (
     read_pyproject_optional_dependencies,
     resolve_groups_to_requirements,
 )
+from nab_python.resolve import build_lock_input
 from nab_python.target import UnevaluableMarkerError
 
 from . import cli as _cli
@@ -252,7 +259,7 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
     )
 
     lock_input = drop_workspace_pins(
-        _cli.build_lock_input(
+        build_lock_input(
             result,
             config=config,
             extras=selected_extras,
@@ -436,9 +443,7 @@ def _check_locked(lock_input: LockInput, *, output: Path | None) -> None:
     lock is never read back into the resolve.
     """
     target = _locked_target_path(output)
-    new_text = _render_or_exit(
-        lambda: _cli.render_lock(lock_input, lock_dir=target.parent)
-    )
+    new_text = _render_or_exit(lambda: render_lock(lock_input, lock_dir=target.parent))
     committed = _packages_only(target.read_text(encoding="utf-8"))
     if _packages_only(new_text) == committed:
         _cli.printer().done(f"Lockfile {target} is up to date.")
@@ -466,17 +471,17 @@ def _emit_pylock(lock_input: LockInput, *, output: Path | None) -> None:
 
 def _write_lock_or_exit(lock_input: LockInput, *, target: Path | None) -> str:
     """Write the lock, mapping every render-time refusal to a clean exit."""
-    return _render_or_exit(lambda: _cli.write_lock(lock_input, output_path=target))
+    return _render_or_exit(lambda: write_lock(lock_input, output_path=target))
 
 
 def _render_or_exit(render: Callable[[], str]) -> str:
     """Run a lock render, mapping every refusal it raises to a clean exit."""
     try:
         return render()
-    except _cli.MissingHashError as e:
+    except MissingHashError as e:
         _cli.printer().error(f"cannot lock: {e}")
         sys.exit(1)
-    except (_cli.DisjointnessError, _cli.DivergentBaseDependencyError) as e:
+    except (DisjointnessError, DivergentBaseDependencyError) as e:
         _cli.printer().error(str(e))
         sys.exit(1)
 
@@ -805,14 +810,12 @@ def _render_requirements_or_exit(
     """
     try:
         if with_hashes:
-            text = _cli.write_requirements_with_hashes(
-                lock_input, output_path=output_path
-            )
+            text = write_requirements_with_hashes(lock_input, output_path=output_path)
         else:
-            text = _cli.write_requirements_without_hashes(
+            text = write_requirements_without_hashes(
                 lock_input, output_path=output_path
             )
-    except _cli.MissingHashError as e:
+    except MissingHashError as e:
         _cli.printer().error(f"cannot lock: {e}")
         sys.exit(1)
     return text, sum(len(lock.pins) for lock in lock_input.targets.values())

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -56,17 +56,7 @@ from nab_python.config_sources import (
     read_env_layer,
     resolve_config,
 )
-from nab_python.download import download_lock  # noqa: F401 - re-exported for tests
-from nab_python.lockfile import (
-    DisjointnessError,  # noqa: F401 - referenced as _cli.DisjointnessError in _lock
-    DivergentBaseDependencyError,  # noqa: F401 - referenced via _cli in _lock
-    MissingHashError,
-    MissingSdistError,
-    render_lock,  # noqa: F401 - referenced as _cli.render_lock in _lock
-    write_lock,  # noqa: F401 - re-exported for tests
-    write_requirements_with_hashes,  # noqa: F401 - re-exported for tests
-    write_requirements_without_hashes,  # noqa: F401 - re-exported for tests
-)
+from nab_python.lockfile import MissingHashError, MissingSdistError
 from nab_python.paths import PathState, path_state
 from nab_python.provider import (
     InvalidUploadTimeError,
@@ -80,10 +70,7 @@ from nab_python.requirements_file import (
     InvalidProjectRequirementError,
     InvalidProjectTableError,
 )
-from nab_python.resolve import (
-    build_lock_input,  # noqa: F401 - referenced as _cli.build_lock_input in _lock
-    resolve_for_targets,
-)
+from nab_python.resolve import resolve_for_targets
 from nab_python.target import NonIntervalMarkerError, UnevaluableMarkerError
 from nab_python.workspace import WorkspaceDiscoveryError
 from nab_resolver.errors import ResolutionError
@@ -720,7 +707,7 @@ def _normalize_layered_bool_flags(argv: list[str]) -> list[str]:
         # --offline [value]: keep an explicit True/False/None, else it is bare.
         if token.startswith("--") and token[2:] in _LAYERED_BOOL_FLAGS:
             following = argv[i + 1] if i + 1 < len(argv) else None
-            if following in _BOOL_FLAG_VALUES:
+            if following is not None and following in _BOOL_FLAG_VALUES:
                 normalized += [token, following]
                 i += 2
             else:

--- a/src/nab/output.py
+++ b/src/nab/output.py
@@ -22,6 +22,8 @@ import time
 from dataclasses import dataclass
 from typing import IO, TYPE_CHECKING
 
+from typing_extensions import override
+
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
 
@@ -309,6 +311,7 @@ class _LevelFormatter(logging.Formatter):
         self._verbose = verbose
         self._color = color_enabled
 
+    @override
     def format(self, record: logging.LogRecord) -> str:
         message = record.getMessage()
         if self._verbose:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1504,7 +1504,7 @@ class TestPythonFlag:
                 "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
             ) as mock_resolve,
             patch(
-                "nab.cli.download_lock",
+                "nab._download.download_lock",
                 return_value=MagicMock(written=(out / "x.whl",), skipped=()),
             ),
         ):
@@ -1940,7 +1940,7 @@ class TestLockCommandUniversal:
                 "nab.cli.resolve_for_targets",
                 return_value=_universal_result(success=True),
             ),
-            patch("nab.cli.write_lock", side_effect=MissingHashError("no hash")),
+            patch("nab._lock.write_lock", side_effect=MissingHashError("no hash")),
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, output=tmp_path / "pylock.toml")
@@ -1965,7 +1965,7 @@ class TestLockCommandUniversal:
                 "nab.cli.resolve_for_targets",
                 return_value=_universal_result(success=True),
             ),
-            patch("nab.cli.write_lock", side_effect=DisjointnessError(hint)),
+            patch("nab._lock.write_lock", side_effect=DisjointnessError(hint)),
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, output=tmp_path / "pylock.toml")
@@ -1989,7 +1989,7 @@ class TestLockCommandUniversal:
                 return_value=_universal_result(success=True),
             ),
             patch(
-                "nab.cli.write_lock",
+                "nab._lock.write_lock",
                 side_effect=DivergentBaseDependencyError(message),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -2108,11 +2108,11 @@ class TestLockCommandUniversal:
                 return_value=_universal_result(success=True),
             ),
             patch(
-                "nab.cli.build_lock_input",
+                "nab._lock.build_lock_input",
                 return_value=MagicMock(name="LockInput"),
             ),
             patch(
-                "nab.cli.write_requirements_without_hashes",
+                "nab._lock.write_requirements_without_hashes",
                 return_value="# py311-linux_x86_64\nfoo==1.0\n",
             ),
         ):
@@ -2294,7 +2294,7 @@ class TestLockCommandUniversal:
                 return_value=_universal_result(success=True),
             ),
             patch(
-                "nab.cli.write_requirements_with_hashes",
+                "nab._lock.write_requirements_with_hashes",
                 side_effect=MissingHashError("no hash"),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -2683,7 +2683,7 @@ class TestLockCommandUniversal:
                 return_value=_universal_result(success=True),
             ),
             patch(
-                "nab.cli.write_requirements_with_hashes",
+                "nab._lock.write_requirements_with_hashes",
                 side_effect=MissingHashError("no hash"),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -3800,7 +3800,7 @@ class TestLockedFlag:
                 "nab.cli.resolve_for_targets",
                 return_value=_stub_resolve_result(pins={"foo": V("1.0")}),
             ),
-            patch("nab.cli.render_lock", side_effect=MissingHashError("no hash")),
+            patch("nab._lock.render_lock", side_effect=MissingHashError("no hash")),
             pytest.raises(SystemExit) as exc,
         ):
             app.cli(
@@ -3847,7 +3847,7 @@ class TestLockedFlag:
                 "nab.cli.resolve_for_targets",
                 return_value=_stub_resolve_result(pins={"foo": V("1.0")}),
             ),
-            patch("nab.cli.render_lock", side_effect=DisjointnessError(hint)),
+            patch("nab._lock.render_lock", side_effect=DisjointnessError(hint)),
             pytest.raises(SystemExit) as exc,
         ):
             app.cli(
@@ -4307,7 +4307,7 @@ class TestCacheFlags:
                 "nab.cli.resolve_for_targets",
                 return_value=_stub_resolve_result(pins={}),
             ) as mock_resolve,
-            patch("nab.cli.write_lock"),
+            patch("nab._lock.write_lock"),
         ):
             lock(pyproject, output=tmp_path / "pylock.toml")
         kwargs = mock_resolve.call_args.kwargs
@@ -4323,7 +4323,7 @@ class TestCacheFlags:
                 "nab.cli.resolve_for_targets",
                 return_value=_stub_resolve_result(pins={}),
             ) as mock_resolve,
-            patch("nab.cli.write_lock"),
+            patch("nab._lock.write_lock"),
         ):
             lock(pyproject, cache_dir=cache, output=tmp_path / "pylock.toml")
         assert mock_resolve.call_args.kwargs["cache_dir"] == cache
@@ -4336,7 +4336,7 @@ class TestCacheFlags:
                 "nab.cli.resolve_for_targets",
                 return_value=_stub_resolve_result(pins={}),
             ) as mock_resolve,
-            patch("nab.cli.write_lock"),
+            patch("nab._lock.write_lock"),
         ):
             lock(pyproject, cache=False, output=tmp_path / "pylock.toml")
         assert mock_resolve.call_args.kwargs["cache_dir"] is None
@@ -4349,7 +4349,7 @@ class TestCacheFlags:
                 "nab.cli.resolve_for_targets",
                 return_value=_stub_resolve_result(pins={}),
             ) as mock_resolve,
-            patch("nab.cli.write_lock"),
+            patch("nab._lock.write_lock"),
         ):
             lock(pyproject, offline=True, output=tmp_path / "pylock.toml")
         assert mock_resolve.call_args.kwargs["offline"] is True
@@ -4424,7 +4424,7 @@ class TestOfflineFlagContract:
                 "nab.cli.resolve_for_targets",
                 return_value=_stub_resolve_result(pins={}),
             ) as mock_resolve,
-            patch("nab.cli.write_lock"),
+            patch("nab._lock.write_lock"),
         ):
             app.cli(
                 args=[
@@ -4507,7 +4507,7 @@ class TestMainNormalizesOfflineFlag:
                 "nab.cli.resolve_for_targets",
                 return_value=_stub_resolve_result(pins={}),
             ) as mock_resolve,
-            patch("nab.cli.write_lock"),
+            patch("nab._lock.write_lock"),
         ):
             main()
         return mock_resolve.call_args.kwargs["offline"]
@@ -4570,7 +4570,7 @@ class TestLayeredRunKnobFlagContract:
                 "nab.cli.resolve_for_targets",
                 return_value=_stub_resolve_result(pins={}),
             ),
-            patch("nab.cli.write_lock"),
+            patch("nab._lock.write_lock"),
             patch("nab.cli._make_transport") as mock_transport,
         ):
             app.cli(
@@ -4733,7 +4733,7 @@ class TestMainWiresOutputOptions:
                 "nab.cli.resolve_for_targets",
                 return_value=_stub_resolve_result(pins={}),
             ),
-            patch("nab.cli.write_lock"),
+            patch("nab._lock.write_lock"),
         ):
             main()
 
@@ -4898,7 +4898,9 @@ class TestDownloadCommand:
         download_result = MagicMock(written=(out / "x.whl",), skipped=())
         with (
             patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()),
-            patch("nab.cli.download_lock", return_value=download_result) as mock_dl,
+            patch(
+                "nab._download.download_lock", return_value=download_result
+            ) as mock_dl,
         ):
             download(pyproject, output=out)
         mock_dl.assert_called_once()
@@ -4913,7 +4915,9 @@ class TestDownloadCommand:
         download_result = MagicMock(written=(), skipped=())
         with (
             patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()),
-            patch("nab.cli.download_lock", return_value=download_result) as mock_dl,
+            patch(
+                "nab._download.download_lock", return_value=download_result
+            ) as mock_dl,
         ):
             download(pyproject, output=out, offline=offline)
         assert mock_dl.call_args.kwargs["offline"] is offline
@@ -4934,7 +4938,7 @@ class TestDownloadCommand:
         )
         with (
             patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()),
-            patch("nab.cli.download_lock", return_value=download_result),
+            patch("nab._download.download_lock", return_value=download_result),
         ):
             download(pyproject, output=out, project_resolution="lowest")
         err = capsys.readouterr().err
@@ -4966,7 +4970,9 @@ class TestDownloadCommand:
                 "nab.cli.resolve_for_targets",
                 return_value=_multi_tuple_universal_result(),
             ),
-            patch("nab.cli.download_lock", return_value=download_result) as mock_dl,
+            patch(
+                "nab._download.download_lock", return_value=download_result
+            ) as mock_dl,
         ):
             download(pyproject, output=out)
         lock_input = mock_dl.call_args.args[0]
@@ -5065,7 +5071,9 @@ class TestDownloadCommand:
         pyproject = _make_pyproject(tmp_path)
         with (
             patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()),
-            patch("nab.cli.download_lock", side_effect=DownloadError("sha mismatch")),
+            patch(
+                "nab._download.download_lock", side_effect=DownloadError("sha mismatch")
+            ),
             pytest.raises(SystemExit, match="1"),
         ):
             download(pyproject)
@@ -5149,7 +5157,7 @@ class TestDownloadCommand:
             patch(
                 "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
             ) as mock_resolve,
-            patch("nab.cli.download_lock", return_value=download_result),
+            patch("nab._download.download_lock", return_value=download_result),
         ):
             download(pyproject, extras=("cpu",))
         assert mock_resolve.call_args.kwargs["extras"] == ("cpu",)
@@ -5165,7 +5173,7 @@ class TestDownloadCommand:
             patch(
                 "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
             ) as mock_resolve,
-            patch("nab.cli.download_lock", return_value=download_result),
+            patch("nab._download.download_lock", return_value=download_result),
         ):
             download(pyproject, groups=("dev",))
         assert mock_resolve.call_args.kwargs["groups"] == ("dev",)
@@ -5181,7 +5189,7 @@ class TestDownloadCommand:
             patch(
                 "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
             ) as mock_resolve,
-            patch("nab.cli.download_lock", return_value=download_result),
+            patch("nab._download.download_lock", return_value=download_result),
         ):
             download(pyproject, all_extras=True)
         assert set(mock_resolve.call_args.kwargs["extras"]) == {"cpu", "gpu"}
@@ -5197,7 +5205,7 @@ class TestDownloadCommand:
             patch(
                 "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
             ) as mock_resolve,
-            patch("nab.cli.download_lock", return_value=download_result),
+            patch("nab._download.download_lock", return_value=download_result),
         ):
             download(pyproject, all_groups=True)
         assert set(mock_resolve.call_args.kwargs["groups"]) == {"dev", "test"}
@@ -5210,7 +5218,7 @@ class TestDownloadCommand:
                 "nab.cli.resolve_for_targets",
                 return_value=_multi_tuple_universal_result(),
             ) as mock_resolve,
-            patch("nab.cli.download_lock", return_value=download_result),
+            patch("nab._download.download_lock", return_value=download_result),
         ):
             download(pyproject, extras=("docs",))
         assert mock_resolve.call_args.kwargs["extras"] == ("docs",)

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -919,7 +919,7 @@ class TestProjectCliOverrides:
             patch(
                 "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
             ) as mock_resolve,
-            patch("nab.cli.write_lock"),
+            patch("nab._lock.write_lock"),
         ):
             app.cli(
                 args=["lock", str(proj), "--no-cache", "--output", str(out), *extra],
@@ -978,7 +978,7 @@ class TestProjectCliOverrides:
             patch(
                 "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
             ) as mock_resolve,
-            patch("nab.cli.write_lock"),
+            patch("nab._lock.write_lock"),
         ):
             app.cli(
                 args=[
@@ -1076,7 +1076,7 @@ class TestDownloadLadder:
             patch(
                 "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
             ) as mock_resolve,
-            patch("nab.cli.download_lock", return_value=download_result),
+            patch("nab._download.download_lock", return_value=download_result),
         ):
             download(proj / "pyproject.toml", output=out, cache=False, offline=offline)
         return mock_resolve.call_args.kwargs

--- a/tests/test_type_check_scope.py
+++ b/tests/test_type_check_scope.py
@@ -1,0 +1,50 @@
+"""Check that all five type-checkers are aimed at the same source trees.
+
+``noxfile.py`` passes ``TYPED_TREES`` on the command line for mypy, ty,
+pyrefly and zuban, while pyright reads only ``[tool.pyright] include``. A
+tree added in one place and forgotten in the other narrows a checker back
+down without failing anything, which is the drift this catches.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any
+
+import tomli
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+NOXFILE = REPO_ROOT / "noxfile.py"
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+
+def _typed_trees() -> set[str]:
+    """The tree list noxfile.py hands to the command-line checkers."""
+    module = ast.parse(NOXFILE.read_text(encoding="utf-8"))
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if any(isinstance(t, ast.Name) and t.id == "TYPED_TREES" for t in node.targets):
+            return set(ast.literal_eval(node.value))
+    raise AssertionError("noxfile.py defines no TYPED_TREES")
+
+
+def _tool_config(tool: str) -> dict[str, Any]:
+    """One ``[tool.<name>]`` table from the root pyproject."""
+    return tomli.loads(PYPROJECT.read_text(encoding="utf-8"))["tool"][tool]
+
+
+def test_pyright_include_covers_every_typed_tree() -> None:
+    """pyright is run with no path argument, so include is its whole scope."""
+    assert _typed_trees() <= set(_tool_config("pyright")["include"])
+
+
+def test_pyrefly_project_includes_covers_every_typed_tree() -> None:
+    """A bare ``pyrefly check`` takes its scope from here, not from noxfile.py."""
+    assert _typed_trees() <= set(_tool_config("pyrefly")["project-includes"])
+
+
+def test_mypy_path_covers_every_typed_tree() -> None:
+    """Each tree is a package base; mypy and zuban both read this setting."""
+    assert _typed_trees() <= set(_tool_config("mypy")["mypy_path"])


### PR DESCRIPTION
nab runs five type checkers in CI and points all five at `nab-resolver/src`, so `nab-index` and the `nab` CLI ship whatever they like. Both were already near clean: 23 sites across ten files, mostly a missing `@override`, a bare `dict`, or an `Any` leaking out through a declared return type. This fixes those and adds both trees to all five checkers, so three of the four packages are enforced rather than one. `nab-python` stays out: its vendored packaging tree would have to be excluded from every checker first, which is its own change.

Most of the CLI's share was one thing. `nab/_lock.py` and `nab/_download.py` read `write_lock`, `download_lock`, `build_lock_input` and six other names off `nab.cli`, which only re-exports them, and `no_implicit_reexport` flags every read. Rather than declare the re-export, the two modules now import each name from `nab_python.lockfile`, `nab_python.resolve` or `nab_python.download`, and `cli.py` drops the imports it was keeping only to be read back through it. That is the move #760 made a level up. The patch targets in the tests moved with the names, which also puts them on the module doing the lookup.

`src/nab/output.py` needs `typing_extensions.override` and the umbrella did not declare `typing_extensions`, so it does now. That changes nothing about what gets installed, since `nab-index` and `nab-python` both already require it.

Four of the checkers take their scope from `TYPED_TREES` in `noxfile.py` while pyright reads `[tool.pyright] include`, so a tree added to one and forgotten in the other would quietly narrow a checker back down. `tests/test_type_check_scope.py` holds the two in step.
