### PR TITLE
reject malformed benchmark requirement lists

### DIFF
--- a/nab-python/benchmarks/_profile_runner.py
+++ b/nab-python/benchmarks/_profile_runner.py
@@ -30,6 +30,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 import scenarios as sc
 from benchmark_config import (
     build_benchmark_config,
+    parse_scenario_requirement_strings,
     parse_trust_unverified_sdist_deps,
 )
 
@@ -75,9 +76,10 @@ def build_inputs(
     host: sc.BenchmarkHost | None = None,
 ) -> dict:
     trust_unverified_sdist_deps = parse_trust_unverified_sdist_deps(name, scenario)
+    requirement_inputs = parse_scenario_requirement_strings(name, scenario)
     python_version = scenario["python_version"]
-    requirement_strings = list(scenario["requirements"])
-    constraint_strings = scenario.get("constraints", [])
+    requirement_strings = requirement_inputs.requirements
+    constraint_strings = requirement_inputs.constraints
     marker_environment = sc.parse_marker_environment(name, scenario)
     build_policy_overrides = sc.parse_build_packages(name, scenario)
     sc.validate_scenario_build_policy(

--- a/nab-python/benchmarks/benchmark_config.py
+++ b/nab-python/benchmarks/benchmark_config.py
@@ -44,6 +44,61 @@ class _BenchmarkResolveInputs(NamedTuple):
     root_extras: set[tuple[str, str]]
 
 
+class ScenarioRequirementStrings(NamedTuple):
+    """Copied requirement and constraint strings from one scenario."""
+
+    requirements: list[str]
+    constraints: list[str]
+
+
+def _scenario_string_list(
+    scenario_name: str,
+    field: str,
+    value: object,
+) -> list[str]:
+    """Validate and copy one scenario list of strings."""
+    if type(value) is not list:
+        msg = f"{scenario_name}: {field} must be a list, got {type(value).__name__}"
+        raise TypeError(msg)
+
+    strings: list[str] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, str):
+            msg = (
+                f"{scenario_name}: {field}[{index}] must be a non-empty string, "
+                f"got {type(item).__name__}"
+            )
+            raise TypeError(msg)
+        if not item:
+            msg = f"{scenario_name}: {field}[{index}] must be a non-empty string"
+            raise ValueError(msg)
+        strings.append(item)
+    return strings
+
+
+def parse_scenario_requirement_strings(
+    scenario_name: str,
+    scenario: Mapping[str, object],
+) -> ScenarioRequirementStrings:
+    """Validate and copy a scenario's root and constraint strings."""
+    if "requirements" not in scenario:
+        msg = f"{scenario_name}: missing required field 'requirements'"
+        raise ValueError(msg)
+
+    return ScenarioRequirementStrings(
+        requirements=_scenario_string_list(
+            scenario_name,
+            "requirements",
+            scenario["requirements"],
+        ),
+        constraints=_scenario_string_list(
+            scenario_name,
+            "constraints",
+            scenario.get("constraints", []),
+        ),
+    )
+
+
 def parse_trust_unverified_sdist_deps(
     scenario_name: str,
     scenario: Mapping[str, object],

--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -37,6 +37,7 @@ from benchmark_config import (
     build_benchmark_provider,
     build_benchmark_resolver_inputs,
     direct_packages_from_requirements,
+    parse_scenario_requirement_strings,
     parse_trust_unverified_sdist_deps,
 )
 from benchmark_host import (
@@ -588,8 +589,12 @@ def select_scenarios(cases: list[CanaryCase]) -> list[CanaryCase]:
         )
         raise _SelectionError(msg)
 
+    # Check each field across the whole selection before moving to the next field.
     for scenario_name, scenario in found_scenarios:
         parse_trust_unverified_sdist_deps(scenario_name, scenario)
+
+    for scenario_name, scenario in found_scenarios:
+        parse_scenario_requirement_strings(scenario_name, scenario)
     return cases
 
 
@@ -599,7 +604,7 @@ def _parse_scenario_selection(
 ) -> list[CanaryCase]:
     try:
         return select_scenarios([parse_canary_case(spec) for spec in specs])
-    except (_SelectionError, TypeError) as exc:
+    except (TypeError, ValueError) as exc:
         parser.error(str(exc))
 
 
@@ -608,7 +613,7 @@ def _parse_default_selection(
 ) -> list[CanaryCase]:
     try:
         return select_scenarios(load_canary_manifest())
-    except (_SelectionError, TypeError) as exc:
+    except (TypeError, ValueError) as exc:
         parser.error(str(exc))
 
 
@@ -754,9 +759,10 @@ def _prepare_canary_execution(
         scenario_name,
         scenario,
     )
+    requirement_inputs = parse_scenario_requirement_strings(scenario_name, scenario)
     python_version = scenario["python_version"]
-    requirement_strings = list(scenario["requirements"])
-    constraint_strings = scenario.get("constraints", [])
+    requirement_strings = requirement_inputs.requirements
+    constraint_strings = requirement_inputs.constraints
     marker_environment = parse_target_marker_environment(scenario_name, scenario)
     raw_build_packages = scenario.get("build_packages", []) or []
     build_policy_overrides = {

--- a/nab-python/benchmarks/scenarios.py
+++ b/nab-python/benchmarks/scenarios.py
@@ -37,6 +37,7 @@ from benchmark_config import (
     build_benchmark_config,
     build_benchmark_provider,
     build_benchmark_resolver_inputs,
+    parse_scenario_requirement_strings,
     parse_trust_unverified_sdist_deps,
 )
 from benchmark_host import (
@@ -579,6 +580,7 @@ def load_standard_corpus(files: list[Path]) -> list[StandardScenario]:
         marker_environment = parse_marker_environment(row.name, row.definition)
         parse_requires_matching_host(row.name, row.definition, marker_environment)
         parse_trust_unverified_sdist_deps(row.logical_key, row.definition)
+        parse_scenario_requirement_strings(row.logical_key, row.definition)
         build_policy_overrides = parse_build_packages(row.name, row.definition)
         if "unsupported_reason" in row.definition:
             continue
@@ -1584,9 +1586,14 @@ def prepare_standard_execution(
     """Prepare and identify one execution without performing network work."""
     scenario_name = execution.scenario.name
     scenario = execution.scenario.definition
+    trust_unverified_sdist_deps = parse_trust_unverified_sdist_deps(
+        scenario_name,
+        scenario,
+    )
+    requirement_inputs = parse_scenario_requirement_strings(scenario_name, scenario)
     python_version: str = scenario["python_version"]
-    requirement_strings: list[str] = list(scenario["requirements"])
-    constraint_strings: list[str] = scenario.get("constraints", [])
+    requirement_strings = requirement_inputs.requirements
+    constraint_strings = requirement_inputs.constraints
     marker_environment = parse_marker_environment(scenario_name, scenario)
     indexes = parse_indexes(scenario_name, scenario)
     index_routes = parse_index_routes(scenario_name, scenario)
@@ -1613,10 +1620,6 @@ def prepare_standard_execution(
         allowed_schemes=frozenset(scenario.get("vcs_allowed_schemes", [])),
         allowed_repos=tuple(scenario.get("vcs_allowed_repos", [])),
         require_pin=scenario.get("vcs_require_pin", True),
-    )
-    trust_unverified_sdist_deps = parse_trust_unverified_sdist_deps(
-        scenario_name,
-        scenario,
     )
     uploaded_prior_to = parse_datetime(datetime_str) if datetime_str else None
     config = build_benchmark_config(

--- a/nab-python/tests/test_benchmark_canary.py
+++ b/nab-python/tests/test_benchmark_canary.py
@@ -543,7 +543,7 @@ def test_canary_main_records_v2_contract(
     monkeypatch.setattr(module, "RESULTS_DIR", tmp_path)
     source = {"commit": "source-sha", "dirty": False, "diff_hash": None}
     monkeypatch.setattr(module, "get_git_source_state", lambda: source)
-    scenario = {"unsupported_reason": "test fixture"}
+    scenario = {"requirements": [], "unsupported_reason": "test fixture"}
     input_hash = module.scenario_input_hash("quick:requests", scenario)
     monkeypatch.setattr(module, "find_scenario", lambda _name: scenario)
     monkeypatch.setattr(
@@ -571,10 +571,47 @@ def test_canary_main_records_v2_contract(
     }
 
 
-def test_canary_main_rejects_non_boolean_sdist_trust_before_result_creation(
+@pytest.mark.parametrize(
+    ("scenario", "default_selection", "message"),
+    [
+        (
+            {
+                "unsupported_reason": "test fixture",
+                "trust_unverified_sdist_deps": "false",
+            },
+            False,
+            "quick:requests: trust_unverified_sdist_deps must be a boolean, got str",
+        ),
+        (
+            {"unsupported_reason": "test fixture"},
+            False,
+            "quick:requests: missing required field 'requirements'",
+        ),
+        (
+            {"requirements": "demo", "unsupported_reason": "test fixture"},
+            False,
+            "quick:requests: requirements must be a list, got str",
+        ),
+        (
+            {"requirements": [""], "unsupported_reason": "test fixture"},
+            False,
+            "quick:requests: requirements[0] must be a non-empty string",
+        ),
+        (
+            {"requirements": [""], "unsupported_reason": "test fixture"},
+            True,
+            "quick:requests: requirements[0] must be a non-empty string",
+        ),
+    ],
+    ids=("sdist-trust", "missing", "scalar", "empty-item", "default-empty-item"),
+)
+def test_canary_main_rejects_scenario_schema_before_result_creation(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
+    scenario: dict[str, object],
+    default_selection: bool,
+    message: str,
 ) -> None:
     module = _harness()
     results_dir = tmp_path / "results"
@@ -584,25 +621,23 @@ def test_canary_main_rejects_non_boolean_sdist_trust_before_result_creation(
         "get_git_source_state",
         lambda: {"commit": "source-sha", "dirty": False, "diff_hash": None},
     )
-    scenario = {
-        "unsupported_reason": "test fixture",
-        "trust_unverified_sdist_deps": "false",
-    }
     monkeypatch.setattr(module, "find_scenario", lambda _name: scenario)
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        ["canary.py", "--commit", "test", "--scenario", "quick:requests"],
-    )
+    if default_selection:
+        monkeypatch.setattr(
+            module,
+            "load_canary_manifest",
+            lambda: [module.CanaryCase("quick:requests", None)],
+        )
+    argv = ["canary.py", "--commit", "test"]
+    if not default_selection:
+        argv.extend(("--scenario", "quick:requests"))
+    monkeypatch.setattr(sys, "argv", argv)
 
     with pytest.raises(SystemExit) as exc_info:
         module.main()
 
     assert exc_info.value.code == 2
-    assert (
-        "quick:requests: trust_unverified_sdist_deps must be a boolean, got str"
-        in capsys.readouterr().err
-    )
+    assert message in capsys.readouterr().err
     assert not results_dir.exists()
 
 

--- a/nab-python/tests/test_benchmark_canary_selection.py
+++ b/nab-python/tests/test_benchmark_canary_selection.py
@@ -326,7 +326,7 @@ def test_existing_summary_is_not_overwritten(
     scenarios_dir = tmp_path / "scenarios"
     scenarios_dir.mkdir()
     (scenarios_dir / "inside.toml").write_text(
-        '[skipped]\nunsupported_reason = "test fixture"\n',
+        '[skipped]\nrequirements = []\nunsupported_reason = "test fixture"\n',
         encoding="utf-8",
     )
     results_dir = tmp_path / "results"

--- a/nab-python/tests/test_benchmark_strategy_matrix.py
+++ b/nab-python/tests/test_benchmark_strategy_matrix.py
@@ -1160,6 +1160,88 @@ def test_parse_trust_unverified_sdist_deps_rejects_other_types(
         )
 
 
+def test_parse_scenario_requirement_strings_returns_fresh_unchanged_lists() -> None:
+    module = _harness("benchmark_config")
+    requirements = ["Z_pkg", " demo >= 1 "]
+    constraints = ["demo!=2", "Other===local"]
+    scenario = {"requirements": requirements, "constraints": constraints}
+
+    parsed = module.parse_scenario_requirement_strings("quick:example", scenario)
+
+    assert parsed.requirements == requirements
+    assert parsed.constraints == constraints
+    assert parsed.requirements is not requirements
+    assert parsed.constraints is not constraints
+
+    parsed.requirements.append("new-root")
+    parsed.constraints.clear()
+    assert scenario == {
+        "requirements": ["Z_pkg", " demo >= 1 "],
+        "constraints": ["demo!=2", "Other===local"],
+    }
+
+
+def test_parse_scenario_requirement_strings_accepts_empty_lists() -> None:
+    module = _harness("benchmark_config")
+    scenario: dict[str, object] = {"requirements": [], "constraints": []}
+
+    parsed = module.parse_scenario_requirement_strings("quick:empty", scenario)
+
+    assert parsed.requirements == []
+    assert parsed.constraints == []
+    assert parsed.requirements is not scenario["requirements"]
+    assert parsed.constraints is not scenario["constraints"]
+
+
+def test_parse_scenario_requirement_strings_requires_requirements() -> None:
+    module = _harness("benchmark_config")
+
+    with pytest.raises(
+        ValueError,
+        match="quick:missing: missing required field 'requirements'",
+    ):
+        module.parse_scenario_requirement_strings("quick:missing", {})
+
+
+@pytest.mark.parametrize("field", ["requirements", "constraints"])
+def test_parse_scenario_requirement_strings_rejects_scalar_fields(field: str) -> None:
+    module = _harness("benchmark_config")
+    scenario: dict[str, object] = {"requirements": []}
+    scenario[field] = "demo"
+
+    with pytest.raises(
+        TypeError,
+        match=rf"quick:scalar: {field} must be a list, got str",
+    ):
+        module.parse_scenario_requirement_strings("quick:scalar", scenario)
+
+
+@pytest.mark.parametrize("field", ["requirements", "constraints"])
+def test_parse_scenario_requirement_strings_rejects_mixed_fields(field: str) -> None:
+    module = _harness("benchmark_config")
+    scenario: dict[str, object] = {"requirements": []}
+    scenario[field] = ["demo", 1]
+
+    with pytest.raises(
+        TypeError,
+        match=rf"quick:mixed: {field}\[1\] must be a non-empty string, got int",
+    ):
+        module.parse_scenario_requirement_strings("quick:mixed", scenario)
+
+
+@pytest.mark.parametrize("field", ["requirements", "constraints"])
+def test_parse_scenario_requirement_strings_rejects_empty_items(field: str) -> None:
+    module = _harness("benchmark_config")
+    scenario: dict[str, object] = {"requirements": []}
+    scenario[field] = ["demo", ""]
+
+    with pytest.raises(
+        ValueError,
+        match=rf"quick:empty-item: {field}\[1\] must be a non-empty string$",
+    ):
+        module.parse_scenario_requirement_strings("quick:empty-item", scenario)
+
+
 @pytest.mark.parametrize(
     ("routes", "message"),
     [
@@ -2435,22 +2517,43 @@ def test_selector_errors_are_actionable(
     assert not (tmp_path / "results").exists()
 
 
-def test_unselected_unsupported_sdist_trust_fails_before_result_creation(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    module = _harness("scenarios")
-    scenarios_dir = tmp_path / "scenarios"
-    _write_corpus(scenarios_dir)
-    (scenarios_dir / "other.toml").write_text(
-        """
+@pytest.mark.parametrize(
+    ("invalid_toml", "message"),
+    [
+        (
+            """
 [other]
 python_version = "3.11"
 requirements = []
 unsupported_reason = "not runnable"
 trust_unverified_sdist_deps = "false"
-""".lstrip(),
+""",
+            "other:other: trust_unverified_sdist_deps must be a boolean, got str",
+        ),
+        (
+            """
+[other]
+python_version = "3.11"
+requirements = "demo"
+unsupported_reason = "not runnable"
+""",
+            "other:other: requirements must be a list, got str",
+        ),
+    ],
+    ids=("sdist-trust", "requirements"),
+)
+def test_unselected_unsupported_definition_fails_before_result_creation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    invalid_toml: str,
+    message: str,
+) -> None:
+    module = _harness("scenarios")
+    scenarios_dir = tmp_path / "scenarios"
+    _write_corpus(scenarios_dir)
+    (scenarios_dir / "other.toml").write_text(
+        invalid_toml.lstrip(),
         encoding="utf-8",
     )
     results_dir = tmp_path / "results"
@@ -2471,10 +2574,7 @@ trust_unverified_sdist_deps = "false"
         module.main(["--commit", "run", "--toml", "quick"])
 
     assert exc_info.value.code == 2
-    assert (
-        "other:other: trust_unverified_sdist_deps must be a boolean, got str"
-        in capsys.readouterr().err
-    )
+    assert message in capsys.readouterr().err
     assert not results_dir.exists()
 
 
@@ -2550,6 +2650,66 @@ def test_standard_canary_and_profile_reject_non_boolean_sdist_trust() -> None:
 
     with pytest.raises(TypeError, match=message):
         profile.build_inputs("example", scenario, host=host)
+
+
+@pytest.mark.parametrize("field", ["requirements", "constraints"])
+def test_standard_direct_preparation_validates_requirement_lists(field: str) -> None:
+    standard = _harness("scenarios")
+    scenario: dict[str, object] = {
+        "python_version": "3.11",
+        "requirements": [],
+    }
+    scenario[field] = "demo"
+    host = _linux_host(standard)
+
+    with pytest.raises(
+        TypeError,
+        match=rf"example: {field} must be a list, got str",
+    ):
+        _prepare_standard_scenario(standard, scenario, host)
+
+
+@pytest.mark.parametrize("field", ["requirements", "constraints"])
+def test_canary_direct_preparation_validates_requirement_lists(field: str) -> None:
+    canary = _harness("canary")
+    scenario: dict[str, object] = {
+        "python_version": "3.11",
+        "requirements": [],
+    }
+    scenario[field] = "demo"
+    host = _linux_host(canary)
+
+    with pytest.raises(
+        TypeError,
+        match=rf"example: {field} must be a list, got str",
+    ):
+        canary._prepare_canary_execution(
+            scenario,
+            scenario_name="example",
+            resolution_override=None,
+            host=host,
+        )
+
+
+@pytest.mark.parametrize("field", ["requirements", "constraints"])
+def test_profile_build_inputs_validates_requirement_lists_before_host_admission(
+    field: str,
+) -> None:
+    profile = _harness("_profile_runner")
+    scenario: dict[str, object] = {
+        "python_version": "3.11",
+        "requirements": [],
+    }
+    scenario[field] = "demo"
+    host = MagicMock()
+
+    with pytest.raises(
+        TypeError,
+        match=rf"example: {field} must be a list, got str",
+    ):
+        profile.build_inputs("example", scenario, host=host)
+
+    host.target_for.assert_not_called()
 
 
 def test_sdist_trust_validation_precedes_host_admission() -> None:


### PR DESCRIPTION
A benchmark scenario with `requirements = "demo"` was interpreted as four one-letter roots; `constraints = "demo"` was split the same way. This could measure a different dependency graph from the one described in the scenario.

Requirement and constraint fields now have to be lists of non-empty strings. Malformed scenarios are rejected before resolution instead of being split into individual characters.