### PR TITLE
fix traceback on an uploaded-prior-to duration with too many digits

### DIFF
--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -1390,10 +1390,10 @@ def _parse_uploaded_prior_to(value: object, *, anchor: datetime) -> datetime:
 
     duration_match = _DURATION_PATTERN.match(value)
     if duration_match is not None:
-        days = int(duration_match.group(1))
+        # ``int()`` raises ValueError past CPython's int-from-string limit.
         try:
-            return anchor - timedelta(days=days)
-        except OverflowError:
+            return anchor - timedelta(days=int(duration_match.group(1)))
+        except (OverflowError, ValueError):
             msg = f"uploaded-prior-to duration is too large: {value!r}"
             raise ConfigError(msg) from None
     try:

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -4342,11 +4342,12 @@ _PAST_INT_LIMIT = "9" * 5000
 
 
 class TestDigitRunPastIntLimit:
-    """A version digit run past CPython's int limit is a config error.
+    """A digit run past CPython's int limit is a config error.
 
     ``Version()`` raises a bare ``ValueError`` for one (not
     ``InvalidVersion``), and a specifier defers the conversion to its first
-    comparison, so each validator forces it and reports the key.
+    comparison, so each version validator forces it and reports the key.
+    ``int()`` rejects the same run when it is a ``P<n>D`` day count.
     """
 
     def test_environment_python(self, tmp_path: Path) -> None:
@@ -4483,6 +4484,13 @@ class TestDigitRunPastIntLimit:
             ConfigError, match=r"dependencies\[0\] is not a valid PEP 508 requirement"
         ):
             read_pyproject_config(path, discover_workspace=False)
+
+    def test_uploaded_prior_to_duration(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path, f'[tool.nab]\nuploaded-prior-to = "P{_PAST_INT_LIMIT}D"\n'
+        )
+        with pytest.raises(ConfigError, match="duration is too large"):
+            read_pyproject_config(path)
 
 
 class TestWorkspace:


### PR DESCRIPTION
A `P<n>D` value with a long enough digit run makes `nab lock` and `nab download` exit with a raw `ValueError` traceback instead of a config error. CPython limits how many digits `int()` will convert, and that conversion sits just outside the `try` that already catches `OverflowError` and raises the same message. Moving it inside and catching `ValueError` as well reports the value as `uploaded-prior-to duration is too large`.
