### PR TITLE
drop provider._normalize_extra and call canonicalize_name directly

### DIFF
--- a/nab-python/src/nab_python/_provider/extras.py
+++ b/nab-python/src/nab_python/_provider/extras.py
@@ -13,6 +13,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from .._vendor.packaging.ranges import VersionRange
+from .._vendor.packaging.utils import canonicalize_name
 from .metadata_resolver import refuse_url_dep
 
 if TYPE_CHECKING:
@@ -110,7 +111,7 @@ def _pick_in_mode(
     checks ``Provides-Extra`` for transitive extras.
     """
     # Late import: ``provider`` imports this module at module load.
-    from ..provider import ExtrasMode, MetadataError, _normalize_extra
+    from ..provider import ExtrasMode, MetadataError
 
     _, _, normalized = provider.split_and_normalize(base)
     is_user = (normalized, extra) in provider.root_extras
@@ -126,7 +127,7 @@ def _pick_in_mode(
             return version
         metadata = provider.metadata_cache.get((normalized, version))
         provided = (
-            {_normalize_extra(e) for e in metadata.provides_extra}
+            {canonicalize_name(e) for e in metadata.provides_extra}
             if metadata
             else set()
         )
@@ -193,7 +194,7 @@ def version_provides_extra(
     extractable metadata in this tuple.
     """
     # Late import: provider imports this module at module load.
-    from ..provider import MetadataError, _normalize_extra
+    from ..provider import MetadataError
 
     _, _, normalized = provider.split_and_normalize(base)
     try:
@@ -202,7 +203,7 @@ def version_provides_extra(
         return False
 
     metadata = provider.metadata_cache[(normalized, version)]
-    provided = {_normalize_extra(e) for e in metadata.provides_extra}
+    provided = {canonicalize_name(e) for e in metadata.provides_extra}
     return extra in provided
 
 

--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -748,16 +748,13 @@ def cache_deps_from_metadata(
     :meth:`nab_python.provider.Provider.get_dependencies` (which hands in a
     bare :class:`WheelMetadata` for a complete ``dependencies`` override).
     """
-    # Late import: ``provider`` imports this module at module load.
-    from ..provider import _normalize_extra
-
     metadata = effective_metadata(provider, cache_key, metadata)
 
     # Split the (possibly overridden) requirements into base deps and
     # per-extra deps, deferring any direct-URL deps that aren't yet active.
     package = cache_key[0]
     provider.metadata_cache[cache_key] = metadata
-    provided_extras = {_normalize_extra(e) for e in metadata.provides_extra}
+    provided_extras: set[str] = {canonicalize_name(e) for e in metadata.provides_extra}
     base_deps: dict[str, VersionRange] = {}
     extra_deps_map: dict[str, dict[str, VersionRange]] = {
         e: {} for e in provided_extras
@@ -862,11 +859,8 @@ def target_dep_signature(
     already refused its own URL deps, so a sibling's URL dep is a divergence to
     report.
     """
-    # Late import: ``provider`` imports this module at module load.
-    from ..provider import _normalize_extra
-
     metadata = effective_metadata(provider, cache_key, metadata)
-    provided_extras = {_normalize_extra(e) for e in metadata.provides_extra}
+    provided_extras: set[str] = {canonicalize_name(e) for e in metadata.provides_extra}
     base_deps: dict[str, VersionRange] = {}
     extra_deps_map: dict[str, dict[str, VersionRange]] = {
         e: {} for e in provided_extras

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -60,7 +60,6 @@ from .provider import (
     VcsConfig,
     VcsPolicy,
     VcsSource,
-    _normalize_extra,
 )
 from .tags import DEFAULT_LIBC, LIBC_MAJOR, Libc, PlatformSpec, platform_kind
 from .target import (
@@ -2391,11 +2390,10 @@ def _parse_override_dependencies(
 def _parse_override_provides_extra(value: object, where: str) -> tuple[str, ...] | None:
     """Parse the ``provides-extra`` body: the extras the override declares.
 
-    A TOML array of extra names, each normalised per PEP 685 (the same
-    rule :func:`nab_python.provider._normalize_extra` applies to parsed
-    ``Provides-Extra``), so an extra compares equal regardless of spelling.
-    A present-but-empty list is stored as ``()`` (declares no extras),
-    distinct from the key being absent (``None``).
+    A TOML array of extra names, each normalised per PEP 685 like a parsed
+    ``Provides-Extra``, so an extra compares equal regardless of spelling. A
+    present-but-empty list is stored as ``()`` (declares no extras), distinct
+    from the key being absent (``None``).
     """
     if value is None:
         return None
@@ -2415,7 +2413,7 @@ def _parse_override_provides_extra(value: object, where: str) -> tuple[str, ...]
                 f" {type(item).__name__}"
             )
             raise ConfigError(msg)
-        out.append(_normalize_extra(item))
+        out.append(canonicalize_name(item))
     return tuple(out)
 
 

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -93,11 +93,6 @@ logger = logging.getLogger(__name__)
 _EXTRA_RE = re.compile(r"^(?P<base>[^\[]+)\[(?P<extra>[^\]]+)\]$")
 
 
-def _normalize_extra(extra: str) -> str:
-    """Normalize an extra name per PEP 685 (same rules as package names)."""
-    return canonicalize_name(extra)
-
-
 def split_extra(package: str) -> tuple[str, str | None]:
     """Split 'name[extra]' into ('name', 'extra'), or ('name', None).
 
@@ -106,7 +101,7 @@ def split_extra(package: str) -> tuple[str, str | None]:
     m = _EXTRA_RE.match(package)
     if m is None:
         return (package, None)
-    return (m.group("base"), _normalize_extra(m.group("extra")))
+    return (m.group("base"), canonicalize_name(m.group("extra")))
 
 
 def join_extra(base: str, extra: str) -> str:
@@ -114,7 +109,7 @@ def join_extra(base: str, extra: str) -> str:
 
     The extra name is normalized per PEP 685.
     """
-    return f"{base}[{_normalize_extra(extra)}]"
+    return f"{base}[{canonicalize_name(extra)}]"
 
 
 class MissingExtraError(Exception):


### PR DESCRIPTION
`provider._normalize_extra` was a one-line forward to `canonicalize_name(extra)`, and three other modules imported that private name across a module boundary. Two of those imports, in `_provider/metadata_resolver.py`, were late imports to break the cycle with `provider`, even though the module already imports `canonicalize_name` at the top. The rest of the code normalizes extra names by calling `canonicalize_name` directly.

This deletes the forward and calls `canonicalize_name` at each site. `metadata_resolver.py` loses both late-import blocks, and the `_parse_override_provides_extra` docstring now states the PEP 685 rule instead of pointing at a private function. No behaviour change.
