### PR TITLE
validate universal benchmark scenario names

### DIFF
--- a/nab-python/benchmarks/universal_result.py
+++ b/nab-python/benchmarks/universal_result.py
@@ -8,6 +8,23 @@ from datetime import datetime
 RESULT_SCHEMA_VERSION = 3
 MANIFEST_FILENAME = "_manifest.json"
 
+_PORTABLE_COMPONENT_START = frozenset(
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_"
+)
+_PORTABLE_COMPONENT_CHARS = _PORTABLE_COMPONENT_START | frozenset(".-")
+_MAX_SCENARIO_NAME_LENGTH = 128
+_MAX_STORAGE_COMPONENT_LENGTH = 255
+_WINDOWS_RESERVED_COMPONENTS = frozenset(
+    {
+        "aux",
+        "con",
+        "nul",
+        "prn",
+        *(f"com{number}" for number in range(1, 10)),
+        *(f"lpt{number}" for number in range(1, 10)),
+    }
+)
+
 _TOP_LEVEL_FIELDS = frozenset(
     {"input", "reason", "result", "merged_pins", "stats", "per_tuple"}
 )
@@ -95,6 +112,35 @@ _TUPLE_TOTALS = {
 }
 
 
+def _is_portable_path_component(value: str, *, max_length: int) -> bool:
+    """Return whether a value is one portable ASCII filename component."""
+    if (
+        not value
+        or len(value) > max_length
+        or value[0] not in _PORTABLE_COMPONENT_START
+        or value.endswith(".")
+        or any(character not in _PORTABLE_COMPONENT_CHARS for character in value)
+    ):
+        return False
+    windows_basename = value.partition(".")[0].casefold()
+    return windows_basename not in _WINDOWS_RESERVED_COMPONENTS
+
+
+def is_portable_scenario_name(value: object) -> bool:
+    """Return whether a scenario name can identify one universal result file."""
+    if not isinstance(value, str):
+        return False
+    result_filename = f"{value}.json"
+    return (
+        _is_portable_path_component(value, max_length=_MAX_SCENARIO_NAME_LENGTH)
+        and _is_portable_path_component(
+            result_filename,
+            max_length=_MAX_STORAGE_COMPONENT_LENGTH,
+        )
+        and result_filename.casefold() != MANIFEST_FILENAME.casefold()
+    )
+
+
 def _is_optional_bool(value: object) -> bool:
     return value is None or type(value) is bool
 
