### PR TITLE
honor scenario sdist trust policy in benchmark profiles

### DIFF
--- a/nab-python/benchmarks/_profile_runner.py
+++ b/nab-python/benchmarks/_profile_runner.py
@@ -135,6 +135,9 @@ def build_inputs(
         "index_routes": sc.parse_index_routes(name, scenario) or None,
         "build_policy_overrides": build_policy_overrides or None,
         "resolution_strategy": resolution_strategy,
+        "trust_unverified_sdist_deps": scenario.get(
+            "trust_unverified_sdist_deps", True
+        ),
         "target": target,
         "host": effective_host,
     }

--- a/nab-python/tests/test_benchmark_strategy_matrix.py
+++ b/nab-python/tests/test_benchmark_strategy_matrix.py
@@ -2011,6 +2011,23 @@ def test_profile_runner_accepts_an_explicit_strategy() -> None:
     assert lowest["resolution_strategy"] is module.sc.ResolutionStrategy.LOWEST
 
 
+def test_profile_runner_uses_scenario_sdist_trust_policy() -> None:
+    module = _harness("_profile_runner")
+    base = {"python_version": "3.11", "requirements": []}
+
+    implicit = module.build_inputs("implicit", base)
+    trusted = module.build_inputs(
+        "trusted", {**base, "trust_unverified_sdist_deps": True}
+    )
+    strict = module.build_inputs(
+        "strict", {**base, "trust_unverified_sdist_deps": False}
+    )
+
+    assert implicit["trust_unverified_sdist_deps"] is True
+    assert trusted["trust_unverified_sdist_deps"] is True
+    assert strict["trust_unverified_sdist_deps"] is False
+
+
 def test_profile_runner_uses_the_admitted_target_for_roots_and_resolution() -> None:
     module = _harness("_profile_runner")
     physical_host = _host(


### PR DESCRIPTION
The single-scenario profiler omitted `trust_unverified_sdist_deps`, so `resolve_scenario` used its strict `False` default while standard and canary runs used the scenario's benchmark policy. This forwards the benchmark's implicit `True` default and explicit `True` or `False` values to the profile run.
