### PR TITLE
record selected pins beside canary results

### DIFF
--- a/nab-python/benchmarks/README.md
+++ b/nab-python/benchmarks/README.md
@@ -47,7 +47,7 @@ Each run initializes `_standard_manifest.json` as incomplete before resolving an
 ### Canary subset
 
 `canary.py` runs the small hard-case subset used by the local verification gate.
-`canary.toml` selects canonical scenario definitions and declares the strategy for each case. Manual selections may use an explicit suffix such as `pip:trustllm@lowest`. The runner records the complete TOML input, effective target and policy, source state, and content hashes. Canary artifacts retain contract version 2: non-default cases reconstruct the equivalent historical selector and input definition at the serialization boundary, so existing scoreboards remain comparable even though strategy-clone files are gone. The local verifier compares success results only when their contract version and host-aware execution hashes match and both source trees are clean.
+`canary.toml` selects canonical scenario definitions and declares the strategy for each case. Manual selections may use an explicit suffix such as `pip:trustllm@lowest`. The runner records the complete TOML input, effective target and policy, source state, and content hashes. Canary comparison results retain contract version 2, including the reconstructed historical selector for a non-default strategy. A paired `canary-pins_<timestamp>.json` file records sorted package pins for each run and identifies its comparison result by filename and SHA-256 digest. Failed runs have an empty pin map. The local verifier compares success results only when their contract versions and host-aware execution hashes match and both source trees are clean.
 
 ## Universal-resolution scenarios
 

--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING, NamedTuple
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
+    from nab_python._vendor.packaging.version import Version
     from nab_python.target import ResolveTarget
 
 if sys.version_info >= (3, 11):
@@ -39,6 +40,11 @@ from benchmark_host import (
     BenchmarkTimeout,
     parse_requires_matching_host,
     parse_target_marker_environment,
+)
+from canary_result import (
+    CANARY_CONTRACT_VERSION,
+    build_canary_artifacts,
+    write_canary_artifacts,
 )
 
 from nab_index.httpx_async_transport import HttpxAsyncTransport
@@ -114,10 +120,15 @@ class CanaryPreparation(NamedTuple):
     inapplicable_reason: str | None
 
 
+class CanaryArtifactPaths(NamedTuple):
+    """The comparison result and its selected-pin sidecar."""
+
+    result: Path
+    pins: Path
+
+
 WALL_TIMEOUT_S = 60
 MAX_ITERATIONS = 50_000
-# Preserve contract v2 for comparisons with existing canary results.
-CANARY_CONTRACT_VERSION = 2
 
 
 def scenario_input_hash(scenario_name: str, scenario: dict) -> str:
@@ -312,6 +323,17 @@ def get_git_commit() -> str:
     return result.stdout.strip()
 
 
