### PR TITLE
validate benchmark index declarations

### DIFF
--- a/nab-python/benchmarks/_profile_runner.py
+++ b/nab-python/benchmarks/_profile_runner.py
@@ -30,6 +30,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 import scenarios as sc
 from benchmark_config import (
     build_benchmark_config,
+    parse_scenario_indexes,
     parse_scenario_project_metadata,
     parse_scenario_requirement_strings,
     parse_scenario_vcs_config,
@@ -81,6 +82,7 @@ def build_inputs(
     requirement_inputs = parse_scenario_requirement_strings(name, scenario)
     vcs_config = parse_scenario_vcs_config(name, scenario)
     project_metadata = parse_scenario_project_metadata(name, scenario)
+    indexes = parse_scenario_indexes(name, scenario)
     python_version = scenario["python_version"]
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
@@ -133,7 +135,7 @@ def build_inputs(
     datetime_str = scenario.get("datetime")
     config = build_benchmark_config(
         uploaded_prior_to=sc.parse_datetime(datetime_str) if datetime_str else None,
-        indexes=sc.parse_indexes(name, scenario),
+        indexes=indexes,
         index_routes=sc.parse_index_routes(name, scenario),
         build_policy_overrides=build_policy_overrides,
         resolution=resolution_strategy,

--- a/nab-python/benchmarks/benchmark_config.py
+++ b/nab-python/benchmarks/benchmark_config.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, NamedTuple
 
+from nab_index.local_index import is_file_url
+from nab_index.multi_index import IndexConfig
+from nab_index.serialization import SimpleSerialization
 from nab_python._vendor.packaging.ranges import VersionRange
 from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.utils import canonicalize_name
 from nab_python.config import NabProjectConfig, PackageOverride
+from nab_python.fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL
 from nab_python.provider import (
     BuildPolicy,
     DistPolicy,
@@ -23,13 +27,16 @@ if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
     from datetime import datetime
 
-    from nab_index.multi_index import IndexConfig
     from nab_python.fetch import FetchCoordinator, IndexRoute
     from nab_python.target import ResolveTarget
 
 
 # Search benchmarks trust pre-2.2 PKG-INFO dependency metadata by default.
 DEFAULT_SCENARIO_TRUST_UNVERIFIED_SDIST_DEPS = True
+DEFAULT_INDEXES: tuple[IndexConfig, ...] = (
+    IndexConfig(DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL),
+)
+_INDEX_KEYS = frozenset({"name", "url", "serialization"})
 
 
 class _BenchmarkResolveInputs(NamedTuple):
@@ -169,6 +176,136 @@ def parse_scenario_project_metadata(
             scenario.get("optional_dependencies", {}),
         ),
     )
+
+
+def _parse_scenario_index_serialization(
+    scenario_name: str,
+    position: int,
+    entry: Mapping[str, object],
+    *,
+    name: str,
+    url: str,
+) -> SimpleSerialization:
+    """Return the serialization requested by one scenario index."""
+    if "serialization" in entry and is_file_url(url):
+        msg = (
+            f"{scenario_name}: indexes[{position}].serialization must be omitted "
+            f"for file:// index {name!r}"
+        )
+        raise ValueError(msg)
+
+    serialization = entry.get("serialization")
+    if serialization is None:
+        return SimpleSerialization.NEGOTIATE
+    if not isinstance(serialization, str):
+        msg = (
+            f"{scenario_name}: indexes[{position}].serialization must be a string, "
+            f"got {type(serialization).__name__}"
+        )
+        raise TypeError(msg)
+
+    try:
+        return SimpleSerialization(serialization)
+    except ValueError as exc:
+        valid = sorted(member.value for member in SimpleSerialization)
+        msg = (
+            f"{scenario_name}: indexes[{position}].serialization must be one "
+            f"of {valid!r}, got {serialization!r}"
+        )
+        raise ValueError(msg) from exc
+
+
+def _parse_scenario_index(
+    scenario_name: str,
+    position: int,
+    value: object,
+) -> IndexConfig:
+    """Validate and copy one index entry from a benchmark scenario."""
+    if not isinstance(value, dict):
+        msg = (
+            f"{scenario_name}: indexes[{position}] must be a table, "
+            f"got {type(value).__name__}"
+        )
+        raise TypeError(msg)
+
+    unknown = sorted(set(value) - _INDEX_KEYS)
+    if unknown:
+        msg = (
+            f"{scenario_name}: unknown indexes[{position}] keys: {unknown!r}; "
+            f"expected {sorted(_INDEX_KEYS)!r}"
+        )
+        raise ValueError(msg)
+    try:
+        name = value["name"]
+        url = value["url"]
+    except KeyError as missing:
+        msg = f"{scenario_name}: indexes[{position}] missing required key {missing!s}"
+        raise ValueError(msg) from None
+    if not isinstance(name, str) or not isinstance(url, str):
+        msg = f"{scenario_name}: indexes[{position}] name and url must be strings"
+        raise TypeError(msg)
+
+    serialization = _parse_scenario_index_serialization(
+        scenario_name,
+        position,
+        value,
+        name=name,
+        url=url,
+    )
+    return IndexConfig(name, url, serialization)
+
+
+def _check_scenario_index_name_uniqueness(
+    scenario_name: str,
+    indexes: Sequence[IndexConfig],
+) -> None:
+    """Reject duplicate scenario index names after parsing every entry."""
+    seen: set[str] = set()
+    for index in indexes:
+        if index.name in seen:
+            msg = f"{scenario_name}: duplicate index name: {index.name!r}"
+            raise ValueError(msg)
+        seen.add(index.name)
+
+
+def parse_scenario_indexes(
+    scenario_name: str,
+    scenario: Mapping[str, object],
+) -> list[IndexConfig]:
+    """Validate and copy the indexes declared by a benchmark scenario."""
+    if "indexes" not in scenario:
+        return list(DEFAULT_INDEXES)
+
+    raw = scenario["indexes"]
+    if not isinstance(raw, list):
+        msg = (
+            f"{scenario_name}: indexes must be an array of tables, "
+            f"got {type(raw).__name__}"
+        )
+        raise TypeError(msg)
+    if not raw:
+        msg = f"{scenario_name}: indexes must contain at least one entry when present"
+        raise ValueError(msg)
+
+    indexes = [
+        _parse_scenario_index(scenario_name, position, entry)
+        for position, entry in enumerate(raw)
+    ]
+    _check_scenario_index_name_uniqueness(scenario_name, indexes)
+    return indexes
+
+
+def benchmark_index_settings(
+    indexes: Sequence[IndexConfig],
+) -> list[dict[str, str]]:
+    """Return effective index settings with default serialization omitted."""
+    settings: list[dict[str, str]] = []
+    for index in indexes:
+        entry = {"name": index.name, "url": index.url}
+        if index.serialization is not SimpleSerialization.NEGOTIATE:
+            entry["serialization"] = index.serialization.value
+        settings.append(entry)
+    return settings
 
 
 def parse_trust_unverified_sdist_deps(

--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -33,10 +33,12 @@ else:
     import tomli as tomllib  # type: ignore[no-redef]
 
 from benchmark_config import (
+    benchmark_index_settings,
     build_benchmark_config,
     build_benchmark_provider,
     build_benchmark_resolver_inputs,
     direct_packages_from_requirements,
+    parse_scenario_indexes,
     parse_scenario_project_metadata,
     parse_scenario_requirement_strings,
     parse_scenario_vcs_config,
@@ -54,7 +56,6 @@ from benchmark_host import (
 )
 
 from nab_index.httpx_async_transport import HttpxAsyncTransport
-from nab_index.multi_index import IndexConfig
 from nab_python._vcs_admission import admit_vcs_url
 from nab_python._vendor.packaging.markers import default_environment
 from nab_python._vendor.packaging.ranges import VersionRange
@@ -62,8 +63,6 @@ from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.utils import canonicalize_name
 from nab_python.config import NabProjectConfig, index_routes_from_config
 from nab_python.fetch import (
-    DEFAULT_INDEX_NAME,
-    DEFAULT_INDEX_URL,
     FetchCoordinator,
     IndexRoute,
 )
@@ -82,9 +81,6 @@ CACHE_DIR = BENCHMARKS_DIR / "cache"
 CANARY_MANIFEST = BENCHMARKS_DIR / "canary.toml"
 CANARY_MANIFEST_SCHEMA = 1
 _LEGACY_STRATEGY_SUFFIXES = ("-lowest", "-lowest-direct")
-DEFAULT_INDEXES: tuple[IndexConfig, ...] = (
-    IndexConfig(DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL),
-)
 
 
 class CanaryCase(NamedTuple):
@@ -376,9 +372,7 @@ def run_one(
                 "runtime": _runtime_manifest(host),
                 "direct_packages": sorted(direct_packages),
                 "target": _target_manifest(target),
-                "indexes": [
-                    {"name": index.name, "url": index.url} for index in config.indexes
-                ],
+                "indexes": benchmark_index_settings(config.indexes),
                 "index_routes": [
                     {"name": route.name, "index": route.index}
                     for route in index_routes_from_config(config)
@@ -602,6 +596,7 @@ def select_scenarios(cases: list[CanaryCase]) -> list[CanaryCase]:
         parse_vcs_allowed_schemes,
         parse_vcs_allowed_repos,
         parse_scenario_project_metadata,
+        parse_scenario_indexes,
     )
     for validate_field in field_validators:
         for scenario_name, scenario in found_scenarios:
@@ -742,15 +737,6 @@ def canary_v2_identity(
     return CanaryV2Identity(f"{stem}-{resolution.value}:{name}", definition)
 
 
-def _canary_indexes(scenario: dict) -> list[IndexConfig]:
-    raw = scenario.get("indexes")
-    if raw is None:
-        return list(DEFAULT_INDEXES)
-    return [
-        IndexConfig(name=str(entry["name"]), url=str(entry["url"])) for entry in raw
-    ]
-
-
 def _canary_index_routes(scenario: dict) -> list[IndexRoute]:
     return [
         IndexRoute(name=str(entry["name"]), index=str(entry["index"]))
@@ -773,6 +759,7 @@ def _prepare_canary_execution(
     requirement_inputs = parse_scenario_requirement_strings(scenario_name, scenario)
     vcs_config = parse_scenario_vcs_config(scenario_name, scenario)
     project_metadata = parse_scenario_project_metadata(scenario_name, scenario)
+    indexes = parse_scenario_indexes(scenario_name, scenario)
     python_version = scenario["python_version"]
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
@@ -793,7 +780,6 @@ def _prepare_canary_execution(
         scenario_name=scenario_name,
         override=resolution_override,
     )
-    indexes = _canary_indexes(scenario)
     index_routes = _canary_index_routes(scenario)
 
     requires_matching_host = parse_requires_matching_host(

--- a/nab-python/benchmarks/scenarios.py
+++ b/nab-python/benchmarks/scenarios.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, NamedTuple
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
+    from nab_index.multi_index import IndexConfig
     from nab_python.target import ResolveTarget
 
 if sys.version_info >= (3, 11):
@@ -33,10 +34,13 @@ else:
     import tomli as tomllib  # type: ignore[no-redef]
 
 from benchmark_config import (
+    DEFAULT_INDEXES,
     DEFAULT_SCENARIO_TRUST_UNVERIFIED_SDIST_DEPS,
+    benchmark_index_settings,
     build_benchmark_config,
     build_benchmark_provider,
     build_benchmark_resolver_inputs,
+    parse_scenario_indexes,
     parse_scenario_project_metadata,
     parse_scenario_requirement_strings,
     parse_scenario_vcs_config,
@@ -52,7 +56,6 @@ from benchmark_host import (
 )
 
 from nab_index.httpx_async_transport import HttpxAsyncTransport
-from nab_index.multi_index import IndexConfig
 from nab_python._vcs_admission import admit_vcs_url
 from nab_python._vendor.packaging.markers import default_environment
 from nab_python._vendor.packaging.ranges import VersionRange
@@ -60,8 +63,6 @@ from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.utils import canonicalize_name
 from nab_python.config import NabProjectConfig, index_routes_from_config
 from nab_python.fetch import (
-    DEFAULT_INDEX_NAME,
-    DEFAULT_INDEX_URL,
     FetchCoordinator,
     IndexRoute,
 )
@@ -84,9 +85,6 @@ STANDARD_MANIFEST_SCHEMA = 3
 _INAPPLICABLE_KEY_PREVIEW = 8
 _STANDARD_METADATA_FILENAMES = frozenset(
     {STANDARD_MANIFEST_FILENAME, "_provenance.json"}
-)
-DEFAULT_INDEXES: tuple[IndexConfig, ...] = (
-    IndexConfig(DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL),
 )
 STANDARD_STRATEGIES = (
     ResolutionStrategy.HIGHEST,
@@ -585,6 +583,7 @@ def load_standard_corpus(files: list[Path]) -> list[StandardScenario]:
         parse_scenario_requirement_strings(row.logical_key, row.definition)
         parse_scenario_vcs_config(row.logical_key, row.definition)
         parse_scenario_project_metadata(row.logical_key, row.definition)
+        parse_scenario_indexes(row.logical_key, row.definition)
         build_policy_overrides = parse_build_packages(row.name, row.definition)
         if "unsupported_reason" in row.definition:
             continue
@@ -1430,9 +1429,7 @@ def _expected_input(  # noqa: PLR0913 - assembling the JSON dump key
     if marker_environment:
         expected_input["marker_environment"] = dict(sorted(marker_environment.items()))
     if list(indexes) != list(DEFAULT_INDEXES):
-        expected_input["indexes"] = [
-            {"name": cfg.name, "url": cfg.url} for cfg in indexes
-        ]
+        expected_input["indexes"] = benchmark_index_settings(indexes)
     if index_routes:
         expected_input["index_routes"] = [
             {"name": o.name, "index": o.index} for o in index_routes
@@ -1482,39 +1479,6 @@ def parse_index_routes(
             )
             raise ValueError(msg) from None
         out.append(IndexRoute(name=str(name), index=str(index)))
-    return out
-
-
-def parse_indexes(scenario_name: str, scenario: dict) -> list[IndexConfig]:
-    """Read the ``indexes`` array; default to PyPI when missing.
-
-    Each entry is a TOML inline table with keys ``name`` and ``url``.
-    Order is significant.
-    """
-    raw = scenario.get("indexes")
-    if raw is None:
-        return list(DEFAULT_INDEXES)
-    if not isinstance(raw, list):
-        msg = (
-            f"{scenario_name}: indexes must be a TOML array of tables,"
-            f" got {type(raw).__name__}"
-        )
-        raise TypeError(msg)
-    out: list[IndexConfig] = []
-    for entry in raw:
-        if not isinstance(entry, dict):
-            msg = (
-                f"{scenario_name}: indexes entries must be tables, got"
-                f" {type(entry).__name__}"
-            )
-            raise TypeError(msg)
-        try:
-            name = entry["name"]
-            url = entry["url"]
-        except KeyError as missing:
-            msg = f"{scenario_name}: indexes entry missing required key {missing!s}"
-            raise ValueError(msg) from None
-        out.append(IndexConfig(name=str(name), url=str(url)))
     return out
 
 
@@ -1596,11 +1560,11 @@ def prepare_standard_execution(
     requirement_inputs = parse_scenario_requirement_strings(scenario_name, scenario)
     vcs_config = parse_scenario_vcs_config(scenario_name, scenario)
     project_metadata = parse_scenario_project_metadata(scenario_name, scenario)
+    indexes = parse_scenario_indexes(scenario_name, scenario)
     python_version: str = scenario["python_version"]
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
     marker_environment = parse_marker_environment(scenario_name, scenario)
-    indexes = parse_indexes(scenario_name, scenario)
     index_routes = parse_index_routes(scenario_name, scenario)
     build_policy_overrides = dict(parse_build_packages(scenario_name, scenario))
     if "unsupported_reason" not in scenario:

--- a/nab-python/tests/test_benchmark_canary.py
+++ b/nab-python/tests/test_benchmark_canary.py
@@ -14,6 +14,9 @@ from types import ModuleType, SimpleNamespace
 import pytest
 from typing_extensions import Self
 
+from nab_index.multi_index import IndexConfig
+from nab_index.serialization import SimpleSerialization
+from nab_python.fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL
 from nab_python.target import ResolveTarget
 
 _CANARY = Path(__file__).resolve().parents[1] / "benchmarks" / "canary.py"
@@ -385,7 +388,13 @@ def test_canary_prepares_inputs_and_summarizes_repeated_runs(
             "requirements": ["demo>=1"],
             "constraints": ["support<3"],
             "datetime": "2025-01-02 03:04:05",
-            "indexes": [{"name": "private", "url": "https://example.test/simple"}],
+            "indexes": [
+                {
+                    "name": "private",
+                    "url": "https://example.test/simple",
+                    "serialization": "html",
+                }
+            ],
             "index_routes": [{"name": "demo", "index": "private"}],
             "build_packages": ["demo"],
             "resolution": "lowest-direct",
@@ -421,7 +430,11 @@ def test_canary_prepares_inputs_and_summarizes_repeated_runs(
     config = kwargs["config"]
     assert config.uploaded_prior_to == module.parse_datetime("2025-01-02 03:04:05")
     assert config.indexes == (
-        module.IndexConfig("private", "https://example.test/simple"),
+        IndexConfig(
+            "private",
+            "https://example.test/simple",
+            SimpleSerialization.HTML,
+        ),
     )
     assert module.index_routes_from_config(config) == [
         module.IndexRoute("demo", "private")
@@ -489,7 +502,13 @@ def test_canary_configures_lowest_direct_roots(
     admission = host.target_for("3.11", {}, requires_matching_host=False)
     assert admission.target is not None
     config = module.build_benchmark_config(
-        indexes=module.DEFAULT_INDEXES,
+        indexes=(
+            IndexConfig(
+                DEFAULT_INDEX_NAME,
+                DEFAULT_INDEX_URL,
+                SimpleSerialization.HTML,
+            ),
+        ),
         resolution=module.ResolutionStrategy.LOWEST_DIRECT,
     )
     result = module.run_one(
@@ -514,7 +533,11 @@ def test_canary_configures_lowest_direct_roots(
 
     assert settings["direct_packages"] == ["other", "root"]
     assert settings["indexes"] == [
-        {"name": module.DEFAULT_INDEX_NAME, "url": module.DEFAULT_INDEX_URL}
+        {
+            "name": DEFAULT_INDEX_NAME,
+            "url": DEFAULT_INDEX_URL,
+            "serialization": "html",
+        }
     ]
     assert settings["target"]["marker_environment"]["python_version"] == "3.11"
     assert settings["target"]["wheel_tags_count"] > 0
@@ -644,6 +667,15 @@ def test_canary_main_records_v2_contract(
             {
                 "requirements": [],
                 "unsupported_reason": "test fixture",
+                "indexes": "private",
+            },
+            False,
+            "quick:requests: indexes must be an array of tables, got str",
+        ),
+        (
+            {
+                "requirements": [],
+                "unsupported_reason": "test fixture",
                 "vcs_allowed_repos": {"https://example.test/repo": False},
             },
             True,
@@ -660,6 +692,7 @@ def test_canary_main_records_v2_contract(
         "vcs-require-pin",
         "vcs-policy",
         "vcs-scheme-table",
+        "indexes",
         "default-vcs-repo-table",
     ),
 )

--- a/nab-python/tests/test_benchmark_canary_selection.py
+++ b/nab-python/tests/test_benchmark_canary_selection.py
@@ -577,10 +577,24 @@ def test_selection_validates_vcs_settings_before_project_metadata(
             {"vcs_allowed_schemes": {"git+https": False}},
             "quick:second: vcs_allowed_schemes must be a list, got dict",
         ),
+        (
+            {"indexes": "private"},
+            {
+                "project_name": "demo-project",
+                "project_extras": ["all"],
+                "optional_dependencies": {"all": "demo"},
+            },
+            "quick:second: optional_dependencies['all'] must be a list, got str",
+        ),
     ],
-    ids=("pin-before-policy", "policy-before-schemes", "schemes-before-repos"),
+    ids=(
+        "pin-before-policy",
+        "policy-before-schemes",
+        "schemes-before-repos",
+        "project-before-indexes",
+    ),
 )
-def test_selection_validates_vcs_fields_across_the_whole_selection(
+def test_selection_validates_fields_across_the_whole_selection(
     monkeypatch: pytest.MonkeyPatch,
     first_scenario: dict[str, object],
     second_scenario: dict[str, object],

--- a/nab-python/tests/test_benchmark_strategy_matrix.py
+++ b/nab-python/tests/test_benchmark_strategy_matrix.py
@@ -19,6 +19,8 @@ from unittest.mock import MagicMock
 import pytest
 
 from nab_index.client import WheelFile
+from nab_index.multi_index import IndexConfig
+from nab_index.serialization import SimpleSerialization
 from nab_python._testing.coordinator_fake import make_coordinator
 from nab_python._vendor.packaging.tags import Tag
 from nab_python.target import ResolveTarget
@@ -228,7 +230,11 @@ def _runner_parity_scenario() -> dict[str, object]:
         "constraints": ["demo<2"],
         "datetime": "2025-01-02 03:04:05",
         "indexes": [
-            {"name": "private", "url": "https://example.test/simple"},
+            {
+                "name": "private",
+                "url": "https://example.test/simple",
+                "serialization": "html",
+            },
         ],
         "index_routes": [{"name": "demo", "index": "private"}],
         "build_packages": ["demo"],
@@ -1078,8 +1084,8 @@ def test_process_scenario_uses_the_planned_target(
 def test_benchmark_config_combines_routing_and_build_policy() -> None:
     module = _harness("scenarios")
     indexes = [
-        module.IndexConfig("pypi", "https://pypi.org/simple/"),
-        module.IndexConfig("private", "https://example.test/simple"),
+        IndexConfig("pypi", "https://pypi.org/simple/"),
+        IndexConfig("private", "https://example.test/simple"),
     ]
     cutoff = module.parse_datetime("2025-01-02 03:04:05")
     vcs = module.VcsConfig(
@@ -1590,6 +1596,264 @@ def test_parse_scenario_project_metadata_rejects_malformed_values(
         module.parse_scenario_project_metadata("quick:project", scenario)
 
 
+def test_parse_scenario_indexes_defaults_to_pypi() -> None:
+    module = _harness("benchmark_config")
+
+    assert module.parse_scenario_indexes("quick:indexes", {}) == list(
+        module.DEFAULT_INDEXES
+    )
+
+
+def test_parse_scenario_indexes_preserves_declaration_details() -> None:
+    module = _harness("benchmark_config")
+    scenario = {
+        "indexes": [
+            {
+                "name": "Private_Index",
+                "url": "not a URL",
+                "serialization": "json",
+            },
+            {
+                "name": "",
+                "url": "",
+                "serialization": "html",
+            },
+            {
+                "name": "third",
+                "url": "https://example.test/simple",
+                "serialization": "negotiate",
+            },
+        ]
+    }
+    original = deepcopy(scenario)
+
+    indexes = module.parse_scenario_indexes("quick:indexes", scenario)
+
+    assert indexes == [
+        module.IndexConfig(
+            "Private_Index",
+            "not a URL",
+            SimpleSerialization.JSON,
+        ),
+        module.IndexConfig("", "", SimpleSerialization.HTML),
+        module.IndexConfig(
+            "third",
+            "https://example.test/simple",
+            SimpleSerialization.NEGOTIATE,
+        ),
+    ]
+    assert scenario == original
+
+
+def test_benchmark_index_settings_omits_only_default_serialization() -> None:
+    module = _harness("benchmark_config")
+
+    settings = module.benchmark_index_settings(
+        [
+            module.IndexConfig("default", "https://one.example/simple"),
+            module.IndexConfig(
+                "pinned",
+                "https://two.example/simple",
+                SimpleSerialization.HTML,
+            ),
+            module.IndexConfig(
+                "json",
+                "https://three.example/simple",
+                SimpleSerialization.JSON,
+            ),
+        ]
+    )
+
+    assert settings == [
+        {"name": "default", "url": "https://one.example/simple"},
+        {
+            "name": "pinned",
+            "url": "https://two.example/simple",
+            "serialization": "html",
+        },
+        {
+            "name": "json",
+            "url": "https://three.example/simple",
+            "serialization": "json",
+        },
+    ]
+
+
+@pytest.mark.parametrize("url", ["https://example.test/simple", "file:///index"])
+def test_parse_scenario_indexes_defaults_to_negotiated_serialization(
+    url: str,
+) -> None:
+    module = _harness("benchmark_config")
+
+    indexes = module.parse_scenario_indexes(
+        "quick:indexes",
+        {"indexes": [{"name": "default", "url": url}]},
+    )
+
+    assert indexes == [
+        module.IndexConfig(
+            "default",
+            url,
+            SimpleSerialization.NEGOTIATE,
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    "url", ["file:/index", "file://localhost/index", "file:///index"]
+)
+@pytest.mark.parametrize("serialization", ["negotiate", "json", "html", 1, "xml"])
+def test_parse_scenario_indexes_rejects_serialization_for_file_urls(
+    url: str,
+    serialization: object,
+) -> None:
+    module = _harness("benchmark_config")
+    message = (
+        "quick:indexes: indexes[0].serialization must be omitted "
+        "for file:// index 'local'"
+    )
+    scenario = {
+        "indexes": [
+            {
+                "name": "local",
+                "url": url,
+                "serialization": serialization,
+            }
+        ]
+    }
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        module.parse_scenario_indexes("quick:indexes", scenario)
+
+
+@pytest.mark.parametrize(
+    ("indexes", "error", "message"),
+    [
+        (
+            "private",
+            TypeError,
+            "quick:indexes: indexes must be an array of tables, got str",
+        ),
+        (
+            None,
+            TypeError,
+            "quick:indexes: indexes must be an array of tables, got NoneType",
+        ),
+        (
+            [],
+            ValueError,
+            "quick:indexes: indexes must contain at least one entry when present",
+        ),
+        (
+            ["private"],
+            TypeError,
+            "quick:indexes: indexes[0] must be a table, got str",
+        ),
+        (
+            [{"name": "private"}],
+            ValueError,
+            "quick:indexes: indexes[0] missing required key 'url'",
+        ),
+        (
+            [{"url": "https://example.test/simple"}],
+            ValueError,
+            "quick:indexes: indexes[0] missing required key 'name'",
+        ),
+        (
+            [{"name": False, "url": "https://example.test/simple"}],
+            TypeError,
+            "quick:indexes: indexes[0] name and url must be strings",
+        ),
+        (
+            [{"name": "private", "url": 123}],
+            TypeError,
+            "quick:indexes: indexes[0] name and url must be strings",
+        ),
+        (
+            [{"typo": True}],
+            ValueError,
+            (
+                "quick:indexes: unknown indexes[0] keys: ['typo']; "
+                "expected ['name', 'serialization', 'url']"
+            ),
+        ),
+        (
+            [
+                {
+                    "name": "private",
+                    "url": "https://example.test/simple",
+                    "serialization": 1,
+                }
+            ],
+            TypeError,
+            "quick:indexes: indexes[0].serialization must be a string, got int",
+        ),
+        (
+            [
+                {
+                    "name": "private",
+                    "url": "https://example.test/simple",
+                    "serialization": "xml",
+                }
+            ],
+            ValueError,
+            (
+                "quick:indexes: indexes[0].serialization must be one of "
+                "['html', 'json', 'negotiate'], got 'xml'"
+            ),
+        ),
+        (
+            [
+                {"name": "private", "url": "https://one.example/simple"},
+                {"name": "private", "url": "https://two.example/simple"},
+                {
+                    "name": "later",
+                    "url": "https://three.example/simple",
+                    "serialization": "xml",
+                },
+            ],
+            ValueError,
+            (
+                "quick:indexes: indexes[2].serialization must be one of "
+                "['html', 'json', 'negotiate'], got 'xml'"
+            ),
+        ),
+        (
+            [
+                {"name": "private", "url": "https://one.example/simple"},
+                {"name": "private", "url": "https://two.example/simple"},
+            ],
+            ValueError,
+            "quick:indexes: duplicate index name: 'private'",
+        ),
+    ],
+    ids=(
+        "array",
+        "null",
+        "empty",
+        "entry",
+        "missing-url",
+        "missing-name",
+        "name-type",
+        "url-type",
+        "unknown-key",
+        "serialization-type",
+        "serialization-value",
+        "parse-before-duplicates",
+        "duplicate",
+    ),
+)
+def test_parse_scenario_indexes_rejects_malformed_values(
+    indexes: object,
+    error: type[Exception],
+    message: str,
+) -> None:
+    module = _harness("benchmark_config")
+
+    with pytest.raises(error, match=re.escape(message)):
+        module.parse_scenario_indexes("quick:indexes", {"indexes": indexes})
+
+
 @pytest.mark.parametrize(
     ("routes", "message"),
     [
@@ -1615,8 +1879,8 @@ def test_benchmark_config_rejects_invalid_index_routes(
     with pytest.raises(ValueError, match=re.escape(message)):
         module.build_benchmark_config(
             indexes=[
-                module.IndexConfig("pypi", "https://pypi.org/simple/"),
-                module.IndexConfig("private", "https://example.test/simple"),
+                IndexConfig("pypi", "https://pypi.org/simple/"),
+                IndexConfig("private", "https://example.test/simple"),
             ],
             index_routes=[module.IndexRoute(*route) for route in routes],
         )
@@ -1639,7 +1903,7 @@ def test_build_benchmark_provider_forwards_project_config(
     )
     config = config_module.build_benchmark_config(
         uploaded_prior_to=scenarios.parse_datetime("2025-01-02 03:04:05"),
-        indexes=[scenarios.IndexConfig("private", "https://example.test/simple")],
+        indexes=[IndexConfig("private", "https://example.test/simple")],
         index_routes=[scenarios.IndexRoute("demo", "private")],
         build_policy_overrides={"demo": scenarios.BuildPolicy.BUILD_REMOTE},
         resolution=config_module.ResolutionStrategy.LOWEST_DIRECT,
@@ -1727,7 +1991,7 @@ def test_resolve_scenario_coordinates_config_target_and_constraints(
     requirements = module.parse_requirements(["demo[feature]"])
     constraints = module.parse_requirements(["demo<2"])
     config = module.build_benchmark_config(
-        indexes=[module.IndexConfig("private", "https://example.test/simple")],
+        indexes=[IndexConfig("private", "https://example.test/simple")],
         index_routes=[module.IndexRoute("demo", "private")],
     )
     coordinator = object()
@@ -2963,6 +3227,30 @@ vcs_allowed_schemes = { "git+https" = false }
 python_version = "3.11"
 requirements = []
 unsupported_reason = "not runnable"
+indexes = "private"
+""",
+            "other:other: indexes must be an array of tables, got str",
+        ),
+        (
+            """
+[other]
+python_version = "3.11"
+requirements = []
+unsupported_reason = "not runnable"
+indexes = "private"
+project_name = "demo-project"
+project_extras = ["all"]
+[other.optional_dependencies]
+all = "demo"
+""",
+            "other:other: optional_dependencies['all'] must be a list, got str",
+        ),
+        (
+            """
+[other]
+python_version = "3.11"
+requirements = []
+unsupported_reason = "not runnable"
 vcs_allowed_repos = { "https://example.test/repo" = false }
 """,
             "other:other: vcs_allowed_repos must be a list, got dict",
@@ -2977,6 +3265,8 @@ vcs_allowed_repos = { "https://example.test/repo" = false }
         "vcs-policy",
         "vcs-policy-table",
         "vcs-scheme-table",
+        "indexes",
+        "project-before-indexes",
         "vcs-repo-table",
     ),
 )
@@ -3072,10 +3362,15 @@ def test_profile_runner_accepts_an_explicit_strategy() -> None:
             {"https://example.test/repo": False},
             "example: vcs_allowed_repos must be a list, got dict",
         ),
+        (
+            "indexes",
+            "private",
+            "example: indexes must be an array of tables, got str",
+        ),
     ],
-    ids=("pin", "policy", "scheme-table", "repo-table"),
+    ids=("pin", "policy", "scheme-table", "repo-table", "indexes"),
 )
-def test_profile_main_validates_vcs_settings_before_host_capture(
+def test_profile_main_validates_schema_before_host_capture(
     monkeypatch: pytest.MonkeyPatch,
     field: str,
     value: object,
@@ -3091,7 +3386,7 @@ def test_profile_main_validates_vcs_settings_before_host_capture(
     monkeypatch.setattr(module.sys, "argv", ["_profile_runner.py", "example"])
 
     def fail_host(*_args: object, **_kwargs: object) -> object:
-        pytest.fail("VCS validation reached host capture")
+        pytest.fail("scenario validation reached host capture")
 
     monkeypatch.setattr(module.sc.BenchmarkHost, "current", classmethod(fail_host))
 
@@ -3129,6 +3424,16 @@ def test_standard_canary_and_profile_build_the_same_project_config() -> None:
         "All_Features",
         "Direct_Use",
     ]
+    assert standard_execution.expected_input["indexes"] == [
+        {
+            "name": "private",
+            "url": "https://example.test/simple",
+            "serialization": "html",
+        }
+    ]
+    assert (
+        standard_execution.config.indexes[0].serialization is SimpleSerialization.HTML
+    )
 
     assert standard_execution.expected_input["requirements"] == [
         "demo[feature]>=1",
@@ -3181,9 +3486,37 @@ def test_all_runners_validate_project_metadata_in_schema_order(
         "project_name": "demo-project",
         "project_extras": ["all"],
         "optional_dependencies": {"all": "demo"},
+        "indexes": "private",
         **vcs_settings,
     }
     host = _linux_host(standard)
+
+    with pytest.raises(TypeError, match=re.escape(message)):
+        _prepare_standard_scenario(standard, scenario, host)
+
+    with pytest.raises(TypeError, match=re.escape(message)):
+        canary._prepare_canary_execution(
+            scenario,
+            scenario_name="example",
+            resolution_override=None,
+            host=host,
+        )
+
+    with pytest.raises(TypeError, match=re.escape(message)):
+        profile.build_inputs("example", scenario, host=host)
+
+
+def test_all_runners_reject_malformed_indexes() -> None:
+    standard = _harness("scenarios")
+    canary = _harness("canary")
+    profile = _harness("_profile_runner")
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        "indexes": [{"name": False, "url": 123}],
+    }
+    host = _linux_host(standard)
+    message = "example: indexes[0] name and url must be strings"
 
     with pytest.raises(TypeError, match=re.escape(message)):
         _prepare_standard_scenario(standard, scenario, host)


### PR DESCRIPTION
A benchmark scenario with `indexes = [{ name = false, url = 123 }]` silently turned those values into `"False"` and `"123"`. A declared `serialization = "html"` was also discarded, so standard, canary, and profile runs negotiated the index response instead.

The three runners now share one index parser that rejects malformed declarations and carries valid serialization choices into resolver configuration and result settings. Scenarios without an `indexes` field still use PyPI, and index declarations without `serialization` still negotiate.
