### PR TITLE
reject duplicate universal benchmark platforms

### DIFF
--- a/nab-python/benchmarks/universal_scenarios.py
+++ b/nab-python/benchmarks/universal_scenarios.py
@@ -244,7 +244,7 @@ def check_lock_consistency(result: ResolveResult) -> tuple[bool, list[str]]:
 
 
 def validate_scenario(scenario_name: str, scenario: dict) -> None:
-    """Reject settings the universal runner would otherwise silently ignore."""
+    """Reject invalid settings before running a universal scenario."""
     unknown = sorted(set(scenario) - UNIVERSAL_SCENARIO_KEYS)
     if unknown:
         msg = f"{scenario_name}: unknown scenario setting(s): {', '.join(unknown)}"
@@ -266,6 +266,12 @@ def validate_scenario(scenario_name: str, scenario: dict) -> None:
     if not scenario["platforms"] or not scenario["requirements"]:
         msg = f"{scenario_name}: platforms and requirements cannot be empty"
         raise ValueError(msg)
+    seen_platforms: set[str] = set()
+    for platform in scenario["platforms"]:
+        if platform in seen_platforms:
+            msg = f"{scenario_name}: platforms has duplicate entry: {platform!r}"
+            raise ValueError(msg)
+        seen_platforms.add(platform)
     for key in ("align_across_tuples", "skip_on_fail"):
         if key in scenario and type(scenario[key]) is not bool:
             msg = f"{scenario_name}: {key} must be a boolean"
@@ -579,6 +585,9 @@ def main() -> None:
         selected = [(name, scenarios[name]) for name in args.scenario]
     else:
         selected = list(scenarios.items())
+
+    for name, scenario in selected:
+        validate_scenario(name, scenario)
 
     result_kind = "universal-selected" if args.scenario else "universal"
     output_dir = RESULTS_DIR / commit / result_kind

--- a/nab-python/tests/test_universal_benchmark.py
+++ b/nab-python/tests/test_universal_benchmark.py
@@ -38,6 +38,14 @@ class _FakeCoordinator:
         pass
 
 
+def _universal_scenario(*platforms: str) -> dict:
+    return {
+        "python": ">=3.11,<3.12",
+        "platforms": list(platforms),
+        "requirements": ["foo"],
+    }
+
+
 def _successful_result() -> tuple[ResolveTarget, ResolveResult]:
     target = ResolveTarget.for_declared(
         python_version="3.11",
@@ -679,6 +687,57 @@ def test_unknown_universal_setting_is_rejected() -> None:
         module.validate_scenario("example", {"parallel": True})
 
 
+def test_duplicate_universal_platforms_are_rejected_in_declaration_order() -> None:
+    module = _harness()
+
+    with pytest.raises(
+        ValueError,
+        match=r"^example: platforms has duplicate entry: 'windows_amd64'$",
+    ):
+        module.validate_scenario(
+            "example",
+            _universal_scenario(
+                "linux_x86_64",
+                "windows_amd64",
+                "macos_arm64",
+                "windows_amd64",
+                "linux_x86_64",
+            ),
+        )
+
+
+def test_process_rejects_duplicate_platforms_before_network(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+
+    def unexpected_transport() -> None:
+        pytest.fail("transport constructed for an invalid scenario")
+
+    monkeypatch.setattr(module, "Urllib3AsyncTransport", unexpected_transport)
+    output_dir = tmp_path / "results"
+
+    with pytest.raises(
+        ValueError,
+        match=r"^example: platforms has duplicate entry: 'linux_x86_64'$",
+    ):
+        module.process_scenario(
+            "example",
+            _universal_scenario(
+                "linux_x86_64",
+                "macos_arm64",
+                "linux_x86_64",
+            ),
+            "commit",
+            force=True,
+            output_dir=output_dir,
+            source=_CLEAN_SOURCE,
+        )
+
+    assert not output_dir.exists()
+
+
 def test_universal_boolean_settings_do_not_coerce_strings() -> None:
     module = _harness()
     with pytest.raises(
@@ -694,6 +753,53 @@ def test_universal_boolean_settings_do_not_coerce_strings() -> None:
                 "align_across_tuples": "false",
             },
         )
+
+
+def test_main_preflights_every_universal_scenario(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    scenarios_dir = tmp_path / "scenarios"
+    scenarios_dir.mkdir()
+    (scenarios_dir / "universal.toml").write_text(
+        """[valid]
+python = ">=3.11,<3.12"
+platforms = ["linux_x86_64"]
+requirements = ["foo"]
+
+[duplicate]
+python = ">=3.11,<3.12"
+platforms = ["linux_x86_64", "linux_x86_64"]
+requirements = ["bar"]
+
+[valid-after]
+python = ">=3.11,<3.12"
+platforms = ["macos_arm64"]
+requirements = ["baz"]
+"""
+    )
+    results_dir = tmp_path / "results"
+    processed: list[str] = []
+
+    def record_process(name: str, *_args: object, **_kwargs: object) -> bool:
+        processed.append(name)
+        return True
+
+    monkeypatch.setattr(module, "SCENARIOS_DIR", scenarios_dir)
+    monkeypatch.setattr(module, "RESULTS_DIR", results_dir)
+    monkeypatch.setattr(module, "get_git_source_state", lambda: _CLEAN_SOURCE)
+    monkeypatch.setattr(module, "process_scenario", record_process)
+    monkeypatch.setattr(sys, "argv", [str(_BENCHMARK), "--commit", "label"])
+
+    with pytest.raises(
+        ValueError,
+        match=r"^duplicate: platforms has duplicate entry: 'linux_x86_64'$",
+    ):
+        module.main()
+
+    assert processed == []
+    assert not (results_dir / "label" / "universal").exists()
 
 
 def test_main_exits_nonzero_for_unexpected_failure(


### PR DESCRIPTION
A universal benchmark declaring the same platform twice expanded into two targets with identical labels. The run printed `ok`, then persisted a result that the validator rejected as malformed.

Universal scenarios now reject the repeated platform before any resolution or result directory is created, so they cannot report success and write an invalid result.