### PR TITLE
validate benchmark index routes before execution

### DIFF
--- a/nab-python/benchmarks/_profile_runner.py
+++ b/nab-python/benchmarks/_profile_runner.py
@@ -30,6 +30,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 import scenarios as sc
 from benchmark_config import (
     build_benchmark_config,
+    parse_scenario_index_routes,
     parse_scenario_indexes,
     parse_scenario_project_metadata,
     parse_scenario_requirement_strings,
@@ -83,6 +84,7 @@ def build_inputs(
     vcs_config = parse_scenario_vcs_config(name, scenario)
     project_metadata = parse_scenario_project_metadata(name, scenario)
     indexes = parse_scenario_indexes(name, scenario)
+    index_routes = parse_scenario_index_routes(name, scenario, indexes)
     python_version = scenario["python_version"]
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
@@ -136,7 +138,7 @@ def build_inputs(
     config = build_benchmark_config(
         uploaded_prior_to=sc.parse_datetime(datetime_str) if datetime_str else None,
         indexes=indexes,
-        index_routes=sc.parse_index_routes(name, scenario),
+        index_routes=index_routes,
         build_policy_overrides=build_policy_overrides,
         resolution=resolution_strategy,
         trust_unverified_sdist_deps=trust_unverified_sdist_deps,

--- a/nab-python/benchmarks/benchmark_config.py
+++ b/nab-python/benchmarks/benchmark_config.py
@@ -9,9 +9,9 @@ from nab_index.multi_index import IndexConfig
 from nab_index.serialization import SimpleSerialization
 from nab_python._vendor.packaging.ranges import VersionRange
 from nab_python._vendor.packaging.requirements import Requirement
-from nab_python._vendor.packaging.utils import canonicalize_name
+from nab_python._vendor.packaging.utils import InvalidName, canonicalize_name
 from nab_python.config import NabProjectConfig, PackageOverride
-from nab_python.fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL
+from nab_python.fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL, IndexRoute
 from nab_python.provider import (
     BuildPolicy,
     DistPolicy,
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
     from datetime import datetime
 
-    from nab_python.fetch import FetchCoordinator, IndexRoute
+    from nab_python.fetch import FetchCoordinator
     from nab_python.target import ResolveTarget
 
 
@@ -37,6 +37,7 @@ DEFAULT_INDEXES: tuple[IndexConfig, ...] = (
     IndexConfig(DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL),
 )
 _INDEX_KEYS = frozenset({"name", "url", "serialization"})
+_INDEX_ROUTE_KEYS = frozenset({"name", "index"})
 
 
 class _BenchmarkResolveInputs(NamedTuple):
@@ -293,6 +294,106 @@ def parse_scenario_indexes(
     ]
     _check_scenario_index_name_uniqueness(scenario_name, indexes)
     return indexes
+
+
+def _parse_scenario_index_route(
+    scenario_name: str,
+    position: int,
+    value: object,
+) -> IndexRoute:
+    """Validate and copy one package route from a benchmark scenario."""
+    if not isinstance(value, dict):
+        msg = (
+            f"{scenario_name}: index_routes[{position}] must be a table, "
+            f"got {type(value).__name__}"
+        )
+        raise TypeError(msg)
+
+    unknown = sorted(set(value) - _INDEX_ROUTE_KEYS)
+    if unknown:
+        msg = (
+            f"{scenario_name}: unknown index_routes[{position}] keys: {unknown!r}; "
+            f"expected {sorted(_INDEX_ROUTE_KEYS)!r}"
+        )
+        raise ValueError(msg)
+    if "name" not in value:
+        msg = f"{scenario_name}: index_routes[{position}] missing required key 'name'"
+        raise ValueError(msg)
+    if "index" not in value:
+        msg = f"{scenario_name}: index_routes[{position}] missing required key 'index'"
+        raise ValueError(msg)
+
+    name = value["name"]
+    index = value["index"]
+    if not isinstance(name, str):
+        msg = (
+            f"{scenario_name}: index_routes[{position}].name must be a string, "
+            f"got {type(name).__name__}"
+        )
+        raise TypeError(msg)
+    if not isinstance(index, str):
+        msg = (
+            f"{scenario_name}: index_routes[{position}].index must be a string, "
+            f"got {type(index).__name__}"
+        )
+        raise TypeError(msg)
+
+    try:
+        canonicalize_name(name, validate=True)
+    except InvalidName as exc:
+        msg = (
+            f"{scenario_name}: index_routes[{position}].name must be a valid "
+            f"distribution name, got {name!r}"
+        )
+        raise ValueError(msg) from exc
+    return IndexRoute(name=name, index=index)
+
+
+def _check_scenario_index_route_relationships(
+    scenario_name: str,
+    routes: Sequence[IndexRoute],
+    indexes: Sequence[IndexConfig],
+) -> None:
+    """Reject duplicate package routes and references to undeclared indexes."""
+    seen: set[str] = set()
+    for route in routes:
+        name = canonicalize_name(route.name, validate=True)
+        if name in seen:
+            msg = f"{scenario_name}: duplicate index route for {name!r}"
+            raise ValueError(msg)
+        seen.add(name)
+
+    declared_indexes = {index.name for index in indexes}
+    for route in routes:
+        if route.index not in declared_indexes:
+            msg = (
+                f"{scenario_name}: index route for {route.name!r} names undeclared "
+                f"index {route.index!r}; declared indexes are "
+                f"{sorted(declared_indexes)!r}"
+            )
+            raise ValueError(msg)
+
+
+def parse_scenario_index_routes(
+    scenario_name: str,
+    scenario: Mapping[str, object],
+    indexes: Sequence[IndexConfig],
+) -> list[IndexRoute]:
+    """Validate and copy the package routes declared by a benchmark scenario."""
+    raw = scenario.get("index_routes", [])
+    if not isinstance(raw, list):
+        msg = (
+            f"{scenario_name}: index_routes must be an array of tables, "
+            f"got {type(raw).__name__}"
+        )
+        raise TypeError(msg)
+
+    routes = [
+        _parse_scenario_index_route(scenario_name, position, entry)
+        for position, entry in enumerate(raw)
+    ]
+    _check_scenario_index_route_relationships(scenario_name, routes, indexes)
+    return routes
 
 
 def benchmark_index_settings(

--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -38,6 +38,7 @@ from benchmark_config import (
     build_benchmark_provider,
     build_benchmark_resolver_inputs,
     direct_packages_from_requirements,
+    parse_scenario_index_routes,
     parse_scenario_indexes,
     parse_scenario_project_metadata,
     parse_scenario_requirement_strings,
@@ -62,10 +63,7 @@ from nab_python._vendor.packaging.ranges import VersionRange
 from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.utils import canonicalize_name
 from nab_python.config import NabProjectConfig, index_routes_from_config
-from nab_python.fetch import (
-    FetchCoordinator,
-    IndexRoute,
-)
+from nab_python.fetch import FetchCoordinator
 from nab_python.provider import (
     BuildPolicy,
     ResolutionStrategy,
@@ -596,11 +594,21 @@ def select_scenarios(cases: list[CanaryCase]) -> list[CanaryCase]:
         parse_vcs_allowed_schemes,
         parse_vcs_allowed_repos,
         parse_scenario_project_metadata,
-        parse_scenario_indexes,
     )
     for validate_field in field_validators:
         for scenario_name, scenario in found_scenarios:
             validate_field(scenario_name, scenario)
+
+    parsed_indexes = [
+        parse_scenario_indexes(scenario_name, scenario)
+        for scenario_name, scenario in found_scenarios
+    ]
+    for (scenario_name, scenario), indexes in zip(
+        found_scenarios,
+        parsed_indexes,
+        strict=True,
+    ):
+        parse_scenario_index_routes(scenario_name, scenario, indexes)
     return cases
 
 
@@ -737,13 +745,6 @@ def canary_v2_identity(
     return CanaryV2Identity(f"{stem}-{resolution.value}:{name}", definition)
 
 
-def _canary_index_routes(scenario: dict) -> list[IndexRoute]:
-    return [
-        IndexRoute(name=str(entry["name"]), index=str(entry["index"]))
-        for entry in scenario.get("index_routes", [])
-    ]
-
-
 def _prepare_canary_execution(
     scenario: dict,
     *,
@@ -760,6 +761,7 @@ def _prepare_canary_execution(
     vcs_config = parse_scenario_vcs_config(scenario_name, scenario)
     project_metadata = parse_scenario_project_metadata(scenario_name, scenario)
     indexes = parse_scenario_indexes(scenario_name, scenario)
+    index_routes = parse_scenario_index_routes(scenario_name, scenario, indexes)
     python_version = scenario["python_version"]
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
@@ -780,7 +782,6 @@ def _prepare_canary_execution(
         scenario_name=scenario_name,
         override=resolution_override,
     )
-    index_routes = _canary_index_routes(scenario)
 
     requires_matching_host = parse_requires_matching_host(
         scenario_name,

--- a/nab-python/benchmarks/scenarios.py
+++ b/nab-python/benchmarks/scenarios.py
@@ -40,6 +40,7 @@ from benchmark_config import (
     build_benchmark_config,
     build_benchmark_provider,
     build_benchmark_resolver_inputs,
+    parse_scenario_index_routes,
     parse_scenario_indexes,
     parse_scenario_project_metadata,
     parse_scenario_requirement_strings,
@@ -583,7 +584,8 @@ def load_standard_corpus(files: list[Path]) -> list[StandardScenario]:
         parse_scenario_requirement_strings(row.logical_key, row.definition)
         parse_scenario_vcs_config(row.logical_key, row.definition)
         parse_scenario_project_metadata(row.logical_key, row.definition)
-        parse_scenario_indexes(row.logical_key, row.definition)
+        indexes = parse_scenario_indexes(row.logical_key, row.definition)
+        parse_scenario_index_routes(row.logical_key, row.definition, indexes)
         build_policy_overrides = parse_build_packages(row.name, row.definition)
         if "unsupported_reason" in row.definition:
             continue
@@ -1443,45 +1445,6 @@ def _expected_input(  # noqa: PLR0913 - assembling the JSON dump key
     return expected_input
 
 
-def parse_index_routes(
-    scenario_name: str,
-    scenario: dict,
-) -> list[IndexRoute]:
-    """Read the ``index_routes`` array of records from a scenario.
-
-    Each entry is a TOML inline table with keys ``name`` (the package
-    name) and ``index`` (the *name* of an entry in ``indexes``).  A route
-    carries no version scope and no marker. Entries are returned in
-    declaration order; ``build_benchmark_config`` rejects duplicate canonical
-    package names.
-    """
-    raw = scenario.get("index_routes", [])
-    if not isinstance(raw, list):
-        msg = (
-            f"{scenario_name}: index_routes must be a TOML array of"
-            f" tables, got {type(raw).__name__}"
-        )
-        raise TypeError(msg)
-    out: list[IndexRoute] = []
-    for entry in raw:
-        if not isinstance(entry, dict):
-            msg = (
-                f"{scenario_name}: index_routes entries must be tables,"
-                f" got {type(entry).__name__}"
-            )
-            raise TypeError(msg)
-        try:
-            name = entry["name"]
-            index = entry["index"]
-        except KeyError as missing:
-            msg = (
-                f"{scenario_name}: index_routes entry missing required key {missing!s}"
-            )
-            raise ValueError(msg) from None
-        out.append(IndexRoute(name=str(name), index=str(index)))
-    return out
-
-
 def parse_marker_environment(
     scenario_name: str,
     scenario: dict,
@@ -1561,11 +1524,11 @@ def prepare_standard_execution(
     vcs_config = parse_scenario_vcs_config(scenario_name, scenario)
     project_metadata = parse_scenario_project_metadata(scenario_name, scenario)
     indexes = parse_scenario_indexes(scenario_name, scenario)
+    index_routes = parse_scenario_index_routes(scenario_name, scenario, indexes)
     python_version: str = scenario["python_version"]
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
     marker_environment = parse_marker_environment(scenario_name, scenario)
-    index_routes = parse_index_routes(scenario_name, scenario)
     build_policy_overrides = dict(parse_build_packages(scenario_name, scenario))
     if "unsupported_reason" not in scenario:
         validate_scenario_build_policy(

--- a/nab-python/tests/test_benchmark_canary.py
+++ b/nab-python/tests/test_benchmark_canary.py
@@ -16,7 +16,7 @@ from typing_extensions import Self
 
 from nab_index.multi_index import IndexConfig
 from nab_index.serialization import SimpleSerialization
-from nab_python.fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL
+from nab_python.fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL, IndexRoute
 from nab_python.target import ResolveTarget
 
 _CANARY = Path(__file__).resolve().parents[1] / "benchmarks" / "canary.py"
@@ -436,9 +436,7 @@ def test_canary_prepares_inputs_and_summarizes_repeated_runs(
             SimpleSerialization.HTML,
         ),
     )
-    assert module.index_routes_from_config(config) == [
-        module.IndexRoute("demo", "private")
-    ]
+    assert module.index_routes_from_config(config) == [IndexRoute("demo", "private")]
     assert len(config.package_overrides) == 1
     assert config.package_overrides[0].build_policy is module.BuildPolicy.BUILD_REMOTE
     assert config.resolution is module.ResolutionStrategy.LOWEST_DIRECT
@@ -676,6 +674,15 @@ def test_canary_main_records_v2_contract(
             {
                 "requirements": [],
                 "unsupported_reason": "test fixture",
+                "index_routes": "private",
+            },
+            False,
+            "quick:requests: index_routes must be an array of tables, got str",
+        ),
+        (
+            {
+                "requirements": [],
+                "unsupported_reason": "test fixture",
                 "vcs_allowed_repos": {"https://example.test/repo": False},
             },
             True,
@@ -693,6 +700,7 @@ def test_canary_main_records_v2_contract(
         "vcs-policy",
         "vcs-scheme-table",
         "indexes",
+        "index-routes",
         "default-vcs-repo-table",
     ),
 )

--- a/nab-python/tests/test_benchmark_canary_selection.py
+++ b/nab-python/tests/test_benchmark_canary_selection.py
@@ -622,6 +622,53 @@ def test_selection_validates_fields_across_the_whole_selection(
         )
 
 
+def test_selection_validates_index_routes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    scenario = {
+        "requirements": [],
+        "indexes": [{"name": "private", "url": "https://example.test/simple"}],
+        "index_routes": [{"name": "demo>=1", "index": "private"}],
+    }
+    monkeypatch.setattr(module, "find_scenario", lambda _name: scenario)
+    message = (
+        "quick:example: index_routes[0].name must be a valid distribution name, "
+        "got 'demo>=1'"
+    )
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        module.select_scenarios([module.CanaryCase("quick:example", None)])
+
+
+def test_selection_validates_all_indexes_before_any_index_routes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    scenarios = {
+        "quick:first": {
+            "requirements": [],
+            "index_routes": "private",
+        },
+        "quick:second": {
+            "requirements": [],
+            "indexes": "private",
+        },
+    }
+    monkeypatch.setattr(module, "find_scenario", scenarios.get)
+
+    with pytest.raises(
+        TypeError,
+        match="quick:second: indexes must be an array of tables, got str",
+    ):
+        module.select_scenarios(
+            [
+                module.CanaryCase("quick:first", None),
+                module.CanaryCase("quick:second", None),
+            ]
+        )
+
+
 def test_empty_scenarios_list_exits_before_creating_results(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/nab-python/tests/test_benchmark_strategy_matrix.py
+++ b/nab-python/tests/test_benchmark_strategy_matrix.py
@@ -23,6 +23,7 @@ from nab_index.multi_index import IndexConfig
 from nab_index.serialization import SimpleSerialization
 from nab_python._testing.coordinator_fake import make_coordinator
 from nab_python._vendor.packaging.tags import Tag
+from nab_python.fetch import IndexRoute
 from nab_python.target import ResolveTarget
 
 _BENCHMARKS = Path(__file__).resolve().parents[1] / "benchmarks"
@@ -236,7 +237,10 @@ def _runner_parity_scenario() -> dict[str, object]:
                 "serialization": "html",
             },
         ],
-        "index_routes": [{"name": "demo", "index": "private"}],
+        "index_routes": [
+            {"name": "Demo_Pkg", "index": "private"},
+            {"name": "Other.Package", "index": "private"},
+        ],
         "build_packages": ["demo"],
         "resolution": "lowest-direct",
         "trust_unverified_sdist_deps": False,
@@ -1855,6 +1859,289 @@ def test_parse_scenario_indexes_rejects_malformed_values(
 
 
 @pytest.mark.parametrize(
+    "scenario", [{}, {"index_routes": []}], ids=("missing", "empty")
+)
+def test_parse_scenario_index_routes_returns_a_fresh_empty_list(
+    scenario: dict[str, object],
+) -> None:
+    module = _harness("benchmark_config")
+
+    first = module.parse_scenario_index_routes(
+        "quick:routes",
+        scenario,
+        list(module.DEFAULT_INDEXES),
+    )
+    second = module.parse_scenario_index_routes(
+        "quick:routes",
+        scenario,
+        list(module.DEFAULT_INDEXES),
+    )
+
+    assert first == second == []
+    assert first is not second
+
+
+def test_parse_scenario_index_routes_preserves_raw_names_and_order() -> None:
+    module = _harness("benchmark_config")
+    indexes = [
+        IndexConfig("private", "https://one.example/simple"),
+        IndexConfig("Private", "https://two.example/simple"),
+    ]
+    scenario = {
+        "index_routes": [
+            {"name": "Demo_Pkg", "index": "Private"},
+            {"name": "Second.Package", "index": "private"},
+        ]
+    }
+    original = deepcopy(scenario)
+
+    routes = module.parse_scenario_index_routes("quick:routes", scenario, indexes)
+
+    assert routes == [
+        IndexRoute("Demo_Pkg", "Private"),
+        IndexRoute("Second.Package", "private"),
+    ]
+    assert scenario == original
+
+
+@pytest.mark.parametrize(
+    ("routes", "error", "message"),
+    [
+        (
+            "private",
+            TypeError,
+            "quick:routes: index_routes must be an array of tables, got str",
+        ),
+        (
+            None,
+            TypeError,
+            "quick:routes: index_routes must be an array of tables, got NoneType",
+        ),
+        (
+            ["private"],
+            TypeError,
+            "quick:routes: index_routes[0] must be a table, got str",
+        ),
+        (
+            [{}],
+            ValueError,
+            "quick:routes: index_routes[0] missing required key 'name'",
+        ),
+        (
+            [{"zulu": True, "alpha": False}],
+            ValueError,
+            (
+                "quick:routes: unknown index_routes[0] keys: ['alpha', 'zulu']; "
+                "expected ['index', 'name']"
+            ),
+        ),
+        (
+            [{"name": "demo", "extra": True}],
+            ValueError,
+            (
+                "quick:routes: unknown index_routes[0] keys: ['extra']; "
+                "expected ['index', 'name']"
+            ),
+        ),
+        (
+            [{"name": "demo", "index": "pypi", "extra": True}],
+            ValueError,
+            (
+                "quick:routes: unknown index_routes[0] keys: ['extra']; "
+                "expected ['index', 'name']"
+            ),
+        ),
+        (
+            [{"index": "private"}],
+            ValueError,
+            "quick:routes: index_routes[0] missing required key 'name'",
+        ),
+        (
+            [{"name": "demo"}],
+            ValueError,
+            "quick:routes: index_routes[0] missing required key 'index'",
+        ),
+        (
+            [{"name": False, "index": "pypi"}],
+            TypeError,
+            "quick:routes: index_routes[0].name must be a string, got bool",
+        ),
+        (
+            [{"name": "demo", "index": 123}],
+            TypeError,
+            "quick:routes: index_routes[0].index must be a string, got int",
+        ),
+    ],
+    ids=(
+        "array",
+        "null",
+        "entry",
+        "missing-name-and-index",
+        "unknown-before-missing",
+        "unknown-before-missing-index",
+        "unknown-with-required-keys",
+        "missing-name",
+        "missing-index",
+        "name-type",
+        "index-type",
+    ),
+)
+def test_parse_scenario_index_routes_rejects_malformed_values(
+    routes: object,
+    error: type[Exception],
+    message: str,
+) -> None:
+    module = _harness("benchmark_config")
+
+    with pytest.raises(error, match=re.escape(message)):
+        module.parse_scenario_index_routes(
+            "quick:routes",
+            {"index_routes": routes},
+            list(module.DEFAULT_INDEXES),
+        )
+
+
+def test_parse_scenario_index_routes_does_not_coerce_index_references() -> None:
+    module = _harness("benchmark_config")
+    scenario = {"index_routes": [{"name": "demo", "index": 123}]}
+    indexes = [IndexConfig("123", "https://example.test/simple")]
+    message = "quick:routes: index_routes[0].index must be a string, got int"
+
+    with pytest.raises(TypeError, match=re.escape(message)):
+        module.parse_scenario_index_routes("quick:routes", scenario, indexes)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "",
+        " ",
+        "demo>=1",
+        "demo[extra]",
+        "demo; python_version < '3.12'",
+        "demo @ https://example.test/demo.whl",
+    ],
+    ids=("empty", "whitespace", "specifier", "extra", "marker", "url"),
+)
+def test_parse_scenario_index_routes_rejects_non_package_names(name: str) -> None:
+    module = _harness("benchmark_config")
+    message = (
+        "quick:routes: index_routes[0].name must be a valid distribution name, "
+        f"got {name!r}"
+    )
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        module.parse_scenario_index_routes(
+            "quick:routes",
+            {"index_routes": [{"name": name, "index": "pypi"}]},
+            list(module.DEFAULT_INDEXES),
+        )
+
+
+@pytest.mark.parametrize(
+    ("routes", "message"),
+    [
+        (
+            [
+                {"name": "demo", "index": "pypi"},
+                {"name": "demo", "index": "pypi"},
+            ],
+            "quick:routes: duplicate index route for 'demo'",
+        ),
+        (
+            [
+                {"name": "Demo_Pkg", "index": "pypi"},
+                {"name": "demo-pkg", "index": "pypi"},
+            ],
+            "quick:routes: duplicate index route for 'demo-pkg'",
+        ),
+        (
+            [
+                {"name": "Bravo_Pkg", "index": "pypi"},
+                {"name": "Alpha.Pkg", "index": "pypi"},
+                {"name": "bravo-pkg", "index": "pypi"},
+                {"name": "alpha-pkg", "index": "pypi"},
+            ],
+            "quick:routes: duplicate index route for 'bravo-pkg'",
+        ),
+        (
+            [{"name": "demo", "index": "missing"}],
+            (
+                "quick:routes: index route for 'demo' names undeclared index "
+                "'missing'; declared indexes are ['Private', 'pypi']"
+            ),
+        ),
+        (
+            [{"name": "demo", "index": "private"}],
+            (
+                "quick:routes: index route for 'demo' names undeclared index "
+                "'private'; declared indexes are ['Private', 'pypi']"
+            ),
+        ),
+        (
+            [
+                {"name": "demo", "index": "missing"},
+                {"name": "demo", "index": "other-missing"},
+            ],
+            "quick:routes: duplicate index route for 'demo'",
+        ),
+    ],
+    ids=(
+        "exact-duplicate",
+        "canonical-duplicate",
+        "first-canonical-duplicate",
+        "undeclared-index",
+        "case-sensitive-index",
+        "duplicate-before-index-reference",
+    ),
+)
+def test_parse_scenario_index_routes_rejects_invalid_relationships(
+    routes: list[dict[str, object]],
+    message: str,
+) -> None:
+    module = _harness("benchmark_config")
+    indexes = [
+        IndexConfig("pypi", "https://pypi.org/simple/"),
+        IndexConfig("Private", "https://example.test/simple"),
+    ]
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        module.parse_scenario_index_routes(
+            "quick:routes",
+            {"index_routes": routes},
+            indexes,
+        )
+
+
+@pytest.mark.parametrize(
+    "earlier_routes",
+    [
+        [
+            {"name": "demo", "index": "pypi"},
+            {"name": "demo", "index": "pypi"},
+        ],
+        [{"name": "demo", "index": "missing"}],
+    ],
+    ids=("duplicate", "undeclared-index"),
+)
+def test_parse_scenario_index_routes_parses_every_entry_before_relationships(
+    earlier_routes: list[dict[str, object]],
+) -> None:
+    module = _harness("benchmark_config")
+    routes = [*earlier_routes, {"name": "later", "index": 123}]
+    message = (
+        f"quick:routes: index_routes[{len(routes) - 1}].index must be a string, got int"
+    )
+
+    with pytest.raises(TypeError, match=re.escape(message)):
+        module.parse_scenario_index_routes(
+            "quick:routes",
+            {"index_routes": routes},
+            list(module.DEFAULT_INDEXES),
+        )
+
+
+@pytest.mark.parametrize(
     ("routes", "message"),
     [
         (
@@ -3237,6 +3524,16 @@ indexes = "private"
 python_version = "3.11"
 requirements = []
 unsupported_reason = "not runnable"
+index_routes = "private"
+""",
+            "other:other: index_routes must be an array of tables, got str",
+        ),
+        (
+            """
+[other]
+python_version = "3.11"
+requirements = []
+unsupported_reason = "not runnable"
 indexes = "private"
 project_name = "demo-project"
 project_extras = ["all"]
@@ -3266,6 +3563,7 @@ vcs_allowed_repos = { "https://example.test/repo" = false }
         "vcs-policy-table",
         "vcs-scheme-table",
         "indexes",
+        "index-routes",
         "project-before-indexes",
         "vcs-repo-table",
     ),
@@ -3367,8 +3665,20 @@ def test_profile_runner_accepts_an_explicit_strategy() -> None:
             "private",
             "example: indexes must be an array of tables, got str",
         ),
+        (
+            "index_routes",
+            "private",
+            "example: index_routes must be an array of tables, got str",
+        ),
     ],
-    ids=("pin", "policy", "scheme-table", "repo-table", "indexes"),
+    ids=(
+        "pin",
+        "policy",
+        "scheme-table",
+        "repo-table",
+        "indexes",
+        "index-routes",
+    ),
 )
 def test_profile_main_validates_schema_before_host_capture(
     monkeypatch: pytest.MonkeyPatch,
@@ -3431,9 +3741,27 @@ def test_standard_canary_and_profile_build_the_same_project_config() -> None:
             "serialization": "html",
         }
     ]
+    assert standard_execution.expected_input["index_routes"] == [
+        {"name": "Demo_Pkg", "index": "private"},
+        {"name": "Other.Package", "index": "private"},
+    ]
     assert (
         standard_execution.config.indexes[0].serialization is SimpleSerialization.HTML
     )
+    assert standard.index_routes_from_config(standard_execution.config) == [
+        IndexRoute("demo-pkg", "private"),
+        IndexRoute("other-package", "private"),
+    ]
+
+    identity = canary.canary_v2_identity(
+        canary.CanaryCase("quick:example", canary.ResolutionStrategy.LOWEST_DIRECT),
+        scenario,
+        canary.ResolutionStrategy.LOWEST_DIRECT,
+    )
+    assert identity.definition["index_routes"] == [
+        {"name": "Demo_Pkg", "index": "private"},
+        {"name": "Other.Package", "index": "private"},
+    ]
 
     assert standard_execution.expected_input["requirements"] == [
         "demo[feature]>=1",
@@ -3514,6 +3842,7 @@ def test_all_runners_reject_malformed_indexes() -> None:
         "python_version": "3.11",
         "requirements": [],
         "indexes": [{"name": False, "url": 123}],
+        "index_routes": "private",
     }
     host = _linux_host(standard)
     message = "example: indexes[0] name and url must be strings"
@@ -3531,6 +3860,114 @@ def test_all_runners_reject_malformed_indexes() -> None:
 
     with pytest.raises(TypeError, match=re.escape(message)):
         profile.build_inputs("example", scenario, host=host)
+
+
+def test_all_runners_reject_malformed_index_routes() -> None:
+    standard = _harness("scenarios")
+    canary = _harness("canary")
+    profile = _harness("_profile_runner")
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        "indexes": [{"name": "private", "url": "https://example.test/simple"}],
+        "index_routes": [{"name": "demo>=1", "index": "private"}],
+    }
+    host = _linux_host(standard)
+    message = (
+        "example: index_routes[0].name must be a valid distribution name, got 'demo>=1'"
+    )
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        _prepare_standard_scenario(standard, scenario, host)
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        canary._prepare_canary_execution(
+            scenario,
+            scenario_name="example",
+            resolution_override=None,
+            host=host,
+        )
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        profile.build_inputs("example", scenario, host=host)
+
+
+def test_all_runners_validate_index_routes_before_build_packages() -> None:
+    standard = _harness("scenarios")
+    canary = _harness("canary")
+    profile = _harness("_profile_runner")
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        "index_routes": [{"name": "demo", "index": 123}],
+        "build_packages": "demo",
+    }
+    host = _linux_host(standard)
+    message = "example: index_routes[0].index must be a string, got int"
+
+    with pytest.raises(TypeError, match=re.escape(message)):
+        _prepare_standard_scenario(standard, scenario, host)
+
+    with pytest.raises(TypeError, match=re.escape(message)):
+        canary._prepare_canary_execution(
+            scenario,
+            scenario_name="example",
+            resolution_override=None,
+            host=host,
+        )
+
+    with pytest.raises(TypeError, match=re.escape(message)):
+        profile.build_inputs("example", scenario, host=host)
+
+
+@pytest.mark.parametrize(
+    ("routes", "message"),
+    [
+        (
+            [
+                {"name": "Demo_Pkg", "index": "pypi"},
+                {"name": "demo-pkg", "index": "pypi"},
+            ],
+            "example: duplicate index route for 'demo-pkg'",
+        ),
+        (
+            [{"name": "demo", "index": "missing"}],
+            (
+                "example: index route for 'demo' names undeclared index 'missing'; "
+                "declared indexes are ['pypi']"
+            ),
+        ),
+    ],
+    ids=("duplicate", "undeclared-index"),
+)
+def test_canary_and_profile_validate_index_route_relationships_before_host_admission(
+    routes: list[dict[str, str]],
+    message: str,
+) -> None:
+    canary = _harness("canary")
+    profile = _harness("_profile_runner")
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        "index_routes": routes,
+    }
+
+    class UnusedHost:
+        """Fail if index-route validation reaches target admission."""
+
+        def target_for(self, *_args: object, **_kwargs: object) -> object:
+            pytest.fail("index-route validation reached host admission")
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        canary._prepare_canary_execution(
+            scenario,
+            scenario_name="example",
+            resolution_override=None,
+            host=UnusedHost(),
+        )
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        profile.build_inputs("example", scenario, host=UnusedHost())
 
 
 def test_profile_project_metadata_validation_precedes_host_admission() -> None:


### PR DESCRIPTION
A benchmark scenario with a declared `private` index and `index_routes = [{ name = "demo>=1", index = "private" }]` accepted a requirement expression where only a package name is valid. The route was stored under `demo>=1`, so it did not affect the `demo` package it appeared to target.

The standard, canary, and profile runners now share one route parser that validates declarations before host or output setup. Recorded settings retain the declared spelling and order, while the effective configuration uses canonical package names. Canonical duplicates and undeclared index references are rejected before resolution.
