### PR TITLE
Share one project config across benchmark runners

### DIFF
--- a/nab-python/benchmarks/_profile_runner.py
+++ b/nab-python/benchmarks/_profile_runner.py
@@ -28,6 +28,7 @@ else:
 sys.path.insert(0, str(Path(__file__).parent))
 
 import scenarios as sc
+from benchmark_config import build_benchmark_config
 
 
 def find_scenario(spec: str) -> tuple[str, dict]:
@@ -127,17 +128,22 @@ def build_inputs(
     )
 
     datetime_str = scenario.get("datetime")
+    config = build_benchmark_config(
+        uploaded_prior_to=sc.parse_datetime(datetime_str) if datetime_str else None,
+        indexes=sc.parse_indexes(name, scenario),
+        index_routes=sc.parse_index_routes(name, scenario),
+        build_policy_overrides=build_policy_overrides,
+        resolution=resolution_strategy,
+        trust_unverified_sdist_deps=scenario.get(
+            "trust_unverified_sdist_deps",
+            True,
+        ),
+        vcs=vcs_config,
+    )
     return {
         "requirements": requirements,
-        "uploaded_prior_to": sc.parse_datetime(datetime_str) if datetime_str else None,
         "constraints": constraints,
-        "indexes": sc.parse_indexes(name, scenario),
-        "index_routes": sc.parse_index_routes(name, scenario) or None,
-        "build_policy_overrides": build_policy_overrides or None,
-        "resolution_strategy": resolution_strategy,
-        "trust_unverified_sdist_deps": scenario.get(
-            "trust_unverified_sdist_deps", True
-        ),
+        "config": config,
         "target": target,
         "host": effective_host,
     }

