### PR TITLE
reject non-boolean benchmark VCS pin settings

### DIFF
--- a/nab-python/benchmarks/_profile_runner.py
+++ b/nab-python/benchmarks/_profile_runner.py
@@ -32,6 +32,7 @@ from benchmark_config import (
     build_benchmark_config,
     parse_scenario_requirement_strings,
     parse_trust_unverified_sdist_deps,
+    parse_vcs_require_pin,
 )
 
 
@@ -77,6 +78,7 @@ def build_inputs(
 ) -> dict:
     trust_unverified_sdist_deps = parse_trust_unverified_sdist_deps(name, scenario)
     requirement_inputs = parse_scenario_requirement_strings(name, scenario)
+    vcs_require_pin = parse_vcs_require_pin(name, scenario)
     python_version = scenario["python_version"]
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
@@ -111,7 +113,7 @@ def build_inputs(
         policy=sc.VcsPolicy(scenario.get("vcs_policy", "block")),
         allowed_schemes=frozenset(scenario.get("vcs_allowed_schemes", [])),
         allowed_repos=tuple(scenario.get("vcs_allowed_repos", [])),
-        require_pin=scenario.get("vcs_require_pin", True),
+        require_pin=vcs_require_pin,
     )
 
     if scenario.get("project_name"):
@@ -182,8 +184,7 @@ def main() -> None:
     resolution_override = (
         sc.ResolutionStrategy(args.resolution) if args.resolution is not None else None
     )
-    host = sc.BenchmarkHost.current(sc.SCENARIO_WALL_TIMEOUT_SECONDS)
-    inputs = build_inputs(name, scenario, resolution_override, host)
+    inputs = build_inputs(name, scenario, resolution_override, host=None)
 
     if not args.cprofile:
         report(name, sc.resolve_scenario(**inputs))

