### PR TITLE
reject non-boolean benchmark sdist trust values

### DIFF
--- a/nab-python/benchmarks/_profile_runner.py
+++ b/nab-python/benchmarks/_profile_runner.py
@@ -28,7 +28,10 @@ else:
 sys.path.insert(0, str(Path(__file__).parent))
 
 import scenarios as sc
-from benchmark_config import build_benchmark_config
+from benchmark_config import (
+    build_benchmark_config,
+    parse_trust_unverified_sdist_deps,
+)
 
 
 def find_scenario(spec: str) -> tuple[str, dict]:
@@ -71,6 +74,7 @@ def build_inputs(
     resolution_override: sc.ResolutionStrategy | None = None,
     host: sc.BenchmarkHost | None = None,
 ) -> dict:
+    trust_unverified_sdist_deps = parse_trust_unverified_sdist_deps(name, scenario)
     python_version = scenario["python_version"]
     requirement_strings = list(scenario["requirements"])
     constraint_strings = scenario.get("constraints", [])
@@ -134,10 +138,7 @@ def build_inputs(
         index_routes=sc.parse_index_routes(name, scenario),
         build_policy_overrides=build_policy_overrides,
         resolution=resolution_strategy,
-        trust_unverified_sdist_deps=scenario.get(
-            "trust_unverified_sdist_deps",
-            True,
-        ),
+        trust_unverified_sdist_deps=trust_unverified_sdist_deps,
         vcs=vcs_config,
     )
     return {

--- a/nab-python/benchmarks/benchmark_config.py
+++ b/nab-python/benchmarks/benchmark_config.py
@@ -27,6 +27,10 @@ if TYPE_CHECKING:
     from nab_python.target import ResolveTarget
 
 
+# Search benchmarks trust pre-2.2 PKG-INFO dependency metadata by default.
+DEFAULT_SCENARIO_TRUST_UNVERIFIED_SDIST_DEPS = True
+
+
 class _BenchmarkResolveInputs(NamedTuple):
     """Inputs shared by one benchmark's provider and resolver.
 
@@ -38,6 +42,24 @@ class _BenchmarkResolveInputs(NamedTuple):
     requirements: dict[str, VersionRange]
     constraints: Mapping[str, VersionRange] | None
     root_extras: set[tuple[str, str]]
+
+
+def parse_trust_unverified_sdist_deps(
+    scenario_name: str,
+    scenario: Mapping[str, object],
+) -> bool:
+    """Read whether a scenario accepts unverified sdist dependency metadata."""
+    value = scenario.get(
+        "trust_unverified_sdist_deps",
+        DEFAULT_SCENARIO_TRUST_UNVERIFIED_SDIST_DEPS,
+    )
+    if type(value) is not bool:
+        msg = (
+            f"{scenario_name}: trust_unverified_sdist_deps must be a boolean, "
+            f"got {type(value).__name__}"
+        )
+        raise TypeError(msg)
+    return value
 
 
 def _package_overrides(

--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -37,6 +37,7 @@ from benchmark_config import (
     build_benchmark_provider,
     build_benchmark_resolver_inputs,
     direct_packages_from_requirements,
+    parse_trust_unverified_sdist_deps,
 )
 from benchmark_host import (
     BenchmarkHost,
@@ -565,11 +566,30 @@ def select_scenarios(cases: list[CanaryCase]) -> list[CanaryCase]:
     if not cases:
         msg = "at least one scenario must be selected"
         raise _SelectionError(msg)
-    missing = [case.scenario for case in cases if find_scenario(case.scenario) is None]
+    missing: list[str] = []
+    found_scenarios: list[tuple[str, dict]] = []
+    for case in cases:
+        scenario = find_scenario(case.scenario)
+        if scenario is None:
+            missing.append(case.scenario)
+            continue
+        found_scenarios.append((case.scenario, scenario))
     if missing:
         label = "scenario" if len(missing) == 1 else "scenarios"
         msg = f"{label} not found: {', '.join(repr(spec) for spec in missing)}"
         raise _SelectionError(msg)
+
+    labels = [case.scenario.split(":", 1)[-1] for case in cases]
+    duplicate_labels = sorted({label for label in labels if labels.count(label) > 1})
+    if duplicate_labels:
+        msg = (
+            "scenario names must be unique across selected files; duplicate(s): "
+            + ", ".join(duplicate_labels)
+        )
+        raise _SelectionError(msg)
+
+    for scenario_name, scenario in found_scenarios:
+        parse_trust_unverified_sdist_deps(scenario_name, scenario)
     return cases
 
 
@@ -579,7 +599,7 @@ def _parse_scenario_selection(
 ) -> list[CanaryCase]:
     try:
         return select_scenarios([parse_canary_case(spec) for spec in specs])
-    except _SelectionError as exc:
+    except (_SelectionError, TypeError) as exc:
         parser.error(str(exc))
 
 
@@ -588,7 +608,7 @@ def _parse_default_selection(
 ) -> list[CanaryCase]:
     try:
         return select_scenarios(load_canary_manifest())
-    except _SelectionError as exc:
+    except (_SelectionError, TypeError) as exc:
         parser.error(str(exc))
 
 
@@ -730,6 +750,10 @@ def _prepare_canary_execution(
     host: BenchmarkHost,
 ) -> CanaryPreparation:
     """Validate and prepare a supported canary scenario for this host."""
+    trust_unverified_sdist_deps = parse_trust_unverified_sdist_deps(
+        scenario_name,
+        scenario,
+    )
     python_version = scenario["python_version"]
     requirement_strings = list(scenario["requirements"])
     constraint_strings = scenario.get("constraints", [])
@@ -797,11 +821,6 @@ def _prepare_canary_execution(
         )
         if constraint_strings
         else None
-    )
-    # See scenarios.py: trust pre-2.2 sdist PKG-INFO deps by default so the
-    # benchmark measures search, not strict PEP 643 sdist rejection.
-    trust_unverified_sdist_deps = bool(
-        scenario.get("trust_unverified_sdist_deps", True)
     )
     datetime_str = scenario.get("datetime")
     config = build_benchmark_config(
@@ -914,12 +933,6 @@ def main() -> None:
         cases_to_run = _parse_default_selection(parser)
 
     labels = [case.scenario.split(":", 1)[-1] for case in cases_to_run]
-    duplicate_labels = sorted({label for label in labels if labels.count(label) > 1})
-    if duplicate_labels:
-        parser.error(
-            "scenario names must be unique across selected files; duplicate(s): "
-            + ", ".join(duplicate_labels)
-        )
 
     out_dir = RESULTS_DIR / commit
     out_dir.mkdir(parents=True, exist_ok=True)

--- a/nab-python/benchmarks/scenarios.py
+++ b/nab-python/benchmarks/scenarios.py
@@ -33,9 +33,11 @@ else:
     import tomli as tomllib  # type: ignore[no-redef]
 
 from benchmark_config import (
+    DEFAULT_SCENARIO_TRUST_UNVERIFIED_SDIST_DEPS,
     build_benchmark_config,
     build_benchmark_provider,
     build_benchmark_resolver_inputs,
+    parse_trust_unverified_sdist_deps,
 )
 from benchmark_host import (
     HOST_TAG_MISMATCH_REASON,
@@ -576,6 +578,7 @@ def load_standard_corpus(files: list[Path]) -> list[StandardScenario]:
     for row in rows:
         marker_environment = parse_marker_environment(row.name, row.definition)
         parse_requires_matching_host(row.name, row.definition, marker_environment)
+        parse_trust_unverified_sdist_deps(row.logical_key, row.definition)
         build_policy_overrides = parse_build_packages(row.name, row.definition)
         if "unsupported_reason" in row.definition:
             continue
@@ -882,7 +885,9 @@ def standard_benchmark_settings(host: BenchmarkHost) -> dict[str, object]:
     return {
         "dist_policy": DistPolicy.WHEEL_OR_SDIST.value,
         "build_policy": BuildPolicy.NEVER.value,
-        "trust_unverified_sdist_deps_default": True,
+        "trust_unverified_sdist_deps_default": (
+            DEFAULT_SCENARIO_TRUST_UNVERIFIED_SDIST_DEPS
+        ),
         "max_iterations": MAX_ITERATIONS,
         "wall_timeout_seconds": host.wall_timeout_seconds,
         "host": host.identity(),
@@ -1609,10 +1614,9 @@ def prepare_standard_execution(
         allowed_repos=tuple(scenario.get("vcs_allowed_repos", [])),
         require_pin=scenario.get("vcs_require_pin", True),
     )
-    # Search benchmarks accept pre-2.2 PKG-INFO dependency metadata by default;
-    # individual strict-policy scenarios opt out explicitly.
-    trust_unverified_sdist_deps: bool = scenario.get(
-        "trust_unverified_sdist_deps", True
+    trust_unverified_sdist_deps = parse_trust_unverified_sdist_deps(
+        scenario_name,
+        scenario,
     )
     uploaded_prior_to = parse_datetime(datetime_str) if datetime_str else None
     config = build_benchmark_config(
@@ -1792,7 +1796,7 @@ def main(argv: list[str] | None = None) -> None:
 
     try:
         all_rows = load_standard_corpus(all_files)
-    except ValueError as exc:
+    except (TypeError, ValueError) as exc:
         parser.error(str(exc))
     selected_stems = {path.stem for path in selected_files}
     selected_rows = [row for row in all_rows if row.toml_stem in selected_stems]

--- a/nab-python/tests/test_benchmark_canary.py
+++ b/nab-python/tests/test_benchmark_canary.py
@@ -571,6 +571,41 @@ def test_canary_main_records_v2_contract(
     }
 
 
+def test_canary_main_rejects_non_boolean_sdist_trust_before_result_creation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _harness()
+    results_dir = tmp_path / "results"
+    monkeypatch.setattr(module, "RESULTS_DIR", results_dir)
+    monkeypatch.setattr(
+        module,
+        "get_git_source_state",
+        lambda: {"commit": "source-sha", "dirty": False, "diff_hash": None},
+    )
+    scenario = {
+        "unsupported_reason": "test fixture",
+        "trust_unverified_sdist_deps": "false",
+    }
+    monkeypatch.setattr(module, "find_scenario", lambda _name: scenario)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["canary.py", "--commit", "test", "--scenario", "quick:requests"],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        module.main()
+
+    assert exc_info.value.code == 2
+    assert (
+        "quick:requests: trust_unverified_sdist_deps must be a boolean, got str"
+        in capsys.readouterr().err
+    )
+    assert not results_dir.exists()
+
+
 def test_canary_main_preserves_v2_lowest_identity_and_effective_settings(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -841,20 +876,39 @@ def test_canary_source_state_preserves_commit_when_hashing_fails(
 
 
 def test_canary_main_rejects_duplicate_output_labels(
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     module = _harness()
+    results_dir = tmp_path / "results"
+    monkeypatch.setattr(module, "RESULTS_DIR", results_dir)
+    monkeypatch.setattr(
+        module,
+        "get_git_source_state",
+        lambda: {"commit": "source-sha", "dirty": False, "diff_hash": None},
+    )
+    scenario = {"trust_unverified_sdist_deps": "false"}
+    monkeypatch.setattr(module, "find_scenario", lambda _name: scenario)
     monkeypatch.setattr(
         sys,
         "argv",
         [
             "canary.py",
+            "--commit",
+            "test",
             "--scenario",
-            "quick:requests",
+            "first:shared",
             "--scenario",
-            "quick:requests",
+            "second:shared",
         ],
     )
 
-    with pytest.raises(SystemExit, match="2"):
+    with pytest.raises(SystemExit) as exc_info:
         module.main()
+
+    stderr = capsys.readouterr().err
+    assert exc_info.value.code == 2
+    assert "scenario names must be unique across selected files" in stderr
+    assert "trust_unverified_sdist_deps" not in stderr
+    assert not results_dir.exists()

--- a/nab-python/tests/test_benchmark_strategy_matrix.py
+++ b/nab-python/tests/test_benchmark_strategy_matrix.py
@@ -240,6 +240,27 @@ def _runner_parity_scenario() -> dict[str, object]:
     }
 
 
+def _prepare_standard_scenario(
+    standard: ModuleType,
+    scenario: dict[str, object],
+    host: object,
+) -> object:
+    """Prepare one standard scenario without running its resolver."""
+    strategy = standard.ResolutionStrategy(
+        scenario.get("resolution", standard.ResolutionStrategy.HIGHEST.value)
+    )
+    row = standard.StandardScenario("quick", "example", scenario)
+    plan = standard.standard_run_plan([row], (strategy,), host)
+    return standard.prepare_standard_execution(
+        plan.executions[0],
+        plan.targets_by_logical_key[row.logical_key],
+        commit="run",
+        source=dict(_CLEAN_SOURCE),
+        corpus_hash="f" * 64,
+        settings_digest="settings",
+    )
+
+
 def _prepare_runner_parity(
     standard: ModuleType,
     canary: ModuleType,
@@ -248,20 +269,7 @@ def _prepare_runner_parity(
     """Prepare equivalent inputs through the three benchmark entry points."""
     scenario = _runner_parity_scenario()
     host = _linux_host(standard)
-    row = standard.StandardScenario("quick", "example", scenario)
-    plan = standard.standard_run_plan(
-        [row],
-        (standard.ResolutionStrategy.LOWEST_DIRECT,),
-        host,
-    )
-    standard_execution = standard.prepare_standard_execution(
-        plan.executions[0],
-        plan.targets_by_logical_key[row.logical_key],
-        commit="run",
-        source=dict(_CLEAN_SOURCE),
-        corpus_hash="f" * 64,
-        settings_digest="settings",
-    )
+    standard_execution = _prepare_standard_scenario(standard, scenario, host)
     canary_preparation = canary._prepare_canary_execution(
         scenario,
         scenario_name="example",
@@ -1103,6 +1111,53 @@ def test_benchmark_config_combines_routing_and_build_policy() -> None:
     assert module.index_routes_from_config(config) == [
         module.IndexRoute("demo-pkg", "private")
     ]
+
+
+@pytest.mark.parametrize(
+    ("scenario", "expected"),
+    [
+        ({}, True),
+        ({"trust_unverified_sdist_deps": True}, True),
+        ({"trust_unverified_sdist_deps": False}, False),
+    ],
+    ids=("implicit", "trusted", "strict"),
+)
+def test_parse_trust_unverified_sdist_deps_accepts_exact_booleans(
+    scenario: dict[str, object],
+    expected: bool,
+) -> None:
+    module = _harness("benchmark_config")
+    original = dict(scenario)
+
+    assert module.parse_trust_unverified_sdist_deps("example", scenario) is expected
+    assert scenario == original
+
+
+@pytest.mark.parametrize(
+    ("invalid", "type_name"),
+    [
+        (0, "int"),
+        (1, "int"),
+        (0.0, "float"),
+        ("false", "str"),
+        ([False], "list"),
+        ({"value": False}, "dict"),
+        (None, "NoneType"),
+    ],
+    ids=("zero", "one", "float", "string", "list", "table", "none"),
+)
+def test_parse_trust_unverified_sdist_deps_rejects_other_types(
+    invalid: object,
+    type_name: str,
+) -> None:
+    module = _harness("benchmark_config")
+    message = f"example: trust_unverified_sdist_deps must be a boolean, got {type_name}"
+
+    with pytest.raises(TypeError, match=message):
+        module.parse_trust_unverified_sdist_deps(
+            "example",
+            {"trust_unverified_sdist_deps": invalid},
+        )
 
 
 @pytest.mark.parametrize(
@@ -2380,6 +2435,49 @@ def test_selector_errors_are_actionable(
     assert not (tmp_path / "results").exists()
 
 
+def test_unselected_unsupported_sdist_trust_fails_before_result_creation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _harness("scenarios")
+    scenarios_dir = tmp_path / "scenarios"
+    _write_corpus(scenarios_dir)
+    (scenarios_dir / "other.toml").write_text(
+        """
+[other]
+python_version = "3.11"
+requirements = []
+unsupported_reason = "not runnable"
+trust_unverified_sdist_deps = "false"
+""".lstrip(),
+        encoding="utf-8",
+    )
+    results_dir = tmp_path / "results"
+    monkeypatch.setattr(module, "SCENARIOS_DIR", scenarios_dir)
+    monkeypatch.setattr(module, "RESULTS_DIR", results_dir)
+    monkeypatch.setattr(module, "get_git_source_state", lambda: _CLEAN_SOURCE)
+
+    def fail_result_creation(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("result namespace creation was reached")
+
+    monkeypatch.setattr(
+        module,
+        "prepare_standard_result_namespace",
+        fail_result_creation,
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        module.main(["--commit", "run", "--toml", "quick"])
+
+    assert exc_info.value.code == 2
+    assert (
+        "other:other: trust_unverified_sdist_deps must be a boolean, got str"
+        in capsys.readouterr().err
+    )
+    assert not results_dir.exists()
+
+
 def test_strategy_sweep_is_only_a_matrix_forwarder(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -2424,6 +2522,59 @@ def test_standard_canary_and_profile_build_the_same_project_config() -> None:
     )
     assert standard_execution.config.constraints == ()
     assert standard_execution.constraint_strings == ["demo<2"]
+    assert "trust_unverified_sdist_deps" not in standard_execution.expected_input
+
+
+def test_standard_canary_and_profile_reject_non_boolean_sdist_trust() -> None:
+    standard = _harness("scenarios")
+    canary = _harness("canary")
+    profile = _harness("_profile_runner")
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        "trust_unverified_sdist_deps": "false",
+    }
+    host = _linux_host(standard)
+    message = "example: trust_unverified_sdist_deps must be a boolean"
+
+    with pytest.raises(TypeError, match=message):
+        _prepare_standard_scenario(standard, scenario, host)
+
+    with pytest.raises(TypeError, match=message):
+        canary._prepare_canary_execution(
+            scenario,
+            scenario_name="example",
+            resolution_override=None,
+            host=host,
+        )
+
+    with pytest.raises(TypeError, match=message):
+        profile.build_inputs("example", scenario, host=host)
+
+
+def test_sdist_trust_validation_precedes_host_admission() -> None:
+    canary = _harness("canary")
+    profile = _harness("_profile_runner")
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        "platform_system": "Windows",
+        "requires_matching_host": True,
+        "trust_unverified_sdist_deps": "false",
+    }
+    host = _linux_host(canary)
+    message = "example: trust_unverified_sdist_deps must be a boolean"
+
+    with pytest.raises(TypeError, match=message):
+        canary._prepare_canary_execution(
+            scenario,
+            scenario_name="example",
+            resolution_override=None,
+            host=host,
+        )
+
+    with pytest.raises(TypeError, match=message):
+        profile.build_inputs("example", scenario, host=host)
 
 
 def test_standard_canary_and_profile_prepare_the_same_resolver_inputs() -> None:


### PR DESCRIPTION
A benchmark scenario containing `trust_unverified_sdist_deps = "false"` silently enabled the policy. Canary converted the string to `true`; the standard and profile runners passed the truthy string through, and standard output recorded Boolean `true`.

All three runners now use one parser that accepts only booleans for this setting. Invalid input is rejected before resolution with the scenario name and received type.
