### PR TITLE
validate benchmark VCS policy and allowlists

### DIFF
--- a/nab-python/benchmarks/_profile_runner.py
+++ b/nab-python/benchmarks/_profile_runner.py
@@ -31,8 +31,8 @@ import scenarios as sc
 from benchmark_config import (
     build_benchmark_config,
     parse_scenario_requirement_strings,
+    parse_scenario_vcs_config,
     parse_trust_unverified_sdist_deps,
-    parse_vcs_require_pin,
 )
 
 
@@ -78,7 +78,7 @@ def build_inputs(
 ) -> dict:
     trust_unverified_sdist_deps = parse_trust_unverified_sdist_deps(name, scenario)
     requirement_inputs = parse_scenario_requirement_strings(name, scenario)
-    vcs_require_pin = parse_vcs_require_pin(name, scenario)
+    vcs_config = parse_scenario_vcs_config(name, scenario)
     python_version = scenario["python_version"]
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
@@ -109,13 +109,6 @@ def build_inputs(
         scenario.get("resolution", sc.ResolutionStrategy.HIGHEST.value)
     )
     resolution_strategy = resolution_override or declared_resolution
-    vcs_config = sc.VcsConfig(
-        policy=sc.VcsPolicy(scenario.get("vcs_policy", "block")),
-        allowed_schemes=frozenset(scenario.get("vcs_allowed_schemes", [])),
-        allowed_repos=tuple(scenario.get("vcs_allowed_repos", [])),
-        require_pin=vcs_require_pin,
-    )
-
     if scenario.get("project_name"):
         requirement_strings += sc.expand_project_extras(
             scenario["project_name"],

--- a/nab-python/benchmarks/benchmark_config.py
+++ b/nab-python/benchmarks/benchmark_config.py
@@ -14,6 +14,7 @@ from nab_python.provider import (
     Provider,
     ResolutionStrategy,
     VcsConfig,
+    VcsPolicy,
     split_extra,
 )
 from nab_python.resolve import constraints_with_root_extra_proxies
@@ -130,6 +131,88 @@ def parse_vcs_require_pin(
         )
         raise TypeError(msg)
     return value
+
+
+def parse_vcs_policy(
+    scenario_name: str,
+    scenario: Mapping[str, object],
+) -> VcsPolicy:
+    """Return the VCS policy declared by a scenario."""
+    value = scenario.get("vcs_policy", VcsPolicy.BLOCK.value)
+    try:
+        return VcsPolicy(value)
+    except (TypeError, ValueError) as exc:
+        valid = sorted(policy.value for policy in VcsPolicy)
+        msg = f"{scenario_name}: vcs_policy must be one of {valid!r}, got {value!r}"
+        raise ValueError(msg) from exc
+
+
+def _scenario_vcs_string_list(
+    scenario_name: str,
+    field: str,
+    value: object,
+) -> list[str]:
+    """Validate and copy one VCS list without interpreting its strings."""
+    if type(value) is not list:
+        msg = f"{scenario_name}: {field} must be a list, got {type(value).__name__}"
+        raise TypeError(msg)
+
+    strings: list[str] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, str):
+            msg = (
+                f"{scenario_name}: {field}[{index}] must be a string, "
+                f"got {type(item).__name__}"
+            )
+            raise TypeError(msg)
+        strings.append(item)
+    return strings
+
+
+def parse_vcs_allowed_schemes(
+    scenario_name: str,
+    scenario: Mapping[str, object],
+) -> frozenset[str]:
+    """Return a scenario's copied VCS scheme allowlist as a set."""
+    return frozenset(
+        _scenario_vcs_string_list(
+            scenario_name,
+            "vcs_allowed_schemes",
+            scenario.get("vcs_allowed_schemes", []),
+        )
+    )
+
+
+def parse_vcs_allowed_repos(
+    scenario_name: str,
+    scenario: Mapping[str, object],
+) -> tuple[str, ...]:
+    """Return a scenario's copied VCS repository allowlist in declaration order."""
+    return tuple(
+        _scenario_vcs_string_list(
+            scenario_name,
+            "vcs_allowed_repos",
+            scenario.get("vcs_allowed_repos", []),
+        )
+    )
+
+
+def parse_scenario_vcs_config(
+    scenario_name: str,
+    scenario: Mapping[str, object],
+) -> VcsConfig:
+    """Build the VCS config declared by a benchmark scenario."""
+    require_pin = parse_vcs_require_pin(scenario_name, scenario)
+    policy = parse_vcs_policy(scenario_name, scenario)
+    allowed_schemes = parse_vcs_allowed_schemes(scenario_name, scenario)
+    allowed_repos = parse_vcs_allowed_repos(scenario_name, scenario)
+
+    return VcsConfig(
+        policy=policy,
+        allowed_schemes=allowed_schemes,
+        allowed_repos=allowed_repos,
+        require_pin=require_pin,
+    )
 
 
 def _package_overrides(

--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -38,7 +38,11 @@ from benchmark_config import (
     build_benchmark_resolver_inputs,
     direct_packages_from_requirements,
     parse_scenario_requirement_strings,
+    parse_scenario_vcs_config,
     parse_trust_unverified_sdist_deps,
+    parse_vcs_allowed_repos,
+    parse_vcs_allowed_schemes,
+    parse_vcs_policy,
     parse_vcs_require_pin,
 )
 from benchmark_host import (
@@ -66,7 +70,6 @@ from nab_python.provider import (
     BuildPolicy,
     ResolutionStrategy,
     VcsConfig,
-    VcsPolicy,
     split_extra,
 )
 from nab_resolver.resolver import Resolver
@@ -590,15 +593,17 @@ def select_scenarios(cases: list[CanaryCase]) -> list[CanaryCase]:
         )
         raise _SelectionError(msg)
 
-    # Check each field across the whole selection before moving to the next field.
-    for scenario_name, scenario in found_scenarios:
-        parse_trust_unverified_sdist_deps(scenario_name, scenario)
-
-    for scenario_name, scenario in found_scenarios:
-        parse_scenario_requirement_strings(scenario_name, scenario)
-
-    for scenario_name, scenario in found_scenarios:
-        parse_vcs_require_pin(scenario_name, scenario)
+    field_validators = (
+        parse_trust_unverified_sdist_deps,
+        parse_scenario_requirement_strings,
+        parse_vcs_require_pin,
+        parse_vcs_policy,
+        parse_vcs_allowed_schemes,
+        parse_vcs_allowed_repos,
+    )
+    for validate_field in field_validators:
+        for scenario_name, scenario in found_scenarios:
+            validate_field(scenario_name, scenario)
     return cases
 
 
@@ -764,7 +769,7 @@ def _prepare_canary_execution(
         scenario,
     )
     requirement_inputs = parse_scenario_requirement_strings(scenario_name, scenario)
-    vcs_require_pin = parse_vcs_require_pin(scenario_name, scenario)
+    vcs_config = parse_scenario_vcs_config(scenario_name, scenario)
     python_version = scenario["python_version"]
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
@@ -784,12 +789,6 @@ def _prepare_canary_execution(
         scenario,
         scenario_name=scenario_name,
         override=resolution_override,
-    )
-    vcs_config = VcsConfig(
-        policy=VcsPolicy(scenario.get("vcs_policy", "block")),
-        allowed_schemes=frozenset(scenario.get("vcs_allowed_schemes", [])),
-        allowed_repos=tuple(scenario.get("vcs_allowed_repos", [])),
-        require_pin=vcs_require_pin,
     )
     indexes = _canary_indexes(scenario)
     index_routes = _canary_index_routes(scenario)

--- a/nab-python/benchmarks/scenarios.py
+++ b/nab-python/benchmarks/scenarios.py
@@ -38,8 +38,8 @@ from benchmark_config import (
     build_benchmark_provider,
     build_benchmark_resolver_inputs,
     parse_scenario_requirement_strings,
+    parse_scenario_vcs_config,
     parse_trust_unverified_sdist_deps,
-    parse_vcs_require_pin,
 )
 from benchmark_host import (
     HOST_TAG_MISMATCH_REASON,
@@ -582,7 +582,7 @@ def load_standard_corpus(files: list[Path]) -> list[StandardScenario]:
         parse_requires_matching_host(row.name, row.definition, marker_environment)
         parse_trust_unverified_sdist_deps(row.logical_key, row.definition)
         parse_scenario_requirement_strings(row.logical_key, row.definition)
-        parse_vcs_require_pin(row.logical_key, row.definition)
+        parse_scenario_vcs_config(row.logical_key, row.definition)
         build_policy_overrides = parse_build_packages(row.name, row.definition)
         if "unsupported_reason" in row.definition:
             continue
@@ -1390,7 +1390,7 @@ def resolve_scenario(
         }
 
 
-def _expected_input(  # noqa: PLR0913, PLR0917 - assembling the JSON dump key
+def _expected_input(  # noqa: PLR0913 - assembling the JSON dump key
     commit: str,
     python_version: str,
     requirement_strings: list[str],
@@ -1398,14 +1398,13 @@ def _expected_input(  # noqa: PLR0913, PLR0917 - assembling the JSON dump key
     datetime_str: str | None,
     project_name: str | None,
     project_extras: list[str],
+    *,
     vcs_config: VcsConfig,
-    vcs_policy_str: str,
     marker_environment: dict[str, str],
     indexes: list[IndexConfig],
     index_routes: list[IndexRoute],
     build_packages: list[str] | None = None,
     resolution_strategy: ResolutionStrategy = ResolutionStrategy.HIGHEST,
-    *,
     trust_unverified_sdist_deps: bool = False,
 ) -> dict:
     """Build the JSON-serialisable ``input`` block describing the scenario."""
@@ -1422,7 +1421,7 @@ def _expected_input(  # noqa: PLR0913, PLR0917 - assembling the JSON dump key
         expected_input["project_name"] = project_name
         expected_input["project_extras"] = project_extras
     if vcs_config.policy is not VcsPolicy.BLOCK:
-        expected_input["vcs_policy"] = vcs_policy_str
+        expected_input["vcs_policy"] = vcs_config.policy.value
         expected_input["vcs_allowed_schemes"] = sorted(vcs_config.allowed_schemes)
         expected_input["vcs_allowed_repos"] = list(vcs_config.allowed_repos)
         expected_input["vcs_require_pin"] = vcs_config.require_pin
@@ -1593,7 +1592,7 @@ def prepare_standard_execution(
         scenario,
     )
     requirement_inputs = parse_scenario_requirement_strings(scenario_name, scenario)
-    vcs_require_pin = parse_vcs_require_pin(scenario_name, scenario)
+    vcs_config = parse_scenario_vcs_config(scenario_name, scenario)
     python_version: str = scenario["python_version"]
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
@@ -1617,13 +1616,6 @@ def prepare_standard_execution(
         requirement_strings.extend(
             expand_project_extras(project_name, project_extras, optional_dependencies)
         )
-    vcs_policy_str: str = scenario.get("vcs_policy", "block")
-    vcs_config = VcsConfig(
-        policy=VcsPolicy(vcs_policy_str),
-        allowed_schemes=frozenset(scenario.get("vcs_allowed_schemes", [])),
-        allowed_repos=tuple(scenario.get("vcs_allowed_repos", [])),
-        require_pin=vcs_require_pin,
-    )
     uploaded_prior_to = parse_datetime(datetime_str) if datetime_str else None
     config = build_benchmark_config(
         uploaded_prior_to=uploaded_prior_to,
@@ -1643,11 +1635,10 @@ def prepare_standard_execution(
             datetime_str,
             project_name,
             project_extras,
-            vcs_config,
-            vcs_policy_str,
-            marker_environment,
-            indexes,
-            index_routes,
+            vcs_config=vcs_config,
+            marker_environment=marker_environment,
+            indexes=indexes,
+            index_routes=index_routes,
             build_packages=sorted(build_policy_overrides),
             resolution_strategy=execution.strategy,
             trust_unverified_sdist_deps=trust_unverified_sdist_deps,

--- a/nab-python/tests/test_benchmark_canary.py
+++ b/nab-python/tests/test_benchmark_canary.py
@@ -611,6 +611,33 @@ def test_canary_main_records_v2_contract(
             False,
             "quick:requests: vcs_require_pin must be a boolean, got str",
         ),
+        (
+            {
+                "requirements": [],
+                "unsupported_reason": "test fixture",
+                "vcs_policy": "permit",
+            },
+            False,
+            "quick:requests: vcs_policy must be one of ['allow', 'block'], got 'permit'",
+        ),
+        (
+            {
+                "requirements": [],
+                "unsupported_reason": "test fixture",
+                "vcs_allowed_schemes": {"git+https": False},
+            },
+            False,
+            "quick:requests: vcs_allowed_schemes must be a list, got dict",
+        ),
+        (
+            {
+                "requirements": [],
+                "unsupported_reason": "test fixture",
+                "vcs_allowed_repos": {"https://example.test/repo": False},
+            },
+            True,
+            "quick:requests: vcs_allowed_repos must be a list, got dict",
+        ),
     ],
     ids=(
         "sdist-trust",
@@ -619,6 +646,9 @@ def test_canary_main_records_v2_contract(
         "empty-item",
         "default-empty-item",
         "vcs-require-pin",
+        "vcs-policy",
+        "vcs-scheme-table",
+        "default-vcs-repo-table",
     ),
 )
 def test_canary_schema_validation_precedes_host_capture_and_result_creation(

--- a/nab-python/tests/test_benchmark_canary_selection.py
+++ b/nab-python/tests/test_benchmark_canary_selection.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
+import re
 import sys
 from collections import Counter
 from pathlib import Path
@@ -481,7 +482,13 @@ def test_selection_validates_requirement_lists_before_vcs_pin_settings(
 ) -> None:
     module = _harness()
     scenarios = {
-        "quick:first": {"requirements": [], "vcs_require_pin": "false"},
+        "quick:first": {
+            "requirements": [],
+            "vcs_require_pin": "false",
+            "vcs_policy": "permit",
+            "vcs_allowed_schemes": {"git+https": False},
+            "vcs_allowed_repos": {"https://example.test/repo": False},
+        },
         "quick:second": {"requirements": "demo"},
     }
     monkeypatch.setattr(module, "find_scenario", scenarios.get)
@@ -490,6 +497,55 @@ def test_selection_validates_requirement_lists_before_vcs_pin_settings(
         TypeError,
         match="quick:second: requirements must be a list, got str",
     ):
+        module.select_scenarios(
+            [
+                module.CanaryCase("quick:first", None),
+                module.CanaryCase("quick:second", None),
+            ]
+        )
+
+
+@pytest.mark.parametrize(
+    ("first_scenario", "second_scenario", "message"),
+    [
+        (
+            {"vcs_policy": "permit"},
+            {"vcs_require_pin": "false"},
+            "quick:second: vcs_require_pin must be a boolean, got str",
+        ),
+        (
+            {"vcs_allowed_schemes": {"git+https": False}},
+            {"vcs_policy": "permit"},
+            "quick:second: vcs_policy must be one of ['allow', 'block'], got 'permit'",
+        ),
+        (
+            {"vcs_allowed_repos": {"https://example.test/repo": False}},
+            {"vcs_allowed_schemes": {"git+https": False}},
+            "quick:second: vcs_allowed_schemes must be a list, got dict",
+        ),
+    ],
+    ids=("pin-before-policy", "policy-before-schemes", "schemes-before-repos"),
+)
+def test_selection_validates_vcs_fields_across_the_whole_selection(
+    monkeypatch: pytest.MonkeyPatch,
+    first_scenario: dict[str, object],
+    second_scenario: dict[str, object],
+    message: str,
+) -> None:
+    module = _harness()
+    scenarios = {
+        "quick:first": {
+            "requirements": [],
+            **first_scenario,
+        },
+        "quick:second": {
+            "requirements": [],
+            **second_scenario,
+        },
+    }
+    monkeypatch.setattr(module, "find_scenario", scenarios.get)
+
+    with pytest.raises((TypeError, ValueError), match=re.escape(message)):
         module.select_scenarios(
             [
                 module.CanaryCase("quick:first", None),

--- a/nab-python/tests/test_benchmark_strategy_matrix.py
+++ b/nab-python/tests/test_benchmark_strategy_matrix.py
@@ -8,6 +8,7 @@ import re
 import sys
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
+from copy import deepcopy
 from dataclasses import dataclass, field
 from operator import setitem
 from pathlib import Path
@@ -1207,6 +1208,143 @@ def test_parse_vcs_require_pin_rejects_other_types(
             "example",
             {"vcs_require_pin": invalid},
         )
+
+
+def test_parse_vcs_policy_normalizes_type_errors() -> None:
+    module = _harness("benchmark_config")
+
+    class InvalidPolicy:
+        """Make Enum lookup fail while comparing a scenario value."""
+
+        def __hash__(self) -> int:
+            return hash("allow")
+
+        def __eq__(self, _other: object) -> bool:
+            raise TypeError("policy values cannot be compared")
+
+        def __repr__(self) -> str:
+            return "<invalid policy>"
+
+    message = (
+        "example: vcs_policy must be one of ['allow', 'block'], got <invalid policy>"
+    )
+    with pytest.raises(ValueError, match=re.escape(message)) as exc_info:
+        module.parse_vcs_policy("example", {"vcs_policy": InvalidPolicy()})
+
+    assert isinstance(exc_info.value.__cause__, TypeError)
+
+
+@pytest.mark.parametrize(
+    ("scenario", "expected_schemes", "expected_repos"),
+    [
+        ({}, frozenset(), ()),
+        (
+            {"vcs_allowed_schemes": [], "vcs_allowed_repos": []},
+            frozenset(),
+            (),
+        ),
+        (
+            {
+                "vcs_allowed_schemes": [
+                    "git+https",
+                    "git+https",
+                    " git+ssh ",
+                    "",
+                ],
+                "vcs_allowed_repos": [
+                    "not a URL",
+                    "not a URL",
+                    " https://example.test/repo ",
+                    "",
+                ],
+            },
+            frozenset({"git+https", " git+ssh ", ""}),
+            (
+                "not a URL",
+                "not a URL",
+                " https://example.test/repo ",
+                "",
+            ),
+        ),
+    ],
+    ids=("missing", "empty", "declared"),
+)
+def test_parse_vcs_allowlists_preserves_declared_values(
+    scenario: dict[str, object],
+    expected_schemes: frozenset[str],
+    expected_repos: tuple[str, ...],
+) -> None:
+    module = _harness("benchmark_config")
+    original = deepcopy(scenario)
+
+    schemes = module.parse_vcs_allowed_schemes("example", scenario)
+    repos = module.parse_vcs_allowed_repos("example", scenario)
+
+    assert schemes == expected_schemes
+    assert repos == expected_repos
+    assert scenario == original
+
+
+@pytest.mark.parametrize(
+    ("parser_name", "field", "invalid", "message"),
+    [
+        (
+            "parse_vcs_allowed_schemes",
+            "vcs_allowed_schemes",
+            {"git+https": False},
+            "example: vcs_allowed_schemes must be a list, got dict",
+        ),
+        (
+            "parse_vcs_allowed_repos",
+            "vcs_allowed_repos",
+            {"https://example.test/repo": False},
+            "example: vcs_allowed_repos must be a list, got dict",
+        ),
+        (
+            "parse_vcs_allowed_schemes",
+            "vcs_allowed_schemes",
+            ("git+https",),
+            "example: vcs_allowed_schemes must be a list, got tuple",
+        ),
+        (
+            "parse_vcs_allowed_repos",
+            "vcs_allowed_repos",
+            ("https://example.test/repo",),
+            "example: vcs_allowed_repos must be a list, got tuple",
+        ),
+        (
+            "parse_vcs_allowed_schemes",
+            "vcs_allowed_schemes",
+            ["git+https", False],
+            "example: vcs_allowed_schemes[1] must be a string, got bool",
+        ),
+        (
+            "parse_vcs_allowed_repos",
+            "vcs_allowed_repos",
+            ["https://example.test/repo", 1],
+            "example: vcs_allowed_repos[1] must be a string, got int",
+        ),
+    ],
+    ids=(
+        "scheme-table",
+        "repo-table",
+        "scheme-tuple",
+        "repo-tuple",
+        "scheme-member",
+        "repo-member",
+    ),
+)
+def test_parse_vcs_allowlists_rejects_non_lists_and_non_strings(
+    parser_name: str,
+    field: str,
+    invalid: object,
+    message: str,
+) -> None:
+    module = _harness("benchmark_config")
+    parser = getattr(module, parser_name)
+
+    with pytest.raises(TypeError, match=re.escape(message)):
+        parser("example", {field: invalid})
 
 
 def test_parse_scenario_requirement_strings_returns_fresh_unchanged_lists() -> None:
@@ -2598,8 +2736,59 @@ vcs_require_pin = "false"
 """,
             "other:other: vcs_require_pin must be a boolean, got str",
         ),
+        (
+            """
+[other]
+python_version = "3.11"
+requirements = []
+unsupported_reason = "not runnable"
+vcs_policy = "permit"
+""",
+            "other:other: vcs_policy must be one of ['allow', 'block'], got 'permit'",
+        ),
+        (
+            """
+[other]
+python_version = "3.11"
+requirements = []
+unsupported_reason = "not runnable"
+vcs_policy = { allow = false }
+""",
+            (
+                "other:other: vcs_policy must be one of ['allow', 'block'], "
+                "got {'allow': False}"
+            ),
+        ),
+        (
+            """
+[other]
+python_version = "3.11"
+requirements = []
+unsupported_reason = "not runnable"
+vcs_allowed_schemes = { "git+https" = false }
+""",
+            "other:other: vcs_allowed_schemes must be a list, got dict",
+        ),
+        (
+            """
+[other]
+python_version = "3.11"
+requirements = []
+unsupported_reason = "not runnable"
+vcs_allowed_repos = { "https://example.test/repo" = false }
+""",
+            "other:other: vcs_allowed_repos must be a list, got dict",
+        ),
     ],
-    ids=("sdist-trust", "requirements", "vcs-require-pin"),
+    ids=(
+        "sdist-trust",
+        "requirements",
+        "vcs-require-pin",
+        "vcs-policy",
+        "vcs-policy-table",
+        "vcs-scheme-table",
+        "vcs-repo-table",
+    ),
 )
 def test_unselected_unsupported_definition_fails_before_host_capture_and_result_creation(
     tmp_path: Path,
@@ -2670,27 +2859,53 @@ def test_profile_runner_accepts_an_explicit_strategy() -> None:
     assert lowest["config"].resolution is module.sc.ResolutionStrategy.LOWEST
 
 
-def test_profile_main_validates_vcs_pin_before_host_capture(
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        (
+            "vcs_require_pin",
+            "false",
+            "example: vcs_require_pin must be a boolean, got str",
+        ),
+        (
+            "vcs_policy",
+            "permit",
+            "example: vcs_policy must be one of ['allow', 'block'], got 'permit'",
+        ),
+        (
+            "vcs_allowed_schemes",
+            {"git+https": False},
+            "example: vcs_allowed_schemes must be a list, got dict",
+        ),
+        (
+            "vcs_allowed_repos",
+            {"https://example.test/repo": False},
+            "example: vcs_allowed_repos must be a list, got dict",
+        ),
+    ],
+    ids=("pin", "policy", "scheme-table", "repo-table"),
+)
+def test_profile_main_validates_vcs_settings_before_host_capture(
     monkeypatch: pytest.MonkeyPatch,
+    field: str,
+    value: object,
+    message: str,
 ) -> None:
     module = _harness("_profile_runner")
     scenario = {
         "python_version": "3.11",
         "requirements": [],
-        "vcs_require_pin": "false",
+        field: value,
     }
     monkeypatch.setattr(module, "find_scenario", lambda _spec: ("example", scenario))
     monkeypatch.setattr(module.sys, "argv", ["_profile_runner.py", "example"])
 
     def fail_host(*_args: object, **_kwargs: object) -> object:
-        pytest.fail("VCS pin validation reached host capture")
+        pytest.fail("VCS validation reached host capture")
 
     monkeypatch.setattr(module.sc.BenchmarkHost, "current", classmethod(fail_host))
 
-    with pytest.raises(
-        TypeError,
-        match="example: vcs_require_pin must be a boolean, got str",
-    ):
+    with pytest.raises((TypeError, ValueError), match=re.escape(message)):
         module.main()
 
 
@@ -2710,6 +2925,11 @@ def test_standard_canary_and_profile_build_the_same_project_config() -> None:
     assert standard_execution.config.constraints == ()
     assert standard_execution.constraint_strings == ["demo<2"]
     assert "trust_unverified_sdist_deps" not in standard_execution.expected_input
+    assert standard_execution.expected_input["vcs_policy"] == "allow"
+    assert standard_execution.expected_input["vcs_allowed_schemes"] == ["git+https"]
+    assert standard_execution.expected_input["vcs_allowed_repos"] == [
+        "https://example.test/project"
+    ]
 
 
 @pytest.mark.parametrize(
@@ -2748,6 +2968,46 @@ def test_standard_canary_and_profile_use_valid_vcs_pin_settings(
     assert scenario == original
 
 
+@pytest.mark.parametrize(
+    ("vcs_setting", "expected"),
+    [
+        ({}, "block"),
+        ({"vcs_policy": "block"}, "block"),
+        ({"vcs_policy": "allow"}, "allow"),
+    ],
+    ids=("implicit", "block", "allow"),
+)
+def test_vcs_policy_matches_across_parser_and_runners(
+    vcs_setting: dict[str, object],
+    expected: str,
+) -> None:
+    config_parser = _harness("benchmark_config")
+    standard = _harness("scenarios")
+    canary = _harness("canary")
+    profile = _harness("_profile_runner")
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        **vcs_setting,
+    }
+    original = dict(scenario)
+    expected_policy = standard.VcsPolicy(expected)
+
+    parsed_config = config_parser.parse_scenario_vcs_config("example", scenario)
+    standard_execution, canary_execution, profile_inputs = _prepare_runner_parity(
+        standard,
+        canary,
+        profile,
+        scenario=scenario,
+    )
+
+    assert parsed_config.policy is expected_policy
+    assert standard_execution.config.vcs.policy is expected_policy
+    assert canary_execution.config.vcs.policy is expected_policy
+    assert profile_inputs["config"].vcs.policy is expected_policy
+    assert scenario == original
+
+
 def test_sdist_trust_validation_precedes_requirement_and_vcs_validation() -> None:
     standard = _harness("scenarios")
     canary = _harness("canary")
@@ -2757,6 +3017,9 @@ def test_sdist_trust_validation_precedes_requirement_and_vcs_validation() -> Non
         "requirements": "demo",
         "trust_unverified_sdist_deps": "false",
         "vcs_require_pin": "false",
+        "vcs_policy": "permit",
+        "vcs_allowed_schemes": {"git+https": False},
+        "vcs_allowed_repos": {"https://example.test/repo": False},
     }
     host = _linux_host(standard)
     message = "example: trust_unverified_sdist_deps must be a boolean"
@@ -2784,6 +3047,9 @@ def test_standard_canary_and_profile_reject_non_boolean_vcs_require_pin() -> Non
         "python_version": "3.11",
         "requirements": [],
         "vcs_require_pin": "false",
+        "vcs_policy": "permit",
+        "vcs_allowed_schemes": {"git+https": False},
+        "vcs_allowed_repos": {"https://example.test/repo": False},
     }
     standard_host = _linux_host(standard)
     message = "example: vcs_require_pin must be a boolean, got str"
@@ -2809,6 +3075,66 @@ def test_standard_canary_and_profile_reject_non_boolean_vcs_require_pin() -> Non
         profile.build_inputs("example", scenario, host=UnusedHost())
 
 
+@pytest.mark.parametrize(
+    ("vcs_settings", "message"),
+    [
+        (
+            {
+                "vcs_policy": "permit",
+                "vcs_allowed_schemes": {"git+https": False},
+                "vcs_allowed_repos": {"https://example.test/repo": False},
+            },
+            "example: vcs_policy must be one of ['allow', 'block'], got 'permit'",
+        ),
+        (
+            {
+                "vcs_allowed_schemes": {"git+https": False},
+                "vcs_allowed_repos": {"https://example.test/repo": False},
+            },
+            "example: vcs_allowed_schemes must be a list, got dict",
+        ),
+        (
+            {"vcs_allowed_repos": {"https://example.test/repo": False}},
+            "example: vcs_allowed_repos must be a list, got dict",
+        ),
+    ],
+    ids=("policy", "schemes", "repos"),
+)
+def test_standard_canary_and_profile_validate_vcs_settings_in_order(
+    vcs_settings: dict[str, object],
+    message: str,
+) -> None:
+    standard = _harness("scenarios")
+    canary = _harness("canary")
+    profile = _harness("_profile_runner")
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        **vcs_settings,
+    }
+    standard_host = _linux_host(standard)
+
+    class UnusedHost:
+        """Fail if VCS validation reaches target admission."""
+
+        def target_for(self, *_args: object, **_kwargs: object) -> object:
+            pytest.fail("VCS validation reached host admission")
+
+    with pytest.raises((TypeError, ValueError), match=re.escape(message)):
+        _prepare_standard_scenario(standard, scenario, standard_host)
+
+    with pytest.raises((TypeError, ValueError), match=re.escape(message)):
+        canary._prepare_canary_execution(
+            scenario,
+            scenario_name="example",
+            resolution_override=None,
+            host=UnusedHost(),
+        )
+
+    with pytest.raises((TypeError, ValueError), match=re.escape(message)):
+        profile.build_inputs("example", scenario, host=UnusedHost())
+
+
 @pytest.mark.parametrize("field", ["requirements", "constraints"])
 def test_standard_requirement_list_validation_precedes_vcs_pin_validation(
     field: str,
@@ -2818,6 +3144,9 @@ def test_standard_requirement_list_validation_precedes_vcs_pin_validation(
         "python_version": "3.11",
         "requirements": [],
         "vcs_require_pin": "false",
+        "vcs_policy": "permit",
+        "vcs_allowed_schemes": {"git+https": False},
+        "vcs_allowed_repos": {"https://example.test/repo": False},
     }
     scenario[field] = "demo"
     host = _linux_host(standard)
@@ -2838,6 +3167,9 @@ def test_canary_requirement_list_validation_precedes_vcs_pin_validation(
         "python_version": "3.11",
         "requirements": [],
         "vcs_require_pin": "false",
+        "vcs_policy": "permit",
+        "vcs_allowed_schemes": {"git+https": False},
+        "vcs_allowed_repos": {"https://example.test/repo": False},
     }
     scenario[field] = "demo"
     host = _linux_host(canary)
@@ -2863,6 +3195,9 @@ def test_profile_requirement_list_validation_precedes_vcs_pin_validation_and_hos
         "python_version": "3.11",
         "requirements": [],
         "vcs_require_pin": "false",
+        "vcs_policy": "permit",
+        "vcs_allowed_schemes": {"git+https": False},
+        "vcs_allowed_repos": {"https://example.test/repo": False},
     }
     scenario[field] = "demo"
     host = MagicMock()


### PR DESCRIPTION
A benchmark scenario could set `vcs_allowed_schemes = { "git+https" = false }` or `vcs_allowed_repos = { "https://example.test/repo" = false }`. The runners iterated the table keys and treated them as allowlist members despite their false values.

Benchmark scenarios now require `vcs_policy` to be `block` or `allow` and both allowlists to be lists of strings. Invalid VCS settings are rejected before resolution.