### PR TITLE
stop dropping unreadable flat wheelhouse entries on Python 3.14

### DIFF
--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -20,6 +20,7 @@ multi-index router can treat local and remote indexes uniformly.
 
 from __future__ import annotations
 
+import errno
 import lzma
 import re
 import stat
@@ -179,17 +180,30 @@ def _read_served_bytes(path: Path, kind: str) -> bytes:
         raise UnreadableLocalIndexError(msg) from exc
 
 
-def _stat_mode(path: Path) -> int | None:
-    """Return ``path``'s ``st_mode``, or ``None`` when it does not exist.
+# The errnos pathlib itself treats as "no such file".
+_ABSENT_ERRNOS = frozenset({errno.ENOENT, errno.ENOTDIR, errno.EBADF, errno.ELOOP})
 
-    Any other failure raises. From Python 3.14 ``Path.exists`` and
-    ``Path.is_file`` swallow every :class:`OSError`, so an unreadable path
-    would read as absent.
+# Windows: drive not ready, invalid name, symlink loop.
+_ABSENT_WINERRORS = frozenset({21, 123, 1921})
+
+
+def _stat_mode(path: Path) -> int | None:
+    """Return ``path``'s ``st_mode``, or ``None`` when nothing is there.
+
+    Only an error meaning the path is absent gives ``None``, so a broken entry
+    skips instead of failing the listing it sits in. Anything else raises: from
+    Python 3.14 ``Path.exists`` and ``Path.is_file`` swallow every
+    :class:`OSError`, so an unreadable path would read as absent.
     """
     try:
         return path.stat().st_mode
-    except (FileNotFoundError, NotADirectoryError):
-        return None
+    except OSError as exc:
+        if (
+            exc.errno in _ABSENT_ERRNOS
+            or getattr(exc, "winerror", None) in _ABSENT_WINERRORS
+        ):
+            return None
+        raise
 
 
 def _is_file(path: Path) -> bool:
@@ -332,7 +346,7 @@ def _scan_flat_wheelhouse(
     unreadable = False
 
     for entry in sorted(root.iterdir()):
-        if not entry.is_file():
+        if not _is_file(entry):
             continue
         if _FLAT_EXTS.search(entry.name) is None:
             unreadable = unreadable or _is_zip_sdist(entry.name, canonical)

--- a/nab-python/tests/test_local_index.py
+++ b/nab-python/tests/test_local_index.py
@@ -43,19 +43,46 @@ def run(coro: Coroutine[Any, Any, _T]) -> _T:
     return asyncio.run(coro)
 
 
+def _fail_path_call(
+    monkeypatch: pytest.MonkeyPatch, method: str, target: Path, error: OSError
+) -> None:
+    """Make one ``Path`` call on ``target`` raise ``error``."""
+    original = getattr(Path, method)
+
+    def failing(self: Path, *args: Any, **kwargs: Any) -> Any:
+        if self == target:
+            raise error
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, method, failing)
+
+
 def _deny_access(monkeypatch: pytest.MonkeyPatch, method: str, target: Path) -> None:
     """Make one ``Path`` call on ``target`` fail with EACCES.
 
     A real chmod would not do: root ignores the mode bits and Windows has none.
     """
-    original = getattr(Path, method)
+    denied = PermissionError(errno.EACCES, "Permission denied", str(target))
+    _fail_path_call(monkeypatch, method, target, denied)
 
-    def denied(self: Path, *args: Any, **kwargs: Any) -> Any:
-        if self == target:
-            raise PermissionError(errno.EACCES, "Permission denied", str(self))
-        return original(self, *args, **kwargs)
 
-    monkeypatch.setattr(Path, method, denied)
+def _swallow_is_file_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Give ``Path.is_file`` Python 3.14's error handling on every version.
+
+    From 3.14 it answers False for any :class:`OSError`, so an entry the
+    process cannot stat reads as "not a file". The scan does not call it, so
+    the patch only bites if someone puts ``entry.is_file()`` back; that is what
+    keeps the tests below able to fail on an older interpreter.
+    """
+    original = Path.is_file
+
+    def is_file(self: Path, *args: Any, **kwargs: Any) -> bool:
+        try:
+            return original(self, *args, **kwargs)
+        except OSError:
+            return False
+
+    monkeypatch.setattr(Path, "is_file", is_file)
 
 
 def _write_wheel(
@@ -470,6 +497,76 @@ class TestFlatWheelhouse:
         assert isinstance(caught.value, IndexAccessError)
         assert not isinstance(caught.value, OSError)
         assert "Permission denied" in str(caught.value)
+
+    def test_unreadable_entry_raises_index_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A release the process cannot stat must fail the listing rather than
+        # drop out of it, which would read as "1.0 is all there is".
+        (tmp_path / "foo-1.0-py3-none-any.whl").write_bytes(b"")
+        denied = tmp_path / "foo-2.0-py3-none-any.whl"
+        denied.write_bytes(b"")
+
+        _swallow_is_file_errors(monkeypatch)
+        _deny_access(monkeypatch, "stat", denied)
+
+        client = LocalIndexClient(tmp_path.as_uri())
+        with pytest.raises(UnreadableLocalIndexError) as caught:
+            run(client.get_files("foo"))
+
+        assert isinstance(caught.value, IndexAccessError)
+        assert not isinstance(caught.value, OSError)
+        assert "Permission denied" in str(caught.value)
+
+    def test_unreadable_entry_of_another_package_raises_index_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A wheelhouse serves every package from one directory, so an entry
+        # naming none of them still fails the listing.
+        (tmp_path / "foo-1.0-py3-none-any.whl").write_bytes(b"")
+        denied = tmp_path / "bar-2.0-py3-none-any.whl"
+        denied.write_bytes(b"")
+
+        _swallow_is_file_errors(monkeypatch)
+        _deny_access(monkeypatch, "stat", denied)
+
+        client = LocalIndexClient(tmp_path.as_uri())
+        with pytest.raises(UnreadableLocalIndexError):
+            run(client.get_files("foo"))
+
+    def test_symlink_cycle_entry_is_skipped(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A junk entry that stats as a symlink loop is not a wheelhouse fault.
+
+        Faked rather than made with :func:`os.symlink`, which needs a
+        privilege the Windows CI runner does not have.
+        """
+        (tmp_path / "foo-1.0-py3-none-any.whl").write_bytes(b"")
+        cycle = tmp_path / "cycle-link"
+        cycle.write_bytes(b"")
+
+        loop = OSError(errno.ELOOP, "Too many levels of symbolic links", str(cycle))
+        _fail_path_call(monkeypatch, "stat", cycle, loop)
+
+        client = LocalIndexClient(tmp_path.as_uri())
+        assert [f.version for f in run(client.get_files("foo"))] == ["1.0"]
+
+    def test_entry_gone_since_listing_is_skipped(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A name the directory no longer holds drops out of the listing."""
+        (tmp_path / "foo-1.0-py3-none-any.whl").write_bytes(b"")
+        original = Path.iterdir
+
+        def iterdir(self: Path) -> Iterator[Path]:
+            yield from original(self)
+            yield self / "foo-2.0-py3-none-any.whl"
+
+        monkeypatch.setattr(Path, "iterdir", iterdir)
+
+        client = LocalIndexClient(tmp_path.as_uri())
+        assert [f.version for f in run(client.get_files("foo"))] == ["1.0"]
 
     def test_listing_order_independent_of_readdir_order(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
Resolving against a flat file:// wheelhouse can pin an older release than the directory holds. The scan filtered entries with a bare Path.is_file(), and from Python 3.14 that answers False for any OSError, so a wheel the process cannot stat reads as "not a file" and silently drops out of the listing.

The scan now uses the same stat probe as the rest of the module, which counts a path as absent only for the errnos pathlib itself treats as "no such file". A refused stat fails the listing with an index error. An entry that has gone since the directory was read, or one that stats as a symlink loop, is still skipped, so one junk name does not fail every package the wheelhouse serves.