--- a/nab-python/benchmarks/_profile_runner.py
+++ b/nab-python/benchmarks/_profile_runner.py
@@ -30,6 +30,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 import scenarios as sc
 from benchmark_config import (
     build_benchmark_config,
+    parse_scenario_index_routes,
     parse_scenario_indexes,
     parse_scenario_project_metadata,
     parse_scenario_requirement_strings,
@@ -83,6 +84,7 @@ def build_inputs(
     vcs_config = parse_scenario_vcs_config(name, scenario)
     project_metadata = parse_scenario_project_metadata(name, scenario)
     indexes = parse_scenario_indexes(name, scenario)
+    index_routes = parse_scenario_index_routes(name, scenario, indexes)
     python_version = scenario["python_version"]
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
@@ -136,7 +138,7 @@ def build_inputs(
     config = build_benchmark_config(
         uploaded_prior_to=sc.parse_datetime(datetime_str) if datetime_str else None,
         indexes=indexes,
-        index_routes=sc.parse_index_routes(name, scenario),
+        index_routes=index_routes,
         build_policy_overrides=build_policy_overrides,
         resolution=resolution_strategy,
         trust_unverified_sdist_deps=trust_unverified_sdist_deps,

--- a/nab-python/benchmarks/_profile_runner.py
+++ b/nab-python/benchmarks/_profile_runner.py
@@ -30,6 +30,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 import scenarios as sc
 from benchmark_config import (
     build_benchmark_config,
+    parse_scenario_requirement_strings,
     parse_trust_unverified_sdist_deps,
 )
 
@@ -75,9 +76,10 @@ def build_inputs(
     host: sc.BenchmarkHost | None = None,
 ) -> dict:
     trust_unverified_sdist_deps = parse_trust_unverified_sdist_deps(name, scenario)
+    requirement_inputs = parse_scenario_requirement_strings(name, scenario)
     python_version = scenario["python_version"]
-    requirement_strings = list(scenario["requirements"])
-    constraint_strings = scenario.get("constraints", [])
+    requirement_strings = requirement_inputs.requirements
+    constraint_strings = requirement_inputs.constraints
     marker_environment = sc.parse_marker_environment(name, scenario)
     build_policy_overrides = sc.parse_build_packages(name, scenario)
     sc.validate_scenario_build_policy(

--- a/nab-python/benchmarks/_profile_runner.py
+++ b/nab-python/benchmarks/_profile_runner.py
@@ -32,6 +32,7 @@ from benchmark_config import (
     build_benchmark_config,
     parse_scenario_requirement_strings,
     parse_trust_unverified_sdist_deps,
+    parse_vcs_require_pin,
 )
 
 
@@ -77,6 +78,7 @@ def build_inputs(
 ) -> dict:
     trust_unverified_sdist_deps = parse_trust_unverified_sdist_deps(name, scenario)
     requirement_inputs = parse_scenario_requirement_strings(name, scenario)
+    vcs_require_pin = parse_vcs_require_pin(name, scenario)
     python_version = scenario["python_version"]
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
@@ -111,7 +113,7 @@ def build_inputs(
         policy=sc.VcsPolicy(scenario.get("vcs_policy", "block")),
         allowed_schemes=frozenset(scenario.get("vcs_allowed_schemes", [])),
         allowed_repos=tuple(scenario.get("vcs_allowed_repos", [])),
-        require_pin=scenario.get("vcs_require_pin", True),
+        require_pin=vcs_require_pin,
     )
 
     if scenario.get("project_name"):
@@ -182,8 +184,7 @@ def main() -> None:
     resolution_override = (
         sc.ResolutionStrategy(args.resolution) if args.resolution is not None else None
     )
-    host = sc.BenchmarkHost.current(sc.SCENARIO_WALL_TIMEOUT_SECONDS)
-    inputs = build_inputs(name, scenario, resolution_override, host)
+    inputs = build_inputs(name, scenario, resolution_override, host=None)
 
     if not args.cprofile:
         report(name, sc.resolve_scenario(**inputs))

--- a/nab-python/benchmarks/_profile_runner.py
+++ b/nab-python/benchmarks/_profile_runner.py
@@ -31,8 +31,8 @@ import scenarios as sc
 from benchmark_config import (
     build_benchmark_config,
     parse_scenario_requirement_strings,
+    parse_scenario_vcs_config,
     parse_trust_unverified_sdist_deps,
-    parse_vcs_require_pin,
 )
 
 
@@ -78,7 +78,7 @@ def build_inputs(
 ) -> dict:
     trust_unverified_sdist_deps = parse_trust_unverified_sdist_deps(name, scenario)
     requirement_inputs = parse_scenario_requirement_strings(name, scenario)
-    vcs_require_pin = parse_vcs_require_pin(name, scenario)
+    vcs_config = parse_scenario_vcs_config(name, scenario)
     python_version = scenario["python_version"]
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
@@ -109,13 +109,6 @@ def build_inputs(
         scenario.get("resolution", sc.ResolutionStrategy.HIGHEST.value)
     )
     resolution_strategy = resolution_override or declared_resolution
-    vcs_config = sc.VcsConfig(
-        policy=sc.VcsPolicy(scenario.get("vcs_policy", "block")),
-        allowed_schemes=frozenset(scenario.get("vcs_allowed_schemes", [])),
-        allowed_repos=tuple(scenario.get("vcs_allowed_repos", [])),
-        require_pin=vcs_require_pin,
-    )
-
     if scenario.get("project_name"):
         requirement_strings += sc.expand_project_extras(
             scenario["project_name"],

--- a/nab-python/benchmarks/_profile_runner.py
+++ b/nab-python/benchmarks/_profile_runner.py
@@ -30,6 +30,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 import scenarios as sc
 from benchmark_config import (
     build_benchmark_config,
+    parse_scenario_indexes,
     parse_scenario_project_metadata,
     parse_scenario_requirement_strings,
     parse_scenario_vcs_config,
@@ -81,6 +82,7 @@ def build_inputs(
     requirement_inputs = parse_scenario_requirement_strings(name, scenario)
     vcs_config = parse_scenario_vcs_config(name, scenario)
     project_metadata = parse_scenario_project_metadata(name, scenario)
+    indexes = parse_scenario_indexes(name, scenario)
     python_version = scenario["python_version"]
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
@@ -133,7 +135,7 @@ def build_inputs(
     datetime_str = scenario.get("datetime")
     config = build_benchmark_config(
         uploaded_prior_to=sc.parse_datetime(datetime_str) if datetime_str else None,
-        indexes=sc.parse_indexes(name, scenario),
+        indexes=indexes,
         index_routes=sc.parse_index_routes(name, scenario),
         build_policy_overrides=build_policy_overrides,
         resolution=resolution_strategy,

--- a/nab-python/benchmarks/_profile_runner.py
+++ b/nab-python/benchmarks/_profile_runner.py
@@ -30,6 +30,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 import scenarios as sc
 from benchmark_config import (
     build_benchmark_config,
+    parse_scenario_project_metadata,
     parse_scenario_requirement_strings,
     parse_scenario_vcs_config,
     parse_trust_unverified_sdist_deps,
@@ -79,6 +80,7 @@ def build_inputs(
     trust_unverified_sdist_deps = parse_trust_unverified_sdist_deps(name, scenario)
     requirement_inputs = parse_scenario_requirement_strings(name, scenario)
     vcs_config = parse_scenario_vcs_config(name, scenario)
+    project_metadata = parse_scenario_project_metadata(name, scenario)
     python_version = scenario["python_version"]
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
@@ -109,11 +111,11 @@ def build_inputs(
         scenario.get("resolution", sc.ResolutionStrategy.HIGHEST.value)
     )
     resolution_strategy = resolution_override or declared_resolution
-    if scenario.get("project_name"):
+    if project_metadata.project_name:
         requirement_strings += sc.expand_project_extras(
-            scenario["project_name"],
-            scenario.get("project_extras", []),
-            scenario.get("optional_dependencies", {}),
+            project_metadata.project_name,
+            project_metadata.project_extras,
+            project_metadata.optional_dependencies,
         )
 
     marker_env = dict(target.marker_env)

--- a/nab-python/benchmarks/_profile_runner.py
+++ b/nab-python/benchmarks/_profile_runner.py
@@ -38,6 +38,7 @@ from benchmark_config import (
     parse_scenario_vcs_config,
     parse_trust_unverified_sdist_deps,
     validate_scenario_build_policy,
+    validate_scenario_settings,
 )
 
 
@@ -81,6 +82,7 @@ def build_inputs(
     resolution_override: sc.ResolutionStrategy | None = None,
     host: sc.BenchmarkHost | None = None,
 ) -> dict:
+    validate_scenario_settings(name, scenario)
     trust_unverified_sdist_deps = parse_trust_unverified_sdist_deps(name, scenario)
     requirement_inputs = parse_scenario_requirement_strings(name, scenario)
     vcs_config = parse_scenario_vcs_config(name, scenario)

--- a/nab-python/benchmarks/_profile_runner.py
+++ b/nab-python/benchmarks/_profile_runner.py
@@ -30,12 +30,14 @@ sys.path.insert(0, str(Path(__file__).parent))
 import scenarios as sc
 from benchmark_config import (
     build_benchmark_config,
+    parse_scenario_build_packages,
     parse_scenario_index_routes,
     parse_scenario_indexes,
     parse_scenario_project_metadata,
     parse_scenario_requirement_strings,
     parse_scenario_vcs_config,
     parse_trust_unverified_sdist_deps,
+    validate_scenario_build_policy,
 )
 
 
@@ -89,12 +91,16 @@ def build_inputs(
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
     marker_environment = sc.parse_marker_environment(name, scenario)
-    build_policy_overrides = sc.parse_build_packages(name, scenario)
-    sc.validate_scenario_build_policy(
+    build_policy_overrides = parse_scenario_build_packages(name, scenario)
+    validate_scenario_build_policy(
         name,
         marker_environment,
         build_policy_overrides,
     )
+    declared_resolution = sc.ResolutionStrategy(
+        scenario.get("resolution", sc.ResolutionStrategy.HIGHEST.value)
+    )
+    resolution_strategy = resolution_override or declared_resolution
     requires_matching_host = sc.parse_requires_matching_host(
         name,
         scenario,
@@ -111,10 +117,6 @@ def build_inputs(
         raise SystemExit(msg)
     target = admission.target
 
-    declared_resolution = sc.ResolutionStrategy(
-        scenario.get("resolution", sc.ResolutionStrategy.HIGHEST.value)
-    )
-    resolution_strategy = resolution_override or declared_resolution
     if project_metadata.project_name:
         requirement_strings += sc.expand_project_extras(
             project_metadata.project_name,

--- a/nab-python/benchmarks/_profile_runner.py
+++ b/nab-python/benchmarks/_profile_runner.py
@@ -28,7 +28,10 @@ else:
 sys.path.insert(0, str(Path(__file__).parent))
 
 import scenarios as sc
-from benchmark_config import build_benchmark_config
+from benchmark_config import (
+    build_benchmark_config,
+    parse_trust_unverified_sdist_deps,
+)
 
 
 def find_scenario(spec: str) -> tuple[str, dict]:
@@ -71,6 +74,7 @@ def build_inputs(
     resolution_override: sc.ResolutionStrategy | None = None,
     host: sc.BenchmarkHost | None = None,
 ) -> dict:
+    trust_unverified_sdist_deps = parse_trust_unverified_sdist_deps(name, scenario)
     python_version = scenario["python_version"]
     requirement_strings = list(scenario["requirements"])
     constraint_strings = scenario.get("constraints", [])
@@ -134,10 +138,7 @@ def build_inputs(
         index_routes=sc.parse_index_routes(name, scenario),
         build_policy_overrides=build_policy_overrides,
         resolution=resolution_strategy,
-        trust_unverified_sdist_deps=scenario.get(
-            "trust_unverified_sdist_deps",
-            True,
-        ),
+        trust_unverified_sdist_deps=trust_unverified_sdist_deps,
         vcs=vcs_config,
     )
     return {

--- a/nab-python/benchmarks/benchmark_config.py
+++ b/nab-python/benchmarks/benchmark_config.py
@@ -45,6 +45,61 @@ class _BenchmarkResolveInputs(NamedTuple):
     root_extras: set[tuple[str, str]]
 
 
+class ScenarioRequirementStrings(NamedTuple):
+    """Copied requirement and constraint strings from one scenario."""
+
+    requirements: list[str]
+    constraints: list[str]
+
+
+def _scenario_string_list(
+    scenario_name: str,
+    field: str,
+    value: object,
+) -> list[str]:
+    """Validate and copy one scenario list of strings."""
+    if type(value) is not list:
+        msg = f"{scenario_name}: {field} must be a list, got {type(value).__name__}"
+        raise TypeError(msg)
+
+    strings: list[str] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, str):
+            msg = (
+                f"{scenario_name}: {field}[{index}] must be a non-empty string, "
+                f"got {type(item).__name__}"
+            )
+            raise TypeError(msg)
+        if not item:
+            msg = f"{scenario_name}: {field}[{index}] must be a non-empty string"
+            raise ValueError(msg)
+        strings.append(item)
+    return strings
+
+
+def parse_scenario_requirement_strings(
+    scenario_name: str,
+    scenario: Mapping[str, object],
+) -> ScenarioRequirementStrings:
+    """Validate and copy a scenario's root and constraint strings."""
+    if "requirements" not in scenario:
+        msg = f"{scenario_name}: missing required field 'requirements'"
+        raise ValueError(msg)
+
+    return ScenarioRequirementStrings(
+        requirements=_scenario_string_list(
+            scenario_name,
+            "requirements",
+            scenario["requirements"],
+        ),
+        constraints=_scenario_string_list(
+            scenario_name,
+            "constraints",
+            scenario.get("constraints", []),
+        ),
+    )
+
+
 def parse_trust_unverified_sdist_deps(
     scenario_name: str,
     scenario: Mapping[str, object],

--- a/nab-python/benchmarks/benchmark_config.py
+++ b/nab-python/benchmarks/benchmark_config.py
@@ -15,6 +15,7 @@ from nab_python.provider import (
     Provider,
     ResolutionStrategy,
     VcsConfig,
+    VcsPolicy,
     join_extra,
     split_extra,
 )
@@ -131,6 +132,88 @@ def parse_vcs_require_pin(
         )
         raise TypeError(msg)
     return value
+
+
+def parse_vcs_policy(
+    scenario_name: str,
+    scenario: Mapping[str, object],
+) -> VcsPolicy:
+    """Return the VCS policy declared by a scenario."""
+    value = scenario.get("vcs_policy", VcsPolicy.BLOCK.value)
+    try:
+        return VcsPolicy(value)
+    except (TypeError, ValueError) as exc:
+        valid = sorted(policy.value for policy in VcsPolicy)
+        msg = f"{scenario_name}: vcs_policy must be one of {valid!r}, got {value!r}"
+        raise ValueError(msg) from exc
+
+
+def _scenario_vcs_string_list(
+    scenario_name: str,
+    field: str,
+    value: object,
+) -> list[str]:
+    """Validate and copy one VCS list without interpreting its strings."""
+    if type(value) is not list:
+        msg = f"{scenario_name}: {field} must be a list, got {type(value).__name__}"
+        raise TypeError(msg)
+
+    strings: list[str] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, str):
+            msg = (
+                f"{scenario_name}: {field}[{index}] must be a string, "
+                f"got {type(item).__name__}"
+            )
+            raise TypeError(msg)
+        strings.append(item)
+    return strings
+
+
+def parse_vcs_allowed_schemes(
+    scenario_name: str,
+    scenario: Mapping[str, object],
+) -> frozenset[str]:
+    """Return a scenario's copied VCS scheme allowlist as a set."""
+    return frozenset(
+        _scenario_vcs_string_list(
+            scenario_name,
+            "vcs_allowed_schemes",
+            scenario.get("vcs_allowed_schemes", []),
+        )
+    )
+
+
+def parse_vcs_allowed_repos(
+    scenario_name: str,
+    scenario: Mapping[str, object],
+) -> tuple[str, ...]:
+    """Return a scenario's copied VCS repository allowlist in declaration order."""
+    return tuple(
+        _scenario_vcs_string_list(
+            scenario_name,
+            "vcs_allowed_repos",
+            scenario.get("vcs_allowed_repos", []),
+        )
+    )
+
+
+def parse_scenario_vcs_config(
+    scenario_name: str,
+    scenario: Mapping[str, object],
+) -> VcsConfig:
+    """Build the VCS config declared by a benchmark scenario."""
+    require_pin = parse_vcs_require_pin(scenario_name, scenario)
+    policy = parse_vcs_policy(scenario_name, scenario)
+    allowed_schemes = parse_vcs_allowed_schemes(scenario_name, scenario)
+    allowed_repos = parse_vcs_allowed_repos(scenario_name, scenario)
+
+    return VcsConfig(
+        policy=policy,
+        allowed_schemes=allowed_schemes,
+        allowed_repos=allowed_repos,
+        require_pin=require_pin,
+    )
 
 
 def _package_overrides(

--- a/nab-python/benchmarks/benchmark_config.py
+++ b/nab-python/benchmarks/benchmark_config.py
@@ -53,6 +53,14 @@ class ScenarioRequirementStrings(NamedTuple):
     constraints: list[str]
 
 
+class ScenarioProjectMetadata(NamedTuple):
+    """Copied project metadata used to expand a scenario's selected extras."""
+
+    project_name: str | None
+    project_extras: list[str]
+    optional_dependencies: dict[str, list[str]]
+
+
 def _scenario_string_list(
     scenario_name: str,
     field: str,
@@ -97,6 +105,69 @@ def parse_scenario_requirement_strings(
             scenario_name,
             "constraints",
             scenario.get("constraints", []),
+        ),
+    )
+
+
+def _scenario_optional_dependencies(
+    scenario_name: str,
+    value: object,
+) -> dict[str, list[str]]:
+    """Validate and copy a scenario's optional-dependency table."""
+    if type(value) is not dict:
+        msg = (
+            f"{scenario_name}: optional_dependencies must be a table, "
+            f"got {type(value).__name__}"
+        )
+        raise TypeError(msg)
+
+    optional_dependencies: dict[str, list[str]] = {}
+    for extra, dependencies in value.items():
+        if not isinstance(extra, str):
+            msg = (
+                f"{scenario_name}: optional_dependencies keys must be "
+                f"non-empty strings, got {type(extra).__name__}"
+            )
+            raise TypeError(msg)
+        if not extra:
+            msg = (
+                f"{scenario_name}: optional_dependencies keys must be non-empty strings"
+            )
+            raise ValueError(msg)
+        optional_dependencies[extra] = _scenario_string_list(
+            scenario_name,
+            f"optional_dependencies[{extra!r}]",
+            dependencies,
+        )
+    return optional_dependencies
+
+
+def parse_scenario_project_metadata(
+    scenario_name: str,
+    scenario: Mapping[str, object],
+) -> ScenarioProjectMetadata:
+    """Validate and copy project metadata from one benchmark scenario."""
+    project_name = scenario.get("project_name")
+    if project_name is not None and not isinstance(project_name, str):
+        msg = (
+            f"{scenario_name}: project_name must be a non-empty string, "
+            f"got {type(project_name).__name__}"
+        )
+        raise TypeError(msg)
+    if project_name == "":
+        msg = f"{scenario_name}: project_name must be a non-empty string"
+        raise ValueError(msg)
+
+    return ScenarioProjectMetadata(
+        project_name=project_name,
+        project_extras=_scenario_string_list(
+            scenario_name,
+            "project_extras",
+            scenario.get("project_extras", []),
+        ),
+        optional_dependencies=_scenario_optional_dependencies(
+            scenario_name,
+            scenario.get("optional_dependencies", {}),
         ),
     )
 

--- a/nab-python/benchmarks/benchmark_config.py
+++ b/nab-python/benchmarks/benchmark_config.py
@@ -39,6 +39,30 @@ DEFAULT_INDEXES: tuple[IndexConfig, ...] = (
 )
 _INDEX_KEYS = frozenset({"name", "url", "serialization"})
 _INDEX_ROUTE_KEYS = frozenset({"name", "index"})
+_SCENARIO_SETTINGS = frozenset(
+    {
+        "requirements",
+        "constraints",
+        "project_name",
+        "project_extras",
+        "optional_dependencies",
+        "indexes",
+        "index_routes",
+        "build_packages",
+        "trust_unverified_sdist_deps",
+        "vcs_policy",
+        "vcs_allowed_schemes",
+        "vcs_allowed_repos",
+        "vcs_require_pin",
+        "python_version",
+        "marker_environment",
+        "platform_system",
+        "resolution",
+        "datetime",
+        "requires_matching_host",
+        "unsupported_reason",
+    }
+)
 
 
 class _BenchmarkResolveInputs(NamedTuple):
@@ -67,6 +91,19 @@ class ScenarioProjectMetadata(NamedTuple):
     project_name: str | None
     project_extras: list[str]
     optional_dependencies: dict[str, list[str]]
+
+
+def validate_scenario_settings(
+    scenario_name: str,
+    scenario: Mapping[str, object],
+) -> None:
+    """Reject setting names that no live benchmark runner understands."""
+    unknown = sorted(
+        setting for setting in scenario if setting not in _SCENARIO_SETTINGS
+    )
+    if unknown:
+        msg = f"{scenario_name}: unknown scenario settings: {unknown!r}"
+        raise ValueError(msg)
 
 
 def _scenario_string_list(

--- a/nab-python/benchmarks/benchmark_config.py
+++ b/nab-python/benchmarks/benchmark_config.py
@@ -1,0 +1,128 @@
+"""Shared project and provider configuration for live-index benchmarks."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from nab_python._vendor.packaging.ranges import VersionRange
+from nab_python._vendor.packaging.requirements import Requirement
+from nab_python._vendor.packaging.utils import canonicalize_name
+from nab_python.config import NabProjectConfig, PackageOverride
+from nab_python.provider import (
+    BuildPolicy,
+    DistPolicy,
+    Provider,
+    ResolutionStrategy,
+    VcsConfig,
+    split_extra,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+    from datetime import datetime
+
+    from nab_index.multi_index import IndexConfig
+    from nab_python.fetch import FetchCoordinator, IndexRoute
+    from nab_python.target import ResolveTarget
+
+
+def _package_overrides(
+    indexes: Sequence[IndexConfig],
+    index_routes: Sequence[IndexRoute],
+    build_policy_overrides: Mapping[str, BuildPolicy],
+) -> tuple[PackageOverride, ...]:
+    """Combine benchmark routing and build settings by canonical package name."""
+    declared_indexes = {index.name for index in indexes}
+    route_indexes: dict[str, str] = {}
+    order: list[str] = []
+
+    for route in index_routes:
+        name = canonicalize_name(route.name)
+        if name in route_indexes:
+            msg = f"duplicate index route for {name!r}"
+            raise ValueError(msg)
+        if route.index not in declared_indexes:
+            msg = f"index route for {name!r} names undeclared index {route.index!r}"
+            raise ValueError(msg)
+        route_indexes[name] = route.index
+        order.append(name)
+
+    build_policies: dict[str, BuildPolicy] = {}
+    for raw_name, policy in build_policy_overrides.items():
+        name = canonicalize_name(raw_name)
+        if name not in order:
+            order.append(name)
+        build_policies[name] = policy
+
+    return tuple(
+        PackageOverride(
+            requirement=Requirement(name),
+            name=name,
+            version_range=VersionRange.full(),
+            build_policy=build_policies.get(name),
+            index=route_indexes.get(name),
+        )
+        for name in order
+    )
+
+
+def build_benchmark_config(
+    *,
+    indexes: Sequence[IndexConfig],
+    uploaded_prior_to: datetime | None = None,
+    index_routes: Sequence[IndexRoute] = (),
+    build_policy_overrides: Mapping[str, BuildPolicy] | None = None,
+    resolution: ResolutionStrategy = ResolutionStrategy.HIGHEST,
+    trust_unverified_sdist_deps: bool = False,
+    vcs: VcsConfig | None = None,
+) -> NabProjectConfig:
+    """Build the project config represented by one benchmark scenario."""
+    return NabProjectConfig(
+        uploaded_prior_to=uploaded_prior_to,
+        dist_policy=DistPolicy.WHEEL_OR_SDIST,
+        build_policy=BuildPolicy.NEVER,
+        trust_unverified_sdist_deps=trust_unverified_sdist_deps,
+        indexes=tuple(indexes),
+        vcs=vcs or VcsConfig(),
+        resolution=resolution,
+        package_overrides=_package_overrides(
+            indexes,
+            index_routes,
+            build_policy_overrides or {},
+        ),
+    )
+
+
+def direct_packages_from_requirements(
+    requirements: Mapping[str, VersionRange],
+) -> frozenset[str]:
+    """Return the direct non-extra package names represented by root requirements."""
+    return frozenset(name for name in requirements if split_extra(name)[1] is None)
+
+
+def build_benchmark_provider(
+    coordinator: FetchCoordinator,
+    *,
+    config: NabProjectConfig,
+    target: ResolveTarget,
+    requirements: dict[str, VersionRange],
+) -> Provider:
+    """Build a provider from a benchmark project config and its roots."""
+    return Provider(
+        coordinator,
+        target=target,
+        root_requirements=requirements,
+        uploaded_prior_to=config.uploaded_prior_to,
+        dist_policy=config.dist_policy,
+        build_policy=config.build_policy,
+        package_overrides=config.package_overrides,
+        index_overrides=config.index_overrides,
+        trust_unverified_sdist_deps=config.trust_unverified_sdist_deps,
+        vcs_config=config.vcs,
+        local_sources=list(config.local_sources) or None,
+        vcs_sources=list(config.vcs_sources) or None,
+        archive_sources=list(config.archive_sources) or None,
+        build_config=config,
+        resolution_strategy=config.resolution,
+        direct_packages=direct_packages_from_requirements(requirements),
+    )

--- a/nab-python/benchmarks/benchmark_config.py
+++ b/nab-python/benchmarks/benchmark_config.py
@@ -397,6 +397,61 @@ def parse_scenario_index_routes(
     return routes
 
 
+def parse_scenario_build_packages(
+    scenario_name: str,
+    scenario: Mapping[str, object],
+) -> dict[str, BuildPolicy]:
+    """Return remote-build overrides preserving declared spelling and order."""
+    raw = scenario.get("build_packages", [])
+    if type(raw) is not list:
+        msg = (
+            f"{scenario_name}: build_packages must be a list of package names, "
+            f"got {type(raw).__name__}"
+        )
+        raise TypeError(msg)
+
+    packages: list[tuple[str, str]] = []
+    for position, name in enumerate(raw):
+        if not isinstance(name, str):
+            msg = (
+                f"{scenario_name}: build_packages[{position}] must be a string, "
+                f"got {type(name).__name__}"
+            )
+            raise TypeError(msg)
+        try:
+            canonical_name = canonicalize_name(name, validate=True)
+        except InvalidName as exc:
+            msg = (
+                f"{scenario_name}: build_packages[{position}] must be a valid "
+                f"distribution name, got {name!r}"
+            )
+            raise ValueError(msg) from exc
+        packages.append((name, canonical_name))
+
+    seen: set[str] = set()
+    for _, canonical_name in packages:
+        if canonical_name in seen:
+            msg = f"{scenario_name}: duplicate build package {canonical_name!r}"
+            raise ValueError(msg)
+        seen.add(canonical_name)
+
+    return {name: BuildPolicy.BUILD_REMOTE for name, _ in packages}
+
+
+def validate_scenario_build_policy(
+    scenario_name: str,
+    marker_environment: Mapping[str, str],
+    build_policy_overrides: Mapping[str, BuildPolicy],
+) -> None:
+    """Reject build policy paired with a marker environment overlay."""
+    if marker_environment and build_policy_overrides:
+        msg = (
+            f"{scenario_name}: build_packages cannot be combined "
+            "with a marker environment overlay"
+        )
+        raise ValueError(msg)
+
+
 def benchmark_index_settings(
     indexes: Sequence[IndexConfig],
 ) -> list[dict[str, str]]:

--- a/nab-python/benchmarks/benchmark_config.py
+++ b/nab-python/benchmarks/benchmark_config.py
@@ -10,9 +10,9 @@ from nab_index.multi_index import IndexConfig
 from nab_index.serialization import SimpleSerialization
 from nab_python._vendor.packaging.ranges import VersionRange
 from nab_python._vendor.packaging.requirements import Requirement
-from nab_python._vendor.packaging.utils import canonicalize_name
+from nab_python._vendor.packaging.utils import InvalidName, canonicalize_name
 from nab_python.config import NabProjectConfig, PackageOverride
-from nab_python.fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL
+from nab_python.fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL, IndexRoute
 from nab_python.provider import (
     BuildPolicy,
     DistPolicy,
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from collections.abc import AbstractSet, Mapping, Sequence
     from datetime import datetime
 
-    from nab_python.fetch import FetchCoordinator, IndexRoute
+    from nab_python.fetch import FetchCoordinator
     from nab_python.target import ResolveTarget
 
 
@@ -38,6 +38,7 @@ DEFAULT_INDEXES: tuple[IndexConfig, ...] = (
     IndexConfig(DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL),
 )
 _INDEX_KEYS = frozenset({"name", "url", "serialization"})
+_INDEX_ROUTE_KEYS = frozenset({"name", "index"})
 
 
 class _BenchmarkResolveInputs(NamedTuple):
@@ -294,6 +295,106 @@ def parse_scenario_indexes(
     ]
     _check_scenario_index_name_uniqueness(scenario_name, indexes)
     return indexes
+
+
+def _parse_scenario_index_route(
+    scenario_name: str,
+    position: int,
+    value: object,
+) -> IndexRoute:
+    """Validate and copy one package route from a benchmark scenario."""
+    if not isinstance(value, dict):
+        msg = (
+            f"{scenario_name}: index_routes[{position}] must be a table, "
+            f"got {type(value).__name__}"
+        )
+        raise TypeError(msg)
+
+    unknown = sorted(set(value) - _INDEX_ROUTE_KEYS)
+    if unknown:
+        msg = (
+            f"{scenario_name}: unknown index_routes[{position}] keys: {unknown!r}; "
+            f"expected {sorted(_INDEX_ROUTE_KEYS)!r}"
+        )
+        raise ValueError(msg)
+    if "name" not in value:
+        msg = f"{scenario_name}: index_routes[{position}] missing required key 'name'"
+        raise ValueError(msg)
+    if "index" not in value:
+        msg = f"{scenario_name}: index_routes[{position}] missing required key 'index'"
+        raise ValueError(msg)
+
+    name = value["name"]
+    index = value["index"]
+    if not isinstance(name, str):
+        msg = (
+            f"{scenario_name}: index_routes[{position}].name must be a string, "
+            f"got {type(name).__name__}"
+        )
+        raise TypeError(msg)
+    if not isinstance(index, str):
+        msg = (
+            f"{scenario_name}: index_routes[{position}].index must be a string, "
+            f"got {type(index).__name__}"
+        )
+        raise TypeError(msg)
+
+    try:
+        canonicalize_name(name, validate=True)
+    except InvalidName as exc:
+        msg = (
+            f"{scenario_name}: index_routes[{position}].name must be a valid "
+            f"distribution name, got {name!r}"
+        )
+        raise ValueError(msg) from exc
+    return IndexRoute(name=name, index=index)
+
+
+def _check_scenario_index_route_relationships(
+    scenario_name: str,
+    routes: Sequence[IndexRoute],
+    indexes: Sequence[IndexConfig],
+) -> None:
+    """Reject duplicate package routes and references to undeclared indexes."""
+    seen: set[str] = set()
+    for route in routes:
+        name = canonicalize_name(route.name, validate=True)
+        if name in seen:
+            msg = f"{scenario_name}: duplicate index route for {name!r}"
+            raise ValueError(msg)
+        seen.add(name)
+
+    declared_indexes = {index.name for index in indexes}
+    for route in routes:
+        if route.index not in declared_indexes:
+            msg = (
+                f"{scenario_name}: index route for {route.name!r} names undeclared "
+                f"index {route.index!r}; declared indexes are "
+                f"{sorted(declared_indexes)!r}"
+            )
+            raise ValueError(msg)
+
+
+def parse_scenario_index_routes(
+    scenario_name: str,
+    scenario: Mapping[str, object],
+    indexes: Sequence[IndexConfig],
+) -> list[IndexRoute]:
+    """Validate and copy the package routes declared by a benchmark scenario."""
+    raw = scenario.get("index_routes", [])
+    if not isinstance(raw, list):
+        msg = (
+            f"{scenario_name}: index_routes must be an array of tables, "
+            f"got {type(raw).__name__}"
+        )
+        raise TypeError(msg)
+
+    routes = [
+        _parse_scenario_index_route(scenario_name, position, entry)
+        for position, entry in enumerate(raw)
+    ]
+    _check_scenario_index_route_relationships(scenario_name, routes, indexes)
+    return routes
 
 
 def benchmark_index_settings(

--- a/nab-python/benchmarks/benchmark_config.py
+++ b/nab-python/benchmarks/benchmark_config.py
@@ -5,10 +5,14 @@ from __future__ import annotations
 from types import MappingProxyType
 from typing import TYPE_CHECKING, NamedTuple
 
+from nab_index.local_index import is_file_url
+from nab_index.multi_index import IndexConfig
+from nab_index.serialization import SimpleSerialization
 from nab_python._vendor.packaging.ranges import VersionRange
 from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.utils import canonicalize_name
 from nab_python.config import NabProjectConfig, PackageOverride
+from nab_python.fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL
 from nab_python.provider import (
     BuildPolicy,
     DistPolicy,
@@ -24,13 +28,16 @@ if TYPE_CHECKING:
     from collections.abc import AbstractSet, Mapping, Sequence
     from datetime import datetime
 
-    from nab_index.multi_index import IndexConfig
     from nab_python.fetch import FetchCoordinator, IndexRoute
     from nab_python.target import ResolveTarget
 
 
 # Search benchmarks trust pre-2.2 PKG-INFO dependency metadata by default.
 DEFAULT_SCENARIO_TRUST_UNVERIFIED_SDIST_DEPS = True
+DEFAULT_INDEXES: tuple[IndexConfig, ...] = (
+    IndexConfig(DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL),
+)
+_INDEX_KEYS = frozenset({"name", "url", "serialization"})
 
 
 class _BenchmarkResolveInputs(NamedTuple):
@@ -170,6 +177,136 @@ def parse_scenario_project_metadata(
             scenario.get("optional_dependencies", {}),
         ),
     )
+
+
+def _parse_scenario_index_serialization(
+    scenario_name: str,
+    position: int,
+    entry: Mapping[str, object],
+    *,
+    name: str,
+    url: str,
+) -> SimpleSerialization:
+    """Return the serialization requested by one scenario index."""
+    if "serialization" in entry and is_file_url(url):
+        msg = (
+            f"{scenario_name}: indexes[{position}].serialization must be omitted "
+            f"for file:// index {name!r}"
+        )
+        raise ValueError(msg)
+
+    serialization = entry.get("serialization")
+    if serialization is None:
+        return SimpleSerialization.NEGOTIATE
+    if not isinstance(serialization, str):
+        msg = (
+            f"{scenario_name}: indexes[{position}].serialization must be a string, "
+            f"got {type(serialization).__name__}"
+        )
+        raise TypeError(msg)
+
+    try:
+        return SimpleSerialization(serialization)
+    except ValueError as exc:
+        valid = sorted(member.value for member in SimpleSerialization)
+        msg = (
+            f"{scenario_name}: indexes[{position}].serialization must be one "
+            f"of {valid!r}, got {serialization!r}"
+        )
+        raise ValueError(msg) from exc
+
+
+def _parse_scenario_index(
+    scenario_name: str,
+    position: int,
+    value: object,
+) -> IndexConfig:
+    """Validate and copy one index entry from a benchmark scenario."""
+    if not isinstance(value, dict):
+        msg = (
+            f"{scenario_name}: indexes[{position}] must be a table, "
+            f"got {type(value).__name__}"
+        )
+        raise TypeError(msg)
+
+    unknown = sorted(set(value) - _INDEX_KEYS)
+    if unknown:
+        msg = (
+            f"{scenario_name}: unknown indexes[{position}] keys: {unknown!r}; "
+            f"expected {sorted(_INDEX_KEYS)!r}"
+        )
+        raise ValueError(msg)
+    try:
+        name = value["name"]
+        url = value["url"]
+    except KeyError as missing:
+        msg = f"{scenario_name}: indexes[{position}] missing required key {missing!s}"
+        raise ValueError(msg) from None
+    if not isinstance(name, str) or not isinstance(url, str):
+        msg = f"{scenario_name}: indexes[{position}] name and url must be strings"
+        raise TypeError(msg)
+
+    serialization = _parse_scenario_index_serialization(
+        scenario_name,
+        position,
+        value,
+        name=name,
+        url=url,
+    )
+    return IndexConfig(name, url, serialization)
+
+
+def _check_scenario_index_name_uniqueness(
+    scenario_name: str,
+    indexes: Sequence[IndexConfig],
+) -> None:
+    """Reject duplicate scenario index names after parsing every entry."""
+    seen: set[str] = set()
+    for index in indexes:
+        if index.name in seen:
+            msg = f"{scenario_name}: duplicate index name: {index.name!r}"
+            raise ValueError(msg)
+        seen.add(index.name)
+
+
+def parse_scenario_indexes(
+    scenario_name: str,
+    scenario: Mapping[str, object],
+) -> list[IndexConfig]:
+    """Validate and copy the indexes declared by a benchmark scenario."""
+    if "indexes" not in scenario:
+        return list(DEFAULT_INDEXES)
+
+    raw = scenario["indexes"]
+    if not isinstance(raw, list):
+        msg = (
+            f"{scenario_name}: indexes must be an array of tables, "
+            f"got {type(raw).__name__}"
+        )
+        raise TypeError(msg)
+    if not raw:
+        msg = f"{scenario_name}: indexes must contain at least one entry when present"
+        raise ValueError(msg)
+
+    indexes = [
+        _parse_scenario_index(scenario_name, position, entry)
+        for position, entry in enumerate(raw)
+    ]
+    _check_scenario_index_name_uniqueness(scenario_name, indexes)
+    return indexes
+
+
+def benchmark_index_settings(
+    indexes: Sequence[IndexConfig],
+) -> list[dict[str, str]]:
+    """Return effective index settings with default serialization omitted."""
+    settings: list[dict[str, str]] = []
+    for index in indexes:
+        entry = {"name": index.name, "url": index.url}
+        if index.serialization is not SimpleSerialization.NEGOTIATE:
+            entry["serialization"] = index.serialization.value
+        settings.append(entry)
+    return settings
 
 
 def parse_trust_unverified_sdist_deps(

--- a/nab-python/benchmarks/benchmark_config.py
+++ b/nab-python/benchmarks/benchmark_config.py
@@ -118,6 +118,21 @@ def parse_trust_unverified_sdist_deps(
     return value
 
 
+def parse_vcs_require_pin(
+    scenario_name: str,
+    scenario: Mapping[str, object],
+) -> bool:
+    """Read whether a scenario requires VCS URLs to pin a commit."""
+    value = scenario.get("vcs_require_pin", True)
+    if type(value) is not bool:
+        msg = (
+            f"{scenario_name}: vcs_require_pin must be a boolean, "
+            f"got {type(value).__name__}"
+        )
+        raise TypeError(msg)
+    return value
+
+
 def _package_overrides(
     indexes: Sequence[IndexConfig],
     index_routes: Sequence[IndexRoute],

--- a/nab-python/benchmarks/benchmark_config.py
+++ b/nab-python/benchmarks/benchmark_config.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from types import MappingProxyType
+from typing import TYPE_CHECKING, NamedTuple
 
 from nab_python._vendor.packaging.ranges import VersionRange
 from nab_python._vendor.packaging.requirements import Requirement
@@ -14,16 +15,30 @@ from nab_python.provider import (
     Provider,
     ResolutionStrategy,
     VcsConfig,
+    join_extra,
     split_extra,
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import AbstractSet, Mapping, Sequence
     from datetime import datetime
 
     from nab_index.multi_index import IndexConfig
     from nab_python.fetch import FetchCoordinator, IndexRoute
     from nab_python.target import ResolveTarget
+
+
+class _BenchmarkResolveInputs(NamedTuple):
+    """Inputs shared by one benchmark's provider and resolver.
+
+    ``requirements`` holds the parsed roots, including extra proxy keys.
+    ``constraints`` is an immutable copy extended to root-extra proxy keys.
+    ``root_extras`` identifies extras requested directly by the benchmark.
+    """
+
+    requirements: dict[str, VersionRange]
+    constraints: Mapping[str, VersionRange] | None
+    root_extras: set[tuple[str, str]]
 
 
 def _package_overrides(
@@ -100,18 +115,60 @@ def direct_packages_from_requirements(
     return frozenset(name for name in requirements if split_extra(name)[1] is None)
 
 
+def _constraints_with_extra_proxies(
+    constraints: Mapping[str, VersionRange],
+    root_extras: AbstractSet[tuple[str, str]],
+) -> Mapping[str, VersionRange]:
+    """Return immutable constraints extended to the requested root-extra proxies.
+
+    An extra proxy resolves under its own ``name[extra]`` key, so copying the base
+    range there both constrains selection and attributes an empty range to the proxy,
+    which is what the product does through its own constraints mapping.
+    """
+    extended = dict(constraints)
+    for name, extra in root_extras:
+        constraint = extended.get(name)
+        if constraint is not None:
+            extended[join_extra(name, extra)] = constraint
+    return MappingProxyType(extended)
+
+
+def build_benchmark_resolver_inputs(
+    requirements: dict[str, VersionRange],
+    constraints: Mapping[str, VersionRange] | None,
+) -> _BenchmarkResolveInputs:
+    """Copy constraints and extend them to the requested root-extra proxies."""
+    root_extras: set[tuple[str, str]] = set()
+    for package in requirements:
+        name, extra = split_extra(package)
+        if extra is not None:
+            root_extras.add((name, extra))
+
+    resolver_constraints = (
+        _constraints_with_extra_proxies(constraints, root_extras)
+        if constraints is not None
+        else None
+    )
+    return _BenchmarkResolveInputs(
+        requirements=requirements,
+        constraints=resolver_constraints,
+        root_extras=root_extras,
+    )
+
+
 def build_benchmark_provider(
     coordinator: FetchCoordinator,
     *,
     config: NabProjectConfig,
     target: ResolveTarget,
-    requirements: dict[str, VersionRange],
+    inputs: _BenchmarkResolveInputs,
 ) -> Provider:
     """Build a provider from a benchmark project config and its roots."""
     return Provider(
         coordinator,
         target=target,
-        root_requirements=requirements,
+        root_requirements=inputs.requirements,
+        root_extras=inputs.root_extras,
         uploaded_prior_to=config.uploaded_prior_to,
         dist_policy=config.dist_policy,
         build_policy=config.build_policy,
@@ -124,5 +181,6 @@ def build_benchmark_provider(
         archive_sources=list(config.archive_sources) or None,
         build_config=config,
         resolution_strategy=config.resolution,
-        direct_packages=direct_packages_from_requirements(requirements),
+        direct_packages=direct_packages_from_requirements(inputs.requirements),
+        constraints=inputs.constraints,
     )

--- a/nab-python/benchmarks/benchmark_config.py
+++ b/nab-python/benchmarks/benchmark_config.py
@@ -28,6 +28,10 @@ if TYPE_CHECKING:
     from nab_python.target import ResolveTarget
 
 
+# Search benchmarks trust pre-2.2 PKG-INFO dependency metadata by default.
+DEFAULT_SCENARIO_TRUST_UNVERIFIED_SDIST_DEPS = True
+
+
 class _BenchmarkResolveInputs(NamedTuple):
     """Inputs shared by one benchmark's provider and resolver.
 
@@ -39,6 +43,24 @@ class _BenchmarkResolveInputs(NamedTuple):
     requirements: dict[str, VersionRange]
     constraints: Mapping[str, VersionRange] | None
     root_extras: set[tuple[str, str]]
+
+
+def parse_trust_unverified_sdist_deps(
+    scenario_name: str,
+    scenario: Mapping[str, object],
+) -> bool:
+    """Read whether a scenario accepts unverified sdist dependency metadata."""
+    value = scenario.get(
+        "trust_unverified_sdist_deps",
+        DEFAULT_SCENARIO_TRUST_UNVERIFIED_SDIST_DEPS,
+    )
+    if type(value) is not bool:
+        msg = (
+            f"{scenario_name}: trust_unverified_sdist_deps must be a boolean, "
+            f"got {type(value).__name__}"
+        )
+        raise TypeError(msg)
+    return value
 
 
 def _package_overrides(

--- a/nab-python/benchmarks/benchmark_host.py
+++ b/nab-python/benchmarks/benchmark_host.py
@@ -10,7 +10,12 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from nab_python.target import IMPLEMENTATION_MARKERS, PLATFORM_MARKERS, ResolveTarget
+from nab_python.target import (
+    IMPLEMENTATION_MARKERS,
+    PEP508_MARKER_VARIABLES,
+    PLATFORM_MARKERS,
+    ResolveTarget,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Mapping
@@ -71,6 +76,11 @@ def parse_target_marker_environment(
         raise TypeError(msg)
 
     marker_environment = dict(raw)
+    unknown = sorted(set(marker_environment) - PEP508_MARKER_VARIABLES)
+    if unknown:
+        msg = f"{scenario_name}: unknown marker_environment variables: {unknown!r}"
+        raise ValueError(msg)
+
     platform_system = scenario.get("platform_system")
     if platform_system is not None:
         if type(platform_system) is not str or not platform_system:

--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -37,6 +37,7 @@ from benchmark_config import (
     build_benchmark_provider,
     build_benchmark_resolver_inputs,
     direct_packages_from_requirements,
+    parse_scenario_build_packages,
     parse_scenario_index_routes,
     parse_scenario_indexes,
     parse_scenario_project_metadata,
@@ -47,6 +48,7 @@ from benchmark_config import (
     parse_vcs_allowed_schemes,
     parse_vcs_policy,
     parse_vcs_require_pin,
+    validate_scenario_build_policy,
 )
 from benchmark_datetime import parse_datetime
 from benchmark_host import (
@@ -64,12 +66,7 @@ from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.utils import canonicalize_name
 from nab_python.config import NabProjectConfig, index_routes_from_config
 from nab_python.fetch import FetchCoordinator
-from nab_python.provider import (
-    BuildPolicy,
-    ResolutionStrategy,
-    VcsConfig,
-    split_extra,
-)
+from nab_python.provider import BuildPolicy, ResolutionStrategy, VcsConfig, split_extra
 from nab_resolver.resolver import DEFAULT_MAX_ITERATIONS, Resolver
 
 BENCHMARKS_DIR = Path(__file__).parent
@@ -550,6 +547,51 @@ def _scenario_file(toml_stem: str) -> Path:
     return toml_path
 
 
+def _validate_selected_execution_fields(
+    cases: list[CanaryCase],
+    scenarios: list[tuple[str, dict]],
+) -> None:
+    """Validate marker, build, resolution, and host fields by phase."""
+    marker_environments = [
+        parse_target_marker_environment(scenario_name, scenario)
+        for scenario_name, scenario in scenarios
+    ]
+    build_policy_overrides: list[dict[str, BuildPolicy]] = [
+        parse_scenario_build_packages(scenario_name, scenario)
+        for scenario_name, scenario in scenarios
+    ]
+
+    for (scenario_name, scenario), marker_environment, overrides in zip(
+        scenarios,
+        marker_environments,
+        build_policy_overrides,
+        strict=True,
+    ):
+        if "unsupported_reason" not in scenario:
+            validate_scenario_build_policy(
+                scenario_name,
+                marker_environment,
+                overrides,
+            )
+
+    for case, (scenario_name, scenario), marker_environment in zip(
+        cases,
+        scenarios,
+        marker_environments,
+        strict=True,
+    ):
+        scenario_resolution(
+            scenario,
+            scenario_name=scenario_name,
+            override=case.resolution,
+        )
+        parse_requires_matching_host(
+            scenario_name,
+            scenario,
+            marker_environment,
+        )
+
+
 def select_scenarios(cases: list[CanaryCase]) -> list[CanaryCase]:
     """Validate every selection before a benchmark run or result write."""
     if not cases:
@@ -600,6 +642,7 @@ def select_scenarios(cases: list[CanaryCase]) -> list[CanaryCase]:
         strict=True,
     ):
         parse_scenario_index_routes(scenario_name, scenario, indexes)
+    _validate_selected_execution_fields(cases, found_scenarios)
     return cases
 
 
@@ -757,16 +800,12 @@ def _prepare_canary_execution(
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
     marker_environment = parse_target_marker_environment(scenario_name, scenario)
-    raw_build_packages = scenario.get("build_packages", []) or []
-    build_policy_overrides = {
-        str(name): BuildPolicy.BUILD_REMOTE for name in raw_build_packages
-    }
-    if marker_environment and build_policy_overrides:
-        msg = (
-            f"{scenario_name}: build_packages cannot be combined "
-            "with a marker environment overlay"
-        )
-        raise ValueError(msg)
+    build_policy_overrides = parse_scenario_build_packages(scenario_name, scenario)
+    validate_scenario_build_policy(
+        scenario_name,
+        marker_environment,
+        build_policy_overrides,
+    )
 
     resolution_strategy = scenario_resolution(
         scenario,

--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -34,6 +34,7 @@ else:
 from benchmark_config import (
     build_benchmark_config,
     build_benchmark_provider,
+    build_benchmark_resolver_inputs,
     direct_packages_from_requirements,
 )
 from benchmark_datetime import parse_datetime
@@ -309,6 +310,7 @@ def run_one(
     host: BenchmarkHost,
 ) -> dict:
     direct_packages = direct_packages_from_requirements(requirements)
+    inputs = build_benchmark_resolver_inputs(requirements, constraints)
     with FetchCoordinator(
         HttpxAsyncTransport(),
         indexes=list(config.indexes),
@@ -319,7 +321,7 @@ def run_one(
             coordinator,
             config=config,
             target=target,
-            requirements=requirements,
+            inputs=inputs,
         )
         resolver = Resolver(
             provider,
@@ -330,7 +332,10 @@ def run_one(
         start = time.monotonic()
         try:
             with host.wall_timeout():
-                raw = resolver.resolve(requirements, constraints=constraints)
+                raw = resolver.resolve(
+                    inputs.requirements,
+                    constraints=inputs.constraints,
+                )
             elapsed = time.monotonic() - start
             result = {k: v for k, v in raw.items() if split_extra(k)[1] is None}
             success = True

--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -36,6 +36,7 @@ from benchmark_config import (
     build_benchmark_provider,
     build_benchmark_resolver_inputs,
     direct_packages_from_requirements,
+    parse_scenario_requirement_strings,
     parse_trust_unverified_sdist_deps,
 )
 from benchmark_datetime import parse_datetime
@@ -579,8 +580,12 @@ def select_scenarios(cases: list[CanaryCase]) -> list[CanaryCase]:
         )
         raise _SelectionError(msg)
 
+    # Check each field across the whole selection before moving to the next field.
     for scenario_name, scenario in found_scenarios:
         parse_trust_unverified_sdist_deps(scenario_name, scenario)
+
+    for scenario_name, scenario in found_scenarios:
+        parse_scenario_requirement_strings(scenario_name, scenario)
     return cases
 
 
@@ -590,7 +595,7 @@ def _parse_scenario_selection(
 ) -> list[CanaryCase]:
     try:
         return select_scenarios([parse_canary_case(spec) for spec in specs])
-    except (_SelectionError, TypeError) as exc:
+    except (TypeError, ValueError) as exc:
         parser.error(str(exc))
 
 
@@ -599,7 +604,7 @@ def _parse_default_selection(
 ) -> list[CanaryCase]:
     try:
         return select_scenarios(load_canary_manifest())
-    except (_SelectionError, TypeError) as exc:
+    except (TypeError, ValueError) as exc:
         parser.error(str(exc))
 
 
@@ -745,9 +750,10 @@ def _prepare_canary_execution(
         scenario_name,
         scenario,
     )
+    requirement_inputs = parse_scenario_requirement_strings(scenario_name, scenario)
     python_version = scenario["python_version"]
-    requirement_strings = list(scenario["requirements"])
-    constraint_strings = scenario.get("constraints", [])
+    requirement_strings = requirement_inputs.requirements
+    constraint_strings = requirement_inputs.constraints
     marker_environment = parse_target_marker_environment(scenario_name, scenario)
     raw_build_packages = scenario.get("build_packages", []) or []
     build_policy_overrides = {

--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -37,7 +37,11 @@ from benchmark_config import (
     build_benchmark_resolver_inputs,
     direct_packages_from_requirements,
     parse_scenario_requirement_strings,
+    parse_scenario_vcs_config,
     parse_trust_unverified_sdist_deps,
+    parse_vcs_allowed_repos,
+    parse_vcs_allowed_schemes,
+    parse_vcs_policy,
     parse_vcs_require_pin,
 )
 from benchmark_datetime import parse_datetime
@@ -66,7 +70,6 @@ from nab_python.provider import (
     BuildPolicy,
     ResolutionStrategy,
     VcsConfig,
-    VcsPolicy,
     split_extra,
 )
 from nab_resolver.resolver import DEFAULT_MAX_ITERATIONS, Resolver
@@ -581,15 +584,17 @@ def select_scenarios(cases: list[CanaryCase]) -> list[CanaryCase]:
         )
         raise _SelectionError(msg)
 
-    # Check each field across the whole selection before moving to the next field.
-    for scenario_name, scenario in found_scenarios:
-        parse_trust_unverified_sdist_deps(scenario_name, scenario)
-
-    for scenario_name, scenario in found_scenarios:
-        parse_scenario_requirement_strings(scenario_name, scenario)
-
-    for scenario_name, scenario in found_scenarios:
-        parse_vcs_require_pin(scenario_name, scenario)
+    field_validators = (
+        parse_trust_unverified_sdist_deps,
+        parse_scenario_requirement_strings,
+        parse_vcs_require_pin,
+        parse_vcs_policy,
+        parse_vcs_allowed_schemes,
+        parse_vcs_allowed_repos,
+    )
+    for validate_field in field_validators:
+        for scenario_name, scenario in found_scenarios:
+            validate_field(scenario_name, scenario)
     return cases
 
 
@@ -755,7 +760,7 @@ def _prepare_canary_execution(
         scenario,
     )
     requirement_inputs = parse_scenario_requirement_strings(scenario_name, scenario)
-    vcs_require_pin = parse_vcs_require_pin(scenario_name, scenario)
+    vcs_config = parse_scenario_vcs_config(scenario_name, scenario)
     python_version = scenario["python_version"]
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
@@ -775,12 +780,6 @@ def _prepare_canary_execution(
         scenario,
         scenario_name=scenario_name,
         override=resolution_override,
-    )
-    vcs_config = VcsConfig(
-        policy=VcsPolicy(scenario.get("vcs_policy", "block")),
-        allowed_schemes=frozenset(scenario.get("vcs_allowed_schemes", [])),
-        allowed_repos=tuple(scenario.get("vcs_allowed_repos", [])),
-        require_pin=vcs_require_pin,
     )
     indexes = _canary_indexes(scenario)
     index_routes = _canary_index_routes(scenario)

--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -38,6 +38,7 @@ from benchmark_config import (
     direct_packages_from_requirements,
     parse_scenario_requirement_strings,
     parse_trust_unverified_sdist_deps,
+    parse_vcs_require_pin,
 )
 from benchmark_datetime import parse_datetime
 from benchmark_host import (
@@ -586,6 +587,9 @@ def select_scenarios(cases: list[CanaryCase]) -> list[CanaryCase]:
 
     for scenario_name, scenario in found_scenarios:
         parse_scenario_requirement_strings(scenario_name, scenario)
+
+    for scenario_name, scenario in found_scenarios:
+        parse_vcs_require_pin(scenario_name, scenario)
     return cases
 
 
@@ -751,6 +755,7 @@ def _prepare_canary_execution(
         scenario,
     )
     requirement_inputs = parse_scenario_requirement_strings(scenario_name, scenario)
+    vcs_require_pin = parse_vcs_require_pin(scenario_name, scenario)
     python_version = scenario["python_version"]
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
@@ -775,7 +780,7 @@ def _prepare_canary_execution(
         policy=VcsPolicy(scenario.get("vcs_policy", "block")),
         allowed_schemes=frozenset(scenario.get("vcs_allowed_schemes", [])),
         allowed_repos=tuple(scenario.get("vcs_allowed_repos", [])),
-        require_pin=scenario.get("vcs_require_pin", True),
+        require_pin=vcs_require_pin,
     )
     indexes = _canary_indexes(scenario)
     index_routes = _canary_index_routes(scenario)
@@ -915,8 +920,6 @@ def main() -> None:
 
     source = get_git_source_state()
     commit = args.commit or str(source["commit"] or "no-git")
-    host = BenchmarkHost.current(WALL_TIMEOUT_S)
-
     cases_to_run: list[CanaryCase]
     if args.scenarios_list:
         with Path(args.scenarios_list).open(encoding="utf-8") as f:
@@ -929,6 +932,7 @@ def main() -> None:
     else:
         cases_to_run = _parse_default_selection(parser)
 
+    host = BenchmarkHost.current(WALL_TIMEOUT_S)
     labels = [case.scenario.split(":", 1)[-1] for case in cases_to_run]
 
     out_dir = RESULTS_DIR / commit

--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -37,6 +37,7 @@ from benchmark_config import (
     build_benchmark_provider,
     build_benchmark_resolver_inputs,
     direct_packages_from_requirements,
+    parse_scenario_index_routes,
     parse_scenario_indexes,
     parse_scenario_project_metadata,
     parse_scenario_requirement_strings,
@@ -62,10 +63,7 @@ from nab_python._vendor.packaging.ranges import VersionRange
 from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.utils import canonicalize_name
 from nab_python.config import NabProjectConfig, index_routes_from_config
-from nab_python.fetch import (
-    FetchCoordinator,
-    IndexRoute,
-)
+from nab_python.fetch import FetchCoordinator
 from nab_python.provider import (
     BuildPolicy,
     ResolutionStrategy,
@@ -587,11 +585,21 @@ def select_scenarios(cases: list[CanaryCase]) -> list[CanaryCase]:
         parse_vcs_allowed_schemes,
         parse_vcs_allowed_repos,
         parse_scenario_project_metadata,
-        parse_scenario_indexes,
     )
     for validate_field in field_validators:
         for scenario_name, scenario in found_scenarios:
             validate_field(scenario_name, scenario)
+
+    parsed_indexes = [
+        parse_scenario_indexes(scenario_name, scenario)
+        for scenario_name, scenario in found_scenarios
+    ]
+    for (scenario_name, scenario), indexes in zip(
+        found_scenarios,
+        parsed_indexes,
+        strict=True,
+    ):
+        parse_scenario_index_routes(scenario_name, scenario, indexes)
     return cases
 
 
@@ -728,13 +736,6 @@ def canary_v2_identity(
     return CanaryV2Identity(f"{stem}-{resolution.value}:{name}", definition)
 
 
-def _canary_index_routes(scenario: dict) -> list[IndexRoute]:
-    return [
-        IndexRoute(name=str(entry["name"]), index=str(entry["index"]))
-        for entry in scenario.get("index_routes", [])
-    ]
-
-
 def _prepare_canary_execution(
     scenario: dict,
     *,
@@ -751,6 +752,7 @@ def _prepare_canary_execution(
     vcs_config = parse_scenario_vcs_config(scenario_name, scenario)
     project_metadata = parse_scenario_project_metadata(scenario_name, scenario)
     indexes = parse_scenario_indexes(scenario_name, scenario)
+    index_routes = parse_scenario_index_routes(scenario_name, scenario, indexes)
     python_version = scenario["python_version"]
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
@@ -771,7 +773,6 @@ def _prepare_canary_execution(
         scenario_name=scenario_name,
         override=resolution_override,
     )
-    index_routes = _canary_index_routes(scenario)
 
     requires_matching_host = parse_requires_matching_host(
         scenario_name,

--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -32,10 +32,12 @@ else:
     import tomli as tomllib  # type: ignore[no-redef]
 
 from benchmark_config import (
+    benchmark_index_settings,
     build_benchmark_config,
     build_benchmark_provider,
     build_benchmark_resolver_inputs,
     direct_packages_from_requirements,
+    parse_scenario_indexes,
     parse_scenario_project_metadata,
     parse_scenario_requirement_strings,
     parse_scenario_vcs_config,
@@ -54,7 +56,6 @@ from benchmark_host import (
 )
 
 from nab_index.httpx_async_transport import HttpxAsyncTransport
-from nab_index.multi_index import IndexConfig
 from nab_python._vcs_admission import admit_vcs_url
 from nab_python._vendor.packaging.markers import default_environment
 from nab_python._vendor.packaging.ranges import VersionRange
@@ -62,8 +63,6 @@ from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.utils import canonicalize_name
 from nab_python.config import NabProjectConfig, index_routes_from_config
 from nab_python.fetch import (
-    DEFAULT_INDEX_NAME,
-    DEFAULT_INDEX_URL,
     FetchCoordinator,
     IndexRoute,
 )
@@ -82,9 +81,6 @@ CACHE_DIR = BENCHMARKS_DIR / "cache"
 CANARY_MANIFEST = BENCHMARKS_DIR / "canary.toml"
 CANARY_MANIFEST_SCHEMA = 1
 _LEGACY_STRATEGY_SUFFIXES = ("-lowest", "-lowest-direct")
-DEFAULT_INDEXES: tuple[IndexConfig, ...] = (
-    IndexConfig(DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL),
-)
 
 
 class CanaryCase(NamedTuple):
@@ -367,9 +363,7 @@ def run_one(
                 "runtime": _runtime_manifest(host),
                 "direct_packages": sorted(direct_packages),
                 "target": _target_manifest(target),
-                "indexes": [
-                    {"name": index.name, "url": index.url} for index in config.indexes
-                ],
+                "indexes": benchmark_index_settings(config.indexes),
                 "index_routes": [
                     {"name": route.name, "index": route.index}
                     for route in index_routes_from_config(config)
@@ -593,6 +587,7 @@ def select_scenarios(cases: list[CanaryCase]) -> list[CanaryCase]:
         parse_vcs_allowed_schemes,
         parse_vcs_allowed_repos,
         parse_scenario_project_metadata,
+        parse_scenario_indexes,
     )
     for validate_field in field_validators:
         for scenario_name, scenario in found_scenarios:
@@ -733,15 +728,6 @@ def canary_v2_identity(
     return CanaryV2Identity(f"{stem}-{resolution.value}:{name}", definition)
 
 
-def _canary_indexes(scenario: dict) -> list[IndexConfig]:
-    raw = scenario.get("indexes")
-    if raw is None:
-        return list(DEFAULT_INDEXES)
-    return [
-        IndexConfig(name=str(entry["name"]), url=str(entry["url"])) for entry in raw
-    ]
-
-
 def _canary_index_routes(scenario: dict) -> list[IndexRoute]:
     return [
         IndexRoute(name=str(entry["name"]), index=str(entry["index"]))
@@ -764,6 +750,7 @@ def _prepare_canary_execution(
     requirement_inputs = parse_scenario_requirement_strings(scenario_name, scenario)
     vcs_config = parse_scenario_vcs_config(scenario_name, scenario)
     project_metadata = parse_scenario_project_metadata(scenario_name, scenario)
+    indexes = parse_scenario_indexes(scenario_name, scenario)
     python_version = scenario["python_version"]
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
@@ -784,7 +771,6 @@ def _prepare_canary_execution(
         scenario_name=scenario_name,
         override=resolution_override,
     )
-    indexes = _canary_indexes(scenario)
     index_routes = _canary_index_routes(scenario)
 
     requires_matching_host = parse_requires_matching_host(

--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -36,6 +36,7 @@ from benchmark_config import (
     build_benchmark_provider,
     build_benchmark_resolver_inputs,
     direct_packages_from_requirements,
+    parse_scenario_project_metadata,
     parse_scenario_requirement_strings,
     parse_scenario_vcs_config,
     parse_trust_unverified_sdist_deps,
@@ -591,6 +592,7 @@ def select_scenarios(cases: list[CanaryCase]) -> list[CanaryCase]:
         parse_vcs_policy,
         parse_vcs_allowed_schemes,
         parse_vcs_allowed_repos,
+        parse_scenario_project_metadata,
     )
     for validate_field in field_validators:
         for scenario_name, scenario in found_scenarios:
@@ -761,6 +763,7 @@ def _prepare_canary_execution(
     )
     requirement_inputs = parse_scenario_requirement_strings(scenario_name, scenario)
     vcs_config = parse_scenario_vcs_config(scenario_name, scenario)
+    project_metadata = parse_scenario_project_metadata(scenario_name, scenario)
     python_version = scenario["python_version"]
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
@@ -798,13 +801,13 @@ def _prepare_canary_execution(
         return CanaryPreparation(None, admission.inapplicable_reason)
     target = admission.target
 
-    project_name = scenario.get("project_name")
+    project_name = project_metadata.project_name
     if project_name:
         requirement_strings.extend(
             expand_project_extras(
                 project_name,
-                scenario.get("project_extras", []),
-                scenario.get("optional_dependencies", {}),
+                project_metadata.project_extras,
+                project_metadata.optional_dependencies,
             )
         )
 

--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -49,6 +49,7 @@ from benchmark_config import (
     parse_vcs_policy,
     parse_vcs_require_pin,
     validate_scenario_build_policy,
+    validate_scenario_settings,
 )
 from benchmark_datetime import parse_datetime
 from benchmark_host import (
@@ -619,6 +620,9 @@ def select_scenarios(cases: list[CanaryCase]) -> list[CanaryCase]:
         )
         raise _SelectionError(msg)
 
+    for scenario_name, scenario in found_scenarios:
+        validate_scenario_settings(scenario_name, scenario)
+
     field_validators = (
         parse_trust_unverified_sdist_deps,
         parse_scenario_requirement_strings,
@@ -787,6 +791,7 @@ def _prepare_canary_execution(
     host: BenchmarkHost,
 ) -> CanaryPreparation:
     """Validate and prepare a supported canary scenario for this host."""
+    validate_scenario_settings(scenario_name, scenario)
     trust_unverified_sdist_deps = parse_trust_unverified_sdist_deps(
         scenario_name,
         scenario,

--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -36,6 +36,7 @@ from benchmark_config import (
     build_benchmark_provider,
     build_benchmark_resolver_inputs,
     direct_packages_from_requirements,
+    parse_trust_unverified_sdist_deps,
 )
 from benchmark_datetime import parse_datetime
 from benchmark_host import (
@@ -556,11 +557,30 @@ def select_scenarios(cases: list[CanaryCase]) -> list[CanaryCase]:
     if not cases:
         msg = "at least one scenario must be selected"
         raise _SelectionError(msg)
-    missing = [case.scenario for case in cases if find_scenario(case.scenario) is None]
+    missing: list[str] = []
+    found_scenarios: list[tuple[str, dict]] = []
+    for case in cases:
+        scenario = find_scenario(case.scenario)
+        if scenario is None:
+            missing.append(case.scenario)
+            continue
+        found_scenarios.append((case.scenario, scenario))
     if missing:
         label = "scenario" if len(missing) == 1 else "scenarios"
         msg = f"{label} not found: {', '.join(repr(spec) for spec in missing)}"
         raise _SelectionError(msg)
+
+    labels = [case.scenario.split(":", 1)[-1] for case in cases]
+    duplicate_labels = sorted({label for label in labels if labels.count(label) > 1})
+    if duplicate_labels:
+        msg = (
+            "scenario names must be unique across selected files; duplicate(s): "
+            + ", ".join(duplicate_labels)
+        )
+        raise _SelectionError(msg)
+
+    for scenario_name, scenario in found_scenarios:
+        parse_trust_unverified_sdist_deps(scenario_name, scenario)
     return cases
 
 
@@ -570,7 +590,7 @@ def _parse_scenario_selection(
 ) -> list[CanaryCase]:
     try:
         return select_scenarios([parse_canary_case(spec) for spec in specs])
-    except _SelectionError as exc:
+    except (_SelectionError, TypeError) as exc:
         parser.error(str(exc))
 
 
@@ -579,7 +599,7 @@ def _parse_default_selection(
 ) -> list[CanaryCase]:
     try:
         return select_scenarios(load_canary_manifest())
-    except _SelectionError as exc:
+    except (_SelectionError, TypeError) as exc:
         parser.error(str(exc))
 
 
@@ -721,6 +741,10 @@ def _prepare_canary_execution(
     host: BenchmarkHost,
 ) -> CanaryPreparation:
     """Validate and prepare a supported canary scenario for this host."""
+    trust_unverified_sdist_deps = parse_trust_unverified_sdist_deps(
+        scenario_name,
+        scenario,
+    )
     python_version = scenario["python_version"]
     requirement_strings = list(scenario["requirements"])
     constraint_strings = scenario.get("constraints", [])
@@ -788,11 +812,6 @@ def _prepare_canary_execution(
         )
         if constraint_strings
         else None
-    )
-    # See scenarios.py: trust pre-2.2 sdist PKG-INFO deps by default so the
-    # benchmark measures search, not strict PEP 643 sdist rejection.
-    trust_unverified_sdist_deps = bool(
-        scenario.get("trust_unverified_sdist_deps", True)
     )
     datetime_str = scenario.get("datetime")
     config = build_benchmark_config(
@@ -905,12 +924,6 @@ def main() -> None:
         cases_to_run = _parse_default_selection(parser)
 
     labels = [case.scenario.split(":", 1)[-1] for case in cases_to_run]
-    duplicate_labels = sorted({label for label in labels if labels.count(label) > 1})
-    if duplicate_labels:
-        parser.error(
-            "scenario names must be unique across selected files; duplicate(s): "
-            + ", ".join(duplicate_labels)
-        )
 
     out_dir = RESULTS_DIR / commit
     out_dir.mkdir(parents=True, exist_ok=True)

--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -24,9 +24,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
-    from datetime import datetime
-
     from nab_python.target import ResolveTarget
 
 if sys.version_info >= (3, 11):
@@ -34,6 +31,11 @@ if sys.version_info >= (3, 11):
 else:
     import tomli as tomllib  # type: ignore[no-redef]
 
+from benchmark_config import (
+    build_benchmark_config,
+    build_benchmark_provider,
+    direct_packages_from_requirements,
+)
 from benchmark_datetime import parse_datetime
 from benchmark_host import (
     BenchmarkHost,
@@ -49,7 +51,7 @@ from nab_python._vendor.packaging.markers import default_environment
 from nab_python._vendor.packaging.ranges import VersionRange
 from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.utils import canonicalize_name
-from nab_python.config import PackageOverride
+from nab_python.config import NabProjectConfig, index_routes_from_config
 from nab_python.fetch import (
     DEFAULT_INDEX_NAME,
     DEFAULT_INDEX_URL,
@@ -58,8 +60,6 @@ from nab_python.fetch import (
 )
 from nab_python.provider import (
     BuildPolicy,
-    DistPolicy,
-    Provider,
     ResolutionStrategy,
     VcsConfig,
     VcsPolicy,
@@ -97,13 +97,8 @@ class PreparedCanaryExecution(NamedTuple):
     """Validated inputs for one or more runs of a canary scenario."""
 
     requirements: dict[str, VersionRange]
-    uploaded_prior_to: datetime | None
     constraints: dict[str, VersionRange] | None
-    indexes: list[IndexConfig]
-    index_routes: list[IndexRoute]
-    build_policy_overrides: dict[str, BuildPolicy]
-    resolution_strategy: ResolutionStrategy
-    trust_unverified_sdist_deps: bool
+    config: NabProjectConfig
     target: ResolveTarget
     host: BenchmarkHost
 
@@ -305,49 +300,26 @@ def get_git_commit() -> str:
     return result.stdout.strip()
 
 
-def run_one(  # noqa: PLR0913 - one wrapper per scenario knob
+def run_one(
     requirements: dict[str, VersionRange],
-    uploaded_prior_to: datetime | None,
     constraints: dict[str, VersionRange] | None,
     *,
-    indexes: list[IndexConfig] | None = None,
-    index_routes: list[IndexRoute] | None = None,
-    build_policy_overrides: Mapping[str, BuildPolicy] | None = None,
-    resolution_strategy: ResolutionStrategy = ResolutionStrategy.HIGHEST,
-    trust_unverified_sdist_deps: bool = False,
+    config: NabProjectConfig,
     target: ResolveTarget,
     host: BenchmarkHost,
 ) -> dict:
-    direct_packages = frozenset(
-        name for name in requirements if split_extra(name)[1] is None
-    )
-    effective_indexes = list(indexes) if indexes is not None else list(DEFAULT_INDEXES)
-    package_overrides = tuple(
-        PackageOverride(
-            requirement=Requirement(name),
-            name=canonicalize_name(name),
-            version_range=VersionRange.full(),
-            build_policy=policy,
-        )
-        for name, policy in (build_policy_overrides or {}).items()
-    )
+    direct_packages = direct_packages_from_requirements(requirements)
     with FetchCoordinator(
         HttpxAsyncTransport(),
-        indexes=effective_indexes,
+        indexes=list(config.indexes),
         cache_dir=CACHE_DIR,
-        index_routes=index_routes,
+        index_routes=index_routes_from_config(config),
     ) as coordinator:
-        provider = Provider(
+        provider = build_benchmark_provider(
             coordinator,
+            config=config,
             target=target,
-            root_requirements=requirements,
-            uploaded_prior_to=uploaded_prior_to,
-            dist_policy=DistPolicy.WHEEL_OR_SDIST,
-            build_policy=BuildPolicy.NEVER,
-            package_overrides=package_overrides,
-            trust_unverified_sdist_deps=trust_unverified_sdist_deps,
-            resolution_strategy=resolution_strategy,
-            direct_packages=direct_packages,
+            requirements=requirements,
         )
         resolver = Resolver(
             provider,
@@ -374,26 +346,26 @@ def run_one(  # noqa: PLR0913 - one wrapper per scenario knob
         ps = provider.stats
         return {
             "settings": {
-                "resolution": resolution_strategy.value,
-                "dist_policy": DistPolicy.WHEEL_OR_SDIST.value,
-                "build_policy": BuildPolicy.NEVER.value,
-                "trust_unverified_sdist_deps": trust_unverified_sdist_deps,
+                "resolution": config.resolution.value,
+                "dist_policy": config.dist_policy.value,
+                "build_policy": config.build_policy.value,
+                "trust_unverified_sdist_deps": config.trust_unverified_sdist_deps,
                 "max_iterations": DEFAULT_MAX_ITERATIONS,
                 "wall_timeout_seconds": host.wall_timeout_seconds,
                 "runtime": _runtime_manifest(host),
                 "direct_packages": sorted(direct_packages),
                 "target": _target_manifest(target),
                 "indexes": [
-                    {"name": index.name, "url": index.url}
-                    for index in effective_indexes
+                    {"name": index.name, "url": index.url} for index in config.indexes
                 ],
                 "index_routes": [
                     {"name": route.name, "index": route.index}
-                    for route in (index_routes or [])
+                    for route in index_routes_from_config(config)
                 ],
                 "build_policy_overrides": {
-                    name: policy.value
-                    for name, policy in sorted((build_policy_overrides or {}).items())
+                    override.name: override.build_policy.value
+                    for override in config.package_overrides
+                    if override.build_policy is not None
                 },
             },
             "success": success,
@@ -818,16 +790,20 @@ def _prepare_canary_execution(
         scenario.get("trust_unverified_sdist_deps", True)
     )
     datetime_str = scenario.get("datetime")
+    config = build_benchmark_config(
+        uploaded_prior_to=parse_datetime(datetime_str) if datetime_str else None,
+        indexes=indexes,
+        index_routes=index_routes,
+        build_policy_overrides=build_policy_overrides,
+        resolution=resolution_strategy,
+        trust_unverified_sdist_deps=trust_unverified_sdist_deps,
+        vcs=vcs_config,
+    )
     return CanaryPreparation(
         PreparedCanaryExecution(
             requirements=requirements,
-            uploaded_prior_to=parse_datetime(datetime_str) if datetime_str else None,
             constraints=constraints,
-            indexes=indexes,
-            index_routes=index_routes,
-            build_policy_overrides=build_policy_overrides,
-            resolution_strategy=resolution_strategy,
-            trust_unverified_sdist_deps=trust_unverified_sdist_deps,
+            config=config,
             target=target,
             host=host,
         ),
@@ -838,13 +814,8 @@ def _prepare_canary_execution(
 def _run_prepared_canary(execution: PreparedCanaryExecution) -> dict:
     return run_one(
         execution.requirements,
-        execution.uploaded_prior_to,
         execution.constraints,
-        indexes=execution.indexes,
-        index_routes=execution.index_routes or None,
-        build_policy_overrides=execution.build_policy_overrides or None,
-        resolution_strategy=execution.resolution_strategy,
-        trust_unverified_sdist_deps=execution.trust_unverified_sdist_deps,
+        config=execution.config,
         target=execution.target,
         host=execution.host,
     )

--- a/nab-python/benchmarks/canary.toml
+++ b/nab-python/benchmarks/canary.toml
@@ -18,7 +18,7 @@ resolution = "lowest"
 
 [[case]]
 scenario = "pip:ultralytics-export"
-resolution = "lowest"
+resolution = "highest"
 
 [[case]]
 scenario = "pip:datacontract-cli"

--- a/nab-python/benchmarks/scenarios.py
+++ b/nab-python/benchmarks/scenarios.py
@@ -39,12 +39,14 @@ from benchmark_config import (
     build_benchmark_config,
     build_benchmark_provider,
     build_benchmark_resolver_inputs,
+    parse_scenario_build_packages,
     parse_scenario_index_routes,
     parse_scenario_indexes,
     parse_scenario_project_metadata,
     parse_scenario_requirement_strings,
     parse_scenario_vcs_config,
     parse_trust_unverified_sdist_deps,
+    validate_scenario_build_policy,
 )
 from benchmark_datetime import parse_datetime
 from benchmark_host import (
@@ -579,22 +581,24 @@ def load_standard_corpus(files: list[Path]) -> list[StandardScenario]:
             for name, definition in scenarios.items()
         )
     for row in rows:
-        marker_environment = parse_marker_environment(row.name, row.definition)
-        parse_requires_matching_host(row.name, row.definition, marker_environment)
         parse_trust_unverified_sdist_deps(row.logical_key, row.definition)
         parse_scenario_requirement_strings(row.logical_key, row.definition)
         parse_scenario_vcs_config(row.logical_key, row.definition)
         parse_scenario_project_metadata(row.logical_key, row.definition)
         indexes = parse_scenario_indexes(row.logical_key, row.definition)
         parse_scenario_index_routes(row.logical_key, row.definition, indexes)
-        build_policy_overrides = parse_build_packages(row.name, row.definition)
-        if "unsupported_reason" in row.definition:
-            continue
-        validate_scenario_build_policy(
+        marker_environment = parse_marker_environment(row.name, row.definition)
+        build_policy_overrides = parse_scenario_build_packages(
             row.name,
-            marker_environment,
-            build_policy_overrides,
+            row.definition,
         )
+        if "unsupported_reason" not in row.definition:
+            validate_scenario_build_policy(
+                row.name,
+                marker_environment,
+                build_policy_overrides,
+            )
+        parse_requires_matching_host(row.name, row.definition, marker_environment)
     return rows
 
 
@@ -1457,7 +1461,7 @@ def _expected_input(  # noqa: PLR0913 - assembling the JSON dump key
             {"name": o.name, "index": o.index} for o in index_routes
         ]
     if build_packages:
-        expected_input["build_packages"] = sorted(build_packages)
+        expected_input["build_packages"] = list(build_packages)
     if resolution_strategy is not ResolutionStrategy.HIGHEST:
         expected_input["resolution"] = resolution_strategy.value
     if trust_unverified_sdist_deps:
@@ -1471,57 +1475,6 @@ def parse_marker_environment(
 ) -> dict[str, str]:
     """Read the ``marker_environment`` table + ``platform_system`` shorthand."""
     return parse_target_marker_environment(scenario_name, scenario)
-
-
-def parse_build_packages(
-    scenario_name: str,
-    scenario: dict,
-) -> Mapping[str, BuildPolicy]:
-    """Read ``build_packages`` and lift them to ``BUILD_REMOTE`` overrides.
-
-    ``build_packages`` is a list of canonical package names whose
-    sdists may be built (PEP 517 backend invocation against the
-    fetched sdist).  The default benchmark policy is
-    ``BuildPolicy.NEVER``; entries here override that on a
-    per-package basis without affecting any other package in the
-    same scenario.
-
-    Use this when the scenario's resolution requires a sdist that
-    has no usable wheel and the build is cheap enough to run inside
-    the benchmark host.  Native or CUDA-heavy sdists belong in
-    ``unsupported.toml`` instead.
-    """
-    raw = scenario.get("build_packages", [])
-    if not isinstance(raw, list):
-        msg = (
-            f"{scenario_name}: build_packages must be an array of"
-            f" package names, got {type(raw).__name__}"
-        )
-        raise TypeError(msg)
-    overrides: dict[str, BuildPolicy] = {}
-    for i, name in enumerate(raw):
-        if not isinstance(name, str):
-            msg = (
-                f"{scenario_name}: build_packages[{i}] must be a string,"
-                f" got {type(name).__name__}"
-            )
-            raise TypeError(msg)
-        overrides[name] = BuildPolicy.BUILD_REMOTE
-    return overrides
-
-
-def validate_scenario_build_policy(
-    scenario_name: str,
-    marker_environment: Mapping[str, str],
-    build_policy_overrides: Mapping[str, BuildPolicy],
-) -> None:
-    """Reject build policy paired with a marker environment overlay."""
-    if marker_environment and build_policy_overrides:
-        msg = (
-            f"{scenario_name}: build_packages cannot be combined "
-            "with a marker environment overlay"
-        )
-        raise ValueError(msg)
 
 
 def prepare_standard_execution(
@@ -1549,7 +1502,7 @@ def prepare_standard_execution(
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
     marker_environment = parse_marker_environment(scenario_name, scenario)
-    build_policy_overrides = dict(parse_build_packages(scenario_name, scenario))
+    build_policy_overrides = parse_scenario_build_packages(scenario_name, scenario)
     if "unsupported_reason" not in scenario:
         validate_scenario_build_policy(
             scenario_name,
@@ -1590,7 +1543,7 @@ def prepare_standard_execution(
             marker_environment=marker_environment,
             indexes=indexes,
             index_routes=index_routes,
-            build_packages=sorted(build_policy_overrides),
+            build_packages=list(build_policy_overrides),
             resolution_strategy=execution.strategy,
             trust_unverified_sdist_deps=trust_unverified_sdist_deps,
         ),

--- a/nab-python/benchmarks/scenarios.py
+++ b/nab-python/benchmarks/scenarios.py
@@ -31,7 +31,11 @@ if sys.version_info >= (3, 11):
 else:
     import tomli as tomllib  # type: ignore[no-redef]
 
-from benchmark_config import build_benchmark_config, build_benchmark_provider
+from benchmark_config import (
+    build_benchmark_config,
+    build_benchmark_provider,
+    build_benchmark_resolver_inputs,
+)
 from benchmark_datetime import parse_datetime
 from benchmark_host import (
     HOST_TAG_MISMATCH_REASON,
@@ -1316,6 +1320,7 @@ def resolve_scenario(
     host: BenchmarkHost,
 ) -> dict:
     """Resolve requirements and return stats dict."""
+    inputs = build_benchmark_resolver_inputs(requirements, constraints)
     with FetchCoordinator(
         HttpxAsyncTransport(),
         indexes=list(config.indexes),
@@ -1326,7 +1331,7 @@ def resolve_scenario(
             coordinator,
             config=config,
             target=target,
-            requirements=requirements,
+            inputs=inputs,
         )
         resolver = Resolver(
             provider,
@@ -1338,7 +1343,10 @@ def resolve_scenario(
         start = time.monotonic()
         try:
             with host.wall_timeout():
-                raw = resolver.resolve(requirements, constraints=constraints)
+                raw = resolver.resolve(
+                    inputs.requirements,
+                    constraints=inputs.constraints,
+                )
             elapsed = time.monotonic() - start
             pins = dict(
                 sorted(

--- a/nab-python/benchmarks/scenarios.py
+++ b/nab-python/benchmarks/scenarios.py
@@ -37,8 +37,8 @@ from benchmark_config import (
     build_benchmark_provider,
     build_benchmark_resolver_inputs,
     parse_scenario_requirement_strings,
+    parse_scenario_vcs_config,
     parse_trust_unverified_sdist_deps,
-    parse_vcs_require_pin,
 )
 from benchmark_datetime import parse_datetime
 from benchmark_host import (
@@ -583,7 +583,7 @@ def load_standard_corpus(files: list[Path]) -> list[StandardScenario]:
         parse_requires_matching_host(row.name, row.definition, marker_environment)
         parse_trust_unverified_sdist_deps(row.logical_key, row.definition)
         parse_scenario_requirement_strings(row.logical_key, row.definition)
-        parse_vcs_require_pin(row.logical_key, row.definition)
+        parse_scenario_vcs_config(row.logical_key, row.definition)
         build_policy_overrides = parse_build_packages(row.name, row.definition)
         if "unsupported_reason" in row.definition:
             continue
@@ -1410,7 +1410,7 @@ def resolve_scenario(
         }
 
 
-def _expected_input(  # noqa: PLR0913, PLR0917 - assembling the JSON dump key
+def _expected_input(  # noqa: PLR0913 - assembling the JSON dump key
     commit: str,
     python_version: str,
     requirement_strings: list[str],
@@ -1418,14 +1418,13 @@ def _expected_input(  # noqa: PLR0913, PLR0917 - assembling the JSON dump key
     datetime_str: str | None,
     project_name: str | None,
     project_extras: list[str],
+    *,
     vcs_config: VcsConfig,
-    vcs_policy_str: str,
     marker_environment: dict[str, str],
     indexes: list[IndexConfig],
     index_routes: list[IndexRoute],
     build_packages: list[str] | None = None,
     resolution_strategy: ResolutionStrategy = ResolutionStrategy.HIGHEST,
-    *,
     trust_unverified_sdist_deps: bool = False,
 ) -> dict:
     """Build the JSON-serialisable ``input`` block describing the scenario."""
@@ -1442,7 +1441,7 @@ def _expected_input(  # noqa: PLR0913, PLR0917 - assembling the JSON dump key
         expected_input["project_name"] = project_name
         expected_input["project_extras"] = project_extras
     if vcs_config.policy is not VcsPolicy.BLOCK:
-        expected_input["vcs_policy"] = vcs_policy_str
+        expected_input["vcs_policy"] = vcs_config.policy.value
         expected_input["vcs_allowed_schemes"] = sorted(vcs_config.allowed_schemes)
         expected_input["vcs_allowed_repos"] = list(vcs_config.allowed_repos)
         expected_input["vcs_require_pin"] = vcs_config.require_pin
@@ -1613,7 +1612,7 @@ def prepare_standard_execution(
         scenario,
     )
     requirement_inputs = parse_scenario_requirement_strings(scenario_name, scenario)
-    vcs_require_pin = parse_vcs_require_pin(scenario_name, scenario)
+    vcs_config = parse_scenario_vcs_config(scenario_name, scenario)
     python_version: str = scenario["python_version"]
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
@@ -1637,13 +1636,6 @@ def prepare_standard_execution(
         requirement_strings.extend(
             expand_project_extras(project_name, project_extras, optional_dependencies)
         )
-    vcs_policy_str: str = scenario.get("vcs_policy", "block")
-    vcs_config = VcsConfig(
-        policy=VcsPolicy(vcs_policy_str),
-        allowed_schemes=frozenset(scenario.get("vcs_allowed_schemes", [])),
-        allowed_repos=tuple(scenario.get("vcs_allowed_repos", [])),
-        require_pin=vcs_require_pin,
-    )
     uploaded_prior_to = parse_datetime(datetime_str) if datetime_str else None
     config = build_benchmark_config(
         uploaded_prior_to=uploaded_prior_to,
@@ -1663,11 +1655,10 @@ def prepare_standard_execution(
             datetime_str,
             project_name,
             project_extras,
-            vcs_config,
-            vcs_policy_str,
-            marker_environment,
-            indexes,
-            index_routes,
+            vcs_config=vcs_config,
+            marker_environment=marker_environment,
+            indexes=indexes,
+            index_routes=index_routes,
             build_packages=sorted(build_policy_overrides),
             resolution_strategy=execution.strategy,
             trust_unverified_sdist_deps=trust_unverified_sdist_deps,

--- a/nab-python/benchmarks/scenarios.py
+++ b/nab-python/benchmarks/scenarios.py
@@ -23,7 +23,6 @@ from typing import TYPE_CHECKING, NamedTuple
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
-    from datetime import datetime
 
     from nab_python.target import ResolveTarget
 
@@ -32,6 +31,7 @@ if sys.version_info >= (3, 11):
 else:
     import tomli as tomllib  # type: ignore[no-redef]
 
+from benchmark_config import build_benchmark_config, build_benchmark_provider
 from benchmark_datetime import parse_datetime
 from benchmark_host import (
     HOST_TAG_MISMATCH_REASON,
@@ -50,7 +50,7 @@ from nab_python._vendor.packaging.ranges import VersionRange
 from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.utils import canonicalize_name, is_normalized_name
 from nab_python._vendor.packaging.version import Version
-from nab_python.config import PackageOverride
+from nab_python.config import NabProjectConfig, index_routes_from_config
 from nab_python.fetch import (
     DEFAULT_INDEX_NAME,
     DEFAULT_INDEX_URL,
@@ -60,7 +60,6 @@ from nab_python.fetch import (
 from nab_python.provider import (
     BuildPolicy,
     DistPolicy,
-    Provider,
     ResolutionStrategy,
     VcsConfig,
     VcsPolicy,
@@ -512,12 +511,7 @@ class PreparedStandardExecution(NamedTuple):
 
     requirement_strings: list[str]
     constraint_strings: list[str]
-    indexes: list[IndexConfig]
-    index_routes: list[IndexRoute]
-    build_policy_overrides: dict[str, BuildPolicy]
-    uploaded_prior_to: datetime | None
-    vcs_config: VcsConfig
-    trust_unverified_sdist_deps: bool
+    config: NabProjectConfig
     target: ResolveTarget
     expected_input: dict[str, object]
 
@@ -1313,49 +1307,26 @@ def write_standard_manifest(  # noqa: PLR0913 - explicit contract fields
     return complete
 
 
-def resolve_scenario(  # noqa: PLR0913 - one wrapper per scenario knob
+def resolve_scenario(
     requirements: dict[str, VersionRange],
-    uploaded_prior_to: datetime | None = None,
     constraints: dict[str, VersionRange] | None = None,
-    indexes: list[IndexConfig] | None = None,
-    index_routes: list[IndexRoute] | None = None,
-    build_policy_overrides: Mapping[str, BuildPolicy] | None = None,
-    resolution_strategy: ResolutionStrategy = ResolutionStrategy.HIGHEST,
     *,
+    config: NabProjectConfig,
     target: ResolveTarget,
     host: BenchmarkHost,
-    trust_unverified_sdist_deps: bool = False,
 ) -> dict:
     """Resolve requirements and return stats dict."""
-    direct_packages = frozenset(
-        name for name in requirements if split_extra(name)[1] is None
-    )
-    package_overrides = tuple(
-        PackageOverride(
-            requirement=Requirement(name),
-            name=canonicalize_name(name),
-            version_range=VersionRange.full(),
-            build_policy=policy,
-        )
-        for name, policy in (build_policy_overrides or {}).items()
-    )
     with FetchCoordinator(
         HttpxAsyncTransport(),
-        indexes=indexes,
+        indexes=list(config.indexes),
         cache_dir=CACHE_DIR,
-        index_routes=index_routes,
+        index_routes=index_routes_from_config(config),
     ) as coordinator:
-        provider = Provider(
+        provider = build_benchmark_provider(
             coordinator,
+            config=config,
             target=target,
-            root_requirements=requirements,
-            uploaded_prior_to=uploaded_prior_to,
-            dist_policy=DistPolicy.WHEEL_OR_SDIST,
-            build_policy=BuildPolicy.NEVER,
-            package_overrides=package_overrides,
-            trust_unverified_sdist_deps=trust_unverified_sdist_deps,
-            resolution_strategy=resolution_strategy,
-            direct_packages=direct_packages,
+            requirements=requirements,
         )
         resolver = Resolver(
             provider,
@@ -1485,9 +1456,9 @@ def parse_index_routes(
 
     Each entry is a TOML inline table with keys ``name`` (the package
     name) and ``index`` (the *name* of an entry in ``indexes``).  A route
-    carries no version scope and no marker.  Entries are returned in
-    declaration order so :func:`nab_python.fetch._resolve_routes` can
-    apply last-match-wins on duplicates.
+    carries no version scope and no marker. Entries are returned in
+    declaration order; ``build_benchmark_config`` rejects duplicate canonical
+    package names.
     """
     raw = scenario.get("index_routes", [])
     if not isinstance(raw, list):
@@ -1655,6 +1626,16 @@ def prepare_standard_execution(
     trust_unverified_sdist_deps: bool = scenario.get(
         "trust_unverified_sdist_deps", True
     )
+    uploaded_prior_to = parse_datetime(datetime_str) if datetime_str else None
+    config = build_benchmark_config(
+        uploaded_prior_to=uploaded_prior_to,
+        indexes=indexes,
+        index_routes=index_routes,
+        build_policy_overrides=build_policy_overrides,
+        resolution=execution.strategy,
+        trust_unverified_sdist_deps=trust_unverified_sdist_deps,
+        vcs=vcs_config,
+    )
     expected_input = {
         **_expected_input(
             commit,
@@ -1684,12 +1665,7 @@ def prepare_standard_execution(
     return PreparedStandardExecution(
         requirement_strings=requirement_strings,
         constraint_strings=constraint_strings,
-        indexes=indexes,
-        index_routes=index_routes,
-        build_policy_overrides=build_policy_overrides,
-        uploaded_prior_to=parse_datetime(datetime_str) if datetime_str else None,
-        vcs_config=vcs_config,
-        trust_unverified_sdist_deps=trust_unverified_sdist_deps,
+        config=config,
         target=target,
         expected_input=expected_input,
     )
@@ -1723,13 +1699,13 @@ def process_scenario(
     requirement_marker_env = dict(prepared.target.marker_env)
     requirements = parse_requirements(
         prepared.requirement_strings,
-        vcs_config=prepared.vcs_config,
+        vcs_config=prepared.config.vcs,
         marker_environment=requirement_marker_env,
     )
     constraints = (
         parse_requirements(
             prepared.constraint_strings,
-            vcs_config=prepared.vcs_config,
+            vcs_config=prepared.config.vcs,
             marker_environment=requirement_marker_env,
         )
         if prepared.constraint_strings
@@ -1737,15 +1713,10 @@ def process_scenario(
     )
     data = resolve_scenario(
         requirements,
-        prepared.uploaded_prior_to,
         constraints,
-        indexes=prepared.indexes,
-        index_routes=prepared.index_routes or None,
-        build_policy_overrides=prepared.build_policy_overrides or None,
-        resolution_strategy=execution.strategy,
+        config=prepared.config,
         target=prepared.target,
         host=host,
-        trust_unverified_sdist_deps=prepared.trust_unverified_sdist_deps,
     )
     data["input"] = prepared.expected_input
 

--- a/nab-python/benchmarks/scenarios.py
+++ b/nab-python/benchmarks/scenarios.py
@@ -47,6 +47,7 @@ from benchmark_config import (
     parse_scenario_vcs_config,
     parse_trust_unverified_sdist_deps,
     validate_scenario_build_policy,
+    validate_scenario_settings,
 )
 from benchmark_datetime import parse_datetime
 from benchmark_host import (
@@ -581,6 +582,7 @@ def load_standard_corpus(files: list[Path]) -> list[StandardScenario]:
             for name, definition in scenarios.items()
         )
     for row in rows:
+        validate_scenario_settings(row.logical_key, row.definition)
         parse_trust_unverified_sdist_deps(row.logical_key, row.definition)
         parse_scenario_requirement_strings(row.logical_key, row.definition)
         parse_scenario_vcs_config(row.logical_key, row.definition)
@@ -1489,6 +1491,7 @@ def prepare_standard_execution(
     """Prepare and identify one execution without performing network work."""
     scenario_name = execution.scenario.name
     scenario = execution.scenario.definition
+    validate_scenario_settings(scenario_name, scenario)
     trust_unverified_sdist_deps = parse_trust_unverified_sdist_deps(
         scenario_name,
         scenario,

--- a/nab-python/benchmarks/scenarios.py
+++ b/nab-python/benchmarks/scenarios.py
@@ -39,6 +39,7 @@ from benchmark_config import (
     build_benchmark_config,
     build_benchmark_provider,
     build_benchmark_resolver_inputs,
+    parse_scenario_index_routes,
     parse_scenario_indexes,
     parse_scenario_project_metadata,
     parse_scenario_requirement_strings,
@@ -584,7 +585,8 @@ def load_standard_corpus(files: list[Path]) -> list[StandardScenario]:
         parse_scenario_requirement_strings(row.logical_key, row.definition)
         parse_scenario_vcs_config(row.logical_key, row.definition)
         parse_scenario_project_metadata(row.logical_key, row.definition)
-        parse_scenario_indexes(row.logical_key, row.definition)
+        indexes = parse_scenario_indexes(row.logical_key, row.definition)
+        parse_scenario_index_routes(row.logical_key, row.definition, indexes)
         build_policy_overrides = parse_build_packages(row.name, row.definition)
         if "unsupported_reason" in row.definition:
             continue
@@ -1463,45 +1465,6 @@ def _expected_input(  # noqa: PLR0913 - assembling the JSON dump key
     return expected_input
 
 
-def parse_index_routes(
-    scenario_name: str,
-    scenario: dict,
-) -> list[IndexRoute]:
-    """Read the ``index_routes`` array of records from a scenario.
-
-    Each entry is a TOML inline table with keys ``name`` (the package
-    name) and ``index`` (the *name* of an entry in ``indexes``).  A route
-    carries no version scope and no marker. Entries are returned in
-    declaration order; ``build_benchmark_config`` rejects duplicate canonical
-    package names.
-    """
-    raw = scenario.get("index_routes", [])
-    if not isinstance(raw, list):
-        msg = (
-            f"{scenario_name}: index_routes must be a TOML array of"
-            f" tables, got {type(raw).__name__}"
-        )
-        raise TypeError(msg)
-    out: list[IndexRoute] = []
-    for entry in raw:
-        if not isinstance(entry, dict):
-            msg = (
-                f"{scenario_name}: index_routes entries must be tables,"
-                f" got {type(entry).__name__}"
-            )
-            raise TypeError(msg)
-        try:
-            name = entry["name"]
-            index = entry["index"]
-        except KeyError as missing:
-            msg = (
-                f"{scenario_name}: index_routes entry missing required key {missing!s}"
-            )
-            raise ValueError(msg) from None
-        out.append(IndexRoute(name=str(name), index=str(index)))
-    return out
-
-
 def parse_marker_environment(
     scenario_name: str,
     scenario: dict,
@@ -1581,11 +1544,11 @@ def prepare_standard_execution(
     vcs_config = parse_scenario_vcs_config(scenario_name, scenario)
     project_metadata = parse_scenario_project_metadata(scenario_name, scenario)
     indexes = parse_scenario_indexes(scenario_name, scenario)
+    index_routes = parse_scenario_index_routes(scenario_name, scenario, indexes)
     python_version: str = scenario["python_version"]
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
     marker_environment = parse_marker_environment(scenario_name, scenario)
-    index_routes = parse_index_routes(scenario_name, scenario)
     build_policy_overrides = dict(parse_build_packages(scenario_name, scenario))
     if "unsupported_reason" not in scenario:
         validate_scenario_build_policy(

--- a/nab-python/benchmarks/scenarios.py
+++ b/nab-python/benchmarks/scenarios.py
@@ -38,6 +38,7 @@ from benchmark_config import (
     build_benchmark_resolver_inputs,
     parse_scenario_requirement_strings,
     parse_trust_unverified_sdist_deps,
+    parse_vcs_require_pin,
 )
 from benchmark_datetime import parse_datetime
 from benchmark_host import (
@@ -582,6 +583,7 @@ def load_standard_corpus(files: list[Path]) -> list[StandardScenario]:
         parse_requires_matching_host(row.name, row.definition, marker_environment)
         parse_trust_unverified_sdist_deps(row.logical_key, row.definition)
         parse_scenario_requirement_strings(row.logical_key, row.definition)
+        parse_vcs_require_pin(row.logical_key, row.definition)
         build_policy_overrides = parse_build_packages(row.name, row.definition)
         if "unsupported_reason" in row.definition:
             continue
@@ -1611,6 +1613,7 @@ def prepare_standard_execution(
         scenario,
     )
     requirement_inputs = parse_scenario_requirement_strings(scenario_name, scenario)
+    vcs_require_pin = parse_vcs_require_pin(scenario_name, scenario)
     python_version: str = scenario["python_version"]
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
@@ -1639,7 +1642,7 @@ def prepare_standard_execution(
         policy=VcsPolicy(vcs_policy_str),
         allowed_schemes=frozenset(scenario.get("vcs_allowed_schemes", [])),
         allowed_repos=tuple(scenario.get("vcs_allowed_repos", [])),
-        require_pin=scenario.get("vcs_require_pin", True),
+        require_pin=vcs_require_pin,
     )
     uploaded_prior_to = parse_datetime(datetime_str) if datetime_str else None
     config = build_benchmark_config(
@@ -1782,7 +1785,6 @@ def main(argv: list[str] | None = None) -> None:
         except argparse.ArgumentTypeError as exc:
             parser.error(str(exc))
     source_start = get_git_source_state()
-    host = BenchmarkHost.current(SCENARIO_WALL_TIMEOUT_SECONDS)
 
     if not SCENARIOS_DIR.is_dir():
         print(f"Error: {SCENARIOS_DIR} does not exist")
@@ -1828,6 +1830,7 @@ def main(argv: list[str] | None = None) -> None:
     )
     mode = "strategy-matrix" if args.strategy_matrix else "default"
     corpus_hash = standard_corpus_hash(all_rows)
+    host = BenchmarkHost.current(SCENARIO_WALL_TIMEOUT_SECONDS)
     plan = standard_run_plan(selected_rows, strategies, host)
     execution_plan = plan.executions
     settings = standard_benchmark_settings(host)

--- a/nab-python/benchmarks/scenarios.py
+++ b/nab-python/benchmarks/scenarios.py
@@ -36,6 +36,7 @@ from benchmark_config import (
     build_benchmark_config,
     build_benchmark_provider,
     build_benchmark_resolver_inputs,
+    parse_scenario_project_metadata,
     parse_scenario_requirement_strings,
     parse_scenario_vcs_config,
     parse_trust_unverified_sdist_deps,
@@ -584,6 +585,7 @@ def load_standard_corpus(files: list[Path]) -> list[StandardScenario]:
         parse_trust_unverified_sdist_deps(row.logical_key, row.definition)
         parse_scenario_requirement_strings(row.logical_key, row.definition)
         parse_scenario_vcs_config(row.logical_key, row.definition)
+        parse_scenario_project_metadata(row.logical_key, row.definition)
         build_policy_overrides = parse_build_packages(row.name, row.definition)
         if "unsupported_reason" in row.definition:
             continue
@@ -1613,6 +1615,7 @@ def prepare_standard_execution(
     )
     requirement_inputs = parse_scenario_requirement_strings(scenario_name, scenario)
     vcs_config = parse_scenario_vcs_config(scenario_name, scenario)
+    project_metadata = parse_scenario_project_metadata(scenario_name, scenario)
     python_version: str = scenario["python_version"]
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
@@ -1627,14 +1630,15 @@ def prepare_standard_execution(
             build_policy_overrides,
         )
     datetime_str: str | None = scenario.get("datetime")
-    project_name: str | None = scenario.get("project_name")
-    project_extras: list[str] = scenario.get("project_extras", [])
-    optional_dependencies: dict[str, list[str]] = scenario.get(
-        "optional_dependencies", {}
-    )
+    project_name = project_metadata.project_name
+    project_extras = project_metadata.project_extras
     if project_name:
         requirement_strings.extend(
-            expand_project_extras(project_name, project_extras, optional_dependencies)
+            expand_project_extras(
+                project_name,
+                project_extras,
+                project_metadata.optional_dependencies,
+            )
         )
     uploaded_prior_to = parse_datetime(datetime_str) if datetime_str else None
     config = build_benchmark_config(

--- a/nab-python/benchmarks/scenarios.py
+++ b/nab-python/benchmarks/scenarios.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, NamedTuple
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
+    from nab_index.multi_index import IndexConfig
     from nab_python.target import ResolveTarget
 
 if sys.version_info >= (3, 11):
@@ -32,10 +33,13 @@ else:
     import tomli as tomllib  # type: ignore[no-redef]
 
 from benchmark_config import (
+    DEFAULT_INDEXES,
     DEFAULT_SCENARIO_TRUST_UNVERIFIED_SDIST_DEPS,
+    benchmark_index_settings,
     build_benchmark_config,
     build_benchmark_provider,
     build_benchmark_resolver_inputs,
+    parse_scenario_indexes,
     parse_scenario_project_metadata,
     parse_scenario_requirement_strings,
     parse_scenario_vcs_config,
@@ -52,7 +56,6 @@ from benchmark_host import (
 )
 
 from nab_index.httpx_async_transport import HttpxAsyncTransport
-from nab_index.multi_index import IndexConfig
 from nab_python._vcs_admission import admit_vcs_url
 from nab_python._vendor.packaging.markers import default_environment
 from nab_python._vendor.packaging.ranges import VersionRange
@@ -61,8 +64,6 @@ from nab_python._vendor.packaging.utils import canonicalize_name, is_normalized_
 from nab_python._vendor.packaging.version import Version
 from nab_python.config import NabProjectConfig, index_routes_from_config
 from nab_python.fetch import (
-    DEFAULT_INDEX_NAME,
-    DEFAULT_INDEX_URL,
     FetchCoordinator,
     IndexRoute,
 )
@@ -85,9 +86,6 @@ STANDARD_MANIFEST_SCHEMA = 4
 _INAPPLICABLE_KEY_PREVIEW = 8
 _STANDARD_METADATA_FILENAMES = frozenset(
     {STANDARD_MANIFEST_FILENAME, "_provenance.json"}
-)
-DEFAULT_INDEXES: tuple[IndexConfig, ...] = (
-    IndexConfig(DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL),
 )
 STANDARD_STRATEGIES = (
     ResolutionStrategy.HIGHEST,
@@ -586,6 +584,7 @@ def load_standard_corpus(files: list[Path]) -> list[StandardScenario]:
         parse_scenario_requirement_strings(row.logical_key, row.definition)
         parse_scenario_vcs_config(row.logical_key, row.definition)
         parse_scenario_project_metadata(row.logical_key, row.definition)
+        parse_scenario_indexes(row.logical_key, row.definition)
         build_policy_overrides = parse_build_packages(row.name, row.definition)
         if "unsupported_reason" in row.definition:
             continue
@@ -1450,9 +1449,7 @@ def _expected_input(  # noqa: PLR0913 - assembling the JSON dump key
     if marker_environment:
         expected_input["marker_environment"] = dict(sorted(marker_environment.items()))
     if list(indexes) != list(DEFAULT_INDEXES):
-        expected_input["indexes"] = [
-            {"name": cfg.name, "url": cfg.url} for cfg in indexes
-        ]
+        expected_input["indexes"] = benchmark_index_settings(indexes)
     if index_routes:
         expected_input["index_routes"] = [
             {"name": o.name, "index": o.index} for o in index_routes
@@ -1502,39 +1499,6 @@ def parse_index_routes(
             )
             raise ValueError(msg) from None
         out.append(IndexRoute(name=str(name), index=str(index)))
-    return out
-
-
-def parse_indexes(scenario_name: str, scenario: dict) -> list[IndexConfig]:
-    """Read the ``indexes`` array; default to PyPI when missing.
-
-    Each entry is a TOML inline table with keys ``name`` and ``url``.
-    Order is significant.
-    """
-    raw = scenario.get("indexes")
-    if raw is None:
-        return list(DEFAULT_INDEXES)
-    if not isinstance(raw, list):
-        msg = (
-            f"{scenario_name}: indexes must be a TOML array of tables,"
-            f" got {type(raw).__name__}"
-        )
-        raise TypeError(msg)
-    out: list[IndexConfig] = []
-    for entry in raw:
-        if not isinstance(entry, dict):
-            msg = (
-                f"{scenario_name}: indexes entries must be tables, got"
-                f" {type(entry).__name__}"
-            )
-            raise TypeError(msg)
-        try:
-            name = entry["name"]
-            url = entry["url"]
-        except KeyError as missing:
-            msg = f"{scenario_name}: indexes entry missing required key {missing!s}"
-            raise ValueError(msg) from None
-        out.append(IndexConfig(name=str(name), url=str(url)))
     return out
 
 
@@ -1616,11 +1580,11 @@ def prepare_standard_execution(
     requirement_inputs = parse_scenario_requirement_strings(scenario_name, scenario)
     vcs_config = parse_scenario_vcs_config(scenario_name, scenario)
     project_metadata = parse_scenario_project_metadata(scenario_name, scenario)
+    indexes = parse_scenario_indexes(scenario_name, scenario)
     python_version: str = scenario["python_version"]
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
     marker_environment = parse_marker_environment(scenario_name, scenario)
-    indexes = parse_indexes(scenario_name, scenario)
     index_routes = parse_index_routes(scenario_name, scenario)
     build_policy_overrides = dict(parse_build_packages(scenario_name, scenario))
     if "unsupported_reason" not in scenario:

--- a/nab-python/benchmarks/scenarios.py
+++ b/nab-python/benchmarks/scenarios.py
@@ -32,9 +32,11 @@ else:
     import tomli as tomllib  # type: ignore[no-redef]
 
 from benchmark_config import (
+    DEFAULT_SCENARIO_TRUST_UNVERIFIED_SDIST_DEPS,
     build_benchmark_config,
     build_benchmark_provider,
     build_benchmark_resolver_inputs,
+    parse_trust_unverified_sdist_deps,
 )
 from benchmark_datetime import parse_datetime
 from benchmark_host import (
@@ -577,6 +579,7 @@ def load_standard_corpus(files: list[Path]) -> list[StandardScenario]:
     for row in rows:
         marker_environment = parse_marker_environment(row.name, row.definition)
         parse_requires_matching_host(row.name, row.definition, marker_environment)
+        parse_trust_unverified_sdist_deps(row.logical_key, row.definition)
         build_policy_overrides = parse_build_packages(row.name, row.definition)
         if "unsupported_reason" in row.definition:
             continue
@@ -874,7 +877,9 @@ def standard_benchmark_settings(host: BenchmarkHost) -> dict[str, object]:
     return {
         "dist_policy": DistPolicy.WHEEL_OR_SDIST.value,
         "build_policy": BuildPolicy.NEVER.value,
-        "trust_unverified_sdist_deps_default": True,
+        "trust_unverified_sdist_deps_default": (
+            DEFAULT_SCENARIO_TRUST_UNVERIFIED_SDIST_DEPS
+        ),
         "max_iterations": DEFAULT_MAX_ITERATIONS,
         "wall_timeout_seconds": host.wall_timeout_seconds,
         "host": host.identity(),
@@ -1629,10 +1634,9 @@ def prepare_standard_execution(
         allowed_repos=tuple(scenario.get("vcs_allowed_repos", [])),
         require_pin=scenario.get("vcs_require_pin", True),
     )
-    # Search benchmarks accept pre-2.2 PKG-INFO dependency metadata by default;
-    # individual strict-policy scenarios opt out explicitly.
-    trust_unverified_sdist_deps: bool = scenario.get(
-        "trust_unverified_sdist_deps", True
+    trust_unverified_sdist_deps = parse_trust_unverified_sdist_deps(
+        scenario_name,
+        scenario,
     )
     uploaded_prior_to = parse_datetime(datetime_str) if datetime_str else None
     config = build_benchmark_config(
@@ -1812,7 +1816,7 @@ def main(argv: list[str] | None = None) -> None:
 
     try:
         all_rows = load_standard_corpus(all_files)
-    except ValueError as exc:
+    except (TypeError, ValueError) as exc:
         parser.error(str(exc))
     selected_stems = {path.stem for path in selected_files}
     selected_rows = [row for row in all_rows if row.toml_stem in selected_stems]

--- a/nab-python/benchmarks/scenarios.py
+++ b/nab-python/benchmarks/scenarios.py
@@ -36,6 +36,7 @@ from benchmark_config import (
     build_benchmark_config,
     build_benchmark_provider,
     build_benchmark_resolver_inputs,
+    parse_scenario_requirement_strings,
     parse_trust_unverified_sdist_deps,
 )
 from benchmark_datetime import parse_datetime
@@ -580,6 +581,7 @@ def load_standard_corpus(files: list[Path]) -> list[StandardScenario]:
         marker_environment = parse_marker_environment(row.name, row.definition)
         parse_requires_matching_host(row.name, row.definition, marker_environment)
         parse_trust_unverified_sdist_deps(row.logical_key, row.definition)
+        parse_scenario_requirement_strings(row.logical_key, row.definition)
         build_policy_overrides = parse_build_packages(row.name, row.definition)
         if "unsupported_reason" in row.definition:
             continue
@@ -1604,9 +1606,14 @@ def prepare_standard_execution(
     """Prepare and identify one execution without performing network work."""
     scenario_name = execution.scenario.name
     scenario = execution.scenario.definition
+    trust_unverified_sdist_deps = parse_trust_unverified_sdist_deps(
+        scenario_name,
+        scenario,
+    )
+    requirement_inputs = parse_scenario_requirement_strings(scenario_name, scenario)
     python_version: str = scenario["python_version"]
-    requirement_strings: list[str] = list(scenario["requirements"])
-    constraint_strings: list[str] = scenario.get("constraints", [])
+    requirement_strings = requirement_inputs.requirements
+    constraint_strings = requirement_inputs.constraints
     marker_environment = parse_marker_environment(scenario_name, scenario)
     indexes = parse_indexes(scenario_name, scenario)
     index_routes = parse_index_routes(scenario_name, scenario)
@@ -1633,10 +1640,6 @@ def prepare_standard_execution(
         allowed_schemes=frozenset(scenario.get("vcs_allowed_schemes", [])),
         allowed_repos=tuple(scenario.get("vcs_allowed_repos", [])),
         require_pin=scenario.get("vcs_require_pin", True),
-    )
-    trust_unverified_sdist_deps = parse_trust_unverified_sdist_deps(
-        scenario_name,
-        scenario,
     )
     uploaded_prior_to = parse_datetime(datetime_str) if datetime_str else None
     config = build_benchmark_config(

--- a/nab-python/benchmarks/scenarios/ai-stack.toml
+++ b/nab-python/benchmarks/scenarios/ai-stack.toml
@@ -531,9 +531,7 @@ requirements = ["pyautogen[long-context]", "PyMuPDF"]
 python_version = "3.11"
 platform_system = "Linux"
 datetime = "2025-06-01 10:00:00"
-# Resolves only by trusting a pre-2.2 sdist's PKG-INFO deps, which the
-# strict PEP 643 default routes to a build (BuildPolicy.NEVER fails).
-trust_unverified_sdist_deps = true
+unsupported_reason = "requires unverified sdist dependency metadata"
 requirements = [
     "streamlit",
     "langchain",
@@ -554,9 +552,7 @@ requirements = [
 python_version = "3.10"
 platform_system = "Linux"
 datetime = "2025-01-16 13:37:05"
-# Resolves only by trusting a pre-2.2 sdist's PKG-INFO deps, which the
-# strict PEP 643 default routes to a build (BuildPolicy.NEVER fails).
-trust_unverified_sdist_deps = true
+unsupported_reason = "requires unverified sdist dependency metadata"
 requirements = [
     "langchain",
     "langchain-community",

--- a/nab-python/tests/test_benchmark_canary.py
+++ b/nab-python/tests/test_benchmark_canary.py
@@ -579,6 +579,41 @@ def test_canary_main_records_v2_contract(
     }
 
 
+def test_canary_main_rejects_non_boolean_sdist_trust_before_result_creation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _harness()
+    results_dir = tmp_path / "results"
+    monkeypatch.setattr(module, "RESULTS_DIR", results_dir)
+    monkeypatch.setattr(
+        module,
+        "get_git_source_state",
+        lambda: {"commit": "source-sha", "dirty": False, "diff_hash": None},
+    )
+    scenario = {
+        "unsupported_reason": "test fixture",
+        "trust_unverified_sdist_deps": "false",
+    }
+    monkeypatch.setattr(module, "find_scenario", lambda _name: scenario)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["canary.py", "--commit", "test", "--scenario", "quick:requests"],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        module.main()
+
+    assert exc_info.value.code == 2
+    assert (
+        "quick:requests: trust_unverified_sdist_deps must be a boolean, got str"
+        in capsys.readouterr().err
+    )
+    assert not results_dir.exists()
+
+
 def test_canary_main_preserves_v2_lowest_identity_and_effective_settings(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -849,20 +884,39 @@ def test_canary_source_state_preserves_commit_when_hashing_fails(
 
 
 def test_canary_main_rejects_duplicate_output_labels(
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     module = _harness()
+    results_dir = tmp_path / "results"
+    monkeypatch.setattr(module, "RESULTS_DIR", results_dir)
+    monkeypatch.setattr(
+        module,
+        "get_git_source_state",
+        lambda: {"commit": "source-sha", "dirty": False, "diff_hash": None},
+    )
+    scenario = {"trust_unverified_sdist_deps": "false"}
+    monkeypatch.setattr(module, "find_scenario", lambda _name: scenario)
     monkeypatch.setattr(
         sys,
         "argv",
         [
             "canary.py",
+            "--commit",
+            "test",
             "--scenario",
-            "quick:requests",
+            "first:shared",
             "--scenario",
-            "quick:requests",
+            "second:shared",
         ],
     )
 
-    with pytest.raises(SystemExit, match="2"):
+    with pytest.raises(SystemExit) as exc_info:
         module.main()
+
+    stderr = capsys.readouterr().err
+    assert exc_info.value.code == 2
+    assert "scenario names must be unique across selected files" in stderr
+    assert "trust_unverified_sdist_deps" not in stderr
+    assert not results_dir.exists()

--- a/nab-python/tests/test_benchmark_canary.py
+++ b/nab-python/tests/test_benchmark_canary.py
@@ -133,7 +133,7 @@ def test_canary_uses_scenario_resolution(
     seen: list[str] = []
 
     def fake_run_one(*_args: object, **kwargs: object) -> dict:
-        seen.append(str(kwargs["resolution_strategy"].value))
+        seen.append(str(kwargs["config"].resolution.value))
         return _run_result()
 
     monkeypatch.setattr(module, "run_one", fake_run_one)
@@ -321,7 +321,7 @@ def test_canary_explicit_resolution_overrides_declared_strategy(
     seen: list[object] = []
 
     def fake_run_one(*_args: object, **kwargs: object) -> dict:
-        seen.append(kwargs["resolution_strategy"])
+        seen.append(kwargs["config"].resolution)
         return _run_result()
 
     monkeypatch.setattr(module, "run_one", fake_run_one)
@@ -417,17 +417,21 @@ def test_canary_prepares_inputs_and_summarizes_repeated_runs(
     assert len(calls) == 3
     assert calls[1:] == [calls[0], calls[0]]
     args, kwargs = calls[0]
-    requirements, uploaded_prior_to, constraints = args
+    requirements, constraints = args
     assert set(requirements) == {"demo"}
-    assert uploaded_prior_to == module.parse_datetime("2025-01-02 03:04:05")
     assert set(constraints) == {"support"}
-    assert kwargs["indexes"] == [
-        module.IndexConfig("private", "https://example.test/simple")
+    config = kwargs["config"]
+    assert config.uploaded_prior_to == module.parse_datetime("2025-01-02 03:04:05")
+    assert config.indexes == (
+        module.IndexConfig("private", "https://example.test/simple"),
+    )
+    assert module.index_routes_from_config(config) == [
+        module.IndexRoute("demo", "private")
     ]
-    assert kwargs["index_routes"] == [module.IndexRoute("demo", "private")]
-    assert kwargs["build_policy_overrides"] == {"demo": module.BuildPolicy.BUILD_REMOTE}
-    assert kwargs["resolution_strategy"] is module.ResolutionStrategy.LOWEST_DIRECT
-    assert kwargs["trust_unverified_sdist_deps"] is True
+    assert len(config.package_overrides) == 1
+    assert config.package_overrides[0].build_policy is module.BuildPolicy.BUILD_REMOTE
+    assert config.resolution is module.ResolutionStrategy.LOWEST_DIRECT
+    assert config.trust_unverified_sdist_deps is True
     assert kwargs["target"].marker_env["python_version"] == "3.11"
     assert kwargs["host"] is host
 
@@ -450,8 +454,7 @@ def test_canary_configures_lowest_direct_roots(
             pass
 
     class FakeProvider:
-        def __init__(self, *_args: object, **kwargs: object) -> None:
-            seen.update(kwargs)
+        def __init__(self) -> None:
             self.stats = SimpleNamespace(
                 metadata_fetched=0,
                 distributions_seen=0,
@@ -472,9 +475,13 @@ def test_canary_configures_lowest_direct_roots(
         def resolve(self, *_args: object, **_kwargs: object) -> dict:
             return {}
 
+    def fake_build_provider(_coordinator: object, **kwargs: object) -> FakeProvider:
+        seen.update(kwargs)
+        return FakeProvider()
+
     monkeypatch.setattr(module, "FetchCoordinator", FakeCoordinator)
     monkeypatch.setattr(module, "HttpxAsyncTransport", object)
-    monkeypatch.setattr(module, "Provider", FakeProvider)
+    monkeypatch.setattr(module, "build_benchmark_provider", fake_build_provider)
     monkeypatch.setattr(module, "Resolver", FakeResolver)
 
     requirements = module.parse_requirements(["Root[feature]", "Other==1"])
@@ -482,11 +489,14 @@ def test_canary_configures_lowest_direct_roots(
     host = module.BenchmarkHost(captured.target, captured.python_runtime, None)
     admission = host.target_for("3.11", {}, requires_matching_host=False)
     assert admission.target is not None
+    config = module.build_benchmark_config(
+        indexes=module.DEFAULT_INDEXES,
+        resolution=module.ResolutionStrategy.LOWEST_DIRECT,
+    )
     result = module.run_one(
         requirements,
         None,
-        None,
-        resolution_strategy=module.ResolutionStrategy.LOWEST_DIRECT,
+        config=config,
         target=admission.target,
         host=host,
     )
@@ -499,16 +509,19 @@ def test_canary_configures_lowest_direct_roots(
     assert settings["trust_unverified_sdist_deps"] is False
     assert settings["max_iterations"] == module.DEFAULT_MAX_ITERATIONS
     assert settings["wall_timeout_seconds"] is None
+
     assert settings["runtime"]["python"] == sys.version
     assert settings["runtime"]["implementation"] == sys.implementation.name
+
     assert settings["direct_packages"] == ["other", "root"]
     assert settings["indexes"] == [
         {"name": module.DEFAULT_INDEX_NAME, "url": module.DEFAULT_INDEX_URL}
     ]
     assert settings["target"]["marker_environment"]["python_version"] == "3.11"
     assert settings["target"]["wheel_tags_count"] > 0
-    assert seen["resolution_strategy"] is module.ResolutionStrategy.LOWEST_DIRECT
-    assert seen["direct_packages"] == frozenset({"root", "other"})
+
+    assert seen["config"] is config
+    assert seen["requirements"] is requirements
     assert seen["target"] is admission.target
     assert resolver_kwargs == {
         "range_type": module.VersionRange,

--- a/nab-python/tests/test_benchmark_canary.py
+++ b/nab-python/tests/test_benchmark_canary.py
@@ -16,7 +16,7 @@ from typing_extensions import Self
 
 from nab_index.multi_index import IndexConfig
 from nab_index.serialization import SimpleSerialization
-from nab_python.fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL
+from nab_python.fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL, IndexRoute
 from nab_python.target import ResolveTarget
 
 pytestmark = pytest.mark.benchmark
@@ -438,9 +438,7 @@ def test_canary_prepares_inputs_and_summarizes_repeated_runs(
             SimpleSerialization.HTML,
         ),
     )
-    assert module.index_routes_from_config(config) == [
-        module.IndexRoute("demo", "private")
-    ]
+    assert module.index_routes_from_config(config) == [IndexRoute("demo", "private")]
     assert len(config.package_overrides) == 1
     assert config.package_overrides[0].build_policy is module.BuildPolicy.BUILD_REMOTE
     assert config.resolution is module.ResolutionStrategy.LOWEST_DIRECT
@@ -684,6 +682,15 @@ def test_canary_main_records_v2_contract(
             {
                 "requirements": [],
                 "unsupported_reason": "test fixture",
+                "index_routes": "private",
+            },
+            False,
+            "quick:requests: index_routes must be an array of tables, got str",
+        ),
+        (
+            {
+                "requirements": [],
+                "unsupported_reason": "test fixture",
                 "vcs_allowed_repos": {"https://example.test/repo": False},
             },
             True,
@@ -701,6 +708,7 @@ def test_canary_main_records_v2_contract(
         "vcs-policy",
         "vcs-scheme-table",
         "indexes",
+        "index-routes",
         "default-vcs-repo-table",
     ),
 )

--- a/nab-python/tests/test_benchmark_canary.py
+++ b/nab-python/tests/test_benchmark_canary.py
@@ -14,6 +14,9 @@ from types import ModuleType, SimpleNamespace
 import pytest
 from typing_extensions import Self
 
+from nab_index.multi_index import IndexConfig
+from nab_index.serialization import SimpleSerialization
+from nab_python.fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL
 from nab_python.target import ResolveTarget
 
 pytestmark = pytest.mark.benchmark
@@ -387,7 +390,13 @@ def test_canary_prepares_inputs_and_summarizes_repeated_runs(
             "requirements": ["demo>=1"],
             "constraints": ["support<3"],
             "datetime": "2025-01-02 03:04:05",
-            "indexes": [{"name": "private", "url": "https://example.test/simple"}],
+            "indexes": [
+                {
+                    "name": "private",
+                    "url": "https://example.test/simple",
+                    "serialization": "html",
+                }
+            ],
             "index_routes": [{"name": "demo", "index": "private"}],
             "build_packages": ["demo"],
             "resolution": "lowest-direct",
@@ -423,7 +432,11 @@ def test_canary_prepares_inputs_and_summarizes_repeated_runs(
     config = kwargs["config"]
     assert config.uploaded_prior_to == module.parse_datetime("2025-01-02 03:04:05")
     assert config.indexes == (
-        module.IndexConfig("private", "https://example.test/simple"),
+        IndexConfig(
+            "private",
+            "https://example.test/simple",
+            SimpleSerialization.HTML,
+        ),
     )
     assert module.index_routes_from_config(config) == [
         module.IndexRoute("demo", "private")
@@ -493,7 +506,13 @@ def test_canary_configures_lowest_direct_roots(
     admission = host.target_for("3.11", {}, requires_matching_host=False)
     assert admission.target is not None
     config = module.build_benchmark_config(
-        indexes=module.DEFAULT_INDEXES,
+        indexes=(
+            IndexConfig(
+                DEFAULT_INDEX_NAME,
+                DEFAULT_INDEX_URL,
+                SimpleSerialization.HTML,
+            ),
+        ),
         resolution=module.ResolutionStrategy.LOWEST_DIRECT,
     )
     result = module.run_one(
@@ -518,7 +537,11 @@ def test_canary_configures_lowest_direct_roots(
 
     assert settings["direct_packages"] == ["other", "root"]
     assert settings["indexes"] == [
-        {"name": module.DEFAULT_INDEX_NAME, "url": module.DEFAULT_INDEX_URL}
+        {
+            "name": DEFAULT_INDEX_NAME,
+            "url": DEFAULT_INDEX_URL,
+            "serialization": "html",
+        }
     ]
     assert settings["target"]["marker_environment"]["python_version"] == "3.11"
     assert settings["target"]["wheel_tags_count"] > 0
@@ -652,6 +675,15 @@ def test_canary_main_records_v2_contract(
             {
                 "requirements": [],
                 "unsupported_reason": "test fixture",
+                "indexes": "private",
+            },
+            False,
+            "quick:requests: indexes must be an array of tables, got str",
+        ),
+        (
+            {
+                "requirements": [],
+                "unsupported_reason": "test fixture",
                 "vcs_allowed_repos": {"https://example.test/repo": False},
             },
             True,
@@ -668,6 +700,7 @@ def test_canary_main_records_v2_contract(
         "vcs-require-pin",
         "vcs-policy",
         "vcs-scheme-table",
+        "indexes",
         "default-vcs-repo-table",
     ),
 )

--- a/nab-python/tests/test_benchmark_canary.py
+++ b/nab-python/tests/test_benchmark_canary.py
@@ -551,7 +551,7 @@ def test_canary_main_records_v2_contract(
     monkeypatch.setattr(module, "RESULTS_DIR", tmp_path)
     source = {"commit": "source-sha", "dirty": False, "diff_hash": None}
     monkeypatch.setattr(module, "get_git_source_state", lambda: source)
-    scenario = {"unsupported_reason": "test fixture"}
+    scenario = {"requirements": [], "unsupported_reason": "test fixture"}
     input_hash = module.scenario_input_hash("quick:requests", scenario)
     monkeypatch.setattr(module, "find_scenario", lambda _name: scenario)
     monkeypatch.setattr(
@@ -579,10 +579,47 @@ def test_canary_main_records_v2_contract(
     }
 
 
-def test_canary_main_rejects_non_boolean_sdist_trust_before_result_creation(
+@pytest.mark.parametrize(
+    ("scenario", "default_selection", "message"),
+    [
+        (
+            {
+                "unsupported_reason": "test fixture",
+                "trust_unverified_sdist_deps": "false",
+            },
+            False,
+            "quick:requests: trust_unverified_sdist_deps must be a boolean, got str",
+        ),
+        (
+            {"unsupported_reason": "test fixture"},
+            False,
+            "quick:requests: missing required field 'requirements'",
+        ),
+        (
+            {"requirements": "demo", "unsupported_reason": "test fixture"},
+            False,
+            "quick:requests: requirements must be a list, got str",
+        ),
+        (
+            {"requirements": [""], "unsupported_reason": "test fixture"},
+            False,
+            "quick:requests: requirements[0] must be a non-empty string",
+        ),
+        (
+            {"requirements": [""], "unsupported_reason": "test fixture"},
+            True,
+            "quick:requests: requirements[0] must be a non-empty string",
+        ),
+    ],
+    ids=("sdist-trust", "missing", "scalar", "empty-item", "default-empty-item"),
+)
+def test_canary_main_rejects_scenario_schema_before_result_creation(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
+    scenario: dict[str, object],
+    default_selection: bool,
+    message: str,
 ) -> None:
     module = _harness()
     results_dir = tmp_path / "results"
@@ -592,25 +629,23 @@ def test_canary_main_rejects_non_boolean_sdist_trust_before_result_creation(
         "get_git_source_state",
         lambda: {"commit": "source-sha", "dirty": False, "diff_hash": None},
     )
-    scenario = {
-        "unsupported_reason": "test fixture",
-        "trust_unverified_sdist_deps": "false",
-    }
     monkeypatch.setattr(module, "find_scenario", lambda _name: scenario)
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        ["canary.py", "--commit", "test", "--scenario", "quick:requests"],
-    )
+    if default_selection:
+        monkeypatch.setattr(
+            module,
+            "load_canary_manifest",
+            lambda: [module.CanaryCase("quick:requests", None)],
+        )
+    argv = ["canary.py", "--commit", "test"]
+    if not default_selection:
+        argv.extend(("--scenario", "quick:requests"))
+    monkeypatch.setattr(sys, "argv", argv)
 
     with pytest.raises(SystemExit) as exc_info:
         module.main()
 
     assert exc_info.value.code == 2
-    assert (
-        "quick:requests: trust_unverified_sdist_deps must be a boolean, got str"
-        in capsys.readouterr().err
-    )
+    assert message in capsys.readouterr().err
     assert not results_dir.exists()
 
 

--- a/nab-python/tests/test_benchmark_canary.py
+++ b/nab-python/tests/test_benchmark_canary.py
@@ -614,6 +614,17 @@ def test_canary_main_records_v2_contract(
             {
                 "requirements": [],
                 "unsupported_reason": "test fixture",
+                "project_name": "demo-project",
+                "project_extras": ["all"],
+                "optional_dependencies": {"all": "demo"},
+            },
+            True,
+            "quick:requests: optional_dependencies['all'] must be a list, got str",
+        ),
+        (
+            {
+                "requirements": [],
+                "unsupported_reason": "test fixture",
                 "vcs_require_pin": "false",
             },
             False,
@@ -653,6 +664,7 @@ def test_canary_main_records_v2_contract(
         "scalar",
         "empty-item",
         "default-empty-item",
+        "default-project-metadata",
         "vcs-require-pin",
         "vcs-policy",
         "vcs-scheme-table",

--- a/nab-python/tests/test_benchmark_canary.py
+++ b/nab-python/tests/test_benchmark_canary.py
@@ -619,6 +619,33 @@ def test_canary_main_records_v2_contract(
             False,
             "quick:requests: vcs_require_pin must be a boolean, got str",
         ),
+        (
+            {
+                "requirements": [],
+                "unsupported_reason": "test fixture",
+                "vcs_policy": "permit",
+            },
+            False,
+            "quick:requests: vcs_policy must be one of ['allow', 'block'], got 'permit'",
+        ),
+        (
+            {
+                "requirements": [],
+                "unsupported_reason": "test fixture",
+                "vcs_allowed_schemes": {"git+https": False},
+            },
+            False,
+            "quick:requests: vcs_allowed_schemes must be a list, got dict",
+        ),
+        (
+            {
+                "requirements": [],
+                "unsupported_reason": "test fixture",
+                "vcs_allowed_repos": {"https://example.test/repo": False},
+            },
+            True,
+            "quick:requests: vcs_allowed_repos must be a list, got dict",
+        ),
     ],
     ids=(
         "sdist-trust",
@@ -627,6 +654,9 @@ def test_canary_main_records_v2_contract(
         "empty-item",
         "default-empty-item",
         "vcs-require-pin",
+        "vcs-policy",
+        "vcs-scheme-table",
+        "default-vcs-repo-table",
     ),
 )
 def test_canary_schema_validation_precedes_host_capture_and_result_creation(

--- a/nab-python/tests/test_benchmark_canary.py
+++ b/nab-python/tests/test_benchmark_canary.py
@@ -610,10 +610,26 @@ def test_canary_main_records_v2_contract(
             True,
             "quick:requests: requirements[0] must be a non-empty string",
         ),
+        (
+            {
+                "requirements": [],
+                "unsupported_reason": "test fixture",
+                "vcs_require_pin": "false",
+            },
+            False,
+            "quick:requests: vcs_require_pin must be a boolean, got str",
+        ),
     ],
-    ids=("sdist-trust", "missing", "scalar", "empty-item", "default-empty-item"),
+    ids=(
+        "sdist-trust",
+        "missing",
+        "scalar",
+        "empty-item",
+        "default-empty-item",
+        "vcs-require-pin",
+    ),
 )
-def test_canary_main_rejects_scenario_schema_before_result_creation(
+def test_canary_schema_validation_precedes_host_capture_and_result_creation(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -629,6 +645,11 @@ def test_canary_main_rejects_scenario_schema_before_result_creation(
         "get_git_source_state",
         lambda: {"commit": "source-sha", "dirty": False, "diff_hash": None},
     )
+
+    def fail_host(*_args: object, **_kwargs: object) -> object:
+        pytest.fail("scenario validation reached host capture")
+
+    monkeypatch.setattr(module.BenchmarkHost, "current", classmethod(fail_host))
     monkeypatch.setattr(module, "find_scenario", lambda _name: scenario)
     if default_selection:
         monkeypatch.setattr(

--- a/nab-python/tests/test_benchmark_canary.py
+++ b/nab-python/tests/test_benchmark_canary.py
@@ -472,7 +472,9 @@ def test_canary_configures_lowest_direct_roots(
                 incompatibilities_learned=0,
             )
 
-        def resolve(self, *_args: object, **_kwargs: object) -> dict:
+        def resolve(self, roots: object, **kwargs: object) -> dict:
+            seen["resolver_roots"] = roots
+            seen["resolver_constraints"] = kwargs["constraints"]
             return {}
 
     def fake_build_provider(_coordinator: object, **kwargs: object) -> FakeProvider:
@@ -485,6 +487,7 @@ def test_canary_configures_lowest_direct_roots(
     monkeypatch.setattr(module, "Resolver", FakeResolver)
 
     requirements = module.parse_requirements(["Root[feature]", "Other==1"])
+    constraints = module.parse_requirements(["root==1"])
     captured = module.BenchmarkHost.current(module.WALL_TIMEOUT_S)
     host = module.BenchmarkHost(captured.target, captured.python_runtime, None)
     admission = host.target_for("3.11", {}, requires_matching_host=False)
@@ -495,7 +498,7 @@ def test_canary_configures_lowest_direct_roots(
     )
     result = module.run_one(
         requirements,
-        None,
+        constraints,
         config=config,
         target=admission.target,
         host=host,
@@ -521,12 +524,23 @@ def test_canary_configures_lowest_direct_roots(
     assert settings["target"]["wheel_tags_count"] > 0
 
     assert seen["config"] is config
-    assert seen["requirements"] is requirements
     assert seen["target"] is admission.target
     assert resolver_kwargs == {
         "range_type": module.VersionRange,
         "root_version": "0",
     }
+
+    inputs = seen["inputs"]
+    assert inputs.requirements is requirements
+    assert inputs.root_extras == {("root", "feature")}
+
+    assert inputs.constraints is not constraints
+    assert set(constraints) == {"root"}
+    assert inputs.constraints is not None
+    assert set(inputs.constraints) == {"root", "root[feature]"}
+
+    assert seen["resolver_roots"] is requirements
+    assert seen["resolver_constraints"] is inputs.constraints
 
 
 def test_canary_main_records_v2_contract(

--- a/nab-python/tests/test_benchmark_canary_selection.py
+++ b/nab-python/tests/test_benchmark_canary_selection.py
@@ -78,6 +78,42 @@ def _resolve_path_as(
     monkeypatch.setattr(Path, "resolve", resolve)
 
 
+def _assert_main_preflight_error(
+    module: ModuleType,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    scenario: dict[str, object],
+    message: str,
+) -> None:
+    """Assert selection fails before canary host capture or result creation."""
+    results_dir = tmp_path / "results"
+    monkeypatch.setattr(module, "find_scenario", lambda _name: scenario)
+    monkeypatch.setattr(module, "RESULTS_DIR", results_dir)
+    monkeypatch.setattr(
+        module,
+        "get_git_source_state",
+        lambda: {"commit": "a" * 40, "dirty": False, "diff_hash": None},
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["canary.py", "--commit", "safe", "--scenario", "quick:example"],
+    )
+
+    def fail_host(*_args: object, **_kwargs: object) -> object:
+        pytest.fail("scenario preflight reached host capture")
+
+    monkeypatch.setattr(module.BenchmarkHost, "current", classmethod(fail_host))
+
+    with pytest.raises(SystemExit) as exc_info:
+        module.main()
+
+    assert exc_info.value.code == 2
+    assert message in capsys.readouterr().err
+    assert not results_dir.exists()
+
+
 def test_default_canary_manifest_preserves_19_strategies() -> None:
     module = _harness()
 
@@ -93,6 +129,15 @@ def test_default_canary_manifest_preserves_19_strategies() -> None:
         "lowest-direct": 5,
     }
     assert all("-lowest" not in case.scenario.split(":", 1)[0] for case in cases)
+
+
+def test_default_canaries_do_not_build_packages() -> None:
+    module = _harness()
+    cases = module.load_canary_manifest()
+
+    assert all(
+        "build_packages" not in module.find_scenario(case.scenario) for case in cases
+    )
 
 
 def test_default_canary_manifest_preserves_v2_input_identities() -> None:
@@ -669,6 +714,132 @@ def test_selection_validates_all_indexes_before_any_index_routes(
                 module.CanaryCase("quick:second", None),
             ]
         )
+
+
+@pytest.mark.parametrize(
+    ("first", "second", "message"),
+    [
+        (
+            {"build_packages": "demo"},
+            {"marker_environment": "Linux"},
+            "quick:second: marker_environment must be a table of strings",
+        ),
+        (
+            {
+                "platform_system": "Linux",
+                "build_packages": ["demo"],
+            },
+            {"build_packages": "demo"},
+            ("quick:second: build_packages must be a list of package names, got str"),
+        ),
+    ],
+    ids=("markers-before-build", "build-shapes-before-compatibility"),
+)
+def test_selection_validates_field_phases_across_the_whole_selection(
+    monkeypatch: pytest.MonkeyPatch,
+    first: dict[str, object],
+    second: dict[str, object],
+    message: str,
+) -> None:
+    module = _harness()
+    scenarios = {
+        "quick:first": {"requirements": [], **first},
+        "quick:second": {"requirements": [], **second},
+    }
+    monkeypatch.setattr(module, "find_scenario", scenarios.get)
+
+    with pytest.raises(TypeError, match=re.escape(message)):
+        module.select_scenarios(
+            [
+                module.CanaryCase("quick:first", None),
+                module.CanaryCase("quick:second", None),
+            ]
+        )
+
+
+def test_selection_validates_build_compatibility_before_resolution_and_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    scenario = {
+        "requirements": [],
+        "platform_system": "Linux",
+        "build_packages": ["demo"],
+        "resolution": "middle",
+        "requires_matching_host": "yes",
+    }
+    monkeypatch.setattr(module, "find_scenario", lambda _name: scenario)
+    message = (
+        "quick:example: build_packages cannot be combined "
+        "with a marker environment overlay"
+    )
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        module.select_scenarios([module.CanaryCase("quick:example", None)])
+
+
+def test_selection_validates_unsupported_build_shape_but_not_compatibility(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    valid_quarantine = {
+        "requirements": [],
+        "unsupported_reason": "marker/build metadata is unsound",
+        "platform_system": "Linux",
+        "build_packages": ["Demo_Pkg"],
+    }
+    invalid_quarantine = {
+        **valid_quarantine,
+        "build_packages": ["demo>=1"],
+    }
+    selected = [module.CanaryCase("quick:example", None)]
+
+    monkeypatch.setattr(
+        module,
+        "find_scenario",
+        lambda _name: valid_quarantine,
+    )
+    assert module.select_scenarios(selected) == selected
+
+    monkeypatch.setattr(module, "find_scenario", lambda _name: invalid_quarantine)
+    with pytest.raises(ValueError, match="valid distribution name"):
+        module.select_scenarios(selected)
+
+
+@pytest.mark.parametrize(
+    ("scenario", "message"),
+    [
+        (
+            {"requirements": [], "build_packages": "demo"},
+            "build_packages must be a list of package names",
+        ),
+        (
+            {"requirements": [], "resolution": "middle"},
+            "resolution must be one of ['highest', 'lowest', 'lowest-direct']",
+        ),
+        (
+            {"requirements": [], "requires_matching_host": "yes"},
+            "requires_matching_host must be a boolean",
+        ),
+    ],
+    ids=("build-packages", "resolution", "host-requirement"),
+)
+def test_selected_scenario_preflight_fails_before_host_and_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    scenario: dict[str, object],
+    message: str,
+) -> None:
+    module = _harness()
+    _assert_main_preflight_error(
+        module,
+        tmp_path,
+        monkeypatch,
+        capsys,
+        scenario,
+        message,
+    )
 
 
 def test_empty_scenarios_list_exits_before_creating_results(

--- a/nab-python/tests/test_benchmark_canary_selection.py
+++ b/nab-python/tests/test_benchmark_canary_selection.py
@@ -328,7 +328,7 @@ def test_existing_summary_is_not_overwritten(
     scenarios_dir = tmp_path / "scenarios"
     scenarios_dir.mkdir()
     (scenarios_dir / "inside.toml").write_text(
-        '[skipped]\nunsupported_reason = "test fixture"\n',
+        '[skipped]\nrequirements = []\nunsupported_reason = "test fixture"\n',
         encoding="utf-8",
     )
     results_dir = tmp_path / "results"

--- a/nab-python/tests/test_benchmark_canary_selection.py
+++ b/nab-python/tests/test_benchmark_canary_selection.py
@@ -717,11 +717,12 @@ def test_selection_validates_all_indexes_before_any_index_routes(
 
 
 @pytest.mark.parametrize(
-    ("first", "second", "message"),
+    ("first", "second", "error", "message"),
     [
         (
             {"build_packages": "demo"},
             {"marker_environment": "Linux"},
+            TypeError,
             "quick:second: marker_environment must be a table of strings",
         ),
         (
@@ -730,15 +731,29 @@ def test_selection_validates_all_indexes_before_any_index_routes(
                 "build_packages": ["demo"],
             },
             {"build_packages": "demo"},
+            TypeError,
             ("quick:second: build_packages must be a list of package names, got str"),
         ),
+        (
+            {"build_packages": "demo"},
+            {"marker_environment": {"platform_codename": "Windows"}},
+            ValueError,
+            (
+                "quick:second: unknown marker_environment variables: ['platform_codename']"
+            ),
+        ),
     ],
-    ids=("markers-before-build", "build-shapes-before-compatibility"),
+    ids=(
+        "marker-shapes-before-build",
+        "build-shapes-before-compatibility",
+        "marker-names-before-build",
+    ),
 )
 def test_selection_validates_field_phases_across_the_whole_selection(
     monkeypatch: pytest.MonkeyPatch,
     first: dict[str, object],
     second: dict[str, object],
+    error: type[Exception],
     message: str,
 ) -> None:
     module = _harness()
@@ -748,7 +763,7 @@ def test_selection_validates_field_phases_across_the_whole_selection(
     }
     monkeypatch.setattr(module, "find_scenario", scenarios.get)
 
-    with pytest.raises(TypeError, match=re.escape(message)):
+    with pytest.raises(error, match=re.escape(message)):
         module.select_scenarios(
             [
                 module.CanaryCase("quick:first", None),
@@ -806,6 +821,26 @@ def test_selection_validates_unsupported_build_shape_but_not_compatibility(
         module.select_scenarios(selected)
 
 
+def test_selection_rejects_unknown_marker_variables_on_unsupported_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    scenario = {
+        "requirements": [],
+        "unsupported_reason": "not runnable",
+        "marker_environment": {"platform_codename": "Windows"},
+    }
+    monkeypatch.setattr(module, "find_scenario", lambda _name: scenario)
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "quick:example: unknown marker_environment variables: ['platform_codename']"
+        ),
+    ):
+        module.select_scenarios([module.CanaryCase("quick:example", None)])
+
+
 @pytest.mark.parametrize(
     ("scenario", "message"),
     [
@@ -821,8 +856,15 @@ def test_selection_validates_unsupported_build_shape_but_not_compatibility(
             {"requirements": [], "requires_matching_host": "yes"},
             "requires_matching_host must be a boolean",
         ),
+        (
+            {
+                "requirements": [],
+                "marker_environment": {"platform_codename": "Windows"},
+            },
+            "unknown marker_environment variables: ['platform_codename']",
+        ),
     ],
-    ids=("build-packages", "resolution", "host-requirement"),
+    ids=("build-packages", "resolution", "host-requirement", "marker-variable"),
 )
 def test_selected_scenario_preflight_fails_before_host_and_output(
     tmp_path: Path,

--- a/nab-python/tests/test_benchmark_canary_selection.py
+++ b/nab-python/tests/test_benchmark_canary_selection.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
+import re
 import sys
 from collections import Counter
 from pathlib import Path
@@ -483,7 +484,13 @@ def test_selection_validates_requirement_lists_before_vcs_pin_settings(
 ) -> None:
     module = _harness()
     scenarios = {
-        "quick:first": {"requirements": [], "vcs_require_pin": "false"},
+        "quick:first": {
+            "requirements": [],
+            "vcs_require_pin": "false",
+            "vcs_policy": "permit",
+            "vcs_allowed_schemes": {"git+https": False},
+            "vcs_allowed_repos": {"https://example.test/repo": False},
+        },
         "quick:second": {"requirements": "demo"},
     }
     monkeypatch.setattr(module, "find_scenario", scenarios.get)
@@ -492,6 +499,55 @@ def test_selection_validates_requirement_lists_before_vcs_pin_settings(
         TypeError,
         match="quick:second: requirements must be a list, got str",
     ):
+        module.select_scenarios(
+            [
+                module.CanaryCase("quick:first", None),
+                module.CanaryCase("quick:second", None),
+            ]
+        )
+
+
+@pytest.mark.parametrize(
+    ("first_scenario", "second_scenario", "message"),
+    [
+        (
+            {"vcs_policy": "permit"},
+            {"vcs_require_pin": "false"},
+            "quick:second: vcs_require_pin must be a boolean, got str",
+        ),
+        (
+            {"vcs_allowed_schemes": {"git+https": False}},
+            {"vcs_policy": "permit"},
+            "quick:second: vcs_policy must be one of ['allow', 'block'], got 'permit'",
+        ),
+        (
+            {"vcs_allowed_repos": {"https://example.test/repo": False}},
+            {"vcs_allowed_schemes": {"git+https": False}},
+            "quick:second: vcs_allowed_schemes must be a list, got dict",
+        ),
+    ],
+    ids=("pin-before-policy", "policy-before-schemes", "schemes-before-repos"),
+)
+def test_selection_validates_vcs_fields_across_the_whole_selection(
+    monkeypatch: pytest.MonkeyPatch,
+    first_scenario: dict[str, object],
+    second_scenario: dict[str, object],
+    message: str,
+) -> None:
+    module = _harness()
+    scenarios = {
+        "quick:first": {
+            "requirements": [],
+            **first_scenario,
+        },
+        "quick:second": {
+            "requirements": [],
+            **second_scenario,
+        },
+    }
+    monkeypatch.setattr(module, "find_scenario", scenarios.get)
+
+    with pytest.raises((TypeError, ValueError), match=re.escape(message)):
         module.select_scenarios(
             [
                 module.CanaryCase("quick:first", None),

--- a/nab-python/tests/test_benchmark_canary_selection.py
+++ b/nab-python/tests/test_benchmark_canary_selection.py
@@ -18,7 +18,7 @@ _EXPECTED_V2_INPUT_HASHES = {
     "pip-lowest:trustllm": "df30174b6d056d4935f4fa1509b0793b54802abcc6d32d54291f4ca4cc1c6956",
     "pip-lowest:copick": "31499574be189da527d8e14ae82f894ea78aede42bb5698805686a68ba441668",
     "pip-lowest:promptflow-vectordb": "df451641b6115b623a42e7cef6d0e8942c191a11d42575289fb4f627a37b0f64",
-    "pip-lowest:ultralytics-export": "a61e66d55fa8b05744c80af5eee833186c54fc60b889d9a80a7c0afbc83569ce",
+    "pip:ultralytics-export": "fe9f57216b10878fec77925c7bac99cb98995625f5946646629b7e7eacde7098",
     "pip-lowest:datacontract-cli": "e4f3cf317d15791206d1379d4917aeae91a9ce0306c3624ec375483b96a7fcd5",
     "pip-lowest:pandas-aws-boto3-dandi-frenzy": "87c9501504c42ecbcf90c610391252dac18e2ab39fde4d7a949410f0f43f9e2b",
     "ai-stack:vllm-transformers-floor": "38b7cba134e62de586d4d19a02dac092df50b4ad8aa16e1f0555abf3eb7877bc",
@@ -87,8 +87,8 @@ def test_default_canary_manifest_preserves_19_strategies() -> None:
     assert selected == cases
     assert len({case.scenario for case in cases}) == _EXPECTED_CANARY_CASES
     assert Counter(case.resolution.value for case in cases) == {
-        "highest": 3,
-        "lowest": 11,
+        "highest": 4,
+        "lowest": 10,
         "lowest-direct": 5,
     }
     assert all("-lowest" not in case.scenario.split(":", 1)[0] for case in cases)

--- a/nab-python/tests/test_benchmark_canary_selection.py
+++ b/nab-python/tests/test_benchmark_canary_selection.py
@@ -508,6 +508,60 @@ def test_selection_validates_requirement_lists_before_vcs_pin_settings(
 
 
 @pytest.mark.parametrize(
+    ("vcs_settings", "message"),
+    [
+        (
+            {"vcs_require_pin": "false"},
+            "quick:first: vcs_require_pin must be a boolean, got str",
+        ),
+        (
+            {"vcs_policy": "permit"},
+            "quick:first: vcs_policy must be one of ['allow', 'block'], got 'permit'",
+        ),
+        (
+            {"vcs_allowed_schemes": {"git+https": False}},
+            "quick:first: vcs_allowed_schemes must be a list, got dict",
+        ),
+        (
+            {"vcs_allowed_repos": {"https://example.test/repo": False}},
+            "quick:first: vcs_allowed_repos must be a list, got dict",
+        ),
+    ],
+    ids=("pin", "policy", "schemes", "repos"),
+)
+def test_selection_validates_vcs_settings_before_project_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    vcs_settings: dict[str, object],
+    message: str,
+) -> None:
+    module = _harness()
+    scenarios = {
+        "quick:first": {
+            "requirements": [],
+            **vcs_settings,
+        },
+        "quick:second": {
+            "requirements": [],
+            "project_name": "demo-project",
+            "project_extras": ["all"],
+            "optional_dependencies": {"all": "demo"},
+        },
+    }
+    monkeypatch.setattr(module, "find_scenario", scenarios.get)
+
+    with pytest.raises(
+        (TypeError, ValueError),
+        match=re.escape(message),
+    ):
+        module.select_scenarios(
+            [
+                module.CanaryCase("quick:first", None),
+                module.CanaryCase("quick:second", None),
+            ]
+        )
+
+
+@pytest.mark.parametrize(
     ("first_scenario", "second_scenario", "message"),
     [
         (

--- a/nab-python/tests/test_benchmark_canary_selection.py
+++ b/nab-python/tests/test_benchmark_canary_selection.py
@@ -43,7 +43,12 @@ def _harness() -> ModuleType:
     assert spec is not None
     assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    benchmark_dir = str(_CANARY.parent)
+    sys.path.insert(0, benchmark_dir)
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.remove(benchmark_dir)
     return module
 
 

--- a/nab-python/tests/test_benchmark_canary_selection.py
+++ b/nab-python/tests/test_benchmark_canary_selection.py
@@ -553,6 +553,46 @@ def test_selection_validates_requirement_lists_before_vcs_pin_settings(
 
 
 @pytest.mark.parametrize(
+    "unsupported_reason",
+    [None, "not runnable"],
+    ids=("supported", "unsupported"),
+)
+def test_selection_validates_unknown_settings_across_the_whole_selection(
+    monkeypatch: pytest.MonkeyPatch,
+    unsupported_reason: str | None,
+) -> None:
+    module = _harness()
+    second: dict[str, object] = {
+        "requirements": [],
+        "trust_unverified_sdist_dependencies": False,
+    }
+    if unsupported_reason is not None:
+        second["unsupported_reason"] = unsupported_reason
+    scenarios = {
+        "quick:first": {
+            "requirements": [],
+            "trust_unverified_sdist_deps": "false",
+        },
+        "quick:second": second,
+    }
+    monkeypatch.setattr(module, "find_scenario", scenarios.get)
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "quick:second: unknown scenario settings: "
+            "['trust_unverified_sdist_dependencies']"
+        ),
+    ):
+        module.select_scenarios(
+            [
+                module.CanaryCase("quick:first", None),
+                module.CanaryCase("quick:second", None),
+            ]
+        )
+
+
+@pytest.mark.parametrize(
     ("vcs_settings", "message"),
     [
         (
@@ -845,6 +885,14 @@ def test_selection_rejects_unknown_marker_variables_on_unsupported_rows(
     ("scenario", "message"),
     [
         (
+            {
+                "requirements": [],
+                "trust_unverified_sdist_deps": "false",
+                "trust_unverified_sdist_dependencies": False,
+            },
+            "unknown scenario settings: ['trust_unverified_sdist_dependencies']",
+        ),
+        (
             {"requirements": [], "build_packages": "demo"},
             "build_packages must be a list of package names",
         ),
@@ -864,7 +912,13 @@ def test_selection_rejects_unknown_marker_variables_on_unsupported_rows(
             "unknown marker_environment variables: ['platform_codename']",
         ),
     ],
-    ids=("build-packages", "resolution", "host-requirement", "marker-variable"),
+    ids=(
+        "unknown-setting",
+        "build-packages",
+        "resolution",
+        "host-requirement",
+        "marker-variable",
+    ),
 )
 def test_selected_scenario_preflight_fails_before_host_and_output(
     tmp_path: Path,

--- a/nab-python/tests/test_benchmark_canary_selection.py
+++ b/nab-python/tests/test_benchmark_canary_selection.py
@@ -478,6 +478,28 @@ def test_missing_scenario_exits_before_creating_results(
     assert not results_dir.exists()
 
 
+def test_selection_validates_requirement_lists_before_vcs_pin_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    scenarios = {
+        "quick:first": {"requirements": [], "vcs_require_pin": "false"},
+        "quick:second": {"requirements": "demo"},
+    }
+    monkeypatch.setattr(module, "find_scenario", scenarios.get)
+
+    with pytest.raises(
+        TypeError,
+        match="quick:second: requirements must be a list, got str",
+    ):
+        module.select_scenarios(
+            [
+                module.CanaryCase("quick:first", None),
+                module.CanaryCase("quick:second", None),
+            ]
+        )
+
+
 def test_empty_scenarios_list_exits_before_creating_results(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/nab-python/tests/test_benchmark_canary_selection.py
+++ b/nab-python/tests/test_benchmark_canary_selection.py
@@ -579,10 +579,24 @@ def test_selection_validates_vcs_settings_before_project_metadata(
             {"vcs_allowed_schemes": {"git+https": False}},
             "quick:second: vcs_allowed_schemes must be a list, got dict",
         ),
+        (
+            {"indexes": "private"},
+            {
+                "project_name": "demo-project",
+                "project_extras": ["all"],
+                "optional_dependencies": {"all": "demo"},
+            },
+            "quick:second: optional_dependencies['all'] must be a list, got str",
+        ),
     ],
-    ids=("pin-before-policy", "policy-before-schemes", "schemes-before-repos"),
+    ids=(
+        "pin-before-policy",
+        "policy-before-schemes",
+        "schemes-before-repos",
+        "project-before-indexes",
+    ),
 )
-def test_selection_validates_vcs_fields_across_the_whole_selection(
+def test_selection_validates_fields_across_the_whole_selection(
     monkeypatch: pytest.MonkeyPatch,
     first_scenario: dict[str, object],
     second_scenario: dict[str, object],

--- a/nab-python/tests/test_benchmark_canary_selection.py
+++ b/nab-python/tests/test_benchmark_canary_selection.py
@@ -32,8 +32,8 @@ _EXPECTED_V2_INPUT_HASHES = {
     "forums-lowest-direct:so-dbt-core-snowflake-79744735": "2f409a250216abc0c5f89f74bf752db4c2b6b1564264d2df2d22dbb8f3a8d541",
     "uv-lowest:uv-issue-16601-xinference": "a6aa7fbec8e1291349a311745800095e4ed52c02805180da8517299860fb5476",
     "uv-lowest:uv-issue-16601-xinference-fixed": "109bb4cd7dd756a96f5b04edd007f3312fe5853c442ea7ee1b64ae6ea234903f",
-    "ai-stack:rag-chroma-langchain": "7dfda04a2fb704451afd48ee66d3fb617955535138f663dc7926ce397a304722",
-    "ai-stack:streamlit-langchain": "906384169268c46027f15ddead1f021edbc2f20589bd165ebf5ddc1e521fe338",
+    "ai-stack:rag-chroma-langchain": "0aeb86e88d6f7410ef858b51c4104d1f5c79349b9c25a1b71e7b59e053b642fe",
+    "ai-stack:streamlit-langchain": "145f34978276b96146e589c080ece06229d3b4817e619f2dfbf7ae95b247f784",
 }
 
 

--- a/nab-python/tests/test_benchmark_canary_selection.py
+++ b/nab-python/tests/test_benchmark_canary_selection.py
@@ -624,6 +624,53 @@ def test_selection_validates_fields_across_the_whole_selection(
         )
 
 
+def test_selection_validates_index_routes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    scenario = {
+        "requirements": [],
+        "indexes": [{"name": "private", "url": "https://example.test/simple"}],
+        "index_routes": [{"name": "demo>=1", "index": "private"}],
+    }
+    monkeypatch.setattr(module, "find_scenario", lambda _name: scenario)
+    message = (
+        "quick:example: index_routes[0].name must be a valid distribution name, "
+        "got 'demo>=1'"
+    )
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        module.select_scenarios([module.CanaryCase("quick:example", None)])
+
+
+def test_selection_validates_all_indexes_before_any_index_routes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    scenarios = {
+        "quick:first": {
+            "requirements": [],
+            "index_routes": "private",
+        },
+        "quick:second": {
+            "requirements": [],
+            "indexes": "private",
+        },
+    }
+    monkeypatch.setattr(module, "find_scenario", scenarios.get)
+
+    with pytest.raises(
+        TypeError,
+        match="quick:second: indexes must be an array of tables, got str",
+    ):
+        module.select_scenarios(
+            [
+                module.CanaryCase("quick:first", None),
+                module.CanaryCase("quick:second", None),
+            ]
+        )
+
+
 def test_empty_scenarios_list_exits_before_creating_results(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/nab-python/tests/test_benchmark_parse_requirements.py
+++ b/nab-python/tests/test_benchmark_parse_requirements.py
@@ -12,6 +12,7 @@ root seeds the resolver the same way in every process.
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
 from types import ModuleType
 from typing import TYPE_CHECKING
@@ -37,7 +38,12 @@ def _harness(name: str) -> ModuleType:
     assert spec is not None
     assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    benchmark_dir = str(_BENCH)
+    sys.path.insert(0, benchmark_dir)
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.remove(benchmark_dir)
     return module
 
 

--- a/nab-python/tests/test_benchmark_strategy_matrix.py
+++ b/nab-python/tests/test_benchmark_strategy_matrix.py
@@ -246,7 +246,7 @@ def _runner_parity_scenario() -> dict[str, object]:
             {"name": "Demo_Pkg", "index": "private"},
             {"name": "Other.Package", "index": "private"},
         ],
-        "build_packages": ["demo"],
+        "build_packages": ["Zulu_Pkg", "alpha.pkg", "Demo-Pkg"],
         "resolution": "lowest-direct",
         "trust_unverified_sdist_deps": False,
         "vcs_policy": "allow",
@@ -305,6 +305,32 @@ def _prepare_runner_parity(
     canary_execution = canary_preparation.execution
     assert canary_execution is not None
     return standard_execution, canary_execution, profile_inputs
+
+
+def _assert_all_runners_reject_scenario(
+    scenario: dict[str, object],
+    error: type[Exception],
+    message: str,
+) -> None:
+    """Assert the three benchmark runners reject one scenario identically."""
+    standard = _harness("scenarios")
+    canary = _harness("canary")
+    profile = _harness("_profile_runner")
+    host = _linux_host(standard)
+
+    with pytest.raises(error, match=re.escape(message)):
+        _prepare_standard_scenario(standard, scenario, host)
+
+    with pytest.raises(error, match=re.escape(message)):
+        canary._prepare_canary_execution(
+            scenario,
+            scenario_name="example",
+            resolution_override=None,
+            host=host,
+        )
+
+    with pytest.raises(error, match=re.escape(message)):
+        profile.build_inputs("example", scenario, host=host)
 
 
 @dataclass(frozen=True, order=True, slots=True)
@@ -2181,6 +2207,153 @@ def test_parse_scenario_index_routes_parses_every_entry_before_relationships(
 
 
 @pytest.mark.parametrize(
+    "scenario", [{}, {"build_packages": []}], ids=("missing", "empty")
+)
+def test_parse_scenario_build_packages_returns_a_fresh_empty_mapping(
+    scenario: dict[str, object],
+) -> None:
+    module = _harness("benchmark_config")
+
+    first = module.parse_scenario_build_packages("quick:build", scenario)
+    second = module.parse_scenario_build_packages("quick:build", scenario)
+
+    assert first == second == {}
+    assert first is not second
+
+
+def test_parse_scenario_build_packages_preserves_raw_names_and_order() -> None:
+    module = _harness("benchmark_config")
+    scenario = {"build_packages": ["Zulu_Pkg", "alpha.pkg", "Demo-Pkg"]}
+    original = deepcopy(scenario)
+
+    overrides = module.parse_scenario_build_packages("quick:build", scenario)
+
+    assert list(overrides) == ["Zulu_Pkg", "alpha.pkg", "Demo-Pkg"]
+    assert set(overrides.values()) == {module.BuildPolicy.BUILD_REMOTE}
+    assert scenario == original
+
+
+@pytest.mark.parametrize(
+    ("build_packages", "error", "message"),
+    [
+        (
+            "demo",
+            TypeError,
+            "quick:build: build_packages must be a list of package names, got str",
+        ),
+        (
+            None,
+            TypeError,
+            "quick:build: build_packages must be a list of package names, got NoneType",
+        ),
+        (
+            [123],
+            TypeError,
+            "quick:build: build_packages[0] must be a string, got int",
+        ),
+    ],
+    ids=("string", "null", "entry"),
+)
+def test_parse_scenario_build_packages_rejects_malformed_values(
+    build_packages: object,
+    error: type[Exception],
+    message: str,
+) -> None:
+    module = _harness("benchmark_config")
+
+    with pytest.raises(error, match=re.escape(message)):
+        module.parse_scenario_build_packages(
+            "quick:build",
+            {"build_packages": build_packages},
+        )
+
+
+def test_parse_scenario_build_packages_rejects_a_list_subclass() -> None:
+    module = _harness("benchmark_config")
+
+    class PackageList(list[str]):
+        pass
+
+    with pytest.raises(
+        TypeError,
+        match=(
+            "quick:build: build_packages must be a list of package names, "
+            "got PackageList"
+        ),
+    ):
+        module.parse_scenario_build_packages(
+            "quick:build",
+            {"build_packages": PackageList(["demo"])},
+        )
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "",
+        " ",
+        "demo>=1",
+        "demo[extra]",
+        "demo; python_version < '3.12'",
+        "demo @ https://example.test/demo.whl",
+    ],
+    ids=("empty", "whitespace", "specifier", "extra", "marker", "url"),
+)
+def test_parse_scenario_build_packages_rejects_non_package_names(name: str) -> None:
+    module = _harness("benchmark_config")
+    message = (
+        "quick:build: build_packages[0] must be a valid distribution name, "
+        f"got {name!r}"
+    )
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        module.parse_scenario_build_packages(
+            "quick:build",
+            {"build_packages": [name]},
+        )
+
+
+@pytest.mark.parametrize(
+    ("build_packages", "message"),
+    [
+        (["demo", "demo"], "quick:build: duplicate build package 'demo'"),
+        (
+            ["Demo_Pkg", "demo-pkg"],
+            "quick:build: duplicate build package 'demo-pkg'",
+        ),
+        (
+            ["Bravo_Pkg", "Alpha.Pkg", "bravo-pkg", "alpha-pkg"],
+            "quick:build: duplicate build package 'bravo-pkg'",
+        ),
+    ],
+    ids=("exact", "canonical", "first-canonical"),
+)
+def test_parse_scenario_build_packages_rejects_duplicates(
+    build_packages: list[str],
+    message: str,
+) -> None:
+    module = _harness("benchmark_config")
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        module.parse_scenario_build_packages(
+            "quick:build",
+            {"build_packages": build_packages},
+        )
+
+
+def test_parse_scenario_build_packages_validates_every_name_before_duplicates() -> None:
+    module = _harness("benchmark_config")
+    scenario = {"build_packages": ["Demo_Pkg", "demo-pkg", "later>=1"]}
+    message = (
+        "quick:build: build_packages[2] must be a valid distribution name, "
+        "got 'later>=1'"
+    )
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        module.parse_scenario_build_packages("quick:build", scenario)
+
+
+@pytest.mark.parametrize(
     ("routes", "message"),
     [
         (
@@ -2534,10 +2707,11 @@ def test_marker_build_scenarios_are_explicitly_unsupported() -> None:
         row.logical_key: row
         for row in rows
         if module.parse_marker_environment(row.name, row.definition)
-        and module.parse_build_packages(row.name, row.definition)
+        and module.parse_scenario_build_packages(row.name, row.definition)
     }
 
     assert set(marker_build_rows) == _MARKER_BUILD_SCENARIOS
+    assert sum("build_packages" in row.definition for row in rows) == 7
     assert all(
         row.definition.get("unsupported_reason") for row in marker_build_rows.values()
     )
@@ -2622,6 +2796,7 @@ python_version = "3.11"
 platform_system = "Linux"
 build_packages = ["demo"]
 requirements = ["demo"]
+requires_matching_host = "yes"
 """.lstrip(),
         encoding="utf-8",
     )
@@ -3756,6 +3931,16 @@ index_routes = "private"
 python_version = "3.11"
 requirements = []
 unsupported_reason = "not runnable"
+build_packages = "demo"
+""",
+            "other: build_packages must be a list of package names, got str",
+        ),
+        (
+            """
+[other]
+python_version = "3.11"
+requirements = []
+unsupported_reason = "not runnable"
 indexes = "private"
 project_name = "demo-project"
 project_extras = ["all"]
@@ -3786,6 +3971,7 @@ vcs_allowed_repos = { "https://example.test/repo" = false }
         "vcs-scheme-table",
         "indexes",
         "index-routes",
+        "build-packages",
         "project-before-indexes",
         "vcs-repo-table",
     ),
@@ -3892,6 +4078,11 @@ def test_profile_runner_accepts_an_explicit_strategy() -> None:
             "private",
             "example: index_routes must be an array of tables, got str",
         ),
+        (
+            "build_packages",
+            "demo",
+            "example: build_packages must be a list of package names, got str",
+        ),
     ],
     ids=(
         "pin",
@@ -3900,6 +4091,7 @@ def test_profile_runner_accepts_an_explicit_strategy() -> None:
         "repo-table",
         "indexes",
         "index-routes",
+        "build-packages",
     ),
 )
 def test_profile_main_validates_schema_before_host_capture(
@@ -3967,12 +4159,26 @@ def test_standard_canary_and_profile_build_the_same_project_config() -> None:
         {"name": "Demo_Pkg", "index": "private"},
         {"name": "Other.Package", "index": "private"},
     ]
+    assert standard_execution.expected_input["build_packages"] == [
+        "Zulu_Pkg",
+        "alpha.pkg",
+        "Demo-Pkg",
+    ]
     assert (
         standard_execution.config.indexes[0].serialization is SimpleSerialization.HTML
     )
     assert standard.index_routes_from_config(standard_execution.config) == [
         IndexRoute("demo-pkg", "private"),
         IndexRoute("other-package", "private"),
+    ]
+    assert [
+        (override.name, override.build_policy)
+        for override in standard_execution.config.package_overrides
+    ] == [
+        ("demo-pkg", standard.BuildPolicy.BUILD_REMOTE),
+        ("other-package", None),
+        ("zulu-pkg", standard.BuildPolicy.BUILD_REMOTE),
+        ("alpha-pkg", standard.BuildPolicy.BUILD_REMOTE),
     ]
 
     identity = canary.canary_v2_identity(
@@ -3983,6 +4189,11 @@ def test_standard_canary_and_profile_build_the_same_project_config() -> None:
     assert identity.definition["index_routes"] == [
         {"name": "Demo_Pkg", "index": "private"},
         {"name": "Other.Package", "index": "private"},
+    ]
+    assert identity.definition["build_packages"] == [
+        "Zulu_Pkg",
+        "alpha.pkg",
+        "Demo-Pkg",
     ]
 
     assert standard_execution.expected_input["requirements"] == [
@@ -4056,90 +4267,138 @@ def test_all_runners_validate_project_metadata_in_schema_order(
         profile.build_inputs("example", scenario, host=host)
 
 
-def test_all_runners_reject_malformed_indexes() -> None:
-    standard = _harness("scenarios")
-    canary = _harness("canary")
-    profile = _harness("_profile_runner")
+def test_all_runners_validate_indexes_before_index_routes() -> None:
     scenario = {
         "python_version": "3.11",
         "requirements": [],
         "indexes": [{"name": False, "url": 123}],
         "index_routes": "private",
     }
-    host = _linux_host(standard)
-    message = "example: indexes[0] name and url must be strings"
 
-    with pytest.raises(TypeError, match=re.escape(message)):
-        _prepare_standard_scenario(standard, scenario, host)
-
-    with pytest.raises(TypeError, match=re.escape(message)):
-        canary._prepare_canary_execution(
-            scenario,
-            scenario_name="example",
-            resolution_override=None,
-            host=host,
-        )
-
-    with pytest.raises(TypeError, match=re.escape(message)):
-        profile.build_inputs("example", scenario, host=host)
+    _assert_all_runners_reject_scenario(
+        scenario,
+        TypeError,
+        "example: indexes[0] name and url must be strings",
+    )
 
 
-def test_all_runners_reject_malformed_index_routes() -> None:
-    standard = _harness("scenarios")
-    canary = _harness("canary")
-    profile = _harness("_profile_runner")
+def test_all_runners_reject_invalid_index_route_names() -> None:
     scenario = {
         "python_version": "3.11",
         "requirements": [],
         "indexes": [{"name": "private", "url": "https://example.test/simple"}],
         "index_routes": [{"name": "demo>=1", "index": "private"}],
     }
-    host = _linux_host(standard)
     message = (
         "example: index_routes[0].name must be a valid distribution name, got 'demo>=1'"
     )
 
-    with pytest.raises(ValueError, match=re.escape(message)):
-        _prepare_standard_scenario(standard, scenario, host)
-
-    with pytest.raises(ValueError, match=re.escape(message)):
-        canary._prepare_canary_execution(
-            scenario,
-            scenario_name="example",
-            resolution_override=None,
-            host=host,
-        )
-
-    with pytest.raises(ValueError, match=re.escape(message)):
-        profile.build_inputs("example", scenario, host=host)
+    _assert_all_runners_reject_scenario(scenario, ValueError, message)
 
 
 def test_all_runners_validate_index_routes_before_build_packages() -> None:
-    standard = _harness("scenarios")
-    canary = _harness("canary")
-    profile = _harness("_profile_runner")
     scenario = {
         "python_version": "3.11",
         "requirements": [],
         "index_routes": [{"name": "demo", "index": 123}],
         "build_packages": "demo",
     }
-    host = _linux_host(standard)
-    message = "example: index_routes[0].index must be a string, got int"
 
-    with pytest.raises(TypeError, match=re.escape(message)):
-        _prepare_standard_scenario(standard, scenario, host)
+    _assert_all_runners_reject_scenario(
+        scenario,
+        TypeError,
+        "example: index_routes[0].index must be a string, got int",
+    )
 
-    with pytest.raises(TypeError, match=re.escape(message)):
+
+def test_all_runners_reject_invalid_build_package_names() -> None:
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        "build_packages": ["demo>=1"],
+    }
+    message = (
+        "example: build_packages[0] must be a valid distribution name, got 'demo>=1'"
+    )
+
+    _assert_all_runners_reject_scenario(scenario, ValueError, message)
+
+
+def test_all_runners_reject_non_list_build_packages() -> None:
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        "build_packages": "demo",
+    }
+
+    _assert_all_runners_reject_scenario(
+        scenario,
+        TypeError,
+        "example: build_packages must be a list of package names, got str",
+    )
+
+
+def test_all_runners_validate_marker_shape_before_build_packages() -> None:
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        "marker_environment": "Linux",
+        "build_packages": "demo",
+    }
+
+    _assert_all_runners_reject_scenario(
+        scenario,
+        TypeError,
+        "example: marker_environment must be a table of strings",
+    )
+
+
+def test_all_runners_validate_build_schema_before_compatibility() -> None:
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        "platform_system": "Linux",
+        "build_packages": ["Demo_Pkg", "demo-pkg"],
+    }
+
+    _assert_all_runners_reject_scenario(
+        scenario,
+        ValueError,
+        "example: duplicate build package 'demo-pkg'",
+    )
+
+
+def test_build_compatibility_precedes_resolution_and_host_validation() -> None:
+    canary = _harness("canary")
+    profile = _harness("_profile_runner")
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        "platform_system": "Linux",
+        "build_packages": ["demo"],
+        "resolution": "middle",
+        "requires_matching_host": "yes",
+    }
+    message = (
+        "example: build_packages cannot be combined with a marker environment overlay"
+    )
+
+    class UnusedHost:
+        """Fail if build-policy validation reaches target admission."""
+
+        def target_for(self, *_args: object, **_kwargs: object) -> object:
+            pytest.fail("build-policy validation reached host admission")
+
+    with pytest.raises(ValueError, match=re.escape(message)):
         canary._prepare_canary_execution(
             scenario,
             scenario_name="example",
             resolution_override=None,
-            host=host,
+            host=UnusedHost(),
         )
 
-    with pytest.raises(TypeError, match=re.escape(message)):
-        profile.build_inputs("example", scenario, host=host)
+    with pytest.raises(ValueError, match=re.escape(message)):
+        profile.build_inputs("example", scenario, host=UnusedHost())
 
 
 @pytest.mark.parametrize(

--- a/nab-python/tests/test_benchmark_strategy_matrix.py
+++ b/nab-python/tests/test_benchmark_strategy_matrix.py
@@ -949,6 +949,140 @@ def test_target_marker_declarations_require_string_values(
 
 
 @pytest.mark.parametrize(
+    ("marker_environment", "unknown"),
+    [
+        ({"platform_codename": "Windows"}, ["platform_codename"]),
+        (
+            {"zulu_marker": "z", "platform_system": "Linux", "alpha_marker": "a"},
+            ["alpha_marker", "zulu_marker"],
+        ),
+    ],
+    ids=("single", "multiple-sorted"),
+)
+def test_target_marker_declarations_reject_unknown_variables(
+    marker_environment: dict[str, str],
+    unknown: list[str],
+) -> None:
+    module = _harness("scenarios")
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(f"invalid: unknown marker_environment variables: {unknown!r}"),
+    ):
+        module.parse_marker_environment(
+            "invalid",
+            {"marker_environment": marker_environment},
+        )
+
+
+def test_target_marker_shape_precedes_unknown_variables() -> None:
+    module = _harness("scenarios")
+    definition = {"marker_environment": {"platform_codename": 1}}
+
+    with pytest.raises(
+        TypeError,
+        match="invalid: marker_environment must be a table of strings",
+    ):
+        module.parse_marker_environment("invalid", definition)
+
+
+@pytest.mark.parametrize(
+    "platform_system",
+    ["Linux", 1],
+    ids=("conflict", "invalid-type"),
+)
+def test_unknown_marker_variables_precede_platform_shorthand_validation(
+    platform_system: object,
+) -> None:
+    module = _harness("scenarios")
+    definition = {
+        "platform_system": platform_system,
+        "marker_environment": {
+            "platform_system": "Windows",
+            "platform_codename": "Windows",
+        },
+    }
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "invalid: unknown marker_environment variables: ['platform_codename']"
+        ),
+    ):
+        module.parse_marker_environment("invalid", definition)
+
+
+@pytest.mark.parametrize(
+    "target_markers",
+    [
+        {"platform_system": "Darwin", "sys_platform": "win32"},
+        {
+            "implementation_name": "cpython",
+            "platform_python_implementation": "PyPy",
+        },
+    ],
+    ids=("platform", "interpreter"),
+)
+def test_unknown_marker_variables_precede_supported_target_validation(
+    target_markers: dict[str, str],
+) -> None:
+    module = _harness("scenarios")
+    definition = {
+        "marker_environment": {
+            "platform_codename": "stable",
+            **target_markers,
+        }
+    }
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "invalid: unknown marker_environment variables: ['platform_codename']"
+        ),
+    ):
+        module.parse_marker_environment("invalid", definition)
+
+
+def test_target_marker_declarations_accept_every_pep508_variable() -> None:
+    module = _harness("scenarios")
+    # Nonalphabetical order makes an accidental sort visible.
+    declared = {
+        "platform_system": "Linux",
+        "python_version": "3.12.5",
+        "implementation_name": "cpython",
+        "sys_platform": "linux",
+        "platform_release": "test-release",
+        "os_name": "posix",
+        "python_full_version": "3.12.5",
+        "platform_machine": "x86_64",
+        "implementation_version": "3.12.5",
+        "platform_version": "test-version",
+        "platform_python_implementation": "CPython",
+    }
+
+    parsed = module.parse_marker_environment(
+        "valid",
+        {"marker_environment": declared},
+    )
+
+    assert parsed == declared
+    assert list(parsed) == list(declared)
+
+
+def test_target_marker_declarations_accept_partial_known_overlays() -> None:
+    module = _harness("scenarios")
+    declared = {"platform_release": "test-release"}
+
+    assert (
+        module.parse_marker_environment(
+            "valid",
+            {"marker_environment": declared},
+        )
+        == declared
+    )
+
+
+@pytest.mark.parametrize(
     ("definition", "expected"),
     [
         ({}, False),
@@ -2831,6 +2965,42 @@ requires_matching_host = "yes"
         module.load_standard_corpus([path])
 
 
+@pytest.mark.parametrize(
+    "unsupported_reason",
+    [None, "not runnable"],
+    ids=("supported", "unsupported"),
+)
+def test_standard_corpus_rejects_unknown_marker_variables(
+    tmp_path: Path,
+    unsupported_reason: str | None,
+) -> None:
+    module = _harness("scenarios")
+    path = tmp_path / "quick.toml"
+    unsupported_declaration = (
+        f'unsupported_reason = "{unsupported_reason}"'
+        if unsupported_reason is not None
+        else ""
+    )
+    path.write_text(
+        f"""
+[example]
+python_version = "3.11"
+requirements = []
+{unsupported_declaration}
+marker_environment = {{ platform_codename = "Windows" }}
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "example: unknown marker_environment variables: ['platform_codename']"
+        ),
+    ):
+        module.load_standard_corpus([path])
+
+
 def test_standard_corpus_rejects_a_strategy_clone(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -4351,6 +4521,35 @@ def test_all_runners_validate_marker_shape_before_build_packages() -> None:
         TypeError,
         "example: marker_environment must be a table of strings",
     )
+
+
+def test_unknown_marker_variables_fail_before_runner_host_admission() -> None:
+    standard = _harness("scenarios")
+    canary = _harness("canary")
+    profile = _harness("_profile_runner")
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        "marker_environment": {"platform_codename": "Windows"},
+    }
+    message = "example: unknown marker_environment variables: ['platform_codename']"
+    host = MagicMock()
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        _prepare_standard_scenario(standard, scenario, host)
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        canary._prepare_canary_execution(
+            scenario,
+            scenario_name="example",
+            resolution_override=None,
+            host=host,
+        )
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        profile.build_inputs("example", scenario, host=host)
+
+    host.target_for.assert_not_called()
 
 
 def test_all_runners_validate_build_schema_before_compatibility() -> None:

--- a/nab-python/tests/test_benchmark_strategy_matrix.py
+++ b/nab-python/tests/test_benchmark_strategy_matrix.py
@@ -118,6 +118,18 @@ def _host(
     return module.BenchmarkHost(target, "test-runtime", wall_timeout_seconds)
 
 
+def _linux_host(module: ModuleType) -> object:
+    """Return the common Linux x86-64 benchmark host used by wiring tests."""
+    return _host(
+        module,
+        system="Linux",
+        sys_platform="linux",
+        machine="x86_64",
+        os_name="posix",
+        platform_tag="manylinux_2_17_x86_64",
+    )
+
+
 def _empty_provider_stats() -> SimpleNamespace:
     fields = (
         "listings_fetched",
@@ -969,38 +981,187 @@ def test_process_scenario_uses_the_planned_target(
     assert payload["result"]["pins"] == {"selected": "1.0"}
 
 
-def test_resolve_scenario_uses_the_supplied_target_and_host(
-    monkeypatch: pytest.MonkeyPatch,
+def test_benchmark_config_combines_routing_and_build_policy() -> None:
+    module = _harness("scenarios")
+    indexes = [
+        module.IndexConfig("pypi", "https://pypi.org/simple/"),
+        module.IndexConfig("private", "https://example.test/simple"),
+    ]
+    cutoff = module.parse_datetime("2025-01-02 03:04:05")
+    vcs = module.VcsConfig(
+        policy=module.VcsPolicy.ALLOW,
+        allowed_schemes=frozenset({"git+https"}),
+        allowed_repos=("https://example.test/project",),
+        require_pin=False,
+    )
+
+    config = module.build_benchmark_config(
+        uploaded_prior_to=cutoff,
+        indexes=indexes,
+        index_routes=[module.IndexRoute("Demo_Pkg", "private")],
+        build_policy_overrides={
+            "demo-pkg": module.BuildPolicy.BUILD_REMOTE,
+            "build-only": module.BuildPolicy.BUILD_REMOTE,
+        },
+        resolution=module.ResolutionStrategy.LOWEST_DIRECT,
+        trust_unverified_sdist_deps=True,
+        vcs=vcs,
+    )
+
+    assert config.constraints == ()
+    assert config.uploaded_prior_to is cutoff
+    assert config.dist_policy is module.DistPolicy.WHEEL_OR_SDIST
+    assert config.build_policy is module.BuildPolicy.NEVER
+    assert config.trust_unverified_sdist_deps is True
+    assert config.indexes == tuple(indexes)
+    assert config.vcs is vcs
+    assert config.resolution is module.ResolutionStrategy.LOWEST_DIRECT
+
+    overrides = {override.name: override for override in config.package_overrides}
+    assert set(overrides) == {"build-only", "demo-pkg"}
+    assert overrides["demo-pkg"].index == "private"
+    assert overrides["demo-pkg"].build_policy is module.BuildPolicy.BUILD_REMOTE
+    assert overrides["build-only"].index is None
+    assert overrides["build-only"].build_policy is module.BuildPolicy.BUILD_REMOTE
+    assert module.index_routes_from_config(config) == [
+        module.IndexRoute("demo-pkg", "private")
+    ]
+
+
+@pytest.mark.parametrize(
+    ("routes", "message"),
+    [
+        (
+            [
+                ("Demo_Pkg", "private"),
+                ("demo-pkg", "private"),
+            ],
+            "duplicate index route for 'demo-pkg'",
+        ),
+        (
+            [("demo", "missing")],
+            "index route for 'demo' names undeclared index 'missing'",
+        ),
+    ],
+)
+def test_benchmark_config_rejects_invalid_index_routes(
+    routes: list[tuple[str, str]],
+    message: str,
 ) -> None:
     module = _harness("scenarios")
-    host = _host(
-        module,
-        system="Linux",
-        sys_platform="linux",
-        machine="x86_64",
-        os_name="posix",
-        platform_tag="manylinux_2_17_x86_64",
-    )
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        module.build_benchmark_config(
+            indexes=[
+                module.IndexConfig("pypi", "https://pypi.org/simple/"),
+                module.IndexConfig("private", "https://example.test/simple"),
+            ],
+            index_routes=[module.IndexRoute(*route) for route in routes],
+        )
+
+
+def test_build_benchmark_provider_forwards_project_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scenarios = _harness("scenarios")
+    config_module = _harness("benchmark_config")
+    host = _linux_host(scenarios)
     admission = host.target_for("3.11", {}, requires_matching_host=False)
     assert admission.target is not None
     target = admission.target
+    requirements = scenarios.parse_requirements(["demo[feature]", "other"])
+    config = config_module.build_benchmark_config(
+        uploaded_prior_to=scenarios.parse_datetime("2025-01-02 03:04:05"),
+        indexes=[scenarios.IndexConfig("private", "https://example.test/simple")],
+        index_routes=[scenarios.IndexRoute("demo", "private")],
+        build_policy_overrides={"demo": scenarios.BuildPolicy.BUILD_REMOTE},
+        resolution=config_module.ResolutionStrategy.LOWEST_DIRECT,
+        trust_unverified_sdist_deps=True,
+        vcs=config_module.VcsConfig(
+            policy=scenarios.VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+https"}),
+            allowed_repos=("https://example.test/project",),
+            require_pin=False,
+        ),
+    )
+    seen: dict[str, object] = {}
+
+    class FakeProvider:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            seen["args"] = args
+            seen["kwargs"] = kwargs
+
+    monkeypatch.setattr(config_module, "Provider", FakeProvider)
+    coordinator = object()
+    provider = config_module.build_benchmark_provider(
+        coordinator,
+        config=config,
+        target=target,
+        requirements=requirements,
+    )
+
+    assert isinstance(provider, FakeProvider)
+    assert seen["args"] == (coordinator,)
+    kwargs = seen["kwargs"]
+    assert isinstance(kwargs, dict)
+    assert kwargs["target"] is target
+    assert kwargs["root_requirements"] is requirements
+    assert "constraints" not in kwargs
+
+    assert kwargs["uploaded_prior_to"] is config.uploaded_prior_to
+    assert kwargs["dist_policy"] is config.dist_policy
+    assert kwargs["build_policy"] is scenarios.BuildPolicy.NEVER
+    assert kwargs["package_overrides"] is config.package_overrides
+    assert kwargs["index_overrides"] is config.index_overrides
+    assert kwargs["trust_unverified_sdist_deps"] is True
+    assert kwargs["vcs_config"] is config.vcs
+
+    assert kwargs["local_sources"] is None
+    assert kwargs["vcs_sources"] is None
+    assert kwargs["archive_sources"] is None
+
+    assert kwargs["build_config"] is config
+    assert kwargs["resolution_strategy"] is config.resolution
+    assert kwargs["direct_packages"] == frozenset({"demo", "other"})
+
+
+def test_resolve_scenario_coordinates_config_target_and_constraints(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness("scenarios")
+    host = _linux_host(module)
+    admission = host.target_for("3.11", {}, requires_matching_host=False)
+    assert admission.target is not None
+    target = admission.target
+    requirements = module.parse_requirements(["demo"])
+    constraints = module.parse_requirements(["support<2"])
+    config = module.build_benchmark_config(
+        indexes=[module.IndexConfig("private", "https://example.test/simple")],
+        index_routes=[module.IndexRoute("demo", "private")],
+    )
+    coordinator = object()
+    provider = SimpleNamespace(stats=_empty_provider_stats())
     seen: dict[str, object] = {}
 
     @contextmanager
-    def fake_coordinator(*_args: object, **_kwargs: object) -> Iterator[object]:
-        yield object()
+    def fake_coordinator(*_args: object, **kwargs: object) -> Iterator[object]:
+        seen["coordinator"] = kwargs
+        yield coordinator
 
-    class FakeProvider:
-        def __init__(self, *_args: object, **kwargs: object) -> None:
-            seen["target"] = kwargs["target"]
-            self.stats = _empty_provider_stats()
+    def fake_build_provider(actual: object, **kwargs: object) -> object:
+        seen["provider_coordinator"] = actual
+        seen["provider"] = kwargs
+        return provider
 
     class FakeResolver:
-        def __init__(self, *_args: object, **kwargs: object) -> None:
+        def __init__(self, actual_provider: object, **kwargs: object) -> None:
+            seen["resolver_provider"] = actual_provider
             seen["resolver_kwargs"] = kwargs
             self.stats = _empty_resolver_stats()
 
-        def resolve(self, *_args: object, **_kwargs: object) -> dict:
+        def resolve(self, roots: object, **kwargs: object) -> dict:
+            seen["resolver_roots"] = roots
+            seen["resolver_constraints"] = kwargs["constraints"]
             return {
                 "z_pkg": Version("2.0.0"),
                 "Demo_Pkg": Version("1.0.0"),
@@ -1015,12 +1176,14 @@ def test_resolve_scenario_uses_the_supplied_target_and_host(
 
     monkeypatch.setattr(module, "FetchCoordinator", fake_coordinator)
     monkeypatch.setattr(module, "HttpxAsyncTransport", object)
-    monkeypatch.setattr(module, "Provider", FakeProvider)
+    monkeypatch.setattr(module, "build_benchmark_provider", fake_build_provider)
     monkeypatch.setattr(module, "Resolver", FakeResolver)
     monkeypatch.setattr(module.BenchmarkHost, "wall_timeout", wall_timeout)
 
     result = module.resolve_scenario(
-        module.parse_requirements(["demo"]),
+        requirements,
+        constraints,
+        config=config,
         target=target,
         host=host,
     )
@@ -1034,14 +1197,27 @@ def test_resolve_scenario_uses_the_supplied_target_and_host(
     assert json.loads(json.dumps(result))["result"] == expected_result
     assert result["result"] == expected_result
     assert result["stats"]["packages_resolved"] == 2
-    assert seen == {
-        "target": target,
-        "resolver_kwargs": {
-            "range_type": module.VersionRange,
-            "root_version": "0",
-        },
-        "timeout": host,
+
+    assert seen["coordinator"] == {
+        "indexes": list(config.indexes),
+        "cache_dir": module.CACHE_DIR,
+        "index_routes": module.index_routes_from_config(config),
     }
+    assert seen["provider_coordinator"] is coordinator
+    assert seen["provider"] == {
+        "config": config,
+        "target": target,
+        "requirements": requirements,
+    }
+
+    assert seen["resolver_provider"] is provider
+    assert seen["resolver_kwargs"] == {
+        "range_type": module.VersionRange,
+        "root_version": "0",
+    }
+    assert seen["resolver_roots"] is requirements
+    assert seen["resolver_constraints"] is constraints
+    assert seen["timeout"] is host
 
 
 def test_resolve_scenario_records_no_pins_after_failure(
@@ -1064,9 +1240,8 @@ def test_resolve_scenario_records_no_pins_after_failure(
     def fake_coordinator(*_args: object, **_kwargs: object) -> Iterator[object]:
         yield object()
 
-    class FakeProvider:
-        def __init__(self, *_args: object, **_kwargs: object) -> None:
-            self.stats = _empty_provider_stats()
+    def fake_build_provider(*_args: object, **_kwargs: object) -> object:
+        return SimpleNamespace(stats=_empty_provider_stats())
 
     class FakeResolver:
         def __init__(self, *_args: object, **_kwargs: object) -> None:
@@ -1077,11 +1252,12 @@ def test_resolve_scenario_records_no_pins_after_failure(
 
     monkeypatch.setattr(module, "FetchCoordinator", fake_coordinator)
     monkeypatch.setattr(module, "HttpxAsyncTransport", object)
-    monkeypatch.setattr(module, "Provider", FakeProvider)
+    monkeypatch.setattr(module, "build_benchmark_provider", fake_build_provider)
     monkeypatch.setattr(module, "Resolver", FakeResolver)
 
     result = module.resolve_scenario(
         module.parse_requirements(["demo"]),
+        config=module.build_benchmark_config(indexes=[]),
         target=admission.target,
         host=host,
     )
@@ -2230,8 +2406,72 @@ def test_profile_runner_accepts_an_explicit_strategy() -> None:
         "example", scenario, module.sc.ResolutionStrategy.LOWEST
     )
 
-    assert default["resolution_strategy"] is module.sc.ResolutionStrategy.HIGHEST
-    assert lowest["resolution_strategy"] is module.sc.ResolutionStrategy.LOWEST
+    assert default["config"].resolution is module.sc.ResolutionStrategy.HIGHEST
+    assert lowest["config"].resolution is module.sc.ResolutionStrategy.LOWEST
+
+
+def test_standard_canary_and_profile_build_the_same_project_config() -> None:
+    standard = _harness("scenarios")
+    canary = _harness("canary")
+    profile = _harness("_profile_runner")
+    host = _host(
+        standard,
+        system="Linux",
+        sys_platform="linux",
+        machine="x86_64",
+        os_name="posix",
+        platform_tag="manylinux_2_17_x86_64",
+    )
+    scenario = {
+        "python_version": "3.11",
+        "requirements": ["demo>=1"],
+        "constraints": ["support<2"],
+        "datetime": "2025-01-02 03:04:05",
+        "indexes": [
+            {"name": "private", "url": "https://example.test/simple"},
+        ],
+        "index_routes": [{"name": "demo", "index": "private"}],
+        "build_packages": ["demo"],
+        "resolution": "lowest-direct",
+        "trust_unverified_sdist_deps": False,
+        "vcs_policy": "allow",
+        "vcs_allowed_schemes": ["git+https"],
+        "vcs_allowed_repos": ["https://example.test/project"],
+        "vcs_require_pin": False,
+    }
+
+    row = standard.StandardScenario("quick", "example", scenario)
+    plan = standard.standard_run_plan(
+        [row],
+        (standard.ResolutionStrategy.LOWEST_DIRECT,),
+        host,
+    )
+    standard_execution = standard.prepare_standard_execution(
+        plan.executions[0],
+        plan.targets_by_logical_key[row.logical_key],
+        commit="run",
+        source=dict(_CLEAN_SOURCE),
+        corpus_hash="f" * 64,
+        settings_digest="settings",
+    )
+    canary_preparation = canary._prepare_canary_execution(
+        scenario,
+        scenario_name="example",
+        resolution_override=None,
+        host=host,
+    )
+    profile_inputs = profile.build_inputs("example", scenario, host=host)
+
+    assert canary_preparation.execution is not None
+    assert (
+        standard_execution.config
+        == canary_preparation.execution.config
+        == profile_inputs["config"]
+    )
+    assert standard_execution.config.constraints == ()
+    assert standard_execution.constraint_strings == ["support<2"]
+    assert set(canary_preparation.execution.constraints or {}) == {"support"}
+    assert set(profile_inputs["constraints"] or {}) == {"support"}
 
 
 def test_profile_runner_uses_scenario_sdist_trust_policy() -> None:
@@ -2246,9 +2486,9 @@ def test_profile_runner_uses_scenario_sdist_trust_policy() -> None:
         "strict", {**base, "trust_unverified_sdist_deps": False}
     )
 
-    assert implicit["trust_unverified_sdist_deps"] is True
-    assert trusted["trust_unverified_sdist_deps"] is True
-    assert strict["trust_unverified_sdist_deps"] is False
+    assert implicit["config"].trust_unverified_sdist_deps is True
+    assert trusted["config"].trust_unverified_sdist_deps is True
+    assert strict["config"].trust_unverified_sdist_deps is False
 
 
 def test_profile_runner_uses_the_admitted_target_for_roots_and_resolution() -> None:

--- a/nab-python/tests/test_benchmark_strategy_matrix.py
+++ b/nab-python/tests/test_benchmark_strategy_matrix.py
@@ -19,6 +19,8 @@ from unittest.mock import MagicMock
 import pytest
 
 from nab_index.client import WheelFile
+from nab_index.multi_index import IndexConfig
+from nab_index.serialization import SimpleSerialization
 from nab_python._testing.coordinator_fake import make_coordinator
 from nab_python._vendor.packaging.tags import Tag
 from nab_python._vendor.packaging.version import Version
@@ -233,7 +235,11 @@ def _runner_parity_scenario() -> dict[str, object]:
         "constraints": ["demo<2"],
         "datetime": "2025-01-02 03:04:05",
         "indexes": [
-            {"name": "private", "url": "https://example.test/simple"},
+            {
+                "name": "private",
+                "url": "https://example.test/simple",
+                "serialization": "html",
+            },
         ],
         "index_routes": [{"name": "demo", "index": "private"}],
         "build_packages": ["demo"],
@@ -1117,8 +1123,8 @@ def test_process_scenario_uses_the_planned_target(
 def test_benchmark_config_combines_routing_and_build_policy() -> None:
     module = _harness("scenarios")
     indexes = [
-        module.IndexConfig("pypi", "https://pypi.org/simple/"),
-        module.IndexConfig("private", "https://example.test/simple"),
+        IndexConfig("pypi", "https://pypi.org/simple/"),
+        IndexConfig("private", "https://example.test/simple"),
     ]
     cutoff = module.parse_datetime("2025-01-02 03:04:05")
     vcs = module.VcsConfig(
@@ -1629,6 +1635,264 @@ def test_parse_scenario_project_metadata_rejects_malformed_values(
         module.parse_scenario_project_metadata("quick:project", scenario)
 
 
+def test_parse_scenario_indexes_defaults_to_pypi() -> None:
+    module = _harness("benchmark_config")
+
+    assert module.parse_scenario_indexes("quick:indexes", {}) == list(
+        module.DEFAULT_INDEXES
+    )
+
+
+def test_parse_scenario_indexes_preserves_declaration_details() -> None:
+    module = _harness("benchmark_config")
+    scenario = {
+        "indexes": [
+            {
+                "name": "Private_Index",
+                "url": "not a URL",
+                "serialization": "json",
+            },
+            {
+                "name": "",
+                "url": "",
+                "serialization": "html",
+            },
+            {
+                "name": "third",
+                "url": "https://example.test/simple",
+                "serialization": "negotiate",
+            },
+        ]
+    }
+    original = deepcopy(scenario)
+
+    indexes = module.parse_scenario_indexes("quick:indexes", scenario)
+
+    assert indexes == [
+        module.IndexConfig(
+            "Private_Index",
+            "not a URL",
+            SimpleSerialization.JSON,
+        ),
+        module.IndexConfig("", "", SimpleSerialization.HTML),
+        module.IndexConfig(
+            "third",
+            "https://example.test/simple",
+            SimpleSerialization.NEGOTIATE,
+        ),
+    ]
+    assert scenario == original
+
+
+def test_benchmark_index_settings_omits_only_default_serialization() -> None:
+    module = _harness("benchmark_config")
+
+    settings = module.benchmark_index_settings(
+        [
+            module.IndexConfig("default", "https://one.example/simple"),
+            module.IndexConfig(
+                "pinned",
+                "https://two.example/simple",
+                SimpleSerialization.HTML,
+            ),
+            module.IndexConfig(
+                "json",
+                "https://three.example/simple",
+                SimpleSerialization.JSON,
+            ),
+        ]
+    )
+
+    assert settings == [
+        {"name": "default", "url": "https://one.example/simple"},
+        {
+            "name": "pinned",
+            "url": "https://two.example/simple",
+            "serialization": "html",
+        },
+        {
+            "name": "json",
+            "url": "https://three.example/simple",
+            "serialization": "json",
+        },
+    ]
+
+
+@pytest.mark.parametrize("url", ["https://example.test/simple", "file:///index"])
+def test_parse_scenario_indexes_defaults_to_negotiated_serialization(
+    url: str,
+) -> None:
+    module = _harness("benchmark_config")
+
+    indexes = module.parse_scenario_indexes(
+        "quick:indexes",
+        {"indexes": [{"name": "default", "url": url}]},
+    )
+
+    assert indexes == [
+        module.IndexConfig(
+            "default",
+            url,
+            SimpleSerialization.NEGOTIATE,
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    "url", ["file:/index", "file://localhost/index", "file:///index"]
+)
+@pytest.mark.parametrize("serialization", ["negotiate", "json", "html", 1, "xml"])
+def test_parse_scenario_indexes_rejects_serialization_for_file_urls(
+    url: str,
+    serialization: object,
+) -> None:
+    module = _harness("benchmark_config")
+    message = (
+        "quick:indexes: indexes[0].serialization must be omitted "
+        "for file:// index 'local'"
+    )
+    scenario = {
+        "indexes": [
+            {
+                "name": "local",
+                "url": url,
+                "serialization": serialization,
+            }
+        ]
+    }
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        module.parse_scenario_indexes("quick:indexes", scenario)
+
+
+@pytest.mark.parametrize(
+    ("indexes", "error", "message"),
+    [
+        (
+            "private",
+            TypeError,
+            "quick:indexes: indexes must be an array of tables, got str",
+        ),
+        (
+            None,
+            TypeError,
+            "quick:indexes: indexes must be an array of tables, got NoneType",
+        ),
+        (
+            [],
+            ValueError,
+            "quick:indexes: indexes must contain at least one entry when present",
+        ),
+        (
+            ["private"],
+            TypeError,
+            "quick:indexes: indexes[0] must be a table, got str",
+        ),
+        (
+            [{"name": "private"}],
+            ValueError,
+            "quick:indexes: indexes[0] missing required key 'url'",
+        ),
+        (
+            [{"url": "https://example.test/simple"}],
+            ValueError,
+            "quick:indexes: indexes[0] missing required key 'name'",
+        ),
+        (
+            [{"name": False, "url": "https://example.test/simple"}],
+            TypeError,
+            "quick:indexes: indexes[0] name and url must be strings",
+        ),
+        (
+            [{"name": "private", "url": 123}],
+            TypeError,
+            "quick:indexes: indexes[0] name and url must be strings",
+        ),
+        (
+            [{"typo": True}],
+            ValueError,
+            (
+                "quick:indexes: unknown indexes[0] keys: ['typo']; "
+                "expected ['name', 'serialization', 'url']"
+            ),
+        ),
+        (
+            [
+                {
+                    "name": "private",
+                    "url": "https://example.test/simple",
+                    "serialization": 1,
+                }
+            ],
+            TypeError,
+            "quick:indexes: indexes[0].serialization must be a string, got int",
+        ),
+        (
+            [
+                {
+                    "name": "private",
+                    "url": "https://example.test/simple",
+                    "serialization": "xml",
+                }
+            ],
+            ValueError,
+            (
+                "quick:indexes: indexes[0].serialization must be one of "
+                "['html', 'json', 'negotiate'], got 'xml'"
+            ),
+        ),
+        (
+            [
+                {"name": "private", "url": "https://one.example/simple"},
+                {"name": "private", "url": "https://two.example/simple"},
+                {
+                    "name": "later",
+                    "url": "https://three.example/simple",
+                    "serialization": "xml",
+                },
+            ],
+            ValueError,
+            (
+                "quick:indexes: indexes[2].serialization must be one of "
+                "['html', 'json', 'negotiate'], got 'xml'"
+            ),
+        ),
+        (
+            [
+                {"name": "private", "url": "https://one.example/simple"},
+                {"name": "private", "url": "https://two.example/simple"},
+            ],
+            ValueError,
+            "quick:indexes: duplicate index name: 'private'",
+        ),
+    ],
+    ids=(
+        "array",
+        "null",
+        "empty",
+        "entry",
+        "missing-url",
+        "missing-name",
+        "name-type",
+        "url-type",
+        "unknown-key",
+        "serialization-type",
+        "serialization-value",
+        "parse-before-duplicates",
+        "duplicate",
+    ),
+)
+def test_parse_scenario_indexes_rejects_malformed_values(
+    indexes: object,
+    error: type[Exception],
+    message: str,
+) -> None:
+    module = _harness("benchmark_config")
+
+    with pytest.raises(error, match=re.escape(message)):
+        module.parse_scenario_indexes("quick:indexes", {"indexes": indexes})
+
+
 @pytest.mark.parametrize(
     ("routes", "message"),
     [
@@ -1654,8 +1918,8 @@ def test_benchmark_config_rejects_invalid_index_routes(
     with pytest.raises(ValueError, match=re.escape(message)):
         module.build_benchmark_config(
             indexes=[
-                module.IndexConfig("pypi", "https://pypi.org/simple/"),
-                module.IndexConfig("private", "https://example.test/simple"),
+                IndexConfig("pypi", "https://pypi.org/simple/"),
+                IndexConfig("private", "https://example.test/simple"),
             ],
             index_routes=[module.IndexRoute(*route) for route in routes],
         )
@@ -1678,7 +1942,7 @@ def test_build_benchmark_provider_forwards_project_config(
     )
     config = config_module.build_benchmark_config(
         uploaded_prior_to=scenarios.parse_datetime("2025-01-02 03:04:05"),
-        indexes=[scenarios.IndexConfig("private", "https://example.test/simple")],
+        indexes=[IndexConfig("private", "https://example.test/simple")],
         index_routes=[scenarios.IndexRoute("demo", "private")],
         build_policy_overrides={"demo": scenarios.BuildPolicy.BUILD_REMOTE},
         resolution=config_module.ResolutionStrategy.LOWEST_DIRECT,
@@ -1766,7 +2030,7 @@ def test_resolve_scenario_coordinates_config_target_and_constraints(
     requirements = module.parse_requirements(["demo[feature]"])
     constraints = module.parse_requirements(["demo<2"])
     config = module.build_benchmark_config(
-        indexes=[module.IndexConfig("private", "https://example.test/simple")],
+        indexes=[IndexConfig("private", "https://example.test/simple")],
         index_routes=[module.IndexRoute("demo", "private")],
     )
     coordinator = object()
@@ -3185,6 +3449,30 @@ vcs_allowed_schemes = { "git+https" = false }
 python_version = "3.11"
 requirements = []
 unsupported_reason = "not runnable"
+indexes = "private"
+""",
+            "other:other: indexes must be an array of tables, got str",
+        ),
+        (
+            """
+[other]
+python_version = "3.11"
+requirements = []
+unsupported_reason = "not runnable"
+indexes = "private"
+project_name = "demo-project"
+project_extras = ["all"]
+[other.optional_dependencies]
+all = "demo"
+""",
+            "other:other: optional_dependencies['all'] must be a list, got str",
+        ),
+        (
+            """
+[other]
+python_version = "3.11"
+requirements = []
+unsupported_reason = "not runnable"
 vcs_allowed_repos = { "https://example.test/repo" = false }
 """,
             "other:other: vcs_allowed_repos must be a list, got dict",
@@ -3199,6 +3487,8 @@ vcs_allowed_repos = { "https://example.test/repo" = false }
         "vcs-policy",
         "vcs-policy-table",
         "vcs-scheme-table",
+        "indexes",
+        "project-before-indexes",
         "vcs-repo-table",
     ),
 )
@@ -3294,10 +3584,15 @@ def test_profile_runner_accepts_an_explicit_strategy() -> None:
             {"https://example.test/repo": False},
             "example: vcs_allowed_repos must be a list, got dict",
         ),
+        (
+            "indexes",
+            "private",
+            "example: indexes must be an array of tables, got str",
+        ),
     ],
-    ids=("pin", "policy", "scheme-table", "repo-table"),
+    ids=("pin", "policy", "scheme-table", "repo-table", "indexes"),
 )
-def test_profile_main_validates_vcs_settings_before_host_capture(
+def test_profile_main_validates_schema_before_host_capture(
     monkeypatch: pytest.MonkeyPatch,
     field: str,
     value: object,
@@ -3313,7 +3608,7 @@ def test_profile_main_validates_vcs_settings_before_host_capture(
     monkeypatch.setattr(module.sys, "argv", ["_profile_runner.py", "example"])
 
     def fail_host(*_args: object, **_kwargs: object) -> object:
-        pytest.fail("VCS validation reached host capture")
+        pytest.fail("scenario validation reached host capture")
 
     monkeypatch.setattr(module.sc.BenchmarkHost, "current", classmethod(fail_host))
 
@@ -3351,6 +3646,16 @@ def test_standard_canary_and_profile_build_the_same_project_config() -> None:
         "All_Features",
         "Direct_Use",
     ]
+    assert standard_execution.expected_input["indexes"] == [
+        {
+            "name": "private",
+            "url": "https://example.test/simple",
+            "serialization": "html",
+        }
+    ]
+    assert (
+        standard_execution.config.indexes[0].serialization is SimpleSerialization.HTML
+    )
 
     assert standard_execution.expected_input["requirements"] == [
         "demo[feature]>=1",
@@ -3403,9 +3708,37 @@ def test_all_runners_validate_project_metadata_in_schema_order(
         "project_name": "demo-project",
         "project_extras": ["all"],
         "optional_dependencies": {"all": "demo"},
+        "indexes": "private",
         **vcs_settings,
     }
     host = _linux_host(standard)
+
+    with pytest.raises(TypeError, match=re.escape(message)):
+        _prepare_standard_scenario(standard, scenario, host)
+
+    with pytest.raises(TypeError, match=re.escape(message)):
+        canary._prepare_canary_execution(
+            scenario,
+            scenario_name="example",
+            resolution_override=None,
+            host=host,
+        )
+
+    with pytest.raises(TypeError, match=re.escape(message)):
+        profile.build_inputs("example", scenario, host=host)
+
+
+def test_all_runners_reject_malformed_indexes() -> None:
+    standard = _harness("scenarios")
+    canary = _harness("canary")
+    profile = _harness("_profile_runner")
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        "indexes": [{"name": False, "url": 123}],
+    }
+    host = _linux_host(standard)
+    message = "example: indexes[0] name and url must be strings"
 
     with pytest.raises(TypeError, match=re.escape(message)):
         _prepare_standard_scenario(standard, scenario, host)

--- a/nab-python/tests/test_benchmark_strategy_matrix.py
+++ b/nab-python/tests/test_benchmark_strategy_matrix.py
@@ -35,6 +35,29 @@ _STANDARD_SCENARIOS = 557
 _RUNNABLE_SCENARIOS = 535
 _UNSUPPORTED_SCENARIOS = 22
 _TOTAL_EXECUTION_IDENTITIES = 1_671
+# Keep the expected vocabulary independent of the validator's private set.
+_LIVE_SCENARIO_SETTINGS = {
+    "requirements",
+    "constraints",
+    "project_name",
+    "project_extras",
+    "optional_dependencies",
+    "indexes",
+    "index_routes",
+    "build_packages",
+    "trust_unverified_sdist_deps",
+    "vcs_policy",
+    "vcs_allowed_schemes",
+    "vcs_allowed_repos",
+    "vcs_require_pin",
+    "python_version",
+    "marker_environment",
+    "platform_system",
+    "resolution",
+    "datetime",
+    "requires_matching_host",
+    "unsupported_reason",
+}
 _MARKER_BUILD_SCENARIOS = {
     "ai-stack:llama-index-experimental-gpt5",
     "ai-stack:open-r1",
@@ -410,6 +433,32 @@ def _harness(name: str) -> ModuleType:
     finally:
         sys.path.remove(str(_BENCHMARKS))
     return module
+
+
+def test_scenario_setting_validator_accepts_the_complete_live_vocabulary() -> None:
+    module = _harness("benchmark_config")
+
+    module.validate_scenario_settings(
+        "example",
+        dict.fromkeys(_LIVE_SCENARIO_SETTINGS),
+    )
+
+
+def test_scenario_setting_validator_sorts_unknown_names() -> None:
+    module = _harness("benchmark_config")
+    scenario = {
+        "trust_unverified_sdist_dependencies": False,
+        "output_directory": "results",
+    }
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "example: unknown scenario settings: "
+            "['output_directory', 'trust_unverified_sdist_dependencies']"
+        ),
+    ):
+        module.validate_scenario_settings("example", scenario)
 
 
 def _matching_host_rows(module: ModuleType) -> dict[str, object]:
@@ -2970,6 +3019,44 @@ requires_matching_host = "yes"
     [None, "not runnable"],
     ids=("supported", "unsupported"),
 )
+def test_standard_corpus_rejects_unknown_settings_before_other_fields(
+    tmp_path: Path,
+    unsupported_reason: str | None,
+) -> None:
+    module = _harness("scenarios")
+    path = tmp_path / "quick.toml"
+    unsupported_declaration = (
+        f'unsupported_reason = "{unsupported_reason}"'
+        if unsupported_reason is not None
+        else ""
+    )
+    path.write_text(
+        f"""
+[example]
+python_version = "3.11"
+requirements = []
+{unsupported_declaration}
+trust_unverified_sdist_deps = "false"
+trust_unverified_sdist_dependencies = false
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "quick:example: unknown scenario settings: "
+            "['trust_unverified_sdist_dependencies']"
+        ),
+    ):
+        module.load_standard_corpus([path])
+
+
+@pytest.mark.parametrize(
+    "unsupported_reason",
+    [None, "not runnable"],
+    ids=("supported", "unsupported"),
+)
 def test_standard_corpus_rejects_unknown_marker_variables(
     tmp_path: Path,
     unsupported_reason: str | None,
@@ -3993,6 +4080,20 @@ python_version = "3.11"
 requirements = []
 unsupported_reason = "not runnable"
 trust_unverified_sdist_deps = "false"
+trust_unverified_sdist_dependencies = false
+""",
+            (
+                "other:other: unknown scenario settings: "
+                "['trust_unverified_sdist_dependencies']"
+            ),
+        ),
+        (
+            """
+[other]
+python_version = "3.11"
+requirements = []
+unsupported_reason = "not runnable"
+trust_unverified_sdist_deps = "false"
 """,
             "other:other: trust_unverified_sdist_deps must be a boolean, got str",
         ),
@@ -4131,6 +4232,7 @@ vcs_allowed_repos = { "https://example.test/repo" = false }
         ),
     ],
     ids=(
+        "unknown-setting",
         "sdist-trust",
         "requirements",
         "project-metadata",
@@ -4219,6 +4321,14 @@ def test_profile_runner_accepts_an_explicit_strategy() -> None:
     ("field", "value", "message"),
     [
         (
+            "trust_unverified_sdist_dependencies",
+            False,
+            (
+                "example: unknown scenario settings: "
+                "['trust_unverified_sdist_dependencies']"
+            ),
+        ),
+        (
             "vcs_require_pin",
             "false",
             "example: vcs_require_pin must be a boolean, got str",
@@ -4255,6 +4365,7 @@ def test_profile_runner_accepts_an_explicit_strategy() -> None:
         ),
     ],
     ids=(
+        "unknown-setting",
         "pin",
         "policy",
         "scheme-table",
@@ -4537,6 +4648,50 @@ def test_unknown_marker_variables_fail_before_runner_host_admission() -> None:
 
     with pytest.raises(ValueError, match=re.escape(message)):
         _prepare_standard_scenario(standard, scenario, host)
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        canary._prepare_canary_execution(
+            scenario,
+            scenario_name="example",
+            resolution_override=None,
+            host=host,
+        )
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        profile.build_inputs("example", scenario, host=host)
+
+    host.target_for.assert_not_called()
+
+
+def test_unknown_scenario_settings_fail_at_every_direct_runner_boundary() -> None:
+    standard = _harness("scenarios")
+    canary = _harness("canary")
+    profile = _harness("_profile_runner")
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        "trust_unverified_sdist_deps": "false",
+        "trust_unverified_sdist_dependencies": False,
+    }
+    message = (
+        "example: unknown scenario settings: ['trust_unverified_sdist_dependencies']"
+    )
+    execution = standard.StandardExecution(
+        standard.StandardScenario("quick", "example", scenario),
+        standard.ResolutionStrategy.HIGHEST,
+    )
+    target = _linux_host(standard).target
+    host = MagicMock()
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        standard.prepare_standard_execution(
+            execution,
+            target,
+            commit="run",
+            source=dict(_CLEAN_SOURCE),
+            corpus_hash="f" * 64,
+            settings_digest="settings",
+        )
 
     with pytest.raises(ValueError, match=re.escape(message)):
         canary._prepare_canary_execution(

--- a/nab-python/tests/test_benchmark_strategy_matrix.py
+++ b/nab-python/tests/test_benchmark_strategy_matrix.py
@@ -32,8 +32,8 @@ pytestmark = pytest.mark.benchmark
 _BENCHMARKS = Path(__file__).resolve().parents[1] / "benchmarks"
 _STANDARD_FILES = 14
 _STANDARD_SCENARIOS = 557
-_RUNNABLE_SCENARIOS = 535
-_UNSUPPORTED_SCENARIOS = 22
+_RUNNABLE_SCENARIOS = 533
+_UNSUPPORTED_SCENARIOS = 24
 _TOTAL_EXECUTION_IDENTITIES = 1_671
 # Keep the expected vocabulary independent of the validator's private set.
 _LIVE_SCENARIO_SETTINGS = {
@@ -67,6 +67,11 @@ _MARKER_BUILD_SCENARIOS = {
     "pip:pip-9572-textract-pypdf2",
     "uv:uv-issue-13321-axolotl-stack",
 }
+_UNVERIFIED_SDIST_METADATA_SCENARIOS = {
+    "ai-stack:rag-chroma-langchain",
+    "ai-stack:streamlit-langchain",
+}
+_UNVERIFIED_SDIST_METADATA_REASON = "requires unverified sdist dependency metadata"
 _MATCHING_HOST_MARKERS = {
     "uv:uv-tensorflow-macos": {
         "implementation_name": "cpython",
@@ -2897,6 +2902,22 @@ def test_marker_build_scenarios_are_explicitly_unsupported() -> None:
     assert sum("build_packages" in row.definition for row in rows) == 7
     assert all(
         row.definition.get("unsupported_reason") for row in marker_build_rows.values()
+    )
+
+
+def test_unverified_sdist_metadata_scenarios_are_explicitly_unsupported() -> None:
+    module = _harness("scenarios")
+    rows = module.load_standard_corpus(module.standard_scenario_files())
+    definitions = {row.logical_key: row.definition for row in rows}
+    affected = {
+        key
+        for key, definition in definitions.items()
+        if definition.get("unsupported_reason") == _UNVERIFIED_SDIST_METADATA_REASON
+    }
+
+    assert affected == _UNVERIFIED_SDIST_METADATA_SCENARIOS
+    assert all(
+        "trust_unverified_sdist_deps" not in definitions[key] for key in affected
     )
 
 

--- a/nab-python/tests/test_benchmark_strategy_matrix.py
+++ b/nab-python/tests/test_benchmark_strategy_matrix.py
@@ -8,6 +8,7 @@ import re
 import sys
 from collections.abc import Callable, Iterator, Mapping
 from contextlib import contextmanager
+from copy import deepcopy
 from dataclasses import dataclass, field
 from operator import setitem
 from pathlib import Path
@@ -1246,6 +1247,143 @@ def test_parse_vcs_require_pin_rejects_other_types(
             "example",
             {"vcs_require_pin": invalid},
         )
+
+
+def test_parse_vcs_policy_normalizes_type_errors() -> None:
+    module = _harness("benchmark_config")
+
+    class InvalidPolicy:
+        """Make Enum lookup fail while comparing a scenario value."""
+
+        def __hash__(self) -> int:
+            return hash("allow")
+
+        def __eq__(self, _other: object) -> bool:
+            raise TypeError("policy values cannot be compared")
+
+        def __repr__(self) -> str:
+            return "<invalid policy>"
+
+    message = (
+        "example: vcs_policy must be one of ['allow', 'block'], got <invalid policy>"
+    )
+    with pytest.raises(ValueError, match=re.escape(message)) as exc_info:
+        module.parse_vcs_policy("example", {"vcs_policy": InvalidPolicy()})
+
+    assert isinstance(exc_info.value.__cause__, TypeError)
+
+
+@pytest.mark.parametrize(
+    ("scenario", "expected_schemes", "expected_repos"),
+    [
+        ({}, frozenset(), ()),
+        (
+            {"vcs_allowed_schemes": [], "vcs_allowed_repos": []},
+            frozenset(),
+            (),
+        ),
+        (
+            {
+                "vcs_allowed_schemes": [
+                    "git+https",
+                    "git+https",
+                    " git+ssh ",
+                    "",
+                ],
+                "vcs_allowed_repos": [
+                    "not a URL",
+                    "not a URL",
+                    " https://example.test/repo ",
+                    "",
+                ],
+            },
+            frozenset({"git+https", " git+ssh ", ""}),
+            (
+                "not a URL",
+                "not a URL",
+                " https://example.test/repo ",
+                "",
+            ),
+        ),
+    ],
+    ids=("missing", "empty", "declared"),
+)
+def test_parse_vcs_allowlists_preserves_declared_values(
+    scenario: dict[str, object],
+    expected_schemes: frozenset[str],
+    expected_repos: tuple[str, ...],
+) -> None:
+    module = _harness("benchmark_config")
+    original = deepcopy(scenario)
+
+    schemes = module.parse_vcs_allowed_schemes("example", scenario)
+    repos = module.parse_vcs_allowed_repos("example", scenario)
+
+    assert schemes == expected_schemes
+    assert repos == expected_repos
+    assert scenario == original
+
+
+@pytest.mark.parametrize(
+    ("parser_name", "field", "invalid", "message"),
+    [
+        (
+            "parse_vcs_allowed_schemes",
+            "vcs_allowed_schemes",
+            {"git+https": False},
+            "example: vcs_allowed_schemes must be a list, got dict",
+        ),
+        (
+            "parse_vcs_allowed_repos",
+            "vcs_allowed_repos",
+            {"https://example.test/repo": False},
+            "example: vcs_allowed_repos must be a list, got dict",
+        ),
+        (
+            "parse_vcs_allowed_schemes",
+            "vcs_allowed_schemes",
+            ("git+https",),
+            "example: vcs_allowed_schemes must be a list, got tuple",
+        ),
+        (
+            "parse_vcs_allowed_repos",
+            "vcs_allowed_repos",
+            ("https://example.test/repo",),
+            "example: vcs_allowed_repos must be a list, got tuple",
+        ),
+        (
+            "parse_vcs_allowed_schemes",
+            "vcs_allowed_schemes",
+            ["git+https", False],
+            "example: vcs_allowed_schemes[1] must be a string, got bool",
+        ),
+        (
+            "parse_vcs_allowed_repos",
+            "vcs_allowed_repos",
+            ["https://example.test/repo", 1],
+            "example: vcs_allowed_repos[1] must be a string, got int",
+        ),
+    ],
+    ids=(
+        "scheme-table",
+        "repo-table",
+        "scheme-tuple",
+        "repo-tuple",
+        "scheme-member",
+        "repo-member",
+    ),
+)
+def test_parse_vcs_allowlists_rejects_non_lists_and_non_strings(
+    parser_name: str,
+    field: str,
+    invalid: object,
+    message: str,
+) -> None:
+    module = _harness("benchmark_config")
+    parser = getattr(module, parser_name)
+
+    with pytest.raises(TypeError, match=re.escape(message)):
+        parser("example", {field: invalid})
 
 
 def test_parse_scenario_requirement_strings_returns_fresh_unchanged_lists() -> None:
@@ -2820,8 +2958,59 @@ vcs_require_pin = "false"
 """,
             "other:other: vcs_require_pin must be a boolean, got str",
         ),
+        (
+            """
+[other]
+python_version = "3.11"
+requirements = []
+unsupported_reason = "not runnable"
+vcs_policy = "permit"
+""",
+            "other:other: vcs_policy must be one of ['allow', 'block'], got 'permit'",
+        ),
+        (
+            """
+[other]
+python_version = "3.11"
+requirements = []
+unsupported_reason = "not runnable"
+vcs_policy = { allow = false }
+""",
+            (
+                "other:other: vcs_policy must be one of ['allow', 'block'], "
+                "got {'allow': False}"
+            ),
+        ),
+        (
+            """
+[other]
+python_version = "3.11"
+requirements = []
+unsupported_reason = "not runnable"
+vcs_allowed_schemes = { "git+https" = false }
+""",
+            "other:other: vcs_allowed_schemes must be a list, got dict",
+        ),
+        (
+            """
+[other]
+python_version = "3.11"
+requirements = []
+unsupported_reason = "not runnable"
+vcs_allowed_repos = { "https://example.test/repo" = false }
+""",
+            "other:other: vcs_allowed_repos must be a list, got dict",
+        ),
     ],
-    ids=("sdist-trust", "requirements", "vcs-require-pin"),
+    ids=(
+        "sdist-trust",
+        "requirements",
+        "vcs-require-pin",
+        "vcs-policy",
+        "vcs-policy-table",
+        "vcs-scheme-table",
+        "vcs-repo-table",
+    ),
 )
 def test_unselected_unsupported_definition_fails_before_host_capture_and_result_creation(
     tmp_path: Path,
@@ -2892,27 +3081,53 @@ def test_profile_runner_accepts_an_explicit_strategy() -> None:
     assert lowest["config"].resolution is module.sc.ResolutionStrategy.LOWEST
 
 
-def test_profile_main_validates_vcs_pin_before_host_capture(
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        (
+            "vcs_require_pin",
+            "false",
+            "example: vcs_require_pin must be a boolean, got str",
+        ),
+        (
+            "vcs_policy",
+            "permit",
+            "example: vcs_policy must be one of ['allow', 'block'], got 'permit'",
+        ),
+        (
+            "vcs_allowed_schemes",
+            {"git+https": False},
+            "example: vcs_allowed_schemes must be a list, got dict",
+        ),
+        (
+            "vcs_allowed_repos",
+            {"https://example.test/repo": False},
+            "example: vcs_allowed_repos must be a list, got dict",
+        ),
+    ],
+    ids=("pin", "policy", "scheme-table", "repo-table"),
+)
+def test_profile_main_validates_vcs_settings_before_host_capture(
     monkeypatch: pytest.MonkeyPatch,
+    field: str,
+    value: object,
+    message: str,
 ) -> None:
     module = _harness("_profile_runner")
     scenario = {
         "python_version": "3.11",
         "requirements": [],
-        "vcs_require_pin": "false",
+        field: value,
     }
     monkeypatch.setattr(module, "find_scenario", lambda _spec: ("example", scenario))
     monkeypatch.setattr(module.sys, "argv", ["_profile_runner.py", "example"])
 
     def fail_host(*_args: object, **_kwargs: object) -> object:
-        pytest.fail("VCS pin validation reached host capture")
+        pytest.fail("VCS validation reached host capture")
 
     monkeypatch.setattr(module.sc.BenchmarkHost, "current", classmethod(fail_host))
 
-    with pytest.raises(
-        TypeError,
-        match="example: vcs_require_pin must be a boolean, got str",
-    ):
+    with pytest.raises((TypeError, ValueError), match=re.escape(message)):
         module.main()
 
 
@@ -2932,6 +3147,11 @@ def test_standard_canary_and_profile_build_the_same_project_config() -> None:
     assert standard_execution.config.constraints == ()
     assert standard_execution.constraint_strings == ["demo<2"]
     assert "trust_unverified_sdist_deps" not in standard_execution.expected_input
+    assert standard_execution.expected_input["vcs_policy"] == "allow"
+    assert standard_execution.expected_input["vcs_allowed_schemes"] == ["git+https"]
+    assert standard_execution.expected_input["vcs_allowed_repos"] == [
+        "https://example.test/project"
+    ]
 
 
 @pytest.mark.parametrize(
@@ -2970,6 +3190,46 @@ def test_standard_canary_and_profile_use_valid_vcs_pin_settings(
     assert scenario == original
 
 
+@pytest.mark.parametrize(
+    ("vcs_setting", "expected"),
+    [
+        ({}, "block"),
+        ({"vcs_policy": "block"}, "block"),
+        ({"vcs_policy": "allow"}, "allow"),
+    ],
+    ids=("implicit", "block", "allow"),
+)
+def test_vcs_policy_matches_across_parser_and_runners(
+    vcs_setting: dict[str, object],
+    expected: str,
+) -> None:
+    config_parser = _harness("benchmark_config")
+    standard = _harness("scenarios")
+    canary = _harness("canary")
+    profile = _harness("_profile_runner")
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        **vcs_setting,
+    }
+    original = dict(scenario)
+    expected_policy = standard.VcsPolicy(expected)
+
+    parsed_config = config_parser.parse_scenario_vcs_config("example", scenario)
+    standard_execution, canary_execution, profile_inputs = _prepare_runner_parity(
+        standard,
+        canary,
+        profile,
+        scenario=scenario,
+    )
+
+    assert parsed_config.policy is expected_policy
+    assert standard_execution.config.vcs.policy is expected_policy
+    assert canary_execution.config.vcs.policy is expected_policy
+    assert profile_inputs["config"].vcs.policy is expected_policy
+    assert scenario == original
+
+
 def test_sdist_trust_validation_precedes_requirement_and_vcs_validation() -> None:
     standard = _harness("scenarios")
     canary = _harness("canary")
@@ -2979,6 +3239,9 @@ def test_sdist_trust_validation_precedes_requirement_and_vcs_validation() -> Non
         "requirements": "demo",
         "trust_unverified_sdist_deps": "false",
         "vcs_require_pin": "false",
+        "vcs_policy": "permit",
+        "vcs_allowed_schemes": {"git+https": False},
+        "vcs_allowed_repos": {"https://example.test/repo": False},
     }
     host = _linux_host(standard)
     message = "example: trust_unverified_sdist_deps must be a boolean"
@@ -3006,6 +3269,9 @@ def test_standard_canary_and_profile_reject_non_boolean_vcs_require_pin() -> Non
         "python_version": "3.11",
         "requirements": [],
         "vcs_require_pin": "false",
+        "vcs_policy": "permit",
+        "vcs_allowed_schemes": {"git+https": False},
+        "vcs_allowed_repos": {"https://example.test/repo": False},
     }
     standard_host = _linux_host(standard)
     message = "example: vcs_require_pin must be a boolean, got str"
@@ -3031,6 +3297,66 @@ def test_standard_canary_and_profile_reject_non_boolean_vcs_require_pin() -> Non
         profile.build_inputs("example", scenario, host=UnusedHost())
 
 
+@pytest.mark.parametrize(
+    ("vcs_settings", "message"),
+    [
+        (
+            {
+                "vcs_policy": "permit",
+                "vcs_allowed_schemes": {"git+https": False},
+                "vcs_allowed_repos": {"https://example.test/repo": False},
+            },
+            "example: vcs_policy must be one of ['allow', 'block'], got 'permit'",
+        ),
+        (
+            {
+                "vcs_allowed_schemes": {"git+https": False},
+                "vcs_allowed_repos": {"https://example.test/repo": False},
+            },
+            "example: vcs_allowed_schemes must be a list, got dict",
+        ),
+        (
+            {"vcs_allowed_repos": {"https://example.test/repo": False}},
+            "example: vcs_allowed_repos must be a list, got dict",
+        ),
+    ],
+    ids=("policy", "schemes", "repos"),
+)
+def test_standard_canary_and_profile_validate_vcs_settings_in_order(
+    vcs_settings: dict[str, object],
+    message: str,
+) -> None:
+    standard = _harness("scenarios")
+    canary = _harness("canary")
+    profile = _harness("_profile_runner")
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        **vcs_settings,
+    }
+    standard_host = _linux_host(standard)
+
+    class UnusedHost:
+        """Fail if VCS validation reaches target admission."""
+
+        def target_for(self, *_args: object, **_kwargs: object) -> object:
+            pytest.fail("VCS validation reached host admission")
+
+    with pytest.raises((TypeError, ValueError), match=re.escape(message)):
+        _prepare_standard_scenario(standard, scenario, standard_host)
+
+    with pytest.raises((TypeError, ValueError), match=re.escape(message)):
+        canary._prepare_canary_execution(
+            scenario,
+            scenario_name="example",
+            resolution_override=None,
+            host=UnusedHost(),
+        )
+
+    with pytest.raises((TypeError, ValueError), match=re.escape(message)):
+        profile.build_inputs("example", scenario, host=UnusedHost())
+
+
 @pytest.mark.parametrize("field", ["requirements", "constraints"])
 def test_standard_requirement_list_validation_precedes_vcs_pin_validation(
     field: str,
@@ -3040,6 +3366,9 @@ def test_standard_requirement_list_validation_precedes_vcs_pin_validation(
         "python_version": "3.11",
         "requirements": [],
         "vcs_require_pin": "false",
+        "vcs_policy": "permit",
+        "vcs_allowed_schemes": {"git+https": False},
+        "vcs_allowed_repos": {"https://example.test/repo": False},
     }
     scenario[field] = "demo"
     host = _linux_host(standard)
@@ -3060,6 +3389,9 @@ def test_canary_requirement_list_validation_precedes_vcs_pin_validation(
         "python_version": "3.11",
         "requirements": [],
         "vcs_require_pin": "false",
+        "vcs_policy": "permit",
+        "vcs_allowed_schemes": {"git+https": False},
+        "vcs_allowed_repos": {"https://example.test/repo": False},
     }
     scenario[field] = "demo"
     host = _linux_host(canary)
@@ -3085,6 +3417,9 @@ def test_profile_requirement_list_validation_precedes_vcs_pin_validation_and_hos
         "python_version": "3.11",
         "requirements": [],
         "vcs_require_pin": "false",
+        "vcs_policy": "permit",
+        "vcs_allowed_schemes": {"git+https": False},
+        "vcs_allowed_repos": {"https://example.test/repo": False},
     }
     scenario[field] = "demo"
     host = MagicMock()

--- a/nab-python/tests/test_benchmark_strategy_matrix.py
+++ b/nab-python/tests/test_benchmark_strategy_matrix.py
@@ -6,15 +6,19 @@ import importlib.util
 import json
 import re
 import sys
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass, field
+from operator import setitem
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from typing import Literal
+from unittest.mock import MagicMock
 
 import pytest
 
+from nab_index.client import WheelFile
+from nab_python._testing.coordinator_fake import make_coordinator
 from nab_python._vendor.packaging.tags import Tag
 from nab_python._vendor.packaging.version import Version
 from nab_python.target import ResolveTarget
@@ -162,6 +166,118 @@ def _empty_resolver_stats() -> SimpleNamespace:
         "incompatibilities_learned",
     )
     return SimpleNamespace(**dict.fromkeys(fields, 0))
+
+
+def _wheel(package: str, version: str) -> WheelFile:
+    """Return one universal wheel with sidecar metadata for benchmark tests."""
+    return WheelFile(
+        filename=f"{package}-{version}-py3-none-any.whl",
+        url=f"https://example.test/{package}-{version}.whl",
+        version=version,
+        requires_python=None,
+        has_metadata=True,
+        upload_time=None,
+        hashes=(("sha256", "a" * 64),),
+    )
+
+
+def _wheel_metadata(package: str, version: str, *fields: str) -> str:
+    """Return wheel metadata with any additional fields requested by a test."""
+    return "\n".join(
+        (
+            "Metadata-Version: 2.1",
+            f"Name: {package}",
+            f"Version: {version}",
+            *fields,
+            "",
+            "",
+        )
+    )
+
+
+def _sidecar(wheel: WheelFile) -> str:
+    """Return the sidecar URL advertised by a benchmark-test wheel."""
+    url = wheel.metadata_url
+    assert url is not None
+    return url
+
+
+def _dropped_extra_coordinator() -> MagicMock:
+    """Return an index where aaa 3.0 no longer provides its x extra."""
+    aaa_wheels = [_wheel("aaa", version) for version in ("1.0", "2.0", "3.0")]
+    bbb_wheel = _wheel("bbb", "1.0")
+    metadata = {
+        _sidecar(wheel): _wheel_metadata(
+            "aaa",
+            wheel.version,
+            "Provides-Extra: x",
+            'Requires-Dist: bbb; extra == "x"',
+        )
+        for wheel in aaa_wheels[:2]
+    }
+    metadata[_sidecar(aaa_wheels[2])] = _wheel_metadata("aaa", "3.0")
+    metadata[_sidecar(bbb_wheel)] = _wheel_metadata("bbb", "1.0")
+
+    return make_coordinator(
+        listings={"aaa": aaa_wheels, "bbb": [bbb_wheel]},
+        metadata_by_url=metadata,
+    )
+
+
+def _runner_parity_scenario() -> dict[str, object]:
+    """Return a scenario that exercises shared runner configuration."""
+    return {
+        "python_version": "3.11",
+        "requirements": ["demo[feature]>=1"],
+        "constraints": ["demo<2"],
+        "datetime": "2025-01-02 03:04:05",
+        "indexes": [
+            {"name": "private", "url": "https://example.test/simple"},
+        ],
+        "index_routes": [{"name": "demo", "index": "private"}],
+        "build_packages": ["demo"],
+        "resolution": "lowest-direct",
+        "trust_unverified_sdist_deps": False,
+        "vcs_policy": "allow",
+        "vcs_allowed_schemes": ["git+https"],
+        "vcs_allowed_repos": ["https://example.test/project"],
+        "vcs_require_pin": False,
+    }
+
+
+def _prepare_runner_parity(
+    standard: ModuleType,
+    canary: ModuleType,
+    profile: ModuleType,
+) -> tuple[object, object, dict[str, object]]:
+    """Prepare equivalent inputs through the three benchmark entry points."""
+    scenario = _runner_parity_scenario()
+    host = _linux_host(standard)
+    row = standard.StandardScenario("quick", "example", scenario)
+    plan = standard.standard_run_plan(
+        [row],
+        (standard.ResolutionStrategy.LOWEST_DIRECT,),
+        host,
+    )
+    standard_execution = standard.prepare_standard_execution(
+        plan.executions[0],
+        plan.targets_by_logical_key[row.logical_key],
+        commit="run",
+        source=dict(_CLEAN_SOURCE),
+        corpus_hash="f" * 64,
+        settings_digest="settings",
+    )
+    canary_preparation = canary._prepare_canary_execution(
+        scenario,
+        scenario_name="example",
+        resolution_override=None,
+        host=host,
+    )
+    profile_inputs = profile.build_inputs("example", scenario, host=host)
+
+    canary_execution = canary_preparation.execution
+    assert canary_execution is not None
+    return standard_execution, canary_execution, profile_inputs
 
 
 @dataclass(frozen=True, order=True, slots=True)
@@ -1070,6 +1186,11 @@ def test_build_benchmark_provider_forwards_project_config(
     assert admission.target is not None
     target = admission.target
     requirements = scenarios.parse_requirements(["demo[feature]", "other"])
+    constraints = scenarios.parse_requirements(["demo<2"])
+    inputs = config_module.build_benchmark_resolver_inputs(
+        requirements,
+        constraints,
+    )
     config = config_module.build_benchmark_config(
         uploaded_prior_to=scenarios.parse_datetime("2025-01-02 03:04:05"),
         indexes=[scenarios.IndexConfig("private", "https://example.test/simple")],
@@ -1097,7 +1218,7 @@ def test_build_benchmark_provider_forwards_project_config(
         coordinator,
         config=config,
         target=target,
-        requirements=requirements,
+        inputs=inputs,
     )
 
     assert isinstance(provider, FakeProvider)
@@ -1106,7 +1227,9 @@ def test_build_benchmark_provider_forwards_project_config(
     assert isinstance(kwargs, dict)
     assert kwargs["target"] is target
     assert kwargs["root_requirements"] is requirements
-    assert "constraints" not in kwargs
+    assert kwargs["root_extras"] == {("demo", "feature")}
+    assert kwargs["constraints"] is inputs.constraints
+    assert set(kwargs["constraints"]) == {"demo", "demo[feature]"}
 
     assert kwargs["uploaded_prior_to"] is config.uploaded_prior_to
     assert kwargs["dist_policy"] is config.dist_policy
@@ -1125,6 +1248,28 @@ def test_build_benchmark_provider_forwards_project_config(
     assert kwargs["direct_packages"] == frozenset({"demo", "other"})
 
 
+def test_benchmark_resolver_inputs_copy_constraints_to_extra_proxies() -> None:
+    scenarios = _harness("scenarios")
+    config_module = _harness("benchmark_config")
+    requirements = scenarios.parse_requirements(["demo[feature]"])
+    constraints = scenarios.parse_requirements(["demo<2"])
+
+    inputs = config_module.build_benchmark_resolver_inputs(
+        requirements,
+        constraints,
+    )
+
+    assert inputs.requirements is requirements
+    assert inputs.root_extras == {("demo", "feature")}
+    assert inputs.constraints is not constraints
+    assert set(constraints) == {"demo"}
+    assert inputs.constraints is not None
+    assert set(inputs.constraints) == {"demo", "demo[feature]"}
+    assert inputs.constraints["demo[feature]"] is inputs.constraints["demo"]
+    with pytest.raises(TypeError):
+        setitem(inputs.constraints, "demo", constraints["demo"])
+
+
 def test_resolve_scenario_coordinates_config_target_and_constraints(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1133,8 +1278,8 @@ def test_resolve_scenario_coordinates_config_target_and_constraints(
     admission = host.target_for("3.11", {}, requires_matching_host=False)
     assert admission.target is not None
     target = admission.target
-    requirements = module.parse_requirements(["demo"])
-    constraints = module.parse_requirements(["support<2"])
+    requirements = module.parse_requirements(["demo[feature]"])
+    constraints = module.parse_requirements(["demo<2"])
     config = module.build_benchmark_config(
         indexes=[module.IndexConfig("private", "https://example.test/simple")],
         index_routes=[module.IndexRoute("demo", "private")],
@@ -1204,10 +1349,15 @@ def test_resolve_scenario_coordinates_config_target_and_constraints(
         "index_routes": module.index_routes_from_config(config),
     }
     assert seen["provider_coordinator"] is coordinator
-    assert seen["provider"] == {
+    provider_kwargs = seen["provider"]
+    assert isinstance(provider_kwargs, dict)
+    assert provider_kwargs == {
         "config": config,
         "target": target,
-        "requirements": requirements,
+        "inputs": module.build_benchmark_resolver_inputs(
+            requirements,
+            constraints,
+        ),
     }
 
     assert seen["resolver_provider"] is provider
@@ -1216,7 +1366,11 @@ def test_resolve_scenario_coordinates_config_target_and_constraints(
         "root_version": "0",
     }
     assert seen["resolver_roots"] is requirements
-    assert seen["resolver_constraints"] is constraints
+    resolver_constraints = seen["resolver_constraints"]
+    assert isinstance(resolver_constraints, Mapping)
+    provider_inputs = provider_kwargs["inputs"]
+    assert resolver_constraints is provider_inputs.constraints
+    assert set(resolver_constraints) == {"demo", "demo[feature]"}
     assert seen["timeout"] is host
 
 
@@ -1268,6 +1422,73 @@ def test_resolve_scenario_records_no_pins_after_failure(
         "pins": {},
     }
     assert result["stats"]["packages_resolved"] == 0
+
+
+@pytest.mark.parametrize(
+    ("constraint", "success", "error_fragments", "expected_packages"),
+    [
+        pytest.param(
+            "aaa==2.0",
+            True,
+            (),
+            2,
+            id="constrained-version-provides-extra",
+        ),
+        pytest.param(
+            "aaa==3.0",
+            False,
+            ("MissingExtraError", "aaa==3.0 does not provide extra 'x'"),
+            0,
+            id="constrained-version-dropped-extra",
+        ),
+        pytest.param(
+            "aaa<0.5",
+            False,
+            ("ResolutionError", "the user constrained aaa[x]", "0.5"),
+            0,
+            id="constraint-empties-extra-proxy",
+        ),
+    ],
+)
+def test_standard_runner_applies_root_extra_constraints(
+    constraint: str,
+    success: bool,
+    error_fragments: tuple[str, ...],
+    expected_packages: int,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness("scenarios")
+    coordinator = _dropped_extra_coordinator()
+
+    @contextmanager
+    def fake_coordinator(*_args: object, **_kwargs: object) -> Iterator[object]:
+        yield coordinator
+
+    monkeypatch.setattr(module, "FetchCoordinator", fake_coordinator)
+    monkeypatch.setattr(module, "HttpxAsyncTransport", object)
+
+    captured = _linux_host(module)
+    host = module.BenchmarkHost(captured.target, captured.python_runtime, None)
+    admission = host.target_for("3.11", {}, requires_matching_host=False)
+    assert admission.target is not None
+    result = module.resolve_scenario(
+        module.parse_requirements(["aaa[x]"]),
+        module.parse_requirements([constraint]),
+        config=module.build_benchmark_config(indexes=module.DEFAULT_INDEXES),
+        target=admission.target,
+        host=host,
+    )
+
+    outcome = result["result"]
+    assert outcome["success"] is success
+    error = outcome["error"]
+    if error_fragments:
+        assert isinstance(error, str)
+        for fragment in error_fragments:
+            assert fragment in error
+    else:
+        assert error is None
+    assert result["stats"]["packages_resolved"] == expected_packages
 
 
 def test_marker_build_scenarios_are_explicitly_unsupported() -> None:
@@ -2414,64 +2635,59 @@ def test_standard_canary_and_profile_build_the_same_project_config() -> None:
     standard = _harness("scenarios")
     canary = _harness("canary")
     profile = _harness("_profile_runner")
-    host = _host(
+    standard_execution, canary_execution, profile_inputs = _prepare_runner_parity(
         standard,
-        system="Linux",
-        sys_platform="linux",
-        machine="x86_64",
-        os_name="posix",
-        platform_tag="manylinux_2_17_x86_64",
+        canary,
+        profile,
     )
-    scenario = {
-        "python_version": "3.11",
-        "requirements": ["demo>=1"],
-        "constraints": ["support<2"],
-        "datetime": "2025-01-02 03:04:05",
-        "indexes": [
-            {"name": "private", "url": "https://example.test/simple"},
-        ],
-        "index_routes": [{"name": "demo", "index": "private"}],
-        "build_packages": ["demo"],
-        "resolution": "lowest-direct",
-        "trust_unverified_sdist_deps": False,
-        "vcs_policy": "allow",
-        "vcs_allowed_schemes": ["git+https"],
-        "vcs_allowed_repos": ["https://example.test/project"],
-        "vcs_require_pin": False,
-    }
 
-    row = standard.StandardScenario("quick", "example", scenario)
-    plan = standard.standard_run_plan(
-        [row],
-        (standard.ResolutionStrategy.LOWEST_DIRECT,),
-        host,
-    )
-    standard_execution = standard.prepare_standard_execution(
-        plan.executions[0],
-        plan.targets_by_logical_key[row.logical_key],
-        commit="run",
-        source=dict(_CLEAN_SOURCE),
-        corpus_hash="f" * 64,
-        settings_digest="settings",
-    )
-    canary_preparation = canary._prepare_canary_execution(
-        scenario,
-        scenario_name="example",
-        resolution_override=None,
-        host=host,
-    )
-    profile_inputs = profile.build_inputs("example", scenario, host=host)
-
-    assert canary_preparation.execution is not None
     assert (
-        standard_execution.config
-        == canary_preparation.execution.config
-        == profile_inputs["config"]
+        standard_execution.config == canary_execution.config == profile_inputs["config"]
     )
     assert standard_execution.config.constraints == ()
-    assert standard_execution.constraint_strings == ["support<2"]
-    assert set(canary_preparation.execution.constraints or {}) == {"support"}
-    assert set(profile_inputs["constraints"] or {}) == {"support"}
+    assert standard_execution.constraint_strings == ["demo<2"]
+
+
+def test_standard_canary_and_profile_prepare_the_same_resolver_inputs() -> None:
+    standard = _harness("scenarios")
+    canary = _harness("canary")
+    profile = _harness("_profile_runner")
+    standard_execution, canary_execution, profile_inputs = _prepare_runner_parity(
+        standard,
+        canary,
+        profile,
+    )
+
+    marker_environment = dict(standard_execution.target.marker_env)
+    standard_requirements = standard.parse_requirements(
+        standard_execution.requirement_strings,
+        vcs_config=standard_execution.config.vcs,
+        marker_environment=marker_environment,
+    )
+    standard_constraints = standard.parse_requirements(
+        standard_execution.constraint_strings,
+        vcs_config=standard_execution.config.vcs,
+        marker_environment=marker_environment,
+    )
+    standard_resolver_inputs = standard.build_benchmark_resolver_inputs(
+        standard_requirements,
+        standard_constraints,
+    )
+    canary_resolver_inputs = canary.build_benchmark_resolver_inputs(
+        canary_execution.requirements,
+        canary_execution.constraints,
+    )
+    profile_resolver_inputs = profile.sc.build_benchmark_resolver_inputs(
+        profile_inputs["requirements"],
+        profile_inputs["constraints"],
+    )
+
+    assert standard_resolver_inputs == canary_resolver_inputs == profile_resolver_inputs
+    assert standard_resolver_inputs.root_extras == {("demo", "feature")}
+    assert set(standard_resolver_inputs.constraints or {}) == {
+        "demo",
+        "demo[feature]",
+    }
 
 
 def test_profile_runner_uses_scenario_sdist_trust_policy() -> None:

--- a/nab-python/tests/test_benchmark_strategy_matrix.py
+++ b/nab-python/tests/test_benchmark_strategy_matrix.py
@@ -245,6 +245,27 @@ def _runner_parity_scenario() -> dict[str, object]:
     }
 
 
+def _prepare_standard_scenario(
+    standard: ModuleType,
+    scenario: dict[str, object],
+    host: object,
+) -> object:
+    """Prepare one standard scenario without running its resolver."""
+    strategy = standard.ResolutionStrategy(
+        scenario.get("resolution", standard.ResolutionStrategy.HIGHEST.value)
+    )
+    row = standard.StandardScenario("quick", "example", scenario)
+    plan = standard.standard_run_plan([row], (strategy,), host)
+    return standard.prepare_standard_execution(
+        plan.executions[0],
+        plan.targets_by_logical_key[row.logical_key],
+        commit="run",
+        source=dict(_CLEAN_SOURCE),
+        corpus_hash="f" * 64,
+        settings_digest="settings",
+    )
+
+
 def _prepare_runner_parity(
     standard: ModuleType,
     canary: ModuleType,
@@ -253,20 +274,7 @@ def _prepare_runner_parity(
     """Prepare equivalent inputs through the three benchmark entry points."""
     scenario = _runner_parity_scenario()
     host = _linux_host(standard)
-    row = standard.StandardScenario("quick", "example", scenario)
-    plan = standard.standard_run_plan(
-        [row],
-        (standard.ResolutionStrategy.LOWEST_DIRECT,),
-        host,
-    )
-    standard_execution = standard.prepare_standard_execution(
-        plan.executions[0],
-        plan.targets_by_logical_key[row.logical_key],
-        commit="run",
-        source=dict(_CLEAN_SOURCE),
-        corpus_hash="f" * 64,
-        settings_digest="settings",
-    )
+    standard_execution = _prepare_standard_scenario(standard, scenario, host)
     canary_preparation = canary._prepare_canary_execution(
         scenario,
         scenario_name="example",
@@ -1142,6 +1150,53 @@ def test_benchmark_config_combines_routing_and_build_policy() -> None:
     assert module.index_routes_from_config(config) == [
         module.IndexRoute("demo-pkg", "private")
     ]
+
+
+@pytest.mark.parametrize(
+    ("scenario", "expected"),
+    [
+        ({}, True),
+        ({"trust_unverified_sdist_deps": True}, True),
+        ({"trust_unverified_sdist_deps": False}, False),
+    ],
+    ids=("implicit", "trusted", "strict"),
+)
+def test_parse_trust_unverified_sdist_deps_accepts_exact_booleans(
+    scenario: dict[str, object],
+    expected: bool,
+) -> None:
+    module = _harness("benchmark_config")
+    original = dict(scenario)
+
+    assert module.parse_trust_unverified_sdist_deps("example", scenario) is expected
+    assert scenario == original
+
+
+@pytest.mark.parametrize(
+    ("invalid", "type_name"),
+    [
+        (0, "int"),
+        (1, "int"),
+        (0.0, "float"),
+        ("false", "str"),
+        ([False], "list"),
+        ({"value": False}, "dict"),
+        (None, "NoneType"),
+    ],
+    ids=("zero", "one", "float", "string", "list", "table", "none"),
+)
+def test_parse_trust_unverified_sdist_deps_rejects_other_types(
+    invalid: object,
+    type_name: str,
+) -> None:
+    module = _harness("benchmark_config")
+    message = f"example: trust_unverified_sdist_deps must be a boolean, got {type_name}"
+
+    with pytest.raises(TypeError, match=message):
+        module.parse_trust_unverified_sdist_deps(
+            "example",
+            {"trust_unverified_sdist_deps": invalid},
+        )
 
 
 @pytest.mark.parametrize(
@@ -2602,6 +2657,49 @@ def test_selector_errors_are_actionable(
     assert not (tmp_path / "results").exists()
 
 
+def test_unselected_unsupported_sdist_trust_fails_before_result_creation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _harness("scenarios")
+    scenarios_dir = tmp_path / "scenarios"
+    _write_corpus(scenarios_dir)
+    (scenarios_dir / "other.toml").write_text(
+        """
+[other]
+python_version = "3.11"
+requirements = []
+unsupported_reason = "not runnable"
+trust_unverified_sdist_deps = "false"
+""".lstrip(),
+        encoding="utf-8",
+    )
+    results_dir = tmp_path / "results"
+    monkeypatch.setattr(module, "SCENARIOS_DIR", scenarios_dir)
+    monkeypatch.setattr(module, "RESULTS_DIR", results_dir)
+    monkeypatch.setattr(module, "get_git_source_state", lambda: _CLEAN_SOURCE)
+
+    def fail_result_creation(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("result namespace creation was reached")
+
+    monkeypatch.setattr(
+        module,
+        "prepare_standard_result_namespace",
+        fail_result_creation,
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        module.main(["--commit", "run", "--toml", "quick"])
+
+    assert exc_info.value.code == 2
+    assert (
+        "other:other: trust_unverified_sdist_deps must be a boolean, got str"
+        in capsys.readouterr().err
+    )
+    assert not results_dir.exists()
+
+
 def test_strategy_sweep_is_only_a_matrix_forwarder(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -2646,6 +2744,59 @@ def test_standard_canary_and_profile_build_the_same_project_config() -> None:
     )
     assert standard_execution.config.constraints == ()
     assert standard_execution.constraint_strings == ["demo<2"]
+    assert "trust_unverified_sdist_deps" not in standard_execution.expected_input
+
+
+def test_standard_canary_and_profile_reject_non_boolean_sdist_trust() -> None:
+    standard = _harness("scenarios")
+    canary = _harness("canary")
+    profile = _harness("_profile_runner")
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        "trust_unverified_sdist_deps": "false",
+    }
+    host = _linux_host(standard)
+    message = "example: trust_unverified_sdist_deps must be a boolean"
+
+    with pytest.raises(TypeError, match=message):
+        _prepare_standard_scenario(standard, scenario, host)
+
+    with pytest.raises(TypeError, match=message):
+        canary._prepare_canary_execution(
+            scenario,
+            scenario_name="example",
+            resolution_override=None,
+            host=host,
+        )
+
+    with pytest.raises(TypeError, match=message):
+        profile.build_inputs("example", scenario, host=host)
+
+
+def test_sdist_trust_validation_precedes_host_admission() -> None:
+    canary = _harness("canary")
+    profile = _harness("_profile_runner")
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        "platform_system": "Windows",
+        "requires_matching_host": True,
+        "trust_unverified_sdist_deps": "false",
+    }
+    host = _linux_host(canary)
+    message = "example: trust_unverified_sdist_deps must be a boolean"
+
+    with pytest.raises(TypeError, match=message):
+        canary._prepare_canary_execution(
+            scenario,
+            scenario_name="example",
+            resolution_override=None,
+            host=host,
+        )
+
+    with pytest.raises(TypeError, match=message):
+        profile.build_inputs("example", scenario, host=host)
 
 
 def test_standard_canary_and_profile_prepare_the_same_resolver_inputs() -> None:

--- a/nab-python/tests/test_benchmark_strategy_matrix.py
+++ b/nab-python/tests/test_benchmark_strategy_matrix.py
@@ -243,6 +243,12 @@ def _runner_parity_scenario() -> dict[str, object]:
         "vcs_allowed_schemes": ["git+https"],
         "vcs_allowed_repos": ["https://example.test/project"],
         "vcs_require_pin": False,
+        "project_name": "Demo_Project",
+        "project_extras": ["All_Features", "Direct_Use"],
+        "optional_dependencies": {
+            "all.features": ["Project_Leaf>=2", "Second.Leaf"],
+            "DIRECT-use": ["Another_Leaf==1"],
+        },
     }
 
 
@@ -1466,6 +1472,161 @@ def test_parse_scenario_requirement_strings_rejects_empty_items(field: str) -> N
         match=rf"quick:empty-item: {field}\[1\] must be a non-empty string$",
     ):
         module.parse_scenario_requirement_strings("quick:empty-item", scenario)
+
+
+def test_parse_scenario_project_metadata_returns_fresh_nested_values() -> None:
+    module = _harness("benchmark_config")
+    project_extras = ["All_Features", "OpenAI"]
+    optional_dependencies = {
+        "all.features": ["Eval_Framework[OpenAI]"],
+        "open_ai": ["OpenAI_Client>=1.62,<2"],
+    }
+    scenario = {
+        "project_name": "Eval_Framework",
+        "project_extras": project_extras,
+        "optional_dependencies": optional_dependencies,
+    }
+    original = deepcopy(scenario)
+
+    parsed = module.parse_scenario_project_metadata(
+        "ecosystem:eval-framework", scenario
+    )
+
+    assert parsed.project_name == "Eval_Framework"
+    assert parsed.project_extras == ["All_Features", "OpenAI"]
+    assert list(parsed.optional_dependencies) == ["all.features", "open_ai"]
+    assert parsed.optional_dependencies == optional_dependencies
+
+    assert parsed.project_extras is not project_extras
+    assert parsed.optional_dependencies is not optional_dependencies
+    for extra, dependencies in optional_dependencies.items():
+        assert parsed.optional_dependencies[extra] is not dependencies
+
+    parsed.project_extras.reverse()
+    parsed.optional_dependencies["all.features"].clear()
+    assert scenario == original
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    [
+        {"project_name": "Eval_Framework"},
+        {"project_extras": ["All_Features", "OpenAI"]},
+        {
+            "optional_dependencies": {
+                "all.features": ["Eval_Framework[OpenAI]"],
+                "open_ai": ["OpenAI_Client>=1.62,<2"],
+            }
+        },
+        {
+            "project_extras": ["OpenAI", "All_Features"],
+            "optional_dependencies": {
+                "open_ai": ["OpenAI_Client>=1.62,<2"],
+                "all.features": ["Eval_Framework[OpenAI]"],
+            },
+        },
+    ],
+    ids=("name", "extras", "optional-dependencies", "extras-and-optional"),
+)
+def test_parse_scenario_project_metadata_accepts_partial_forms(
+    scenario: dict[str, object],
+) -> None:
+    module = _harness("benchmark_config")
+
+    parsed = module.parse_scenario_project_metadata(
+        "ecosystem:eval-framework", scenario
+    )
+
+    assert parsed.project_name == scenario.get("project_name")
+    assert parsed.project_extras == scenario.get("project_extras", [])
+    assert list(parsed.optional_dependencies) == list(
+        scenario.get("optional_dependencies", {})
+    )
+    assert parsed.optional_dependencies == scenario.get("optional_dependencies", {})
+
+
+@pytest.mark.parametrize(
+    ("scenario", "error", "message"),
+    [
+        (
+            {"project_name": False},
+            TypeError,
+            "quick:project: project_name must be a non-empty string, got bool",
+        ),
+        (
+            {"project_name": ""},
+            ValueError,
+            "quick:project: project_name must be a non-empty string",
+        ),
+        (
+            {"project_extras": "all"},
+            TypeError,
+            "quick:project: project_extras must be a list, got str",
+        ),
+        (
+            {"project_extras": ["all", 1]},
+            TypeError,
+            "quick:project: project_extras[1] must be a non-empty string, got int",
+        ),
+        (
+            {"project_extras": ["all", ""]},
+            ValueError,
+            "quick:project: project_extras[1] must be a non-empty string",
+        ),
+        (
+            {"optional_dependencies": ["demo"]},
+            TypeError,
+            "quick:project: optional_dependencies must be a table, got list",
+        ),
+        (
+            {"optional_dependencies": {"all": "demo"}},
+            TypeError,
+            "quick:project: optional_dependencies['all'] must be a list, got str",
+        ),
+        (
+            {"optional_dependencies": {"all": ["demo", 1]}},
+            TypeError,
+            (
+                "quick:project: optional_dependencies['all'][1] must be a "
+                "non-empty string, got int"
+            ),
+        ),
+        (
+            {"optional_dependencies": {"all": ["demo", ""]}},
+            ValueError,
+            (
+                "quick:project: optional_dependencies['all'][1] must be a "
+                "non-empty string"
+            ),
+        ),
+        (
+            {"optional_dependencies": {"": ["demo"]}},
+            ValueError,
+            "quick:project: optional_dependencies keys must be non-empty strings",
+        ),
+    ],
+    ids=(
+        "project-name-type",
+        "project-name-empty",
+        "project-extras-scalar",
+        "project-extras-member",
+        "project-extras-empty",
+        "optional-dependencies-array",
+        "optional-dependency-scalar",
+        "optional-dependency-member",
+        "optional-dependency-empty",
+        "optional-dependency-empty-key",
+    ),
+)
+def test_parse_scenario_project_metadata_rejects_malformed_values(
+    scenario: dict[str, object],
+    error: type[Exception],
+    message: str,
+) -> None:
+    module = _harness("benchmark_config")
+
+    with pytest.raises(error, match=re.escape(message)):
+        module.parse_scenario_project_metadata("quick:project", scenario)
 
 
 @pytest.mark.parametrize(
@@ -2954,6 +3115,33 @@ unsupported_reason = "not runnable"
 python_version = "3.11"
 requirements = []
 unsupported_reason = "not runnable"
+project_name = "demo-project"
+project_extras = ["all"]
+[other.optional_dependencies]
+all = "demo"
+""",
+            "other:other: optional_dependencies['all'] must be a list, got str",
+        ),
+        (
+            """
+[other]
+python_version = "3.11"
+requirements = []
+unsupported_reason = "not runnable"
+vcs_require_pin = "false"
+project_name = "demo-project"
+project_extras = ["all"]
+[other.optional_dependencies]
+all = "demo"
+""",
+            "other:other: vcs_require_pin must be a boolean, got str",
+        ),
+        (
+            """
+[other]
+python_version = "3.11"
+requirements = []
+unsupported_reason = "not runnable"
 vcs_require_pin = "false"
 """,
             "other:other: vcs_require_pin must be a boolean, got str",
@@ -3005,6 +3193,8 @@ vcs_allowed_repos = { "https://example.test/repo" = false }
     ids=(
         "sdist-trust",
         "requirements",
+        "project-metadata",
+        "vcs-before-project-metadata",
         "vcs-require-pin",
         "vcs-policy",
         "vcs-policy-table",
@@ -3135,10 +3325,13 @@ def test_standard_canary_and_profile_build_the_same_project_config() -> None:
     standard = _harness("scenarios")
     canary = _harness("canary")
     profile = _harness("_profile_runner")
+    scenario = _runner_parity_scenario()
+    original = deepcopy(scenario)
     standard_execution, canary_execution, profile_inputs = _prepare_runner_parity(
         standard,
         canary,
         profile,
+        scenario=scenario,
     )
 
     assert (
@@ -3146,12 +3339,112 @@ def test_standard_canary_and_profile_build_the_same_project_config() -> None:
     )
     assert standard_execution.config.constraints == ()
     assert standard_execution.constraint_strings == ["demo<2"]
+
     assert "trust_unverified_sdist_deps" not in standard_execution.expected_input
     assert standard_execution.expected_input["vcs_policy"] == "allow"
     assert standard_execution.expected_input["vcs_allowed_schemes"] == ["git+https"]
     assert standard_execution.expected_input["vcs_allowed_repos"] == [
         "https://example.test/project"
     ]
+    assert standard_execution.expected_input["project_name"] == "Demo_Project"
+    assert standard_execution.expected_input["project_extras"] == [
+        "All_Features",
+        "Direct_Use",
+    ]
+
+    assert standard_execution.expected_input["requirements"] == [
+        "demo[feature]>=1",
+        "Project_Leaf>=2",
+        "Second.Leaf",
+        "Another_Leaf==1",
+    ]
+    assert set(canary_execution.requirements) == {
+        "another-leaf",
+        "demo",
+        "demo[feature]",
+        "project-leaf",
+        "second-leaf",
+    }
+    assert set(profile_inputs["requirements"]) == {
+        "another-leaf",
+        "demo",
+        "demo[feature]",
+        "project-leaf",
+        "second-leaf",
+    }
+
+    assert scenario == original
+
+
+@pytest.mark.parametrize(
+    ("vcs_settings", "message"),
+    [
+        (
+            {},
+            "example: optional_dependencies['all'] must be a list, got str",
+        ),
+        (
+            {"vcs_require_pin": "false"},
+            "example: vcs_require_pin must be a boolean, got str",
+        ),
+    ],
+    ids=("project-metadata", "vcs-precedence"),
+)
+def test_all_runners_validate_project_metadata_in_schema_order(
+    vcs_settings: dict[str, object],
+    message: str,
+) -> None:
+    standard = _harness("scenarios")
+    canary = _harness("canary")
+    profile = _harness("_profile_runner")
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        "project_name": "demo-project",
+        "project_extras": ["all"],
+        "optional_dependencies": {"all": "demo"},
+        **vcs_settings,
+    }
+    host = _linux_host(standard)
+
+    with pytest.raises(TypeError, match=re.escape(message)):
+        _prepare_standard_scenario(standard, scenario, host)
+
+    with pytest.raises(TypeError, match=re.escape(message)):
+        canary._prepare_canary_execution(
+            scenario,
+            scenario_name="example",
+            resolution_override=None,
+            host=host,
+        )
+
+    with pytest.raises(TypeError, match=re.escape(message)):
+        profile.build_inputs("example", scenario, host=host)
+
+
+def test_profile_project_metadata_validation_precedes_host_admission() -> None:
+    profile = _harness("_profile_runner")
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        "project_name": "demo-project",
+        "project_extras": ["all"],
+        "optional_dependencies": {"all": "demo"},
+    }
+
+    class UnusedHost:
+        """Fail if project-metadata validation reaches target admission."""
+
+        def target_for(self, *_args: object, **_kwargs: object) -> object:
+            pytest.fail("project-metadata validation reached host admission")
+
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "example: optional_dependencies['all'] must be a list, got str"
+        ),
+    ):
+        profile.build_inputs("example", scenario, host=UnusedHost())
 
 
 @pytest.mark.parametrize(

--- a/nab-python/tests/test_benchmark_strategy_matrix.py
+++ b/nab-python/tests/test_benchmark_strategy_matrix.py
@@ -1199,6 +1199,88 @@ def test_parse_trust_unverified_sdist_deps_rejects_other_types(
         )
 
 
+def test_parse_scenario_requirement_strings_returns_fresh_unchanged_lists() -> None:
+    module = _harness("benchmark_config")
+    requirements = ["Z_pkg", " demo >= 1 "]
+    constraints = ["demo!=2", "Other===local"]
+    scenario = {"requirements": requirements, "constraints": constraints}
+
+    parsed = module.parse_scenario_requirement_strings("quick:example", scenario)
+
+    assert parsed.requirements == requirements
+    assert parsed.constraints == constraints
+    assert parsed.requirements is not requirements
+    assert parsed.constraints is not constraints
+
+    parsed.requirements.append("new-root")
+    parsed.constraints.clear()
+    assert scenario == {
+        "requirements": ["Z_pkg", " demo >= 1 "],
+        "constraints": ["demo!=2", "Other===local"],
+    }
+
+
+def test_parse_scenario_requirement_strings_accepts_empty_lists() -> None:
+    module = _harness("benchmark_config")
+    scenario: dict[str, object] = {"requirements": [], "constraints": []}
+
+    parsed = module.parse_scenario_requirement_strings("quick:empty", scenario)
+
+    assert parsed.requirements == []
+    assert parsed.constraints == []
+    assert parsed.requirements is not scenario["requirements"]
+    assert parsed.constraints is not scenario["constraints"]
+
+
+def test_parse_scenario_requirement_strings_requires_requirements() -> None:
+    module = _harness("benchmark_config")
+
+    with pytest.raises(
+        ValueError,
+        match="quick:missing: missing required field 'requirements'",
+    ):
+        module.parse_scenario_requirement_strings("quick:missing", {})
+
+
+@pytest.mark.parametrize("field", ["requirements", "constraints"])
+def test_parse_scenario_requirement_strings_rejects_scalar_fields(field: str) -> None:
+    module = _harness("benchmark_config")
+    scenario: dict[str, object] = {"requirements": []}
+    scenario[field] = "demo"
+
+    with pytest.raises(
+        TypeError,
+        match=rf"quick:scalar: {field} must be a list, got str",
+    ):
+        module.parse_scenario_requirement_strings("quick:scalar", scenario)
+
+
+@pytest.mark.parametrize("field", ["requirements", "constraints"])
+def test_parse_scenario_requirement_strings_rejects_mixed_fields(field: str) -> None:
+    module = _harness("benchmark_config")
+    scenario: dict[str, object] = {"requirements": []}
+    scenario[field] = ["demo", 1]
+
+    with pytest.raises(
+        TypeError,
+        match=rf"quick:mixed: {field}\[1\] must be a non-empty string, got int",
+    ):
+        module.parse_scenario_requirement_strings("quick:mixed", scenario)
+
+
+@pytest.mark.parametrize("field", ["requirements", "constraints"])
+def test_parse_scenario_requirement_strings_rejects_empty_items(field: str) -> None:
+    module = _harness("benchmark_config")
+    scenario: dict[str, object] = {"requirements": []}
+    scenario[field] = ["demo", ""]
+
+    with pytest.raises(
+        ValueError,
+        match=rf"quick:empty-item: {field}\[1\] must be a non-empty string$",
+    ):
+        module.parse_scenario_requirement_strings("quick:empty-item", scenario)
+
+
 @pytest.mark.parametrize(
     ("routes", "message"),
     [
@@ -2657,22 +2739,43 @@ def test_selector_errors_are_actionable(
     assert not (tmp_path / "results").exists()
 
 
-def test_unselected_unsupported_sdist_trust_fails_before_result_creation(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    module = _harness("scenarios")
-    scenarios_dir = tmp_path / "scenarios"
-    _write_corpus(scenarios_dir)
-    (scenarios_dir / "other.toml").write_text(
-        """
+@pytest.mark.parametrize(
+    ("invalid_toml", "message"),
+    [
+        (
+            """
 [other]
 python_version = "3.11"
 requirements = []
 unsupported_reason = "not runnable"
 trust_unverified_sdist_deps = "false"
-""".lstrip(),
+""",
+            "other:other: trust_unverified_sdist_deps must be a boolean, got str",
+        ),
+        (
+            """
+[other]
+python_version = "3.11"
+requirements = "demo"
+unsupported_reason = "not runnable"
+""",
+            "other:other: requirements must be a list, got str",
+        ),
+    ],
+    ids=("sdist-trust", "requirements"),
+)
+def test_unselected_unsupported_definition_fails_before_result_creation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    invalid_toml: str,
+    message: str,
+) -> None:
+    module = _harness("scenarios")
+    scenarios_dir = tmp_path / "scenarios"
+    _write_corpus(scenarios_dir)
+    (scenarios_dir / "other.toml").write_text(
+        invalid_toml.lstrip(),
         encoding="utf-8",
     )
     results_dir = tmp_path / "results"
@@ -2693,10 +2796,7 @@ trust_unverified_sdist_deps = "false"
         module.main(["--commit", "run", "--toml", "quick"])
 
     assert exc_info.value.code == 2
-    assert (
-        "other:other: trust_unverified_sdist_deps must be a boolean, got str"
-        in capsys.readouterr().err
-    )
+    assert message in capsys.readouterr().err
     assert not results_dir.exists()
 
 
@@ -2772,6 +2872,66 @@ def test_standard_canary_and_profile_reject_non_boolean_sdist_trust() -> None:
 
     with pytest.raises(TypeError, match=message):
         profile.build_inputs("example", scenario, host=host)
+
+
+@pytest.mark.parametrize("field", ["requirements", "constraints"])
+def test_standard_direct_preparation_validates_requirement_lists(field: str) -> None:
+    standard = _harness("scenarios")
+    scenario: dict[str, object] = {
+        "python_version": "3.11",
+        "requirements": [],
+    }
+    scenario[field] = "demo"
+    host = _linux_host(standard)
+
+    with pytest.raises(
+        TypeError,
+        match=rf"example: {field} must be a list, got str",
+    ):
+        _prepare_standard_scenario(standard, scenario, host)
+
+
+@pytest.mark.parametrize("field", ["requirements", "constraints"])
+def test_canary_direct_preparation_validates_requirement_lists(field: str) -> None:
+    canary = _harness("canary")
+    scenario: dict[str, object] = {
+        "python_version": "3.11",
+        "requirements": [],
+    }
+    scenario[field] = "demo"
+    host = _linux_host(canary)
+
+    with pytest.raises(
+        TypeError,
+        match=rf"example: {field} must be a list, got str",
+    ):
+        canary._prepare_canary_execution(
+            scenario,
+            scenario_name="example",
+            resolution_override=None,
+            host=host,
+        )
+
+
+@pytest.mark.parametrize("field", ["requirements", "constraints"])
+def test_profile_build_inputs_validates_requirement_lists_before_host_admission(
+    field: str,
+) -> None:
+    profile = _harness("_profile_runner")
+    scenario: dict[str, object] = {
+        "python_version": "3.11",
+        "requirements": [],
+    }
+    scenario[field] = "demo"
+    host = MagicMock()
+
+    with pytest.raises(
+        TypeError,
+        match=rf"example: {field} must be a list, got str",
+    ):
+        profile.build_inputs("example", scenario, host=host)
+
+    host.target_for.assert_not_called()
 
 
 def test_sdist_trust_validation_precedes_host_admission() -> None:

--- a/nab-python/tests/test_benchmark_strategy_matrix.py
+++ b/nab-python/tests/test_benchmark_strategy_matrix.py
@@ -24,6 +24,7 @@ from nab_index.serialization import SimpleSerialization
 from nab_python._testing.coordinator_fake import make_coordinator
 from nab_python._vendor.packaging.tags import Tag
 from nab_python._vendor.packaging.version import Version
+from nab_python.fetch import IndexRoute
 from nab_python.target import ResolveTarget
 
 pytestmark = pytest.mark.benchmark
@@ -241,7 +242,10 @@ def _runner_parity_scenario() -> dict[str, object]:
                 "serialization": "html",
             },
         ],
-        "index_routes": [{"name": "demo", "index": "private"}],
+        "index_routes": [
+            {"name": "Demo_Pkg", "index": "private"},
+            {"name": "Other.Package", "index": "private"},
+        ],
         "build_packages": ["demo"],
         "resolution": "lowest-direct",
         "trust_unverified_sdist_deps": False,
@@ -1894,6 +1898,289 @@ def test_parse_scenario_indexes_rejects_malformed_values(
 
 
 @pytest.mark.parametrize(
+    "scenario", [{}, {"index_routes": []}], ids=("missing", "empty")
+)
+def test_parse_scenario_index_routes_returns_a_fresh_empty_list(
+    scenario: dict[str, object],
+) -> None:
+    module = _harness("benchmark_config")
+
+    first = module.parse_scenario_index_routes(
+        "quick:routes",
+        scenario,
+        list(module.DEFAULT_INDEXES),
+    )
+    second = module.parse_scenario_index_routes(
+        "quick:routes",
+        scenario,
+        list(module.DEFAULT_INDEXES),
+    )
+
+    assert first == second == []
+    assert first is not second
+
+
+def test_parse_scenario_index_routes_preserves_raw_names_and_order() -> None:
+    module = _harness("benchmark_config")
+    indexes = [
+        IndexConfig("private", "https://one.example/simple"),
+        IndexConfig("Private", "https://two.example/simple"),
+    ]
+    scenario = {
+        "index_routes": [
+            {"name": "Demo_Pkg", "index": "Private"},
+            {"name": "Second.Package", "index": "private"},
+        ]
+    }
+    original = deepcopy(scenario)
+
+    routes = module.parse_scenario_index_routes("quick:routes", scenario, indexes)
+
+    assert routes == [
+        IndexRoute("Demo_Pkg", "Private"),
+        IndexRoute("Second.Package", "private"),
+    ]
+    assert scenario == original
+
+
+@pytest.mark.parametrize(
+    ("routes", "error", "message"),
+    [
+        (
+            "private",
+            TypeError,
+            "quick:routes: index_routes must be an array of tables, got str",
+        ),
+        (
+            None,
+            TypeError,
+            "quick:routes: index_routes must be an array of tables, got NoneType",
+        ),
+        (
+            ["private"],
+            TypeError,
+            "quick:routes: index_routes[0] must be a table, got str",
+        ),
+        (
+            [{}],
+            ValueError,
+            "quick:routes: index_routes[0] missing required key 'name'",
+        ),
+        (
+            [{"zulu": True, "alpha": False}],
+            ValueError,
+            (
+                "quick:routes: unknown index_routes[0] keys: ['alpha', 'zulu']; "
+                "expected ['index', 'name']"
+            ),
+        ),
+        (
+            [{"name": "demo", "extra": True}],
+            ValueError,
+            (
+                "quick:routes: unknown index_routes[0] keys: ['extra']; "
+                "expected ['index', 'name']"
+            ),
+        ),
+        (
+            [{"name": "demo", "index": "pypi", "extra": True}],
+            ValueError,
+            (
+                "quick:routes: unknown index_routes[0] keys: ['extra']; "
+                "expected ['index', 'name']"
+            ),
+        ),
+        (
+            [{"index": "private"}],
+            ValueError,
+            "quick:routes: index_routes[0] missing required key 'name'",
+        ),
+        (
+            [{"name": "demo"}],
+            ValueError,
+            "quick:routes: index_routes[0] missing required key 'index'",
+        ),
+        (
+            [{"name": False, "index": "pypi"}],
+            TypeError,
+            "quick:routes: index_routes[0].name must be a string, got bool",
+        ),
+        (
+            [{"name": "demo", "index": 123}],
+            TypeError,
+            "quick:routes: index_routes[0].index must be a string, got int",
+        ),
+    ],
+    ids=(
+        "array",
+        "null",
+        "entry",
+        "missing-name-and-index",
+        "unknown-before-missing",
+        "unknown-before-missing-index",
+        "unknown-with-required-keys",
+        "missing-name",
+        "missing-index",
+        "name-type",
+        "index-type",
+    ),
+)
+def test_parse_scenario_index_routes_rejects_malformed_values(
+    routes: object,
+    error: type[Exception],
+    message: str,
+) -> None:
+    module = _harness("benchmark_config")
+
+    with pytest.raises(error, match=re.escape(message)):
+        module.parse_scenario_index_routes(
+            "quick:routes",
+            {"index_routes": routes},
+            list(module.DEFAULT_INDEXES),
+        )
+
+
+def test_parse_scenario_index_routes_does_not_coerce_index_references() -> None:
+    module = _harness("benchmark_config")
+    scenario = {"index_routes": [{"name": "demo", "index": 123}]}
+    indexes = [IndexConfig("123", "https://example.test/simple")]
+    message = "quick:routes: index_routes[0].index must be a string, got int"
+
+    with pytest.raises(TypeError, match=re.escape(message)):
+        module.parse_scenario_index_routes("quick:routes", scenario, indexes)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "",
+        " ",
+        "demo>=1",
+        "demo[extra]",
+        "demo; python_version < '3.12'",
+        "demo @ https://example.test/demo.whl",
+    ],
+    ids=("empty", "whitespace", "specifier", "extra", "marker", "url"),
+)
+def test_parse_scenario_index_routes_rejects_non_package_names(name: str) -> None:
+    module = _harness("benchmark_config")
+    message = (
+        "quick:routes: index_routes[0].name must be a valid distribution name, "
+        f"got {name!r}"
+    )
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        module.parse_scenario_index_routes(
+            "quick:routes",
+            {"index_routes": [{"name": name, "index": "pypi"}]},
+            list(module.DEFAULT_INDEXES),
+        )
+
+
+@pytest.mark.parametrize(
+    ("routes", "message"),
+    [
+        (
+            [
+                {"name": "demo", "index": "pypi"},
+                {"name": "demo", "index": "pypi"},
+            ],
+            "quick:routes: duplicate index route for 'demo'",
+        ),
+        (
+            [
+                {"name": "Demo_Pkg", "index": "pypi"},
+                {"name": "demo-pkg", "index": "pypi"},
+            ],
+            "quick:routes: duplicate index route for 'demo-pkg'",
+        ),
+        (
+            [
+                {"name": "Bravo_Pkg", "index": "pypi"},
+                {"name": "Alpha.Pkg", "index": "pypi"},
+                {"name": "bravo-pkg", "index": "pypi"},
+                {"name": "alpha-pkg", "index": "pypi"},
+            ],
+            "quick:routes: duplicate index route for 'bravo-pkg'",
+        ),
+        (
+            [{"name": "demo", "index": "missing"}],
+            (
+                "quick:routes: index route for 'demo' names undeclared index "
+                "'missing'; declared indexes are ['Private', 'pypi']"
+            ),
+        ),
+        (
+            [{"name": "demo", "index": "private"}],
+            (
+                "quick:routes: index route for 'demo' names undeclared index "
+                "'private'; declared indexes are ['Private', 'pypi']"
+            ),
+        ),
+        (
+            [
+                {"name": "demo", "index": "missing"},
+                {"name": "demo", "index": "other-missing"},
+            ],
+            "quick:routes: duplicate index route for 'demo'",
+        ),
+    ],
+    ids=(
+        "exact-duplicate",
+        "canonical-duplicate",
+        "first-canonical-duplicate",
+        "undeclared-index",
+        "case-sensitive-index",
+        "duplicate-before-index-reference",
+    ),
+)
+def test_parse_scenario_index_routes_rejects_invalid_relationships(
+    routes: list[dict[str, object]],
+    message: str,
+) -> None:
+    module = _harness("benchmark_config")
+    indexes = [
+        IndexConfig("pypi", "https://pypi.org/simple/"),
+        IndexConfig("Private", "https://example.test/simple"),
+    ]
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        module.parse_scenario_index_routes(
+            "quick:routes",
+            {"index_routes": routes},
+            indexes,
+        )
+
+
+@pytest.mark.parametrize(
+    "earlier_routes",
+    [
+        [
+            {"name": "demo", "index": "pypi"},
+            {"name": "demo", "index": "pypi"},
+        ],
+        [{"name": "demo", "index": "missing"}],
+    ],
+    ids=("duplicate", "undeclared-index"),
+)
+def test_parse_scenario_index_routes_parses_every_entry_before_relationships(
+    earlier_routes: list[dict[str, object]],
+) -> None:
+    module = _harness("benchmark_config")
+    routes = [*earlier_routes, {"name": "later", "index": 123}]
+    message = (
+        f"quick:routes: index_routes[{len(routes) - 1}].index must be a string, got int"
+    )
+
+    with pytest.raises(TypeError, match=re.escape(message)):
+        module.parse_scenario_index_routes(
+            "quick:routes",
+            {"index_routes": routes},
+            list(module.DEFAULT_INDEXES),
+        )
+
+
+@pytest.mark.parametrize(
     ("routes", "message"),
     [
         (
@@ -3459,6 +3746,16 @@ indexes = "private"
 python_version = "3.11"
 requirements = []
 unsupported_reason = "not runnable"
+index_routes = "private"
+""",
+            "other:other: index_routes must be an array of tables, got str",
+        ),
+        (
+            """
+[other]
+python_version = "3.11"
+requirements = []
+unsupported_reason = "not runnable"
 indexes = "private"
 project_name = "demo-project"
 project_extras = ["all"]
@@ -3488,6 +3785,7 @@ vcs_allowed_repos = { "https://example.test/repo" = false }
         "vcs-policy-table",
         "vcs-scheme-table",
         "indexes",
+        "index-routes",
         "project-before-indexes",
         "vcs-repo-table",
     ),
@@ -3589,8 +3887,20 @@ def test_profile_runner_accepts_an_explicit_strategy() -> None:
             "private",
             "example: indexes must be an array of tables, got str",
         ),
+        (
+            "index_routes",
+            "private",
+            "example: index_routes must be an array of tables, got str",
+        ),
     ],
-    ids=("pin", "policy", "scheme-table", "repo-table", "indexes"),
+    ids=(
+        "pin",
+        "policy",
+        "scheme-table",
+        "repo-table",
+        "indexes",
+        "index-routes",
+    ),
 )
 def test_profile_main_validates_schema_before_host_capture(
     monkeypatch: pytest.MonkeyPatch,
@@ -3653,9 +3963,27 @@ def test_standard_canary_and_profile_build_the_same_project_config() -> None:
             "serialization": "html",
         }
     ]
+    assert standard_execution.expected_input["index_routes"] == [
+        {"name": "Demo_Pkg", "index": "private"},
+        {"name": "Other.Package", "index": "private"},
+    ]
     assert (
         standard_execution.config.indexes[0].serialization is SimpleSerialization.HTML
     )
+    assert standard.index_routes_from_config(standard_execution.config) == [
+        IndexRoute("demo-pkg", "private"),
+        IndexRoute("other-package", "private"),
+    ]
+
+    identity = canary.canary_v2_identity(
+        canary.CanaryCase("quick:example", canary.ResolutionStrategy.LOWEST_DIRECT),
+        scenario,
+        canary.ResolutionStrategy.LOWEST_DIRECT,
+    )
+    assert identity.definition["index_routes"] == [
+        {"name": "Demo_Pkg", "index": "private"},
+        {"name": "Other.Package", "index": "private"},
+    ]
 
     assert standard_execution.expected_input["requirements"] == [
         "demo[feature]>=1",
@@ -3736,6 +4064,7 @@ def test_all_runners_reject_malformed_indexes() -> None:
         "python_version": "3.11",
         "requirements": [],
         "indexes": [{"name": False, "url": 123}],
+        "index_routes": "private",
     }
     host = _linux_host(standard)
     message = "example: indexes[0] name and url must be strings"
@@ -3753,6 +4082,114 @@ def test_all_runners_reject_malformed_indexes() -> None:
 
     with pytest.raises(TypeError, match=re.escape(message)):
         profile.build_inputs("example", scenario, host=host)
+
+
+def test_all_runners_reject_malformed_index_routes() -> None:
+    standard = _harness("scenarios")
+    canary = _harness("canary")
+    profile = _harness("_profile_runner")
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        "indexes": [{"name": "private", "url": "https://example.test/simple"}],
+        "index_routes": [{"name": "demo>=1", "index": "private"}],
+    }
+    host = _linux_host(standard)
+    message = (
+        "example: index_routes[0].name must be a valid distribution name, got 'demo>=1'"
+    )
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        _prepare_standard_scenario(standard, scenario, host)
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        canary._prepare_canary_execution(
+            scenario,
+            scenario_name="example",
+            resolution_override=None,
+            host=host,
+        )
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        profile.build_inputs("example", scenario, host=host)
+
+
+def test_all_runners_validate_index_routes_before_build_packages() -> None:
+    standard = _harness("scenarios")
+    canary = _harness("canary")
+    profile = _harness("_profile_runner")
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        "index_routes": [{"name": "demo", "index": 123}],
+        "build_packages": "demo",
+    }
+    host = _linux_host(standard)
+    message = "example: index_routes[0].index must be a string, got int"
+
+    with pytest.raises(TypeError, match=re.escape(message)):
+        _prepare_standard_scenario(standard, scenario, host)
+
+    with pytest.raises(TypeError, match=re.escape(message)):
+        canary._prepare_canary_execution(
+            scenario,
+            scenario_name="example",
+            resolution_override=None,
+            host=host,
+        )
+
+    with pytest.raises(TypeError, match=re.escape(message)):
+        profile.build_inputs("example", scenario, host=host)
+
+
+@pytest.mark.parametrize(
+    ("routes", "message"),
+    [
+        (
+            [
+                {"name": "Demo_Pkg", "index": "pypi"},
+                {"name": "demo-pkg", "index": "pypi"},
+            ],
+            "example: duplicate index route for 'demo-pkg'",
+        ),
+        (
+            [{"name": "demo", "index": "missing"}],
+            (
+                "example: index route for 'demo' names undeclared index 'missing'; "
+                "declared indexes are ['pypi']"
+            ),
+        ),
+    ],
+    ids=("duplicate", "undeclared-index"),
+)
+def test_canary_and_profile_validate_index_route_relationships_before_host_admission(
+    routes: list[dict[str, str]],
+    message: str,
+) -> None:
+    canary = _harness("canary")
+    profile = _harness("_profile_runner")
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        "index_routes": routes,
+    }
+
+    class UnusedHost:
+        """Fail if index-route validation reaches target admission."""
+
+        def target_for(self, *_args: object, **_kwargs: object) -> object:
+            pytest.fail("index-route validation reached host admission")
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        canary._prepare_canary_execution(
+            scenario,
+            scenario_name="example",
+            resolution_override=None,
+            host=UnusedHost(),
+        )
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        profile.build_inputs("example", scenario, host=UnusedHost())
 
 
 def test_profile_project_metadata_validation_precedes_host_admission() -> None:

--- a/nab-python/tests/test_benchmark_strategy_matrix.py
+++ b/nab-python/tests/test_benchmark_strategy_matrix.py
@@ -270,9 +270,11 @@ def _prepare_runner_parity(
     standard: ModuleType,
     canary: ModuleType,
     profile: ModuleType,
+    *,
+    scenario: dict[str, object] | None = None,
 ) -> tuple[object, object, dict[str, object]]:
     """Prepare equivalent inputs through the three benchmark entry points."""
-    scenario = _runner_parity_scenario()
+    scenario = _runner_parity_scenario() if scenario is None else scenario
     host = _linux_host(standard)
     standard_execution = _prepare_standard_scenario(standard, scenario, host)
     canary_preparation = canary._prepare_canary_execution(
@@ -1196,6 +1198,53 @@ def test_parse_trust_unverified_sdist_deps_rejects_other_types(
         module.parse_trust_unverified_sdist_deps(
             "example",
             {"trust_unverified_sdist_deps": invalid},
+        )
+
+
+@pytest.mark.parametrize(
+    ("scenario", "expected"),
+    [
+        ({}, True),
+        ({"vcs_require_pin": True}, True),
+        ({"vcs_require_pin": False}, False),
+    ],
+    ids=("implicit", "required", "optional"),
+)
+def test_parse_vcs_require_pin_accepts_exact_booleans(
+    scenario: dict[str, object],
+    expected: bool,
+) -> None:
+    module = _harness("benchmark_config")
+    original = dict(scenario)
+
+    assert module.parse_vcs_require_pin("example", scenario) is expected
+    assert scenario == original
+
+
+@pytest.mark.parametrize(
+    ("invalid", "type_name"),
+    [
+        (0, "int"),
+        (1, "int"),
+        (0.0, "float"),
+        ("false", "str"),
+        ([False], "list"),
+        ({"value": False}, "dict"),
+        (None, "NoneType"),
+    ],
+    ids=("zero", "one", "float", "string", "list", "table", "none"),
+)
+def test_parse_vcs_require_pin_rejects_other_types(
+    invalid: object,
+    type_name: str,
+) -> None:
+    module = _harness("benchmark_config")
+    message = f"example: vcs_require_pin must be a boolean, got {type_name}"
+
+    with pytest.raises(TypeError, match=message):
+        module.parse_vcs_require_pin(
+            "example",
+            {"vcs_require_pin": invalid},
         )
 
 
@@ -2761,10 +2810,20 @@ unsupported_reason = "not runnable"
 """,
             "other:other: requirements must be a list, got str",
         ),
+        (
+            """
+[other]
+python_version = "3.11"
+requirements = []
+unsupported_reason = "not runnable"
+vcs_require_pin = "false"
+""",
+            "other:other: vcs_require_pin must be a boolean, got str",
+        ),
     ],
-    ids=("sdist-trust", "requirements"),
+    ids=("sdist-trust", "requirements", "vcs-require-pin"),
 )
-def test_unselected_unsupported_definition_fails_before_result_creation(
+def test_unselected_unsupported_definition_fails_before_host_capture_and_result_creation(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -2783,9 +2842,13 @@ def test_unselected_unsupported_definition_fails_before_result_creation(
     monkeypatch.setattr(module, "RESULTS_DIR", results_dir)
     monkeypatch.setattr(module, "get_git_source_state", lambda: _CLEAN_SOURCE)
 
+    def fail_host(*_args: object, **_kwargs: object) -> object:
+        pytest.fail("scenario validation reached host capture")
+
     def fail_result_creation(*_args: object, **_kwargs: object) -> None:
         raise AssertionError("result namespace creation was reached")
 
+    monkeypatch.setattr(module.BenchmarkHost, "current", classmethod(fail_host))
     monkeypatch.setattr(
         module,
         "prepare_standard_result_namespace",
@@ -2829,6 +2892,30 @@ def test_profile_runner_accepts_an_explicit_strategy() -> None:
     assert lowest["config"].resolution is module.sc.ResolutionStrategy.LOWEST
 
 
+def test_profile_main_validates_vcs_pin_before_host_capture(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness("_profile_runner")
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        "vcs_require_pin": "false",
+    }
+    monkeypatch.setattr(module, "find_scenario", lambda _spec: ("example", scenario))
+    monkeypatch.setattr(module.sys, "argv", ["_profile_runner.py", "example"])
+
+    def fail_host(*_args: object, **_kwargs: object) -> object:
+        pytest.fail("VCS pin validation reached host capture")
+
+    monkeypatch.setattr(module.sc.BenchmarkHost, "current", classmethod(fail_host))
+
+    with pytest.raises(
+        TypeError,
+        match="example: vcs_require_pin must be a boolean, got str",
+    ):
+        module.main()
+
+
 def test_standard_canary_and_profile_build_the_same_project_config() -> None:
     standard = _harness("scenarios")
     canary = _harness("canary")
@@ -2847,14 +2934,51 @@ def test_standard_canary_and_profile_build_the_same_project_config() -> None:
     assert "trust_unverified_sdist_deps" not in standard_execution.expected_input
 
 
-def test_standard_canary_and_profile_reject_non_boolean_sdist_trust() -> None:
+@pytest.mark.parametrize(
+    ("vcs_setting", "expected"),
+    [
+        ({}, True),
+        ({"vcs_require_pin": True}, True),
+        ({"vcs_require_pin": False}, False),
+    ],
+    ids=("implicit", "required", "optional"),
+)
+def test_standard_canary_and_profile_use_valid_vcs_pin_settings(
+    vcs_setting: dict[str, object],
+    expected: bool,
+) -> None:
     standard = _harness("scenarios")
     canary = _harness("canary")
     profile = _harness("_profile_runner")
     scenario = {
         "python_version": "3.11",
         "requirements": [],
+        **vcs_setting,
+    }
+    original = dict(scenario)
+
+    standard_execution, canary_execution, profile_inputs = _prepare_runner_parity(
+        standard,
+        canary,
+        profile,
+        scenario=scenario,
+    )
+
+    assert standard_execution.config.vcs.require_pin is expected
+    assert canary_execution.config.vcs.require_pin is expected
+    assert profile_inputs["config"].vcs.require_pin is expected
+    assert scenario == original
+
+
+def test_sdist_trust_validation_precedes_requirement_and_vcs_validation() -> None:
+    standard = _harness("scenarios")
+    canary = _harness("canary")
+    profile = _harness("_profile_runner")
+    scenario = {
+        "python_version": "3.11",
+        "requirements": "demo",
         "trust_unverified_sdist_deps": "false",
+        "vcs_require_pin": "false",
     }
     host = _linux_host(standard)
     message = "example: trust_unverified_sdist_deps must be a boolean"
@@ -2874,12 +2998,48 @@ def test_standard_canary_and_profile_reject_non_boolean_sdist_trust() -> None:
         profile.build_inputs("example", scenario, host=host)
 
 
+def test_standard_canary_and_profile_reject_non_boolean_vcs_require_pin() -> None:
+    standard = _harness("scenarios")
+    canary = _harness("canary")
+    profile = _harness("_profile_runner")
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        "vcs_require_pin": "false",
+    }
+    standard_host = _linux_host(standard)
+    message = "example: vcs_require_pin must be a boolean, got str"
+
+    class UnusedHost:
+        """Fail if schema validation reaches target admission."""
+
+        def target_for(self, *_args: object, **_kwargs: object) -> object:
+            pytest.fail("VCS pin validation reached host admission")
+
+    with pytest.raises(TypeError, match=message):
+        _prepare_standard_scenario(standard, scenario, standard_host)
+
+    with pytest.raises(TypeError, match=message):
+        canary._prepare_canary_execution(
+            scenario,
+            scenario_name="example",
+            resolution_override=None,
+            host=UnusedHost(),
+        )
+
+    with pytest.raises(TypeError, match=message):
+        profile.build_inputs("example", scenario, host=UnusedHost())
+
+
 @pytest.mark.parametrize("field", ["requirements", "constraints"])
-def test_standard_direct_preparation_validates_requirement_lists(field: str) -> None:
+def test_standard_requirement_list_validation_precedes_vcs_pin_validation(
+    field: str,
+) -> None:
     standard = _harness("scenarios")
     scenario: dict[str, object] = {
         "python_version": "3.11",
         "requirements": [],
+        "vcs_require_pin": "false",
     }
     scenario[field] = "demo"
     host = _linux_host(standard)
@@ -2892,11 +3052,14 @@ def test_standard_direct_preparation_validates_requirement_lists(field: str) -> 
 
 
 @pytest.mark.parametrize("field", ["requirements", "constraints"])
-def test_canary_direct_preparation_validates_requirement_lists(field: str) -> None:
+def test_canary_requirement_list_validation_precedes_vcs_pin_validation(
+    field: str,
+) -> None:
     canary = _harness("canary")
     scenario: dict[str, object] = {
         "python_version": "3.11",
         "requirements": [],
+        "vcs_require_pin": "false",
     }
     scenario[field] = "demo"
     host = _linux_host(canary)
@@ -2914,13 +3077,14 @@ def test_canary_direct_preparation_validates_requirement_lists(field: str) -> No
 
 
 @pytest.mark.parametrize("field", ["requirements", "constraints"])
-def test_profile_build_inputs_validates_requirement_lists_before_host_admission(
+def test_profile_requirement_list_validation_precedes_vcs_pin_validation_and_host_admission(
     field: str,
 ) -> None:
     profile = _harness("_profile_runner")
     scenario: dict[str, object] = {
         "python_version": "3.11",
         "requirements": [],
+        "vcs_require_pin": "false",
     }
     scenario[field] = "demo"
     host = MagicMock()


### PR DESCRIPTION
A scenario with `build_packages = ["demo"]` gives that package a `BUILD_REMOTE` override while the benchmark-wide policy stays `never`. If the selected sdist needs dynamic metadata, the old provider reaches the build path with no `NabProjectConfig` for the build environment.

Standard, canary and profile runs now build one project config per prepared run and use it to construct both the fetch coordinator and the provider:

- constraints stay on the resolver call
- duplicate package routes, and routes to undeclared indexes, are rejected while the config is built
- `_extend_constraints_to_proxies` becomes `constraints_with_root_extra_proxies`, returning the extended mapping instead of mutating in place, so a runner can build it the same way `_resolve_one_target` does