--- a/nab-python/benchmarks/benchmark_config.py
+++ b/nab-python/benchmarks/benchmark_config.py
@@ -117,6 +117,21 @@ def parse_trust_unverified_sdist_deps(
     return value
 
 
+def parse_vcs_require_pin(
+    scenario_name: str,
+    scenario: Mapping[str, object],
+) -> bool:
+    """Read whether a scenario requires VCS URLs to pin a commit."""
+    value = scenario.get("vcs_require_pin", True)
+    if type(value) is not bool:
+        msg = (
+            f"{scenario_name}: vcs_require_pin must be a boolean, "
+            f"got {type(value).__name__}"
+        )
+        raise TypeError(msg)
+    return value
+
+
 def _package_overrides(
     indexes: Sequence[IndexConfig],
     index_routes: Sequence[IndexRoute],

--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -39,6 +39,7 @@ from benchmark_config import (
     direct_packages_from_requirements,
     parse_scenario_requirement_strings,
     parse_trust_unverified_sdist_deps,
+    parse_vcs_require_pin,
 )
 from benchmark_host import (
     BenchmarkHost,
@@ -595,6 +596,9 @@ def select_scenarios(cases: list[CanaryCase]) -> list[CanaryCase]:
 
     for scenario_name, scenario in found_scenarios:
         parse_scenario_requirement_strings(scenario_name, scenario)
+
+    for scenario_name, scenario in found_scenarios:
+        parse_vcs_require_pin(scenario_name, scenario)
     return cases
 
 
@@ -760,6 +764,7 @@ def _prepare_canary_execution(
         scenario,
     )
     requirement_inputs = parse_scenario_requirement_strings(scenario_name, scenario)
+    vcs_require_pin = parse_vcs_require_pin(scenario_name, scenario)
     python_version = scenario["python_version"]
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
@@ -784,7 +789,7 @@ def _prepare_canary_execution(
         policy=VcsPolicy(scenario.get("vcs_policy", "block")),
         allowed_schemes=frozenset(scenario.get("vcs_allowed_schemes", [])),
         allowed_repos=tuple(scenario.get("vcs_allowed_repos", [])),
-        require_pin=scenario.get("vcs_require_pin", True),
+        require_pin=vcs_require_pin,
     )
     indexes = _canary_indexes(scenario)
     index_routes = _canary_index_routes(scenario)
@@ -924,8 +929,6 @@ def main() -> None:
 
     source = get_git_source_state()
     commit = args.commit or str(source["commit"] or "no-git")
-    host = BenchmarkHost.current(WALL_TIMEOUT_S)
-
     cases_to_run: list[CanaryCase]
     if args.scenarios_list:
         with Path(args.scenarios_list).open(encoding="utf-8") as f:
@@ -938,6 +941,7 @@ def main() -> None:
     else:
         cases_to_run = _parse_default_selection(parser)
 
+    host = BenchmarkHost.current(WALL_TIMEOUT_S)
     labels = [case.scenario.split(":", 1)[-1] for case in cases_to_run]
 
     out_dir = RESULTS_DIR / commit

--- a/nab-python/benchmarks/scenarios.py
+++ b/nab-python/benchmarks/scenarios.py
@@ -39,6 +39,7 @@ from benchmark_config import (
     build_benchmark_resolver_inputs,
     parse_scenario_requirement_strings,
     parse_trust_unverified_sdist_deps,
+    parse_vcs_require_pin,
 )
 from benchmark_host import (
     HOST_TAG_MISMATCH_REASON,
@@ -581,6 +582,7 @@ def load_standard_corpus(files: list[Path]) -> list[StandardScenario]:
         parse_requires_matching_host(row.name, row.definition, marker_environment)
         parse_trust_unverified_sdist_deps(row.logical_key, row.definition)
         parse_scenario_requirement_strings(row.logical_key, row.definition)
+        parse_vcs_require_pin(row.logical_key, row.definition)
         build_policy_overrides = parse_build_packages(row.name, row.definition)
         if "unsupported_reason" in row.definition:
             continue
@@ -1591,6 +1593,7 @@ def prepare_standard_execution(
         scenario,
     )
     requirement_inputs = parse_scenario_requirement_strings(scenario_name, scenario)
+    vcs_require_pin = parse_vcs_require_pin(scenario_name, scenario)
     python_version: str = scenario["python_version"]
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
@@ -1619,7 +1622,7 @@ def prepare_standard_execution(
         policy=VcsPolicy(vcs_policy_str),
         allowed_schemes=frozenset(scenario.get("vcs_allowed_schemes", [])),
         allowed_repos=tuple(scenario.get("vcs_allowed_repos", [])),
-        require_pin=scenario.get("vcs_require_pin", True),
+        require_pin=vcs_require_pin,
     )
     uploaded_prior_to = parse_datetime(datetime_str) if datetime_str else None
     config = build_benchmark_config(
@@ -1762,7 +1765,6 @@ def main(argv: list[str] | None = None) -> None:
         except argparse.ArgumentTypeError as exc:
             parser.error(str(exc))
     source_start = get_git_source_state()
-    host = BenchmarkHost.current(SCENARIO_WALL_TIMEOUT_SECONDS)
 
     if not SCENARIOS_DIR.is_dir():
         print(f"Error: {SCENARIOS_DIR} does not exist")
@@ -1808,6 +1810,7 @@ def main(argv: list[str] | None = None) -> None:
     )
     mode = "strategy-matrix" if args.strategy_matrix else "default"
     corpus_hash = standard_corpus_hash(all_rows)
+    host = BenchmarkHost.current(SCENARIO_WALL_TIMEOUT_SECONDS)
     plan = standard_run_plan(selected_rows, strategies, host)
     execution_plan = plan.executions
     settings = standard_benchmark_settings(host)

--- a/nab-python/tests/test_benchmark_canary.py
+++ b/nab-python/tests/test_benchmark_canary.py
@@ -602,10 +602,26 @@ def test_canary_main_records_v2_contract(
             True,
             "quick:requests: requirements[0] must be a non-empty string",
         ),
+        (
+            {
+                "requirements": [],
+                "unsupported_reason": "test fixture",
+                "vcs_require_pin": "false",
+            },
+            False,
+            "quick:requests: vcs_require_pin must be a boolean, got str",
+        ),
     ],
-    ids=("sdist-trust", "missing", "scalar", "empty-item", "default-empty-item"),
+    ids=(
+        "sdist-trust",
+        "missing",
+        "scalar",
+        "empty-item",
+        "default-empty-item",
+        "vcs-require-pin",
+    ),
 )
-def test_canary_main_rejects_scenario_schema_before_result_creation(
+def test_canary_schema_validation_precedes_host_capture_and_result_creation(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -621,6 +637,11 @@ def test_canary_main_rejects_scenario_schema_before_result_creation(
         "get_git_source_state",
         lambda: {"commit": "source-sha", "dirty": False, "diff_hash": None},
     )
+
+    def fail_host(*_args: object, **_kwargs: object) -> object:
+        pytest.fail("scenario validation reached host capture")
+
+    monkeypatch.setattr(module.BenchmarkHost, "current", classmethod(fail_host))
     monkeypatch.setattr(module, "find_scenario", lambda _name: scenario)
     if default_selection:
         monkeypatch.setattr(

--- a/nab-python/tests/test_benchmark_canary_selection.py
+++ b/nab-python/tests/test_benchmark_canary_selection.py
@@ -476,6 +476,28 @@ def test_missing_scenario_exits_before_creating_results(
     assert not results_dir.exists()
 
 
+def test_selection_validates_requirement_lists_before_vcs_pin_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    scenarios = {
+        "quick:first": {"requirements": [], "vcs_require_pin": "false"},
+        "quick:second": {"requirements": "demo"},
+    }
+    monkeypatch.setattr(module, "find_scenario", scenarios.get)
+
+    with pytest.raises(
+        TypeError,
+        match="quick:second: requirements must be a list, got str",
+    ):
+        module.select_scenarios(
+            [
+                module.CanaryCase("quick:first", None),
+                module.CanaryCase("quick:second", None),
+            ]
+        )
+
+
 def test_empty_scenarios_list_exits_before_creating_results(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/nab-python/tests/test_benchmark_strategy_matrix.py
+++ b/nab-python/tests/test_benchmark_strategy_matrix.py
@@ -265,9 +265,11 @@ def _prepare_runner_parity(
     standard: ModuleType,
     canary: ModuleType,
     profile: ModuleType,
+    *,
+    scenario: dict[str, object] | None = None,
 ) -> tuple[object, object, dict[str, object]]:
     """Prepare equivalent inputs through the three benchmark entry points."""
-    scenario = _runner_parity_scenario()
+    scenario = _runner_parity_scenario() if scenario is None else scenario
     host = _linux_host(standard)
     standard_execution = _prepare_standard_scenario(standard, scenario, host)
     canary_preparation = canary._prepare_canary_execution(
@@ -1157,6 +1159,53 @@ def test_parse_trust_unverified_sdist_deps_rejects_other_types(
         module.parse_trust_unverified_sdist_deps(
             "example",
             {"trust_unverified_sdist_deps": invalid},
+        )
+
+
+@pytest.mark.parametrize(
+    ("scenario", "expected"),
+    [
+        ({}, True),
+        ({"vcs_require_pin": True}, True),
+        ({"vcs_require_pin": False}, False),
+    ],
+    ids=("implicit", "required", "optional"),
+)
+def test_parse_vcs_require_pin_accepts_exact_booleans(
+    scenario: dict[str, object],
+    expected: bool,
+) -> None:
+    module = _harness("benchmark_config")
+    original = dict(scenario)
+
+    assert module.parse_vcs_require_pin("example", scenario) is expected
+    assert scenario == original
+
+
+@pytest.mark.parametrize(
+    ("invalid", "type_name"),
+    [
+        (0, "int"),
+        (1, "int"),
+        (0.0, "float"),
+        ("false", "str"),
+        ([False], "list"),
+        ({"value": False}, "dict"),
+        (None, "NoneType"),
+    ],
+    ids=("zero", "one", "float", "string", "list", "table", "none"),
+)
+def test_parse_vcs_require_pin_rejects_other_types(
+    invalid: object,
+    type_name: str,
+) -> None:
+    module = _harness("benchmark_config")
+    message = f"example: vcs_require_pin must be a boolean, got {type_name}"
+
+    with pytest.raises(TypeError, match=message):
+        module.parse_vcs_require_pin(
+            "example",
+            {"vcs_require_pin": invalid},
         )
 
 
@@ -2539,10 +2588,20 @@ unsupported_reason = "not runnable"
 """,
             "other:other: requirements must be a list, got str",
         ),
+        (
+            """
+[other]
+python_version = "3.11"
+requirements = []
+unsupported_reason = "not runnable"
+vcs_require_pin = "false"
+""",
+            "other:other: vcs_require_pin must be a boolean, got str",
+        ),
     ],
-    ids=("sdist-trust", "requirements"),
+    ids=("sdist-trust", "requirements", "vcs-require-pin"),
 )
-def test_unselected_unsupported_definition_fails_before_result_creation(
+def test_unselected_unsupported_definition_fails_before_host_capture_and_result_creation(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -2561,9 +2620,13 @@ def test_unselected_unsupported_definition_fails_before_result_creation(
     monkeypatch.setattr(module, "RESULTS_DIR", results_dir)
     monkeypatch.setattr(module, "get_git_source_state", lambda: _CLEAN_SOURCE)
 
+    def fail_host(*_args: object, **_kwargs: object) -> object:
+        pytest.fail("scenario validation reached host capture")
+
     def fail_result_creation(*_args: object, **_kwargs: object) -> None:
         raise AssertionError("result namespace creation was reached")
 
+    monkeypatch.setattr(module.BenchmarkHost, "current", classmethod(fail_host))
     monkeypatch.setattr(
         module,
         "prepare_standard_result_namespace",
@@ -2607,6 +2670,30 @@ def test_profile_runner_accepts_an_explicit_strategy() -> None:
     assert lowest["config"].resolution is module.sc.ResolutionStrategy.LOWEST
 
 
+def test_profile_main_validates_vcs_pin_before_host_capture(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness("_profile_runner")
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        "vcs_require_pin": "false",
+    }
+    monkeypatch.setattr(module, "find_scenario", lambda _spec: ("example", scenario))
+    monkeypatch.setattr(module.sys, "argv", ["_profile_runner.py", "example"])
+
+    def fail_host(*_args: object, **_kwargs: object) -> object:
+        pytest.fail("VCS pin validation reached host capture")
+
+    monkeypatch.setattr(module.sc.BenchmarkHost, "current", classmethod(fail_host))
+
+    with pytest.raises(
+        TypeError,
+        match="example: vcs_require_pin must be a boolean, got str",
+    ):
+        module.main()
+
+
 def test_standard_canary_and_profile_build_the_same_project_config() -> None:
     standard = _harness("scenarios")
     canary = _harness("canary")
@@ -2625,14 +2712,51 @@ def test_standard_canary_and_profile_build_the_same_project_config() -> None:
     assert "trust_unverified_sdist_deps" not in standard_execution.expected_input
 
 
-def test_standard_canary_and_profile_reject_non_boolean_sdist_trust() -> None:
+@pytest.mark.parametrize(
+    ("vcs_setting", "expected"),
+    [
+        ({}, True),
+        ({"vcs_require_pin": True}, True),
+        ({"vcs_require_pin": False}, False),
+    ],
+    ids=("implicit", "required", "optional"),
+)
+def test_standard_canary_and_profile_use_valid_vcs_pin_settings(
+    vcs_setting: dict[str, object],
+    expected: bool,
+) -> None:
     standard = _harness("scenarios")
     canary = _harness("canary")
     profile = _harness("_profile_runner")
     scenario = {
         "python_version": "3.11",
         "requirements": [],
+        **vcs_setting,
+    }
+    original = dict(scenario)
+
+    standard_execution, canary_execution, profile_inputs = _prepare_runner_parity(
+        standard,
+        canary,
+        profile,
+        scenario=scenario,
+    )
+
+    assert standard_execution.config.vcs.require_pin is expected
+    assert canary_execution.config.vcs.require_pin is expected
+    assert profile_inputs["config"].vcs.require_pin is expected
+    assert scenario == original
+
+
+def test_sdist_trust_validation_precedes_requirement_and_vcs_validation() -> None:
+    standard = _harness("scenarios")
+    canary = _harness("canary")
+    profile = _harness("_profile_runner")
+    scenario = {
+        "python_version": "3.11",
+        "requirements": "demo",
         "trust_unverified_sdist_deps": "false",
+        "vcs_require_pin": "false",
     }
     host = _linux_host(standard)
     message = "example: trust_unverified_sdist_deps must be a boolean"
@@ -2652,12 +2776,48 @@ def test_standard_canary_and_profile_reject_non_boolean_sdist_trust() -> None:
         profile.build_inputs("example", scenario, host=host)
 
 
+def test_standard_canary_and_profile_reject_non_boolean_vcs_require_pin() -> None:
+    standard = _harness("scenarios")
+    canary = _harness("canary")
+    profile = _harness("_profile_runner")
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        "vcs_require_pin": "false",
+    }
+    standard_host = _linux_host(standard)
+    message = "example: vcs_require_pin must be a boolean, got str"
+
+    class UnusedHost:
+        """Fail if schema validation reaches target admission."""
+
+        def target_for(self, *_args: object, **_kwargs: object) -> object:
+            pytest.fail("VCS pin validation reached host admission")
+
+    with pytest.raises(TypeError, match=message):
+        _prepare_standard_scenario(standard, scenario, standard_host)
+
+    with pytest.raises(TypeError, match=message):
+        canary._prepare_canary_execution(
+            scenario,
+            scenario_name="example",
+            resolution_override=None,
+            host=UnusedHost(),
+        )
+
+    with pytest.raises(TypeError, match=message):
+        profile.build_inputs("example", scenario, host=UnusedHost())
+
+
 @pytest.mark.parametrize("field", ["requirements", "constraints"])
-def test_standard_direct_preparation_validates_requirement_lists(field: str) -> None:
+def test_standard_requirement_list_validation_precedes_vcs_pin_validation(
+    field: str,
+) -> None:
     standard = _harness("scenarios")
     scenario: dict[str, object] = {
         "python_version": "3.11",
         "requirements": [],
+        "vcs_require_pin": "false",
     }
     scenario[field] = "demo"
     host = _linux_host(standard)
@@ -2670,11 +2830,14 @@ def test_standard_direct_preparation_validates_requirement_lists(field: str) -> 
 
 
 @pytest.mark.parametrize("field", ["requirements", "constraints"])
-def test_canary_direct_preparation_validates_requirement_lists(field: str) -> None:
+def test_canary_requirement_list_validation_precedes_vcs_pin_validation(
+    field: str,
+) -> None:
     canary = _harness("canary")
     scenario: dict[str, object] = {
         "python_version": "3.11",
         "requirements": [],
+        "vcs_require_pin": "false",
     }
     scenario[field] = "demo"
     host = _linux_host(canary)
@@ -2692,13 +2855,14 @@ def test_canary_direct_preparation_validates_requirement_lists(field: str) -> No
 
 
 @pytest.mark.parametrize("field", ["requirements", "constraints"])
-def test_profile_build_inputs_validates_requirement_lists_before_host_admission(
+def test_profile_requirement_list_validation_precedes_vcs_pin_validation_and_host_admission(
     field: str,
 ) -> None:
     profile = _harness("_profile_runner")
     scenario: dict[str, object] = {
         "python_version": "3.11",
         "requirements": [],
+        "vcs_require_pin": "false",
     }
     scenario[field] = "demo"
     host = MagicMock()


### PR DESCRIPTION
`vcs_require_pin = "false"` was accepted in benchmark scenarios and, because the string is truthy, silently required VCS URLs to pin a commit. A value such as `vcs_require_pin = 0` could silently disable the same policy, even though ordinary Nab configuration rejects non-boolean values.

Benchmark scenarios now reject a non-boolean `vcs_require_pin` value before resolution. Omitting the setting still requires pinned VCS URLs.