### PR TITLE
raise BuildBackendError for an unencodable build requirement

### DIFF
--- a/nab-python/src/nab_python/_build/runner.py
+++ b/nab-python/src/nab_python/_build/runner.py
@@ -32,7 +32,7 @@ import zlib
 from contextlib import contextmanager
 from email import message_from_string
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import build
 import pyproject_hooks
@@ -197,7 +197,18 @@ def _install_extra_requires(
     if not extra:
         return
 
-    # PEP 517 requires the hook to return a list of strings.
+    _validate_extra_requires(extra, backend=backend)
+
+    logger.debug("build backend asked for extras: %s", extra)
+    env.install(extra)
+
+
+def _validate_extra_requires(extra: list[Any], *, backend: str) -> None:
+    """Reject a hook result the build env cannot install.
+
+    PEP 517 requires strings, and the build env writes each one into the
+    UTF-8 pyproject its inner resolve reads.
+    """
     non_str = [item for item in extra if not isinstance(item, str)]
     if non_str:
         msg = (
@@ -206,8 +217,16 @@ def _install_extra_requires(
         )
         raise BuildBackendError(msg)
 
-    logger.debug("build backend asked for extras: %s", extra)
-    env.install(extra)
+    for item in extra:
+        try:
+            item.encode("utf-8")
+        except UnicodeEncodeError as exc:
+            msg = (
+                f"build backend {backend!r} returned a build requirement from"
+                f" get_requires_for_build_wheel that cannot be encoded as"
+                f" UTF-8: {item!r}"
+            )
+            raise BuildBackendError(msg) from exc
 
 
 def _read_pyproject(source_dir: Path) -> dict:

--- a/nab-python/tests/test_build_runner.py
+++ b/nab-python/tests/test_build_runner.py
@@ -726,6 +726,50 @@ class TestRunBuildBackend:
         ):
             run_build_backend(tmp_path, config=config)
 
+    def test_unencodable_build_requirement_wrapped(
+        self,
+        tmp_path: Path,
+        config: NabProjectConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A build requirement with no UTF-8 encoding is wrapped.
+
+        A backend that derives a requirement from a filesystem name passes
+        on what ``os.fsdecode`` gave it, so a name that is not valid UTF-8
+        comes back as a lone surrogate.
+        """
+        monkeypatch.setattr("venv.EnvBuilder", _StubEnvBuilder)
+        monkeypatch.setattr(
+            "nab_python._build.env._venv_scheme_paths",
+            lambda _python: {"purelib": str(tmp_path)},
+        )
+
+        (tmp_path / "pyproject.toml").write_text(
+            '[build-system]\nrequires = []\nbuild-backend = "setuptools.build_meta"\n',
+            encoding="utf-8",
+        )
+
+        project = MagicMock()
+        project.get_requires_for_build.return_value = [
+            "setuptools",
+            "pkg @ file:///vendor/p\udce9kg-1.0-py3-none-any.whl",
+        ]
+
+        with (
+            patch(
+                "nab_python._build.runner.build.ProjectBuilder.from_isolated_env",
+                return_value=project,
+            ),
+            pytest.raises(BuildBackendError) as excinfo,
+        ):
+            run_build_backend(tmp_path, config=config)
+
+        message = str(excinfo.value)
+        assert "cannot be encoded as UTF-8" in message
+
+        # The message carries the repr, so the surrogate appears escaped.
+        assert r"pkg @ file:///vendor/p\udce9kg-1.0-py3-none-any.whl" in message
+
 
 class TestShouldSkipPrepare:
     """Unit tests for the hatchling+dynamic-deps detection predicate."""


### PR DESCRIPTION
When a build backend's `get_requires_for_build_wheel` returns a requirement string that cannot be encoded as UTF-8, the resolve aborts with a raw `UnicodeEncodeError` traceback instead of skipping the sdist. A backend that builds a requirement out of a filesystem name passes on whatever `os.fsdecode` gave it, so an undecodable byte in the path arrives as a lone surrogate.

The build env writes those requirements into a UTF-8 pyproject for its inner resolve, and `UnicodeEncodeError` is a `ValueError`, so none of the except clauses in `_prepared_project` caught it. `_install_extra_requires` now checks that each requirement encodes before it reaches the env and raises `BuildBackendError` naming the backend and the string, which the provider already turns into a skipped candidate.