+def _result_pins(solution: Mapping[str, Version]) -> dict[str, str]:
+    """Return normalized base-package pins for a canary run."""
+    return dict(
+        sorted(
+            (canonicalize_name(name), str(version))
+            for name, version in solution.items()
+            if split_extra(name)[1] is None
+        )
+    )
+
+
 def run_one(  # noqa: PLR0913 - one wrapper per scenario knob
     requirements: dict[str, VersionRange],
     uploaded_prior_to: datetime | None,
@@ -363,15 +385,16 @@ def run_one(  # noqa: PLR0913 - one wrapper per scenario knob
             max_iterations=MAX_ITERATIONS,
         )
 
+        pins: dict[str, str] = {}
         start = time.monotonic()
         try:
             with host.wall_timeout():
                 raw = resolver.resolve(requirements, constraints=constraints)
             elapsed = time.monotonic() - start
-            result = {k: v for k, v in raw.items() if split_extra(k)[1] is None}
+            pins = _result_pins(raw)
             success = True
             error = None
-            packages = len(result)
+            packages = len(pins)
         except (BenchmarkTimeout, Exception) as exc:
             elapsed = time.monotonic() - start
             success = False
@@ -406,6 +429,7 @@ def run_one(  # noqa: PLR0913 - one wrapper per scenario knob
             },
             "success": success,
             "error": error,
+            "pins": pins,
             "decisions": rs.decisions,
             "conflicts": rs.conflicts,
             "backjumps": rs.backjumps,
@@ -624,12 +648,20 @@ def _check_result_directory(
         parser.error(str(exc))
 
 
-def _summary_path(parser: argparse.ArgumentParser, label: str) -> Path:
+def _artifact_paths(
+    parser: argparse.ArgumentParser,
+    label: str,
+) -> CanaryArtifactPaths:
+    """Return paired paths for one canary invocation."""
     try:
         out_dir = _result_directory(label)
     except _SelectionError as exc:
         parser.error(str(exc))
-    return out_dir / f"canary_{int(time.time())}.json"
+    suffix = int(time.time())
+    return CanaryArtifactPaths(
+        result=out_dir / f"canary_{suffix}.json",
+        pins=out_dir / f"canary-pins_{suffix}.json",
+    )
 
 
 def find_scenario(spec: str) -> dict | None:
@@ -1010,10 +1042,14 @@ def main() -> None:
             f"{summary['max_decisions']:>8}"
         )
 
-    out_file = _summary_path(parser, commit)
-    with out_file.open("x", encoding="utf-8") as f:
-        f.write(json.dumps(summary_all, indent=2) + "\n")
-    print(f"\nResults: {out_file}")
+    paths = _artifact_paths(parser, commit)
+    artifacts = build_canary_artifacts(
+        summary_all,
+        paths.result.name,
+    )
+    write_canary_artifacts(paths.result, paths.pins, artifacts)
+    print(f"\nResults: {paths.result}")
+    print(f"Pins: {paths.pins}")
 
 
 if __name__ == "__main__":

--- a/nab-python/benchmarks/canary_result.py
+++ b/nab-python/benchmarks/canary_result.py
@@ -1,0 +1,402 @@
+"""Persist canary comparison results and their selected-pin sidecars."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import tempfile
+from pathlib import Path
+from typing import NamedTuple
+
+from nab_python._vendor.packaging.utils import is_normalized_name
+from nab_python._vendor.packaging.version import Version
+from nab_python.provider import split_extra
+
+CANARY_CONTRACT_VERSION = 2
+CANARY_PINS_CONTRACT_VERSION = 1
+CANARY_RUN_FIELDS = frozenset(
+    {
+        "settings",
+        "success",
+        "error",
+        "decisions",
+        "conflicts",
+        "backjumps",
+        "restarts",
+        "incompatibilities_learned",
+        "metadata_fetched",
+        "distributions_seen",
+        "look_ahead_rejections",
+        "packages",
+        "wall_time_seconds",
+    }
+)
+_CANARY_RECORD_FIELDS = frozenset(
+    {
+        "contract_version",
+        "scenario",
+        "source",
+        "input_hash",
+        "execution_hash",
+        "input",
+        "effective_settings",
+        "runs",
+        "summary",
+    }
+)
+_PIN_RUN_FIELDS = frozenset({"run", "success", "packages", "pins"})
+_RESULT_FILENAME = re.compile(r"canary_([0-9]+)\.json")
+_SHA256 = re.compile(r"[0-9a-f]{64}")
+_DIRECTORY_FSYNC_SUPPORTED = os.name != "nt"
+
+
+class CanaryArtifacts(NamedTuple):
+    """Serialized comparison and selected-pin artifacts for one invocation."""
+
+    result: str
+    pins: str
+
+
+def _json_text(value: object) -> str:
+    return json.dumps(value, indent=2) + "\n"
+
+
+def _pins_are_valid(value: object) -> bool:
+    """Return whether a value is a sorted map of normalized package pins."""
+    if not isinstance(value, dict) or list(value) != sorted(value):
+        return False
+    for name, version in value.items():
+        if (
+            not isinstance(name, str)
+            or not name
+            or not is_normalized_name(name)
+            or split_extra(name)[1] is not None
+            or not isinstance(version, str)
+            or not version
+        ):
+            return False
+        try:
+            normalized_version = str(Version(version))
+        except ValueError:
+            return False
+        if normalized_version != version:
+            return False
+    return True
+
+
+def _split_run(index: int, run: object) -> tuple[dict, dict]:
+    """Split one internal run into comparison metrics and selected pins."""
+    if not isinstance(run, dict):
+        msg = "canary run must be an object"
+        raise TypeError(msg)
+    if set(run) != CANARY_RUN_FIELDS | {"pins"}:
+        msg = "canary run does not match the internal result shape"
+        raise ValueError(msg)
+
+    success = run["success"]
+    packages = run["packages"]
+    pins = run["pins"]
+    if type(success) is not bool or type(packages) is not int or packages < 0:
+        msg = "canary run has invalid selected pins"
+        raise ValueError(msg)
+    if not _pins_are_valid(pins) or packages != len(pins):
+        msg = "canary run has invalid selected pins"
+        raise ValueError(msg)
+    if not success and pins:
+        msg = "failed canary run has selected pins"
+        raise ValueError(msg)
+
+    result_run = {name: value for name, value in run.items() if name != "pins"}
+    pin_run = {
+        "run": index,
+        "success": success,
+        "packages": packages,
+        "pins": pins,
+    }
+    return result_run, pin_run
+
+
+def _validate_result_identity(
+    identity: object,
+    *,
+    result_filename: str,
+    result_text: str,
+) -> None:
+    """Check that a sidecar names and hashes its comparison result."""
+    expected = {
+        "filename": result_filename,
+        "sha256": hashlib.sha256(result_text.encode()).hexdigest(),
+    }
+    if not isinstance(identity, dict) or identity != expected:
+        msg = "canary pin artifact does not identify its comparison result"
+        raise ValueError(msg)
+
+
+def _validate_pin_run(
+    name: str,
+    index: int,
+    result_run: object,
+    pin_run: object,
+) -> None:
+    """Check one pin row against the same-position comparison row."""
+    if not isinstance(result_run, dict) or set(result_run) != CANARY_RUN_FIELDS:
+        msg = f"invalid canary comparison run for {name!r}"
+        raise ValueError(msg)
+    if not isinstance(pin_run, dict) or set(pin_run) != _PIN_RUN_FIELDS:
+        msg = f"invalid canary pin run for {name!r}"
+        raise ValueError(msg)
+
+    result_success = result_run["success"]
+    result_packages = result_run["packages"]
+    success = pin_run["success"]
+    packages = pin_run["packages"]
+    pins = pin_run["pins"]
+    if (
+        type(result_success) is not bool
+        or type(result_packages) is not int
+        or result_packages < 0
+    ):
+        msg = f"invalid canary comparison run for {name!r}"
+        raise ValueError(msg)
+    if pin_run["run"] != index or type(pin_run["run"]) is not int:
+        msg = f"canary pin run order does not match {name!r}"
+        raise ValueError(msg)
+    if type(success) is not bool or type(packages) is not int or packages < 0:
+        msg = f"invalid canary pin run for {name!r}"
+        raise ValueError(msg)
+    if success is not result_success or packages != result_packages:
+        msg = f"canary pin run does not match {name!r}"
+        raise ValueError(msg)
+    if not _pins_are_valid(pins) or packages != len(pins) or (not success and pins):
+        msg = f"invalid canary pin run for {name!r}"
+        raise ValueError(msg)
+
+
+def _validate_scenario(
+    name: str,
+    result_record: dict,
+    pin_record: object,
+) -> None:
+    """Check one scenario sidecar against its comparison record."""
+    if set(result_record) != _CANARY_RECORD_FIELDS or (
+        type(result_record["contract_version"]) is not int
+        or result_record["contract_version"] != CANARY_CONTRACT_VERSION
+    ):
+        msg = f"invalid canary comparison record for {name!r}"
+        raise ValueError(msg)
+    if not isinstance(pin_record, dict) or set(pin_record) != {
+        "input_hash",
+        "execution_hash",
+        "runs",
+    }:
+        msg = f"invalid canary pin record for {name!r}"
+        raise ValueError(msg)
+    input_hash = result_record["input_hash"]
+    execution_hash = result_record["execution_hash"]
+    if (
+        not isinstance(input_hash, str)
+        or _SHA256.fullmatch(input_hash) is None
+        or not isinstance(execution_hash, str)
+        or _SHA256.fullmatch(execution_hash) is None
+        or pin_record["input_hash"] != input_hash
+        or pin_record["execution_hash"] != execution_hash
+    ):
+        msg = f"canary pin identity does not match {name!r}"
+        raise ValueError(msg)
+
+    result_runs = result_record.get("runs")
+    pin_runs = pin_record["runs"]
+    if not isinstance(result_runs, list) or not isinstance(pin_runs, list):
+        msg = f"canary pin runs for {name!r} must be arrays"
+        raise TypeError(msg)
+    if len(pin_runs) != len(result_runs):
+        msg = f"canary pin runs do not match {name!r}"
+        raise ValueError(msg)
+    for index, (result_run, pin_run) in enumerate(
+        zip(result_runs, pin_runs, strict=True)
+    ):
+        _validate_pin_run(name, index, result_run, pin_run)
+
+
+def validate_canary_pins_artifact(
+    result_text: str,
+    pins_data: object,
+    *,
+    result_filename: str,
+) -> None:
+    """Validate a selected-pin sidecar against its comparison result."""
+    if _RESULT_FILENAME.fullmatch(result_filename) is None:
+        msg = "invalid canary comparison filename"
+        raise ValueError(msg)
+    if not isinstance(result_text, str):
+        msg = "serialized canary comparison result must be text"
+        raise TypeError(msg)
+    try:
+        result_data = json.loads(result_text)
+    except ValueError as exc:
+        msg = "invalid serialized canary comparison result"
+        raise ValueError(msg) from exc
+    if not isinstance(result_data, dict) or any(
+        not isinstance(name, str) or not name or not isinstance(record, dict)
+        for name, record in result_data.items()
+    ):
+        msg = "canary comparison artifact must contain scenario records"
+        raise TypeError(msg)
+    if not isinstance(pins_data, dict):
+        msg = "canary pin artifact must be an object"
+        raise TypeError(msg)
+    if set(pins_data) != {
+        "pins_contract_version",
+        "canary_result",
+        "scenarios",
+    }:
+        msg = "invalid canary pin artifact shape"
+        raise ValueError(msg)
+    if type(pins_data["pins_contract_version"]) is not int or (
+        pins_data["pins_contract_version"] != CANARY_PINS_CONTRACT_VERSION
+    ):
+        msg = "invalid canary pin contract version"
+        raise ValueError(msg)
+
+    _validate_result_identity(
+        pins_data["canary_result"],
+        result_filename=result_filename,
+        result_text=result_text,
+    )
+
+    scenarios = pins_data["scenarios"]
+    if not isinstance(scenarios, dict):
+        msg = "canary pin scenarios must be an object"
+        raise TypeError(msg)
+    if list(scenarios) != list(result_data):
+        msg = "canary pin artifact scenario set does not match its comparison result"
+        raise ValueError(msg)
+    for name, result_record in result_data.items():
+        _validate_scenario(name, result_record, scenarios[name])
+
+
+def build_canary_artifacts(
+    records: dict[str, dict],
+    result_filename: str,
+) -> CanaryArtifacts:
+    """Build paired contract-v2 and selected-pin artifacts."""
+    result_data: dict[str, dict] = {}
+    pin_scenarios: dict[str, dict] = {}
+    for name, record in records.items():
+        runs = record.get("runs")
+        if not isinstance(runs, list):
+            msg = f"canary record runs for {name!r} must be an array"
+            raise TypeError(msg)
+
+        split_runs = [_split_run(index, run) for index, run in enumerate(runs)]
+        result_data[name] = {**record, "runs": [run[0] for run in split_runs]}
+        pin_scenarios[name] = {
+            "input_hash": record.get("input_hash"),
+            "execution_hash": record.get("execution_hash"),
+            "runs": [run[1] for run in split_runs],
+        }
+
+    result_text = _json_text(result_data)
+    pins_data = {
+        "pins_contract_version": CANARY_PINS_CONTRACT_VERSION,
+        "canary_result": {
+            "filename": result_filename,
+            "sha256": hashlib.sha256(result_text.encode()).hexdigest(),
+        },
+        "scenarios": pin_scenarios,
+    }
+    pins_text = _json_text(pins_data)
+    validate_canary_pins_artifact(
+        result_text,
+        json.loads(pins_text),
+        result_filename=result_filename,
+    )
+    return CanaryArtifacts(result=result_text, pins=pins_text)
+
+
+def _validate_artifact_paths(result_path: Path, pins_path: Path) -> None:
+    """Check paired final paths before creating staged files."""
+    match = _RESULT_FILENAME.fullmatch(result_path.name)
+    expected_pins_name = f"canary-pins_{match.group(1)}.json" if match else None
+    if (
+        match is None
+        or pins_path.name != expected_pins_name
+        or result_path.parent != pins_path.parent
+        or result_path.parent.is_symlink()
+        or not result_path.parent.is_dir()
+    ):
+        msg = "invalid canary artifact paths"
+        raise ValueError(msg)
+    if os.path.lexists(result_path) or os.path.lexists(pins_path):
+        msg = "canary artifact path already exists"
+        raise FileExistsError(msg)
+
+
+def _validate_artifact_texts(
+    result_path: Path,
+    artifacts: CanaryArtifacts,
+) -> None:
+    """Parse and validate both serialized payloads before publication."""
+    try:
+        pins_data = json.loads(artifacts.pins)
+    except (TypeError, ValueError) as exc:
+        msg = "invalid serialized canary artifacts"
+        raise ValueError(msg) from exc
+    validate_canary_pins_artifact(
+        artifacts.result,
+        pins_data,
+        result_filename=result_path.name,
+    )
+
+
+def _stage_artifact(path: Path, text: str) -> None:
+    """Write and sync one artifact inside the private staging directory."""
+    with path.open("xb") as staged:
+        staged.write(text.encode())
+        staged.flush()
+        os.fsync(staged.fileno())
+
+
+def _sync_directory(path: Path) -> None:
+    """Sync directory changes on platforms that expose directory handles."""
+    if not _DIRECTORY_FSYNC_SUPPORTED:
+        return
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    descriptor = os.open(path, flags)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _publish_exclusive(staged: Path, destination: Path) -> None:
+    """Publish a staged file atomically without replacing a destination."""
+    os.link(staged, destination)
+    _sync_directory(destination.parent)
+
+
+def write_canary_artifacts(
+    result_path: Path,
+    pins_path: Path,
+    artifacts: CanaryArtifacts,
+) -> None:
+    """Publish a sidecar before making its bound comparison result visible."""
+    _validate_artifact_paths(result_path, pins_path)
+    _validate_artifact_texts(result_path, artifacts)
+    try:
+        with tempfile.TemporaryDirectory(
+            dir=result_path.parent,
+            prefix=".canary-artifacts-",
+        ) as staging_dir:
+            staging_path = Path(staging_dir)
+            result_staged = staging_path / result_path.name
+            pins_staged = staging_path / pins_path.name
+            _stage_artifact(result_staged, artifacts.result)
+            _stage_artifact(pins_staged, artifacts.pins)
+
+            _publish_exclusive(pins_staged, pins_path)
+            _publish_exclusive(result_staged, result_path)
+    finally:
+        _sync_directory(result_path.parent)

--- a/nab-python/tests/test_benchmark_canary.py
+++ b/nab-python/tests/test_benchmark_canary.py
@@ -8,12 +8,14 @@ import json
 import shutil
 import subprocess
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
 import pytest
 from typing_extensions import Self
 
+from nab_python._vendor.packaging.version import Version
 from nab_python.target import ResolveTarget
 
 _CANARY = Path(__file__).resolve().parents[1] / "benchmarks" / "canary.py"
@@ -33,20 +35,27 @@ def _harness() -> ModuleType:
     return module
 
 
+def _result_contract(module: ModuleType) -> ModuleType:
+    """Return the canary-result module imported by the benchmark harness."""
+    return sys.modules[module.build_canary_artifacts.__module__]
+
+
 def _run_result(
     *,
     success: bool = True,
     decisions: int = 1,
     distributions_seen: int = 0,
     metadata_fetched: int = 0,
-    packages: int = 0,
+    pins: dict[str, str] | None = None,
     conflicts: int = 0,
     backjumps: int = 0,
     wall_time_seconds: float = 0.0,
 ) -> dict[str, object]:
+    selected_pins = {} if pins is None else pins
     return {
         "success": success,
         "error": None if success else "resolution failed",
+        "pins": selected_pins,
         "decisions": decisions,
         "conflicts": conflicts,
         "backjumps": backjumps,
@@ -55,9 +64,56 @@ def _run_result(
         "metadata_fetched": metadata_fetched,
         "distributions_seen": distributions_seen,
         "look_ahead_rejections": 0,
-        "packages": packages,
+        "packages": len(selected_pins),
         "wall_time_seconds": wall_time_seconds,
     }
+
+
+def _patch_run_one_boundaries(
+    module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    resolve: Callable[..., dict[str, Version]],
+) -> dict[str, object]:
+    """Install deterministic dependencies for ``run_one`` result tests."""
+    seen: dict[str, object] = {}
+
+    class FakeCoordinator:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        def __enter__(self) -> Self:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            pass
+
+    class FakeProvider:
+        def __init__(self, *_args: object, **kwargs: object) -> None:
+            seen.update(kwargs)
+            self.stats = SimpleNamespace(
+                metadata_fetched=0,
+                distributions_seen=0,
+                look_ahead_rejections=0,
+            )
+
+    class FakeResolver:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            self.stats = SimpleNamespace(
+                decisions=0,
+                conflicts=0,
+                backjumps=0,
+                restarts=0,
+                incompatibilities_learned=0,
+            )
+
+        def resolve(self, *args: object, **kwargs: object) -> dict[str, Version]:
+            return resolve(*args, **kwargs)
+
+    monkeypatch.setattr(module, "FetchCoordinator", FakeCoordinator)
+    monkeypatch.setattr(module, "HttpxAsyncTransport", object)
+    monkeypatch.setattr(module, "Provider", FakeProvider)
+    monkeypatch.setattr(module, "Resolver", FakeResolver)
+    return seen
 
 
 def test_wall_timeout_noops_without_posix_alarm(
@@ -292,7 +348,7 @@ def test_canary_filters_root_markers_with_the_admitted_target(
     def fake_run_one(requirements: dict, *_args: object, **kwargs: object) -> dict:
         seen["requirements"] = set(requirements)
         seen["target_python"] = kwargs["target"].marker_env["python_version"]
-        return _run_result(packages=1)
+        return _run_result(pins={"selected": "1.0"})
 
     monkeypatch.setattr(module, "run_one", fake_run_one)
     module.median_run(
@@ -337,7 +393,7 @@ def test_canary_explicit_resolution_overrides_declared_strategy(
     assert seen == [module.ResolutionStrategy.LOWEST]
 
 
-def test_canary_prepares_inputs_and_summarizes_repeated_runs(
+def test_canary_prepares_inputs_and_summarizes_runs_with_different_pins(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     module = _harness()
@@ -347,7 +403,7 @@ def test_canary_prepares_inputs_and_summarizes_repeated_runs(
             decisions=1,
             distributions_seen=9,
             metadata_fetched=3,
-            packages=1,
+            pins={"demo": "1.0"},
             conflicts=7,
             backjumps=4,
             wall_time_seconds=0.1,
@@ -357,7 +413,6 @@ def test_canary_prepares_inputs_and_summarizes_repeated_runs(
             decisions=9,
             distributions_seen=3,
             metadata_fetched=9,
-            packages=0,
             conflicts=1,
             backjumps=8,
             wall_time_seconds=0.3,
@@ -366,7 +421,7 @@ def test_canary_prepares_inputs_and_summarizes_repeated_runs(
             decisions=5,
             distributions_seen=6,
             metadata_fetched=6,
-            packages=3,
+            pins={"demo": "2.0", "first": "1.0", "second": "1.0"},
             conflicts=4,
             backjumps=2,
             wall_time_seconds=0.2,
@@ -397,6 +452,7 @@ def test_canary_prepares_inputs_and_summarizes_repeated_runs(
     )
 
     assert runs == returned_runs
+    assert runs[0]["pins"] != runs[2]["pins"]
     assert summary == {
         "success_runs": "2/3",
         "median_decisions": 5,
@@ -434,44 +490,11 @@ def test_canary_configures_lowest_direct_roots(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     module = _harness()
-    seen: dict[str, object] = {}
 
-    class FakeCoordinator:
-        def __init__(self, *_args: object, **_kwargs: object) -> None:
-            pass
+    def resolve(*_args: object, **_kwargs: object) -> dict[str, Version]:
+        return {}
 
-        def __enter__(self) -> Self:
-            return self
-
-        def __exit__(self, *_args: object) -> None:
-            pass
-
-    class FakeProvider:
-        def __init__(self, *_args: object, **kwargs: object) -> None:
-            seen.update(kwargs)
-            self.stats = SimpleNamespace(
-                metadata_fetched=0,
-                distributions_seen=0,
-                look_ahead_rejections=0,
-            )
-
-    class FakeResolver:
-        def __init__(self, *_args: object, **_kwargs: object) -> None:
-            self.stats = SimpleNamespace(
-                decisions=0,
-                conflicts=0,
-                backjumps=0,
-                restarts=0,
-                incompatibilities_learned=0,
-            )
-
-        def resolve(self, *_args: object, **_kwargs: object) -> dict:
-            return {}
-
-    monkeypatch.setattr(module, "FetchCoordinator", FakeCoordinator)
-    monkeypatch.setattr(module, "HttpxAsyncTransport", object)
-    monkeypatch.setattr(module, "Provider", FakeProvider)
-    monkeypatch.setattr(module, "Resolver", FakeResolver)
+    seen = _patch_run_one_boundaries(module, monkeypatch, resolve)
 
     requirements = module.parse_requirements(["Root[feature]", "Other==1"])
     captured = module.BenchmarkHost.current(module.WALL_TIMEOUT_S)
@@ -508,7 +531,76 @@ def test_canary_configures_lowest_direct_roots(
     assert seen["target"] is admission.target
 
 
-def test_canary_main_records_v2_contract(
+def test_canary_records_normalized_pins_after_timing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    events: list[str] = []
+    clock_values = iter((10.0, 11.25))
+
+    def monotonic() -> float:
+        events.append("clock")
+        return next(clock_values)
+
+    real_result_pins = module._result_pins
+
+    def result_pins(solution: dict[str, Version]) -> dict[str, str]:
+        events.append("pins")
+        return real_result_pins(solution)
+
+    def resolve(*_args: object, **_kwargs: object) -> dict[str, Version]:
+        return {
+            "Z_Pkg": Version("2.0.0"),
+            "Demo_Pkg": Version("01.0"),
+            "demo_pkg[feature]": Version("1.0"),
+        }
+
+    _patch_run_one_boundaries(module, monkeypatch, resolve)
+    monkeypatch.setattr(module, "time", SimpleNamespace(monotonic=monotonic))
+    monkeypatch.setattr(module, "_result_pins", result_pins)
+    host = module.BenchmarkHost.current(module.WALL_TIMEOUT_S)
+
+    result = module.run_one(
+        module.parse_requirements(["demo-pkg"]),
+        None,
+        None,
+        target=host.target,
+        host=host,
+    )
+
+    assert result["pins"] == {"demo-pkg": "1.0", "z-pkg": "2.0.0"}
+    assert list(result["pins"]) == ["demo-pkg", "z-pkg"]
+    assert result["packages"] == 2
+    assert result["wall_time_seconds"] == 1.25
+    assert events == ["clock", "clock", "pins"]
+
+
+def test_canary_records_no_pins_after_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+
+    def resolve(*_args: object, **_kwargs: object) -> dict[str, Version]:
+        raise RuntimeError("fixture failure")
+
+    _patch_run_one_boundaries(module, monkeypatch, resolve)
+    host = module.BenchmarkHost.current(module.WALL_TIMEOUT_S)
+
+    result = module.run_one(
+        module.parse_requirements(["demo"]),
+        None,
+        None,
+        target=host.target,
+        host=host,
+    )
+
+    assert result["success"] is False
+    assert result["error"] == "RuntimeError: fixture failure"
+    assert result["pins"] == {}
+    assert result["packages"] == 0
+
+
+def test_canary_main_records_contract_for_skipped_case(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -528,8 +620,10 @@ def test_canary_main_records_v2_contract(
     module.main()
 
     result_path = next((tmp_path / "test").glob("canary_*.json"))
-    data = json.loads(result_path.read_text())
-    assert data == {
+    pins_path = next((tmp_path / "test").glob("canary-pins_*.json"))
+    contract = _result_contract(module)
+    result_data = json.loads(result_path.read_text())
+    assert result_data == {
         "requests": {
             "contract_version": module.CANARY_CONTRACT_VERSION,
             "scenario": "quick:requests",
@@ -542,9 +636,23 @@ def test_canary_main_records_v2_contract(
             "summary": {"skipped": "test fixture"},
         }
     }
+    assert json.loads(pins_path.read_text()) == {
+        "pins_contract_version": contract.CANARY_PINS_CONTRACT_VERSION,
+        "canary_result": {
+            "filename": result_path.name,
+            "sha256": hashlib.sha256(result_path.read_bytes()).hexdigest(),
+        },
+        "scenarios": {
+            "requests": {
+                "input_hash": input_hash,
+                "execution_hash": module.scenario_execution_hash(input_hash, None),
+                "runs": [],
+            }
+        },
+    }
 
 
-def test_canary_main_preserves_v2_lowest_identity_and_effective_settings(
+def test_canary_main_preserves_v2_input_identity_and_effective_settings(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -557,6 +665,7 @@ def test_canary_main_preserves_v2_lowest_identity_and_effective_settings(
     run = {
         "success": True,
         "error": None,
+        "pins": {"demo": "1.0"},
         "decisions": 1,
         "conflicts": 0,
         "backjumps": 0,
@@ -615,9 +724,13 @@ def test_canary_main_preserves_v2_lowest_identity_and_effective_settings(
 
     module.main()
 
-    record = json.loads(next((tmp_path / "test").glob("canary_*.json")).read_text())[
-        "example"
-    ]
+    result_paths = list((tmp_path / "test").glob("canary_*.json"))
+    assert len(result_paths) == 1
+    result_path = result_paths[0]
+    record = json.loads(result_path.read_text())["example"]
+    pins_record = json.loads(
+        next((tmp_path / "test").glob("canary-pins_*.json")).read_text()
+    )["scenarios"]["example"]
     expected_input = {**scenario, "resolution": "lowest"}
     expected_input_hash = module.scenario_input_hash(
         "quick-lowest:example", expected_input
@@ -627,9 +740,20 @@ def test_canary_main_preserves_v2_lowest_identity_and_effective_settings(
     assert record["input"] == expected_input
     assert record["input_hash"] == expected_input_hash
     assert record["effective_settings"] == settings
+    assert "pins" not in record["runs"][0]
+    assert pins_record["runs"] == [
+        {
+            "run": 0,
+            "success": True,
+            "packages": 1,
+            "pins": {"demo": "1.0"},
+        }
+    ]
+    assert pins_record["input_hash"] == expected_input_hash
     assert record["execution_hash"] == module.scenario_execution_hash(
         expected_input_hash, settings
     )
+    assert pins_record["execution_hash"] == record["execution_hash"]
 
 
 def test_canary_input_hash_captures_executable_definition() -> None:

--- a/nab-python/tests/test_benchmark_canary_result.py
+++ b/nab-python/tests/test_benchmark_canary_result.py
@@ -1,0 +1,574 @@
+"""Tests for canary result and selected-pin persistence."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import os
+import stat
+import sys
+from functools import lru_cache
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_CONTRACT = Path(__file__).resolve().parents[1] / "benchmarks" / "canary_result.py"
+
+
+@lru_cache(maxsize=1)
+def _harness() -> ModuleType:
+    """Load the persistence contract once for this test module."""
+    spec = importlib.util.spec_from_file_location("_benchmark_canary_result", _CONTRACT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(_CONTRACT.parent))
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.remove(str(_CONTRACT.parent))
+    return module
+
+
+def _run(*, success: bool = True, version: str = "1.0") -> dict:
+    pins = {"demo": version} if success else {}
+    return {
+        "settings": {"resolution": "highest"},
+        "success": success,
+        "error": None if success else "resolution failed",
+        "pins": pins,
+        "decisions": 1,
+        "conflicts": 0,
+        "backjumps": 0,
+        "restarts": 0,
+        "incompatibilities_learned": 0,
+        "metadata_fetched": 0,
+        "distributions_seen": 0,
+        "look_ahead_rejections": 0,
+        "packages": len(pins),
+        "wall_time_seconds": 0.0,
+    }
+
+
+def _record(*, success: bool = True) -> dict:
+    """Return one complete internal record for persistence tests."""
+    run = _run(success=success)
+    return {
+        "contract_version": 2,
+        "scenario": "quick:example",
+        "source": {"commit": "a" * 40, "dirty": False, "diff_hash": None},
+        "input_hash": "b" * 64,
+        "execution_hash": "c" * 64,
+        "input": {"requirements": ["demo"]},
+        "effective_settings": run["settings"],
+        "runs": [run],
+        "summary": {},
+    }
+
+
+def test_pin_sidecar_preserves_the_v2_result_bytes() -> None:
+    module = _harness()
+    record = _record()
+    artifacts = module.build_canary_artifacts(
+        {"example": record},
+        "canary_123.json",
+    )
+
+    result_data = json.loads(artifacts.result)
+    pins_data = json.loads(artifacts.pins)
+    expected_run = {
+        name: value for name, value in record["runs"][0].items() if name != "pins"
+    }
+    expected_text = (
+        json.dumps(
+            {"example": {**record, "runs": [expected_run]}},
+            indent=2,
+        )
+        + "\n"
+    )
+
+    assert artifacts.result == expected_text
+    assert result_data["example"]["contract_version"] == 2
+    assert set(result_data["example"]["runs"][0]) == module.CANARY_RUN_FIELDS
+    assert pins_data["scenarios"]["example"]["runs"] == [
+        {
+            "run": 0,
+            "success": True,
+            "packages": 1,
+            "pins": {"demo": "1.0"},
+        }
+    ]
+    assert pins_data["canary_result"] == {
+        "filename": "canary_123.json",
+        "sha256": hashlib.sha256(artifacts.result.encode()).hexdigest(),
+    }
+    assert Path("canary_123.json").match("canary_*.json")
+    assert not Path("canary-pins_123.json").match("canary_*.json")
+
+
+@pytest.mark.parametrize(
+    ("path", "value", "match"),
+    [
+        (("canary_result", "sha256"), "0" * 64, "identify"),
+        (("scenarios", "example", "input_hash"), "0" * 64, "identity"),
+        (("scenarios", "example", "execution_hash"), "0" * 64, "identity"),
+        (("scenarios", "example", "runs"), [], "runs do not match"),
+    ],
+)
+def test_pin_sidecar_rejects_pairing_changes(
+    path: tuple[str, ...],
+    value: object,
+    match: str,
+) -> None:
+    module = _harness()
+    artifacts = module.build_canary_artifacts(
+        {"example": _record()},
+        "canary_123.json",
+    )
+    pins_data = json.loads(artifacts.pins)
+    target = pins_data
+    for component in path[:-1]:
+        target = target[component]
+    target[path[-1]] = value
+
+    with pytest.raises(ValueError, match=match):
+        module.validate_canary_pins_artifact(
+            artifacts.result,
+            pins_data,
+            result_filename="canary_123.json",
+        )
+
+
+@pytest.mark.parametrize(
+    "result_filename",
+    ["../canary_123.json", "canary-pins_123.json", "canary_123.json/other"],
+)
+def test_pin_sidecar_rejects_result_path_tricks(result_filename: str) -> None:
+    module = _harness()
+
+    with pytest.raises(ValueError, match="comparison filename"):
+        module.build_canary_artifacts(
+            {"example": _record()},
+            result_filename,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "match"),
+    [
+        ("run", 1, "run order"),
+        ("success", False, "does not match"),
+        ("packages", True, "invalid canary pin run"),
+        ("packages", 2, "does not match"),
+        ("pins", {"demo": "01.0"}, "invalid canary pin run"),
+    ],
+)
+def test_pin_sidecar_rejects_run_changes(
+    field: str,
+    value: object,
+    match: str,
+) -> None:
+    module = _harness()
+    artifacts = module.build_canary_artifacts(
+        {"example": _record()},
+        "canary_123.json",
+    )
+    pins_data = json.loads(artifacts.pins)
+    pins_data["scenarios"]["example"]["runs"][0][field] = value
+
+    with pytest.raises(ValueError, match=match):
+        module.validate_canary_pins_artifact(
+            artifacts.result,
+            pins_data,
+            result_filename="canary_123.json",
+        )
+
+
+def test_pin_sidecar_rejects_reordered_runs() -> None:
+    module = _harness()
+    record = _record()
+    record["runs"].append(_run(version="2.0"))
+    artifacts = module.build_canary_artifacts(
+        {"example": record},
+        "canary_123.json",
+    )
+    pins_data = json.loads(artifacts.pins)
+    pins_data["scenarios"]["example"]["runs"].reverse()
+
+    with pytest.raises(ValueError, match="run order"):
+        module.validate_canary_pins_artifact(
+            artifacts.result,
+            pins_data,
+            result_filename="canary_123.json",
+        )
+
+
+@pytest.mark.parametrize("packages", [True, 1.0])
+def test_pin_sidecar_rejects_noninteger_result_package_count(
+    packages: object,
+) -> None:
+    module = _harness()
+    artifacts = module.build_canary_artifacts(
+        {"example": _record()},
+        "canary_123.json",
+    )
+    result_data = json.loads(artifacts.result)
+    result_data["example"]["runs"][0]["packages"] = packages
+    result_text = json.dumps(result_data, indent=2) + "\n"
+    pins_data = json.loads(artifacts.pins)
+    pins_data["canary_result"]["sha256"] = hashlib.sha256(
+        result_text.encode()
+    ).hexdigest()
+
+    with pytest.raises(ValueError, match="invalid canary comparison run"):
+        module.validate_canary_pins_artifact(
+            result_text,
+            pins_data,
+            result_filename="canary_123.json",
+        )
+
+
+def test_pin_sidecar_rejects_a_non_v2_comparison_record() -> None:
+    module = _harness()
+    record = _record()
+    record["contract_version"] = 3
+
+    with pytest.raises(ValueError, match="comparison record"):
+        module.build_canary_artifacts(
+            {"example": record},
+            "canary_123.json",
+        )
+
+
+def test_artifacts_publish_the_sidecar_first(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    artifacts = module.build_canary_artifacts(
+        {"example": _record()},
+        "canary_123.json",
+    )
+    result_path = tmp_path / "canary_123.json"
+    pins_path = tmp_path / "canary-pins_123.json"
+    published: list[str] = []
+    real_link = module.os.link
+
+    def link(source: Path, destination: Path) -> None:
+        published.append(Path(destination).name)
+        real_link(source, destination)
+
+    monkeypatch.setattr(module.os, "link", link)
+    module.write_canary_artifacts(result_path, pins_path, artifacts)
+
+    assert published == [pins_path.name, result_path.name]
+    assert result_path.read_bytes() == artifacts.result.encode()
+    assert pins_path.read_bytes() == artifacts.pins.encode()
+    assert not list(tmp_path.glob(".canary-artifacts-*"))
+
+
+def test_artifacts_keep_the_default_new_file_mode(tmp_path: Path) -> None:
+    module = _harness()
+    artifacts = module.build_canary_artifacts(
+        {"example": _record()},
+        "canary_123.json",
+    )
+    reference_path = tmp_path / "reference.json"
+    result_path = tmp_path / "canary_123.json"
+    pins_path = tmp_path / "canary-pins_123.json"
+    reference_path.write_text("{}\n")
+
+    module.write_canary_artifacts(result_path, pins_path, artifacts)
+
+    expected_mode = stat.S_IMODE(reference_path.stat().st_mode)
+    assert stat.S_IMODE(result_path.stat().st_mode) == expected_mode
+    assert stat.S_IMODE(pins_path.stat().st_mode) == expected_mode
+
+
+def test_artifacts_sync_files_and_published_names(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    artifacts = module.build_canary_artifacts(
+        {"example": _record()},
+        "canary_123.json",
+    )
+    result_path = tmp_path / "canary_123.json"
+    pins_path = tmp_path / "canary-pins_123.json"
+    calls: list[str] = []
+    real_fsync = module.os.fsync
+    real_link = module.os.link
+
+    def fsync(descriptor: int) -> None:
+        kind = "directory" if stat.S_ISDIR(os.fstat(descriptor).st_mode) else "file"
+        calls.append(f"sync:{kind}")
+        real_fsync(descriptor)
+
+    def link(source: Path, destination: Path) -> None:
+        calls.append(f"link:{Path(destination).name}")
+        real_link(source, destination)
+
+    monkeypatch.setattr(module.os, "fsync", fsync)
+    monkeypatch.setattr(module.os, "link", link)
+    module.write_canary_artifacts(result_path, pins_path, artifacts)
+
+    expected_calls = [
+        "sync:file",
+        "sync:file",
+        f"link:{pins_path.name}",
+    ]
+    if module._DIRECTORY_FSYNC_SUPPORTED:
+        expected_calls.append("sync:directory")
+    expected_calls.append(f"link:{result_path.name}")
+    if module._DIRECTORY_FSYNC_SUPPORTED:
+        expected_calls.extend(["sync:directory", "sync:directory"])
+    assert calls == expected_calls
+
+
+def test_directory_sync_has_a_platform_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+
+    def unexpected_open(*_args: object, **_kwargs: object) -> int:
+        raise AssertionError("directory open should be skipped")
+
+    monkeypatch.setattr(module, "_DIRECTORY_FSYNC_SUPPORTED", False)
+    monkeypatch.setattr(module.os, "open", unexpected_open)
+
+    module._sync_directory(tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("damaged", "match"),
+    [("result", "serialized"), ("pins", "artifact shape")],
+)
+def test_artifact_writer_validates_both_payloads_before_publication(
+    tmp_path: Path,
+    damaged: str,
+    match: str,
+) -> None:
+    module = _harness()
+    artifacts = module.build_canary_artifacts(
+        {"example": _record()},
+        "canary_123.json",
+    )
+    if damaged == "result":
+        artifacts = module.CanaryArtifacts(
+            result=artifacts.result + "not json\n",
+            pins=artifacts.pins,
+        )
+    else:
+        artifacts = module.CanaryArtifacts(
+            result=artifacts.result,
+            pins="{}\n",
+        )
+
+    with pytest.raises(ValueError, match=match):
+        module.write_canary_artifacts(
+            tmp_path / "canary_123.json",
+            tmp_path / "canary-pins_123.json",
+            artifacts,
+        )
+
+    assert not list(tmp_path.iterdir())
+
+
+def test_second_stage_failure_cleans_private_staging_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    artifacts = module.build_canary_artifacts(
+        {"example": _record()},
+        "canary_123.json",
+    )
+    real_stage = module._stage_artifact
+
+    def stage(path: Path, text: str) -> None:
+        if path.name == "canary-pins_123.json":
+            raise OSError("sidecar staging failed")
+        real_stage(path, text)
+
+    monkeypatch.setattr(module, "_stage_artifact", stage)
+
+    with pytest.raises(OSError, match="sidecar staging failed"):
+        module.write_canary_artifacts(
+            tmp_path / "canary_123.json",
+            tmp_path / "canary-pins_123.json",
+            artifacts,
+        )
+
+    assert not list(tmp_path.iterdir())
+
+
+@pytest.mark.parametrize("existing", ["result", "pins"])
+def test_artifacts_reject_existing_targets(tmp_path: Path, existing: str) -> None:
+    module = _harness()
+    artifacts = module.build_canary_artifacts(
+        {"example": _record()},
+        "canary_123.json",
+    )
+    result_path = tmp_path / "canary_123.json"
+    pins_path = tmp_path / "canary-pins_123.json"
+    existing_path = result_path if existing == "result" else pins_path
+    other_path = pins_path if existing == "result" else result_path
+    existing_path.write_text("existing\n")
+
+    with pytest.raises(FileExistsError, match="already exists"):
+        module.write_canary_artifacts(result_path, pins_path, artifacts)
+
+    assert existing_path.read_text() == "existing\n"
+    assert not other_path.exists()
+    assert not list(tmp_path.glob(".canary-artifacts-*"))
+
+
+def test_sidecar_publish_failure_leaves_no_artifacts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    artifacts = module.build_canary_artifacts(
+        {"example": _record()},
+        "canary_123.json",
+    )
+    result_path = tmp_path / "canary_123.json"
+    pins_path = tmp_path / "canary-pins_123.json"
+    real_link = module.os.link
+
+    def link(source: Path, destination: Path) -> None:
+        if Path(destination) == pins_path:
+            raise OSError("sidecar publish failed")
+        real_link(source, destination)
+
+    monkeypatch.setattr(module.os, "link", link)
+
+    with pytest.raises(OSError, match="sidecar publish failed"):
+        module.write_canary_artifacts(result_path, pins_path, artifacts)
+
+    assert not result_path.exists()
+    assert not pins_path.exists()
+    assert not list(tmp_path.glob(".canary-artifacts-*"))
+
+
+def test_publish_rejects_a_target_created_after_preflight(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    artifacts = module.build_canary_artifacts(
+        {"example": _record()},
+        "canary_123.json",
+    )
+    result_path = tmp_path / "canary_123.json"
+    pins_path = tmp_path / "canary-pins_123.json"
+    real_link = module.os.link
+
+    def link(source: Path, destination: Path) -> None:
+        if Path(destination) == pins_path:
+            pins_path.write_text("raced\n")
+        real_link(source, destination)
+
+    monkeypatch.setattr(module.os, "link", link)
+
+    with pytest.raises(FileExistsError):
+        module.write_canary_artifacts(result_path, pins_path, artifacts)
+
+    assert not result_path.exists()
+    assert pins_path.read_text() == "raced\n"
+    assert not list(tmp_path.glob(".canary-artifacts-*"))
+
+
+def test_primary_publish_failure_leaves_bound_sidecar(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    artifacts = module.build_canary_artifacts(
+        {"example": _record()},
+        "canary_123.json",
+    )
+    result_path = tmp_path / "canary_123.json"
+    pins_path = tmp_path / "canary-pins_123.json"
+    real_link = module.os.link
+
+    def link(source: Path, destination: Path) -> None:
+        if Path(destination) == result_path:
+            raise OSError("primary publish failed")
+        real_link(source, destination)
+
+    monkeypatch.setattr(module.os, "link", link)
+
+    with pytest.raises(OSError, match="primary publish failed"):
+        module.write_canary_artifacts(result_path, pins_path, artifacts)
+
+    assert not result_path.exists()
+    assert pins_path.read_bytes() == artifacts.pins.encode()
+    assert not list(tmp_path.glob(".canary-artifacts-*"))
+
+
+def test_artifacts_reject_mismatched_paths(tmp_path: Path) -> None:
+    module = _harness()
+    artifacts = module.build_canary_artifacts(
+        {"example": _record()},
+        "canary_123.json",
+    )
+
+    with pytest.raises(ValueError, match="artifact paths"):
+        module.write_canary_artifacts(
+            tmp_path / "canary_123.json",
+            tmp_path / "other" / "canary-pins_123.json",
+            artifacts,
+        )
+
+
+@pytest.mark.parametrize(
+    "pins",
+    [
+        {"Demo": "1.0"},
+        {"demo/": "1.0"},
+        {"demo": "01.0"},
+        {"demo[extra]": "1.0"},
+        {"z-package": "1.0", "a-package": "1.0"},
+    ],
+)
+def test_pin_sidecar_rejects_noncanonical_pins(pins: dict[str, str]) -> None:
+    module = _harness()
+    record = _record()
+    record["runs"][0]["pins"] = pins
+
+    with pytest.raises(ValueError, match="invalid selected pins"):
+        module.build_canary_artifacts(
+            {"example": record},
+            "canary_123.json",
+        )
+
+
+@pytest.mark.parametrize("packages", [True, 2])
+def test_pin_sidecar_rejects_invalid_package_count(packages: object) -> None:
+    module = _harness()
+    record = _record()
+    record["runs"][0]["packages"] = packages
+
+    with pytest.raises(ValueError, match="invalid selected pins"):
+        module.build_canary_artifacts(
+            {"example": record},
+            "canary_123.json",
+        )
+
+
+def test_pin_sidecar_rejects_pins_from_a_failed_run() -> None:
+    module = _harness()
+    record = _record(success=False)
+    record["runs"][0]["packages"] = 1
+    record["runs"][0]["pins"] = {"demo": "1.0"}
+
+    with pytest.raises(ValueError, match="failed canary run"):
+        module.build_canary_artifacts(
+            {"example": record},
+            "canary_123.json",
+        )


### PR DESCRIPTION
The `pip:pandas-aws-boto3-dandi-frenzy` sdist-policy audit produced successful strict and trusted runs with 52 and 2 pins, respectively. Canary output preserved the aggregate package count but not the selected versions, so the artifact could not show that the trusted run retained only `dandi==0.4.0` and `selenium==0.9.2`.

Each canary invocation now writes normalized pins for every run to a paired sidecar that names and hashes its comparison result. The primary result remains contract v2 with the same shape, so existing scoreboards can continue reading it without a migration. Failed runs have an empty pin map.