### PR TITLE
validate benchmark project metadata

### DIFF
--- a/nab-python/benchmarks/_profile_runner.py
+++ b/nab-python/benchmarks/_profile_runner.py
@@ -30,6 +30,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 import scenarios as sc
 from benchmark_config import (
     build_benchmark_config,
+    parse_scenario_project_metadata,
     parse_scenario_requirement_strings,
     parse_scenario_vcs_config,
     parse_trust_unverified_sdist_deps,
@@ -79,6 +80,7 @@ def build_inputs(
     trust_unverified_sdist_deps = parse_trust_unverified_sdist_deps(name, scenario)
     requirement_inputs = parse_scenario_requirement_strings(name, scenario)
     vcs_config = parse_scenario_vcs_config(name, scenario)
+    project_metadata = parse_scenario_project_metadata(name, scenario)
     python_version = scenario["python_version"]
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
@@ -109,11 +111,11 @@ def build_inputs(
         scenario.get("resolution", sc.ResolutionStrategy.HIGHEST.value)
     )
     resolution_strategy = resolution_override or declared_resolution
-    if scenario.get("project_name"):
+    if project_metadata.project_name:
         requirement_strings += sc.expand_project_extras(
-            scenario["project_name"],
-            scenario.get("project_extras", []),
-            scenario.get("optional_dependencies", {}),
+            project_metadata.project_name,
+            project_metadata.project_extras,
+            project_metadata.optional_dependencies,
         )
 
     marker_env = dict(target.marker_env)

--- a/nab-python/benchmarks/benchmark_config.py
+++ b/nab-python/benchmarks/benchmark_config.py
@@ -52,6 +52,14 @@ class ScenarioRequirementStrings(NamedTuple):
     constraints: list[str]
 
 
+class ScenarioProjectMetadata(NamedTuple):
+    """Copied project metadata used to expand a scenario's selected extras."""
+
+    project_name: str | None
+    project_extras: list[str]
+    optional_dependencies: dict[str, list[str]]
+
+
 def _scenario_string_list(
     scenario_name: str,
     field: str,
@@ -96,6 +104,69 @@ def parse_scenario_requirement_strings(
             scenario_name,
             "constraints",
             scenario.get("constraints", []),
+        ),
+    )
+
+
+def _scenario_optional_dependencies(
+    scenario_name: str,
+    value: object,
+) -> dict[str, list[str]]:
+    """Validate and copy a scenario's optional-dependency table."""
+    if type(value) is not dict:
+        msg = (
+            f"{scenario_name}: optional_dependencies must be a table, "
+            f"got {type(value).__name__}"
+        )
+        raise TypeError(msg)
+
+    optional_dependencies: dict[str, list[str]] = {}
+    for extra, dependencies in value.items():
+        if not isinstance(extra, str):
+            msg = (
+                f"{scenario_name}: optional_dependencies keys must be "
+                f"non-empty strings, got {type(extra).__name__}"
+            )
+            raise TypeError(msg)
+        if not extra:
+            msg = (
+                f"{scenario_name}: optional_dependencies keys must be non-empty strings"
+            )
+            raise ValueError(msg)
+        optional_dependencies[extra] = _scenario_string_list(
+            scenario_name,
+            f"optional_dependencies[{extra!r}]",
+            dependencies,
+        )
+    return optional_dependencies
+
+
+def parse_scenario_project_metadata(
+    scenario_name: str,
+    scenario: Mapping[str, object],
+) -> ScenarioProjectMetadata:
+    """Validate and copy project metadata from one benchmark scenario."""
+    project_name = scenario.get("project_name")
+    if project_name is not None and not isinstance(project_name, str):
+        msg = (
+            f"{scenario_name}: project_name must be a non-empty string, "
+            f"got {type(project_name).__name__}"
+        )
+        raise TypeError(msg)
+    if project_name == "":
+        msg = f"{scenario_name}: project_name must be a non-empty string"
+        raise ValueError(msg)
+
+    return ScenarioProjectMetadata(
+        project_name=project_name,
+        project_extras=_scenario_string_list(
+            scenario_name,
+            "project_extras",
+            scenario.get("project_extras", []),
+        ),
+        optional_dependencies=_scenario_optional_dependencies(
+            scenario_name,
+            scenario.get("optional_dependencies", {}),
         ),
     )
 

--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -37,6 +37,7 @@ from benchmark_config import (
     build_benchmark_provider,
     build_benchmark_resolver_inputs,
     direct_packages_from_requirements,
+    parse_scenario_project_metadata,
     parse_scenario_requirement_strings,
     parse_scenario_vcs_config,
     parse_trust_unverified_sdist_deps,
@@ -600,6 +601,7 @@ def select_scenarios(cases: list[CanaryCase]) -> list[CanaryCase]:
         parse_vcs_policy,
         parse_vcs_allowed_schemes,
         parse_vcs_allowed_repos,
+        parse_scenario_project_metadata,
     )
     for validate_field in field_validators:
         for scenario_name, scenario in found_scenarios:
@@ -770,6 +772,7 @@ def _prepare_canary_execution(
     )
     requirement_inputs = parse_scenario_requirement_strings(scenario_name, scenario)
     vcs_config = parse_scenario_vcs_config(scenario_name, scenario)
+    project_metadata = parse_scenario_project_metadata(scenario_name, scenario)
     python_version = scenario["python_version"]
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
@@ -807,13 +810,13 @@ def _prepare_canary_execution(
         return CanaryPreparation(None, admission.inapplicable_reason)
     target = admission.target
 
-    project_name = scenario.get("project_name")
+    project_name = project_metadata.project_name
     if project_name:
         requirement_strings.extend(
             expand_project_extras(
                 project_name,
-                scenario.get("project_extras", []),
-                scenario.get("optional_dependencies", {}),
+                project_metadata.project_extras,
+                project_metadata.optional_dependencies,
             )
         )
 

--- a/nab-python/benchmarks/scenarios.py
+++ b/nab-python/benchmarks/scenarios.py
@@ -37,6 +37,7 @@ from benchmark_config import (
     build_benchmark_config,
     build_benchmark_provider,
     build_benchmark_resolver_inputs,
+    parse_scenario_project_metadata,
     parse_scenario_requirement_strings,
     parse_scenario_vcs_config,
     parse_trust_unverified_sdist_deps,
@@ -583,6 +584,7 @@ def load_standard_corpus(files: list[Path]) -> list[StandardScenario]:
         parse_trust_unverified_sdist_deps(row.logical_key, row.definition)
         parse_scenario_requirement_strings(row.logical_key, row.definition)
         parse_scenario_vcs_config(row.logical_key, row.definition)
+        parse_scenario_project_metadata(row.logical_key, row.definition)
         build_policy_overrides = parse_build_packages(row.name, row.definition)
         if "unsupported_reason" in row.definition:
             continue
@@ -1593,6 +1595,7 @@ def prepare_standard_execution(
     )
     requirement_inputs = parse_scenario_requirement_strings(scenario_name, scenario)
     vcs_config = parse_scenario_vcs_config(scenario_name, scenario)
+    project_metadata = parse_scenario_project_metadata(scenario_name, scenario)
     python_version: str = scenario["python_version"]
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
@@ -1607,14 +1610,15 @@ def prepare_standard_execution(
             build_policy_overrides,
         )
     datetime_str: str | None = scenario.get("datetime")
-    project_name: str | None = scenario.get("project_name")
-    project_extras: list[str] = scenario.get("project_extras", [])
-    optional_dependencies: dict[str, list[str]] = scenario.get(
-        "optional_dependencies", {}
-    )
+    project_name = project_metadata.project_name
+    project_extras = project_metadata.project_extras
     if project_name:
         requirement_strings.extend(
-            expand_project_extras(project_name, project_extras, optional_dependencies)
+            expand_project_extras(
+                project_name,
+                project_extras,
+                project_metadata.optional_dependencies,
+            )
         )
     uploaded_prior_to = parse_datetime(datetime_str) if datetime_str else None
     config = build_benchmark_config(

--- a/nab-python/tests/test_benchmark_canary.py
+++ b/nab-python/tests/test_benchmark_canary.py
@@ -606,6 +606,17 @@ def test_canary_main_records_v2_contract(
             {
                 "requirements": [],
                 "unsupported_reason": "test fixture",
+                "project_name": "demo-project",
+                "project_extras": ["all"],
+                "optional_dependencies": {"all": "demo"},
+            },
+            True,
+            "quick:requests: optional_dependencies['all'] must be a list, got str",
+        ),
+        (
+            {
+                "requirements": [],
+                "unsupported_reason": "test fixture",
                 "vcs_require_pin": "false",
             },
             False,
@@ -645,6 +656,7 @@ def test_canary_main_records_v2_contract(
         "scalar",
         "empty-item",
         "default-empty-item",
+        "default-project-metadata",
         "vcs-require-pin",
         "vcs-policy",
         "vcs-scheme-table",

--- a/nab-python/tests/test_benchmark_canary_selection.py
+++ b/nab-python/tests/test_benchmark_canary_selection.py
@@ -506,6 +506,60 @@ def test_selection_validates_requirement_lists_before_vcs_pin_settings(
 
 
 @pytest.mark.parametrize(
+    ("vcs_settings", "message"),
+    [
+        (
+            {"vcs_require_pin": "false"},
+            "quick:first: vcs_require_pin must be a boolean, got str",
+        ),
+        (
+            {"vcs_policy": "permit"},
+            "quick:first: vcs_policy must be one of ['allow', 'block'], got 'permit'",
+        ),
+        (
+            {"vcs_allowed_schemes": {"git+https": False}},
+            "quick:first: vcs_allowed_schemes must be a list, got dict",
+        ),
+        (
+            {"vcs_allowed_repos": {"https://example.test/repo": False}},
+            "quick:first: vcs_allowed_repos must be a list, got dict",
+        ),
+    ],
+    ids=("pin", "policy", "schemes", "repos"),
+)
+def test_selection_validates_vcs_settings_before_project_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    vcs_settings: dict[str, object],
+    message: str,
+) -> None:
+    module = _harness()
+    scenarios = {
+        "quick:first": {
+            "requirements": [],
+            **vcs_settings,
+        },
+        "quick:second": {
+            "requirements": [],
+            "project_name": "demo-project",
+            "project_extras": ["all"],
+            "optional_dependencies": {"all": "demo"},
+        },
+    }
+    monkeypatch.setattr(module, "find_scenario", scenarios.get)
+
+    with pytest.raises(
+        (TypeError, ValueError),
+        match=re.escape(message),
+    ):
+        module.select_scenarios(
+            [
+                module.CanaryCase("quick:first", None),
+                module.CanaryCase("quick:second", None),
+            ]
+        )
+
+
+@pytest.mark.parametrize(
     ("first_scenario", "second_scenario", "message"),
     [
         (

--- a/nab-python/tests/test_benchmark_strategy_matrix.py
+++ b/nab-python/tests/test_benchmark_strategy_matrix.py
@@ -238,6 +238,12 @@ def _runner_parity_scenario() -> dict[str, object]:
         "vcs_allowed_schemes": ["git+https"],
         "vcs_allowed_repos": ["https://example.test/project"],
         "vcs_require_pin": False,
+        "project_name": "Demo_Project",
+        "project_extras": ["All_Features", "Direct_Use"],
+        "optional_dependencies": {
+            "all.features": ["Project_Leaf>=2", "Second.Leaf"],
+            "DIRECT-use": ["Another_Leaf==1"],
+        },
     }
 
 
@@ -1427,6 +1433,161 @@ def test_parse_scenario_requirement_strings_rejects_empty_items(field: str) -> N
         match=rf"quick:empty-item: {field}\[1\] must be a non-empty string$",
     ):
         module.parse_scenario_requirement_strings("quick:empty-item", scenario)
+
+
+def test_parse_scenario_project_metadata_returns_fresh_nested_values() -> None:
+    module = _harness("benchmark_config")
+    project_extras = ["All_Features", "OpenAI"]
+    optional_dependencies = {
+        "all.features": ["Eval_Framework[OpenAI]"],
+        "open_ai": ["OpenAI_Client>=1.62,<2"],
+    }
+    scenario = {
+        "project_name": "Eval_Framework",
+        "project_extras": project_extras,
+        "optional_dependencies": optional_dependencies,
+    }
+    original = deepcopy(scenario)
+
+    parsed = module.parse_scenario_project_metadata(
+        "ecosystem:eval-framework", scenario
+    )
+
+    assert parsed.project_name == "Eval_Framework"
+    assert parsed.project_extras == ["All_Features", "OpenAI"]
+    assert list(parsed.optional_dependencies) == ["all.features", "open_ai"]
+    assert parsed.optional_dependencies == optional_dependencies
+
+    assert parsed.project_extras is not project_extras
+    assert parsed.optional_dependencies is not optional_dependencies
+    for extra, dependencies in optional_dependencies.items():
+        assert parsed.optional_dependencies[extra] is not dependencies
+
+    parsed.project_extras.reverse()
+    parsed.optional_dependencies["all.features"].clear()
+    assert scenario == original
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    [
+        {"project_name": "Eval_Framework"},
+        {"project_extras": ["All_Features", "OpenAI"]},
+        {
+            "optional_dependencies": {
+                "all.features": ["Eval_Framework[OpenAI]"],
+                "open_ai": ["OpenAI_Client>=1.62,<2"],
+            }
+        },
+        {
+            "project_extras": ["OpenAI", "All_Features"],
+            "optional_dependencies": {
+                "open_ai": ["OpenAI_Client>=1.62,<2"],
+                "all.features": ["Eval_Framework[OpenAI]"],
+            },
+        },
+    ],
+    ids=("name", "extras", "optional-dependencies", "extras-and-optional"),
+)
+def test_parse_scenario_project_metadata_accepts_partial_forms(
+    scenario: dict[str, object],
+) -> None:
+    module = _harness("benchmark_config")
+
+    parsed = module.parse_scenario_project_metadata(
+        "ecosystem:eval-framework", scenario
+    )
+
+    assert parsed.project_name == scenario.get("project_name")
+    assert parsed.project_extras == scenario.get("project_extras", [])
+    assert list(parsed.optional_dependencies) == list(
+        scenario.get("optional_dependencies", {})
+    )
+    assert parsed.optional_dependencies == scenario.get("optional_dependencies", {})
+
+
+@pytest.mark.parametrize(
+    ("scenario", "error", "message"),
+    [
+        (
+            {"project_name": False},
+            TypeError,
+            "quick:project: project_name must be a non-empty string, got bool",
+        ),
+        (
+            {"project_name": ""},
+            ValueError,
+            "quick:project: project_name must be a non-empty string",
+        ),
+        (
+            {"project_extras": "all"},
+            TypeError,
+            "quick:project: project_extras must be a list, got str",
+        ),
+        (
+            {"project_extras": ["all", 1]},
+            TypeError,
+            "quick:project: project_extras[1] must be a non-empty string, got int",
+        ),
+        (
+            {"project_extras": ["all", ""]},
+            ValueError,
+            "quick:project: project_extras[1] must be a non-empty string",
+        ),
+        (
+            {"optional_dependencies": ["demo"]},
+            TypeError,
+            "quick:project: optional_dependencies must be a table, got list",
+        ),
+        (
+            {"optional_dependencies": {"all": "demo"}},
+            TypeError,
+            "quick:project: optional_dependencies['all'] must be a list, got str",
+        ),
+        (
+            {"optional_dependencies": {"all": ["demo", 1]}},
+            TypeError,
+            (
+                "quick:project: optional_dependencies['all'][1] must be a "
+                "non-empty string, got int"
+            ),
+        ),
+        (
+            {"optional_dependencies": {"all": ["demo", ""]}},
+            ValueError,
+            (
+                "quick:project: optional_dependencies['all'][1] must be a "
+                "non-empty string"
+            ),
+        ),
+        (
+            {"optional_dependencies": {"": ["demo"]}},
+            ValueError,
+            "quick:project: optional_dependencies keys must be non-empty strings",
+        ),
+    ],
+    ids=(
+        "project-name-type",
+        "project-name-empty",
+        "project-extras-scalar",
+        "project-extras-member",
+        "project-extras-empty",
+        "optional-dependencies-array",
+        "optional-dependency-scalar",
+        "optional-dependency-member",
+        "optional-dependency-empty",
+        "optional-dependency-empty-key",
+    ),
+)
+def test_parse_scenario_project_metadata_rejects_malformed_values(
+    scenario: dict[str, object],
+    error: type[Exception],
+    message: str,
+) -> None:
+    module = _harness("benchmark_config")
+
+    with pytest.raises(error, match=re.escape(message)):
+        module.parse_scenario_project_metadata("quick:project", scenario)
 
 
 @pytest.mark.parametrize(
@@ -2732,6 +2893,33 @@ unsupported_reason = "not runnable"
 python_version = "3.11"
 requirements = []
 unsupported_reason = "not runnable"
+project_name = "demo-project"
+project_extras = ["all"]
+[other.optional_dependencies]
+all = "demo"
+""",
+            "other:other: optional_dependencies['all'] must be a list, got str",
+        ),
+        (
+            """
+[other]
+python_version = "3.11"
+requirements = []
+unsupported_reason = "not runnable"
+vcs_require_pin = "false"
+project_name = "demo-project"
+project_extras = ["all"]
+[other.optional_dependencies]
+all = "demo"
+""",
+            "other:other: vcs_require_pin must be a boolean, got str",
+        ),
+        (
+            """
+[other]
+python_version = "3.11"
+requirements = []
+unsupported_reason = "not runnable"
 vcs_require_pin = "false"
 """,
             "other:other: vcs_require_pin must be a boolean, got str",
@@ -2783,6 +2971,8 @@ vcs_allowed_repos = { "https://example.test/repo" = false }
     ids=(
         "sdist-trust",
         "requirements",
+        "project-metadata",
+        "vcs-before-project-metadata",
         "vcs-require-pin",
         "vcs-policy",
         "vcs-policy-table",
@@ -2913,10 +3103,13 @@ def test_standard_canary_and_profile_build_the_same_project_config() -> None:
     standard = _harness("scenarios")
     canary = _harness("canary")
     profile = _harness("_profile_runner")
+    scenario = _runner_parity_scenario()
+    original = deepcopy(scenario)
     standard_execution, canary_execution, profile_inputs = _prepare_runner_parity(
         standard,
         canary,
         profile,
+        scenario=scenario,
     )
 
     assert (
@@ -2924,12 +3117,112 @@ def test_standard_canary_and_profile_build_the_same_project_config() -> None:
     )
     assert standard_execution.config.constraints == ()
     assert standard_execution.constraint_strings == ["demo<2"]
+
     assert "trust_unverified_sdist_deps" not in standard_execution.expected_input
     assert standard_execution.expected_input["vcs_policy"] == "allow"
     assert standard_execution.expected_input["vcs_allowed_schemes"] == ["git+https"]
     assert standard_execution.expected_input["vcs_allowed_repos"] == [
         "https://example.test/project"
     ]
+    assert standard_execution.expected_input["project_name"] == "Demo_Project"
+    assert standard_execution.expected_input["project_extras"] == [
+        "All_Features",
+        "Direct_Use",
+    ]
+
+    assert standard_execution.expected_input["requirements"] == [
+        "demo[feature]>=1",
+        "Project_Leaf>=2",
+        "Second.Leaf",
+        "Another_Leaf==1",
+    ]
+    assert set(canary_execution.requirements) == {
+        "another-leaf",
+        "demo",
+        "demo[feature]",
+        "project-leaf",
+        "second-leaf",
+    }
+    assert set(profile_inputs["requirements"]) == {
+        "another-leaf",
+        "demo",
+        "demo[feature]",
+        "project-leaf",
+        "second-leaf",
+    }
+
+    assert scenario == original
+
+
+@pytest.mark.parametrize(
+    ("vcs_settings", "message"),
+    [
+        (
+            {},
+            "example: optional_dependencies['all'] must be a list, got str",
+        ),
+        (
+            {"vcs_require_pin": "false"},
+            "example: vcs_require_pin must be a boolean, got str",
+        ),
+    ],
+    ids=("project-metadata", "vcs-precedence"),
+)
+def test_all_runners_validate_project_metadata_in_schema_order(
+    vcs_settings: dict[str, object],
+    message: str,
+) -> None:
+    standard = _harness("scenarios")
+    canary = _harness("canary")
+    profile = _harness("_profile_runner")
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        "project_name": "demo-project",
+        "project_extras": ["all"],
+        "optional_dependencies": {"all": "demo"},
+        **vcs_settings,
+    }
+    host = _linux_host(standard)
+
+    with pytest.raises(TypeError, match=re.escape(message)):
+        _prepare_standard_scenario(standard, scenario, host)
+
+    with pytest.raises(TypeError, match=re.escape(message)):
+        canary._prepare_canary_execution(
+            scenario,
+            scenario_name="example",
+            resolution_override=None,
+            host=host,
+        )
+
+    with pytest.raises(TypeError, match=re.escape(message)):
+        profile.build_inputs("example", scenario, host=host)
+
+
+def test_profile_project_metadata_validation_precedes_host_admission() -> None:
+    profile = _harness("_profile_runner")
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        "project_name": "demo-project",
+        "project_extras": ["all"],
+        "optional_dependencies": {"all": "demo"},
+    }
+
+    class UnusedHost:
+        """Fail if project-metadata validation reaches target admission."""
+
+        def target_for(self, *_args: object, **_kwargs: object) -> object:
+            pytest.fail("project-metadata validation reached host admission")
+
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "example: optional_dependencies['all'] must be a list, got str"
+        ),
+    ):
+        profile.build_inputs("example", scenario, host=UnusedHost())
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
A benchmark scenario with `optional_dependencies = { all = "demo" }` treated the string as an iterable of requirements. Standard, canary, and profile passed `d`, `e`, `m`, and `o` to the resolver as separate roots, while ordinary Nab rejects the equivalent project metadata.

All three runners now use one shared parser before expanding selected extras. It validates `project_name`, `project_extras`, and the optional-dependency table, then returns fresh copies of the lists and nested table.