@@ -160,8 +206,7 @@ def _valid_input(value: object, reason: object) -> bool:
         return False
     return (
         value["benchmark_schema"] == RESULT_SCHEMA_VERSION
-        and isinstance(value["scenario"], str)
-        and bool(value["scenario"])
+        and is_portable_scenario_name(value["scenario"])
         and isinstance(value["commit"], str)
         and bool(value["commit"])
         and _valid_source(value["source"])

--- a/nab-python/benchmarks/universal_scenarios.py
+++ b/nab-python/benchmarks/universal_scenarios.py
@@ -43,6 +43,7 @@ else:
 from universal_result import (
     MANIFEST_FILENAME,
     RESULT_SCHEMA_VERSION,
+    is_portable_scenario_name,
     result_is_accepted,
     result_is_well_formed,
 )
@@ -243,8 +244,32 @@ def check_lock_consistency(result: ResolveResult) -> tuple[bool, list[str]]:
     return not problems, problems
 
 
+def _validate_scenario_names(names: list[str]) -> None:
+    """Reject names that cannot identify distinct universal result files."""
+    invalid = sorted(name for name in names if not is_portable_scenario_name(name))
+    if invalid:
+        rendered = ", ".join(repr(name) for name in invalid)
+        msg = f"invalid universal scenario name(s): {rendered}"
+        raise ValueError(msg)
+
+    names_by_casefold: dict[str, list[str]] = {}
+    for name in names:
+        names_by_casefold.setdefault(name.casefold(), []).append(name)
+    collisions = [group for group in names_by_casefold.values() if len(group) > 1]
+    if collisions:
+        rendered = ", ".join(
+            " / ".join(repr(name) for name in group) for group in collisions
+        )
+        msg = (
+            "universal scenario names collide on case-insensitive filesystems: "
+            f"{rendered}"
+        )
+        raise ValueError(msg)
+
+
 def validate_scenario(scenario_name: str, scenario: dict) -> None:
     """Reject invalid settings before running a universal scenario."""
+    _validate_scenario_names([scenario_name])
     unknown = sorted(set(scenario) - UNIVERSAL_SCENARIO_KEYS)
     if unknown:
         msg = f"{scenario_name}: unknown scenario setting(s): {', '.join(unknown)}"
@@ -573,6 +598,7 @@ def main() -> None:
     toml_path = SCENARIOS_DIR / "universal.toml"
     print(f"Running universal scenarios from {toml_path}")
     scenarios = tomllib.loads(toml_path.read_text())
+    _validate_scenario_names(list(scenarios))
     if args.scenario:
         duplicates = sorted(
             {name for name in args.scenario if args.scenario.count(name) > 1}

--- a/nab-python/benchmarks/universal_summary.py
+++ b/nab-python/benchmarks/universal_summary.py
@@ -10,6 +10,7 @@ from typing import cast
 from universal_result import (
     MANIFEST_FILENAME,
     RESULT_SCHEMA_VERSION,
+    is_portable_scenario_name,
     result_is_accepted,
     result_is_well_formed,
 )
@@ -20,12 +21,10 @@ RESULTS_DIR = Path(__file__).parent / "results"
 def _valid_scenario_names(value: object) -> bool:
     if not isinstance(value, list) or not value:
         return False
-    if not all(isinstance(name, str) and name for name in value):
+    if not all(is_portable_scenario_name(name) for name in value):
         return False
     names: list[str] = value
-    return all(Path(name).name == name for name in names) and len(set(names)) == len(
-        names
-    )
+    return len({name.casefold() for name in names}) == len(names)
 
 
 def _valid_clean_source(value: object) -> bool:

--- a/nab-python/tests/test_universal_benchmark.py
+++ b/nab-python/tests/test_universal_benchmark.py
@@ -25,6 +25,38 @@ _BENCHMARK = (
 if str(_BENCHMARK.parent) not in sys.path:
     sys.path.insert(0, str(_BENCHMARK.parent))
 _CLEAN_SOURCE = {"commit": "a" * 40, "dirty": False, "diff_hash": None}
+_WINDOWS_DEVICE_NAMES = (
+    "AUX",
+    "CON",
+    "NUL",
+    "PRN",
+    *(f"COM{number}" for number in range(1, 10)),
+    *(f"LPT{number}" for number in range(1, 10)),
+)
+_WINDOWS_DEVICE_NAMES_WITH_EXTENSIONS = (
+    "AuX.txt",
+    "cOn.lock",
+    "NuL.json",
+    "pRn.data",
+    "cOm1.json",
+    "COM9.txt",
+    "lPt1.lock",
+    "LPT9.data",
+)
+_PORTABLE_WINDOWS_DEVICE_NEAR_MISSES = (
+    "AUX1",
+    "CONSOLE",
+    "NULL",
+    "PRINTER",
+    "COM0",
+    "COM10",
+    "LPT0",
+    "LPT10",
+    "x.AUX",
+    "prefix.COM1",
+    "_AUX",
+    "COM1-file",
+)
 
 
 class _FakeCoordinator:
@@ -38,7 +70,7 @@ class _FakeCoordinator:
         pass
 
 
-def _universal_scenario(*platforms: str) -> dict:
+def _universal_scenario(*platforms: str) -> dict[str, object]:
     return {
         "python": ">=3.11,<3.12",
         "platforms": list(platforms),
@@ -687,6 +719,75 @@ def test_unknown_universal_setting_is_rejected() -> None:
         module.validate_scenario("example", {"parallel": True})
 
 
+@pytest.mark.parametrize(
+    ("name", "valid"),
+    [
+        ("a", True),
+        ("a" * 128, True),
+        ("a" * 129, False),
+        ("A.b-c_1", True),
+        ("_manifest", False),
+        ("_MANIFEST", False),
+        ("_manifest.json", True),
+        ("../escape", False),
+        (r"parent\child", False),
+        (".hidden", False),
+        ("-flag", False),
+        ("trailing.", False),
+        ("café", False),
+        *((name, False) for name in _WINDOWS_DEVICE_NAMES),
+        *((name, False) for name in _WINDOWS_DEVICE_NAMES_WITH_EXTENSIONS),
+        *((name, True) for name in _PORTABLE_WINDOWS_DEVICE_NEAR_MISSES),
+    ],
+)
+def test_universal_scenario_names_produce_portable_result_files(
+    name: str,
+    valid: bool,
+) -> None:
+    module = _harness()
+
+    assert module.is_portable_scenario_name(name) is valid
+
+
+@pytest.mark.parametrize(
+    ("name", "well_formed"),
+    [
+        ("example", True),
+        ("_manifest", False),
+        ("_manifest.json", True),
+    ],
+)
+def test_universal_result_contract_uses_portable_scenario_names(
+    name: str,
+    well_formed: bool,
+) -> None:
+    module = _harness()
+    data = _result_data(
+        {
+            "success": True,
+            "resolution_success": True,
+            "lock_consistent": True,
+            "timed_out": False,
+        }
+    )
+    data["input"]["scenario"] = name
+
+    assert module.result_is_well_formed(data) is well_formed
+
+
+def test_universal_scenario_names_cannot_collide_case_insensitively() -> None:
+    module = _harness()
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "universal scenario names collide on case-insensitive filesystems: "
+            "'Example' / 'example'"
+        ),
+    ):
+        module._validate_scenario_names(["Example", "example"])
+
+
 def test_duplicate_universal_platforms_are_rejected_in_declaration_order() -> None:
     module = _harness()
 
@@ -706,9 +807,31 @@ def test_duplicate_universal_platforms_are_rejected_in_declaration_order() -> No
         )
 
 
-def test_process_rejects_duplicate_platforms_before_network(
+@pytest.mark.parametrize(
+    ("scenario_name", "scenario", "message"),
+    [
+        (
+            "example",
+            _universal_scenario(
+                "linux_x86_64",
+                "macos_arm64",
+                "linux_x86_64",
+            ),
+            r"^example: platforms has duplicate entry: 'linux_x86_64'$",
+        ),
+        (
+            "_manifest",
+            _universal_scenario("linux_x86_64"),
+            r"^invalid universal scenario name\(s\): '_manifest'$",
+        ),
+    ],
+)
+def test_process_rejects_invalid_scenarios_before_network(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    scenario_name: str,
+    scenario: dict[str, object],
+    message: str,
 ) -> None:
     module = _harness()
 
@@ -718,17 +841,10 @@ def test_process_rejects_duplicate_platforms_before_network(
     monkeypatch.setattr(module, "Urllib3AsyncTransport", unexpected_transport)
     output_dir = tmp_path / "results"
 
-    with pytest.raises(
-        ValueError,
-        match=r"^example: platforms has duplicate entry: 'linux_x86_64'$",
-    ):
+    with pytest.raises(ValueError, match=message):
         module.process_scenario(
-            "example",
-            _universal_scenario(
-                "linux_x86_64",
-                "macos_arm64",
-                "linux_x86_64",
-            ),
+            scenario_name,
+            scenario,
             "commit",
             force=True,
             output_dir=output_dir,
@@ -800,6 +916,57 @@ requirements = ["baz"]
 
     assert processed == []
     assert not (results_dir / "label" / "universal").exists()
+
+
+def test_main_rejects_an_unselected_manifest_scenario_name_before_any_run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    scenarios_dir = tmp_path / "scenarios"
+    scenarios_dir.mkdir()
+    (scenarios_dir / "universal.toml").write_text(
+        """[valid]
+python = ">=3.11,<3.12"
+platforms = ["linux_x86_64"]
+requirements = ["foo"]
+
+[_manifest]
+python = ">=3.11,<3.12"
+platforms = ["linux_x86_64"]
+requirements = ["bar"]
+
+[valid-after]
+python = ">=3.11,<3.12"
+platforms = ["macos_arm64"]
+requirements = ["baz"]
+"""
+    )
+    results_dir = tmp_path / "results"
+    processed: list[str] = []
+
+    def record_process(name: str, *_args: object, **_kwargs: object) -> bool:
+        processed.append(name)
+        return True
+
+    monkeypatch.setattr(module, "SCENARIOS_DIR", scenarios_dir)
+    monkeypatch.setattr(module, "RESULTS_DIR", results_dir)
+    monkeypatch.setattr(module, "get_git_source_state", lambda: _CLEAN_SOURCE)
+    monkeypatch.setattr(module, "process_scenario", record_process)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [str(_BENCHMARK), "--commit", "label", "--scenario", "valid"],
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"^invalid universal scenario name\(s\): '_manifest'$",
+    ):
+        module.main()
+
+    assert processed == []
+    assert not (results_dir / "label").exists()
 
 
 def test_main_exits_nonzero_for_unexpected_failure(
@@ -906,6 +1073,24 @@ def test_universal_scenarios_only_override_alignment_for_noalign_cases() -> None
     assert not any(
         scenario.get("align_across_tuples") is True for scenario in scenarios.values()
     )
+
+
+@pytest.mark.parametrize(
+    ("names", "valid"),
+    [
+        (["example"], True),
+        (["_manifest"], False),
+        (["_manifest.json"], True),
+        (["Example", "example"], False),
+    ],
+)
+def test_summary_requires_portable_distinct_scenario_names(
+    names: list[str],
+    valid: bool,
+) -> None:
+    module = _summary_harness()
+
+    assert module._valid_scenario_names(names) is valid
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
A universal scenario named `_manifest` wrote its result to `_manifest.json`. After a successful resolve, the final run manifest replaced that file, and the summary rejected the run when it read the manifest as a scenario result.

The runner now validates every scenario name before selection or result creation. Persisted results and summaries use the same portable filename rule, which reserves `_manifest.json` for the run manifest and rejects case-insensitive collisions.