### PR TITLE
validate benchmark build package declarations

### DIFF
--- a/nab-python/benchmarks/_profile_runner.py
+++ b/nab-python/benchmarks/_profile_runner.py
@@ -30,12 +30,14 @@ sys.path.insert(0, str(Path(__file__).parent))
 import scenarios as sc
 from benchmark_config import (
     build_benchmark_config,
+    parse_scenario_build_packages,
     parse_scenario_index_routes,
     parse_scenario_indexes,
     parse_scenario_project_metadata,
     parse_scenario_requirement_strings,
     parse_scenario_vcs_config,
     parse_trust_unverified_sdist_deps,
+    validate_scenario_build_policy,
 )
 
 
@@ -89,12 +91,16 @@ def build_inputs(
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
     marker_environment = sc.parse_marker_environment(name, scenario)
-    build_policy_overrides = sc.parse_build_packages(name, scenario)
-    sc.validate_scenario_build_policy(
+    build_policy_overrides = parse_scenario_build_packages(name, scenario)
+    validate_scenario_build_policy(
         name,
         marker_environment,
         build_policy_overrides,
     )
+    declared_resolution = sc.ResolutionStrategy(
+        scenario.get("resolution", sc.ResolutionStrategy.HIGHEST.value)
+    )
+    resolution_strategy = resolution_override or declared_resolution
     requires_matching_host = sc.parse_requires_matching_host(
         name,
         scenario,
@@ -111,10 +117,6 @@ def build_inputs(
         raise SystemExit(msg)
     target = admission.target
 
-    declared_resolution = sc.ResolutionStrategy(
-        scenario.get("resolution", sc.ResolutionStrategy.HIGHEST.value)
-    )
-    resolution_strategy = resolution_override or declared_resolution
     if project_metadata.project_name:
         requirement_strings += sc.expand_project_extras(
             project_metadata.project_name,

--- a/nab-python/benchmarks/benchmark_config.py
+++ b/nab-python/benchmarks/benchmark_config.py
@@ -396,6 +396,61 @@ def parse_scenario_index_routes(
     return routes
 
 
+def parse_scenario_build_packages(
+    scenario_name: str,
+    scenario: Mapping[str, object],
+) -> dict[str, BuildPolicy]:
+    """Return remote-build overrides preserving declared spelling and order."""
+    raw = scenario.get("build_packages", [])
+    if type(raw) is not list:
+        msg = (
+            f"{scenario_name}: build_packages must be a list of package names, "
+            f"got {type(raw).__name__}"
+        )
+        raise TypeError(msg)
+
+    packages: list[tuple[str, str]] = []
+    for position, name in enumerate(raw):
+        if not isinstance(name, str):
+            msg = (
+                f"{scenario_name}: build_packages[{position}] must be a string, "
+                f"got {type(name).__name__}"
+            )
+            raise TypeError(msg)
+        try:
+            canonical_name = canonicalize_name(name, validate=True)
+        except InvalidName as exc:
+            msg = (
+                f"{scenario_name}: build_packages[{position}] must be a valid "
+                f"distribution name, got {name!r}"
+            )
+            raise ValueError(msg) from exc
+        packages.append((name, canonical_name))
+
+    seen: set[str] = set()
+    for _, canonical_name in packages:
+        if canonical_name in seen:
+            msg = f"{scenario_name}: duplicate build package {canonical_name!r}"
+            raise ValueError(msg)
+        seen.add(canonical_name)
+
+    return {name: BuildPolicy.BUILD_REMOTE for name, _ in packages}
+
+
+def validate_scenario_build_policy(
+    scenario_name: str,
+    marker_environment: Mapping[str, str],
+    build_policy_overrides: Mapping[str, BuildPolicy],
+) -> None:
+    """Reject build policy paired with a marker environment overlay."""
+    if marker_environment and build_policy_overrides:
+        msg = (
+            f"{scenario_name}: build_packages cannot be combined "
+            "with a marker environment overlay"
+        )
+        raise ValueError(msg)
+
+
 def benchmark_index_settings(
     indexes: Sequence[IndexConfig],
 ) -> list[dict[str, str]]:

--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -38,6 +38,7 @@ from benchmark_config import (
     build_benchmark_provider,
     build_benchmark_resolver_inputs,
     direct_packages_from_requirements,
+    parse_scenario_build_packages,
     parse_scenario_index_routes,
     parse_scenario_indexes,
     parse_scenario_project_metadata,
@@ -48,6 +49,7 @@ from benchmark_config import (
     parse_vcs_allowed_schemes,
     parse_vcs_policy,
     parse_vcs_require_pin,
+    validate_scenario_build_policy,
 )
 from benchmark_host import (
     BenchmarkHost,
@@ -64,12 +66,7 @@ from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.utils import canonicalize_name
 from nab_python.config import NabProjectConfig, index_routes_from_config
 from nab_python.fetch import FetchCoordinator
-from nab_python.provider import (
-    BuildPolicy,
-    ResolutionStrategy,
-    VcsConfig,
-    split_extra,
-)
+from nab_python.provider import BuildPolicy, ResolutionStrategy, VcsConfig, split_extra
 from nab_resolver.resolver import Resolver
 
 BENCHMARKS_DIR = Path(__file__).parent
@@ -559,6 +556,51 @@ def _scenario_file(toml_stem: str) -> Path:
     return toml_path
 
 
+def _validate_selected_execution_fields(
+    cases: list[CanaryCase],
+    scenarios: list[tuple[str, dict]],
+) -> None:
+    """Validate marker, build, resolution, and host fields by phase."""
+    marker_environments = [
+        parse_target_marker_environment(scenario_name, scenario)
+        for scenario_name, scenario in scenarios
+    ]
+    build_policy_overrides: list[dict[str, BuildPolicy]] = [
+        parse_scenario_build_packages(scenario_name, scenario)
+        for scenario_name, scenario in scenarios
+    ]
+
+    for (scenario_name, scenario), marker_environment, overrides in zip(
+        scenarios,
+        marker_environments,
+        build_policy_overrides,
+        strict=True,
+    ):
+        if "unsupported_reason" not in scenario:
+            validate_scenario_build_policy(
+                scenario_name,
+                marker_environment,
+                overrides,
+            )
+
+    for case, (scenario_name, scenario), marker_environment in zip(
+        cases,
+        scenarios,
+        marker_environments,
+        strict=True,
+    ):
+        scenario_resolution(
+            scenario,
+            scenario_name=scenario_name,
+            override=case.resolution,
+        )
+        parse_requires_matching_host(
+            scenario_name,
+            scenario,
+            marker_environment,
+        )
+
+
 def select_scenarios(cases: list[CanaryCase]) -> list[CanaryCase]:
     """Validate every selection before a benchmark run or result write."""
     if not cases:
@@ -609,6 +651,7 @@ def select_scenarios(cases: list[CanaryCase]) -> list[CanaryCase]:
         strict=True,
     ):
         parse_scenario_index_routes(scenario_name, scenario, indexes)
+    _validate_selected_execution_fields(cases, found_scenarios)
     return cases
 
 
@@ -766,16 +809,12 @@ def _prepare_canary_execution(
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
     marker_environment = parse_target_marker_environment(scenario_name, scenario)
-    raw_build_packages = scenario.get("build_packages", []) or []
-    build_policy_overrides = {
-        str(name): BuildPolicy.BUILD_REMOTE for name in raw_build_packages
-    }
-    if marker_environment and build_policy_overrides:
-        msg = (
-            f"{scenario_name}: build_packages cannot be combined "
-            "with a marker environment overlay"
-        )
-        raise ValueError(msg)
+    build_policy_overrides = parse_scenario_build_packages(scenario_name, scenario)
+    validate_scenario_build_policy(
+        scenario_name,
+        marker_environment,
+        build_policy_overrides,
+    )
 
     resolution_strategy = scenario_resolution(
         scenario,

--- a/nab-python/benchmarks/scenarios.py
+++ b/nab-python/benchmarks/scenarios.py
@@ -40,12 +40,14 @@ from benchmark_config import (
     build_benchmark_config,
     build_benchmark_provider,
     build_benchmark_resolver_inputs,
+    parse_scenario_build_packages,
     parse_scenario_index_routes,
     parse_scenario_indexes,
     parse_scenario_project_metadata,
     parse_scenario_requirement_strings,
     parse_scenario_vcs_config,
     parse_trust_unverified_sdist_deps,
+    validate_scenario_build_policy,
 )
 from benchmark_host import (
     HOST_TAG_MISMATCH_REASON,
@@ -578,22 +580,24 @@ def load_standard_corpus(files: list[Path]) -> list[StandardScenario]:
             for name, definition in scenarios.items()
         )
     for row in rows:
-        marker_environment = parse_marker_environment(row.name, row.definition)
-        parse_requires_matching_host(row.name, row.definition, marker_environment)
         parse_trust_unverified_sdist_deps(row.logical_key, row.definition)
         parse_scenario_requirement_strings(row.logical_key, row.definition)
         parse_scenario_vcs_config(row.logical_key, row.definition)
         parse_scenario_project_metadata(row.logical_key, row.definition)
         indexes = parse_scenario_indexes(row.logical_key, row.definition)
         parse_scenario_index_routes(row.logical_key, row.definition, indexes)
-        build_policy_overrides = parse_build_packages(row.name, row.definition)
-        if "unsupported_reason" in row.definition:
-            continue
-        validate_scenario_build_policy(
+        marker_environment = parse_marker_environment(row.name, row.definition)
+        build_policy_overrides = parse_scenario_build_packages(
             row.name,
-            marker_environment,
-            build_policy_overrides,
+            row.definition,
         )
+        if "unsupported_reason" not in row.definition:
+            validate_scenario_build_policy(
+                row.name,
+                marker_environment,
+                build_policy_overrides,
+            )
+        parse_requires_matching_host(row.name, row.definition, marker_environment)
     return rows
 
 
@@ -1437,7 +1441,7 @@ def _expected_input(  # noqa: PLR0913 - assembling the JSON dump key
             {"name": o.name, "index": o.index} for o in index_routes
         ]
     if build_packages:
-        expected_input["build_packages"] = sorted(build_packages)
+        expected_input["build_packages"] = list(build_packages)
     if resolution_strategy is not ResolutionStrategy.HIGHEST:
         expected_input["resolution"] = resolution_strategy.value
     if trust_unverified_sdist_deps:
@@ -1451,57 +1455,6 @@ def parse_marker_environment(
 ) -> dict[str, str]:
     """Read the ``marker_environment`` table + ``platform_system`` shorthand."""
     return parse_target_marker_environment(scenario_name, scenario)
-
-
-def parse_build_packages(
-    scenario_name: str,
-    scenario: dict,
-) -> Mapping[str, BuildPolicy]:
-    """Read ``build_packages`` and lift them to ``BUILD_REMOTE`` overrides.
-
-    ``build_packages`` is a list of canonical package names whose
-    sdists may be built (PEP 517 backend invocation against the
-    fetched sdist).  The default benchmark policy is
-    ``BuildPolicy.NEVER``; entries here override that on a
-    per-package basis without affecting any other package in the
-    same scenario.
-
-    Use this when the scenario's resolution requires a sdist that
-    has no usable wheel and the build is cheap enough to run inside
-    the benchmark host.  Native or CUDA-heavy sdists belong in
-    ``unsupported.toml`` instead.
-    """
-    raw = scenario.get("build_packages", [])
-    if not isinstance(raw, list):
-        msg = (
-            f"{scenario_name}: build_packages must be an array of"
-            f" package names, got {type(raw).__name__}"
-        )
-        raise TypeError(msg)
-    overrides: dict[str, BuildPolicy] = {}
-    for i, name in enumerate(raw):
-        if not isinstance(name, str):
-            msg = (
-                f"{scenario_name}: build_packages[{i}] must be a string,"
-                f" got {type(name).__name__}"
-            )
-            raise TypeError(msg)
-        overrides[name] = BuildPolicy.BUILD_REMOTE
-    return overrides
-
-
-def validate_scenario_build_policy(
-    scenario_name: str,
-    marker_environment: Mapping[str, str],
-    build_policy_overrides: Mapping[str, BuildPolicy],
-) -> None:
-    """Reject build policy paired with a marker environment overlay."""
-    if marker_environment and build_policy_overrides:
-        msg = (
-            f"{scenario_name}: build_packages cannot be combined "
-            "with a marker environment overlay"
-        )
-        raise ValueError(msg)
 
 
 def prepare_standard_execution(
@@ -1529,7 +1482,7 @@ def prepare_standard_execution(
     requirement_strings = requirement_inputs.requirements
     constraint_strings = requirement_inputs.constraints
     marker_environment = parse_marker_environment(scenario_name, scenario)
-    build_policy_overrides = dict(parse_build_packages(scenario_name, scenario))
+    build_policy_overrides = parse_scenario_build_packages(scenario_name, scenario)
     if "unsupported_reason" not in scenario:
         validate_scenario_build_policy(
             scenario_name,
@@ -1570,7 +1523,7 @@ def prepare_standard_execution(
             marker_environment=marker_environment,
             indexes=indexes,
             index_routes=index_routes,
-            build_packages=sorted(build_policy_overrides),
+            build_packages=list(build_policy_overrides),
             resolution_strategy=execution.strategy,
             trust_unverified_sdist_deps=trust_unverified_sdist_deps,
         ),

--- a/nab-python/tests/test_benchmark_canary_selection.py
+++ b/nab-python/tests/test_benchmark_canary_selection.py
@@ -76,6 +76,42 @@ def _resolve_path_as(
     monkeypatch.setattr(Path, "resolve", resolve)
 
 
+def _assert_main_preflight_error(
+    module: ModuleType,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    scenario: dict[str, object],
+    message: str,
+) -> None:
+    """Assert selection fails before canary host capture or result creation."""
+    results_dir = tmp_path / "results"
+    monkeypatch.setattr(module, "find_scenario", lambda _name: scenario)
+    monkeypatch.setattr(module, "RESULTS_DIR", results_dir)
+    monkeypatch.setattr(
+        module,
+        "get_git_source_state",
+        lambda: {"commit": "a" * 40, "dirty": False, "diff_hash": None},
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["canary.py", "--commit", "safe", "--scenario", "quick:example"],
+    )
+
+    def fail_host(*_args: object, **_kwargs: object) -> object:
+        pytest.fail("scenario preflight reached host capture")
+
+    monkeypatch.setattr(module.BenchmarkHost, "current", classmethod(fail_host))
+
+    with pytest.raises(SystemExit) as exc_info:
+        module.main()
+
+    assert exc_info.value.code == 2
+    assert message in capsys.readouterr().err
+    assert not results_dir.exists()
+
+
 def test_default_canary_manifest_preserves_19_strategies() -> None:
     module = _harness()
 
@@ -91,6 +127,15 @@ def test_default_canary_manifest_preserves_19_strategies() -> None:
         "lowest-direct": 5,
     }
     assert all("-lowest" not in case.scenario.split(":", 1)[0] for case in cases)
+
+
+def test_default_canaries_do_not_build_packages() -> None:
+    module = _harness()
+    cases = module.load_canary_manifest()
+
+    assert all(
+        "build_packages" not in module.find_scenario(case.scenario) for case in cases
+    )
 
 
 def test_default_canary_manifest_preserves_v2_input_identities() -> None:
@@ -667,6 +712,132 @@ def test_selection_validates_all_indexes_before_any_index_routes(
                 module.CanaryCase("quick:second", None),
             ]
         )
+
+
+@pytest.mark.parametrize(
+    ("first", "second", "message"),
+    [
+        (
+            {"build_packages": "demo"},
+            {"marker_environment": "Linux"},
+            "quick:second: marker_environment must be a table of strings",
+        ),
+        (
+            {
+                "platform_system": "Linux",
+                "build_packages": ["demo"],
+            },
+            {"build_packages": "demo"},
+            ("quick:second: build_packages must be a list of package names, got str"),
+        ),
+    ],
+    ids=("markers-before-build", "build-shapes-before-compatibility"),
+)
+def test_selection_validates_field_phases_across_the_whole_selection(
+    monkeypatch: pytest.MonkeyPatch,
+    first: dict[str, object],
+    second: dict[str, object],
+    message: str,
+) -> None:
+    module = _harness()
+    scenarios = {
+        "quick:first": {"requirements": [], **first},
+        "quick:second": {"requirements": [], **second},
+    }
+    monkeypatch.setattr(module, "find_scenario", scenarios.get)
+
+    with pytest.raises(TypeError, match=re.escape(message)):
+        module.select_scenarios(
+            [
+                module.CanaryCase("quick:first", None),
+                module.CanaryCase("quick:second", None),
+            ]
+        )
+
+
+def test_selection_validates_build_compatibility_before_resolution_and_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    scenario = {
+        "requirements": [],
+        "platform_system": "Linux",
+        "build_packages": ["demo"],
+        "resolution": "middle",
+        "requires_matching_host": "yes",
+    }
+    monkeypatch.setattr(module, "find_scenario", lambda _name: scenario)
+    message = (
+        "quick:example: build_packages cannot be combined "
+        "with a marker environment overlay"
+    )
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        module.select_scenarios([module.CanaryCase("quick:example", None)])
+
+
+def test_selection_validates_unsupported_build_shape_but_not_compatibility(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    valid_quarantine = {
+        "requirements": [],
+        "unsupported_reason": "marker/build metadata is unsound",
+        "platform_system": "Linux",
+        "build_packages": ["Demo_Pkg"],
+    }
+    invalid_quarantine = {
+        **valid_quarantine,
+        "build_packages": ["demo>=1"],
+    }
+    selected = [module.CanaryCase("quick:example", None)]
+
+    monkeypatch.setattr(
+        module,
+        "find_scenario",
+        lambda _name: valid_quarantine,
+    )
+    assert module.select_scenarios(selected) == selected
+
+    monkeypatch.setattr(module, "find_scenario", lambda _name: invalid_quarantine)
+    with pytest.raises(ValueError, match="valid distribution name"):
+        module.select_scenarios(selected)
+
+
+@pytest.mark.parametrize(
+    ("scenario", "message"),
+    [
+        (
+            {"requirements": [], "build_packages": "demo"},
+            "build_packages must be a list of package names",
+        ),
+        (
+            {"requirements": [], "resolution": "middle"},
+            "resolution must be one of ['highest', 'lowest', 'lowest-direct']",
+        ),
+        (
+            {"requirements": [], "requires_matching_host": "yes"},
+            "requires_matching_host must be a boolean",
+        ),
+    ],
+    ids=("build-packages", "resolution", "host-requirement"),
+)
+def test_selected_scenario_preflight_fails_before_host_and_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    scenario: dict[str, object],
+    message: str,
+) -> None:
+    module = _harness()
+    _assert_main_preflight_error(
+        module,
+        tmp_path,
+        monkeypatch,
+        capsys,
+        scenario,
+        message,
+    )
 
 
 def test_empty_scenarios_list_exits_before_creating_results(

--- a/nab-python/tests/test_benchmark_strategy_matrix.py
+++ b/nab-python/tests/test_benchmark_strategy_matrix.py
@@ -241,7 +241,7 @@ def _runner_parity_scenario() -> dict[str, object]:
             {"name": "Demo_Pkg", "index": "private"},
             {"name": "Other.Package", "index": "private"},
         ],
-        "build_packages": ["demo"],
+        "build_packages": ["Zulu_Pkg", "alpha.pkg", "Demo-Pkg"],
         "resolution": "lowest-direct",
         "trust_unverified_sdist_deps": False,
         "vcs_policy": "allow",
@@ -300,6 +300,32 @@ def _prepare_runner_parity(
     canary_execution = canary_preparation.execution
     assert canary_execution is not None
     return standard_execution, canary_execution, profile_inputs
+
+
+def _assert_all_runners_reject_scenario(
+    scenario: dict[str, object],
+    error: type[Exception],
+    message: str,
+) -> None:
+    """Assert the three benchmark runners reject one scenario identically."""
+    standard = _harness("scenarios")
+    canary = _harness("canary")
+    profile = _harness("_profile_runner")
+    host = _linux_host(standard)
+
+    with pytest.raises(error, match=re.escape(message)):
+        _prepare_standard_scenario(standard, scenario, host)
+
+    with pytest.raises(error, match=re.escape(message)):
+        canary._prepare_canary_execution(
+            scenario,
+            scenario_name="example",
+            resolution_override=None,
+            host=host,
+        )
+
+    with pytest.raises(error, match=re.escape(message)):
+        profile.build_inputs("example", scenario, host=host)
 
 
 @dataclass(frozen=True, order=True, slots=True)
@@ -2142,6 +2168,153 @@ def test_parse_scenario_index_routes_parses_every_entry_before_relationships(
 
 
 @pytest.mark.parametrize(
+    "scenario", [{}, {"build_packages": []}], ids=("missing", "empty")
+)
+def test_parse_scenario_build_packages_returns_a_fresh_empty_mapping(
+    scenario: dict[str, object],
+) -> None:
+    module = _harness("benchmark_config")
+
+    first = module.parse_scenario_build_packages("quick:build", scenario)
+    second = module.parse_scenario_build_packages("quick:build", scenario)
+
+    assert first == second == {}
+    assert first is not second
+
+
+def test_parse_scenario_build_packages_preserves_raw_names_and_order() -> None:
+    module = _harness("benchmark_config")
+    scenario = {"build_packages": ["Zulu_Pkg", "alpha.pkg", "Demo-Pkg"]}
+    original = deepcopy(scenario)
+
+    overrides = module.parse_scenario_build_packages("quick:build", scenario)
+
+    assert list(overrides) == ["Zulu_Pkg", "alpha.pkg", "Demo-Pkg"]
+    assert set(overrides.values()) == {module.BuildPolicy.BUILD_REMOTE}
+    assert scenario == original
+
+
+@pytest.mark.parametrize(
+    ("build_packages", "error", "message"),
+    [
+        (
+            "demo",
+            TypeError,
+            "quick:build: build_packages must be a list of package names, got str",
+        ),
+        (
+            None,
+            TypeError,
+            "quick:build: build_packages must be a list of package names, got NoneType",
+        ),
+        (
+            [123],
+            TypeError,
+            "quick:build: build_packages[0] must be a string, got int",
+        ),
+    ],
+    ids=("string", "null", "entry"),
+)
+def test_parse_scenario_build_packages_rejects_malformed_values(
+    build_packages: object,
+    error: type[Exception],
+    message: str,
+) -> None:
+    module = _harness("benchmark_config")
+
+    with pytest.raises(error, match=re.escape(message)):
+        module.parse_scenario_build_packages(
+            "quick:build",
+            {"build_packages": build_packages},
+        )
+
+
+def test_parse_scenario_build_packages_rejects_a_list_subclass() -> None:
+    module = _harness("benchmark_config")
+
+    class PackageList(list[str]):
+        pass
+
+    with pytest.raises(
+        TypeError,
+        match=(
+            "quick:build: build_packages must be a list of package names, "
+            "got PackageList"
+        ),
+    ):
+        module.parse_scenario_build_packages(
+            "quick:build",
+            {"build_packages": PackageList(["demo"])},
+        )
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "",
+        " ",
+        "demo>=1",
+        "demo[extra]",
+        "demo; python_version < '3.12'",
+        "demo @ https://example.test/demo.whl",
+    ],
+    ids=("empty", "whitespace", "specifier", "extra", "marker", "url"),
+)
+def test_parse_scenario_build_packages_rejects_non_package_names(name: str) -> None:
+    module = _harness("benchmark_config")
+    message = (
+        "quick:build: build_packages[0] must be a valid distribution name, "
+        f"got {name!r}"
+    )
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        module.parse_scenario_build_packages(
+            "quick:build",
+            {"build_packages": [name]},
+        )
+
+
+@pytest.mark.parametrize(
+    ("build_packages", "message"),
+    [
+        (["demo", "demo"], "quick:build: duplicate build package 'demo'"),
+        (
+            ["Demo_Pkg", "demo-pkg"],
+            "quick:build: duplicate build package 'demo-pkg'",
+        ),
+        (
+            ["Bravo_Pkg", "Alpha.Pkg", "bravo-pkg", "alpha-pkg"],
+            "quick:build: duplicate build package 'bravo-pkg'",
+        ),
+    ],
+    ids=("exact", "canonical", "first-canonical"),
+)
+def test_parse_scenario_build_packages_rejects_duplicates(
+    build_packages: list[str],
+    message: str,
+) -> None:
+    module = _harness("benchmark_config")
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        module.parse_scenario_build_packages(
+            "quick:build",
+            {"build_packages": build_packages},
+        )
+
+
+def test_parse_scenario_build_packages_validates_every_name_before_duplicates() -> None:
+    module = _harness("benchmark_config")
+    scenario = {"build_packages": ["Demo_Pkg", "demo-pkg", "later>=1"]}
+    message = (
+        "quick:build: build_packages[2] must be a valid distribution name, "
+        "got 'later>=1'"
+    )
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        module.parse_scenario_build_packages("quick:build", scenario)
+
+
+@pytest.mark.parametrize(
     ("routes", "message"),
     [
         (
@@ -2426,10 +2599,11 @@ def test_marker_build_scenarios_are_explicitly_unsupported() -> None:
         row.logical_key: row
         for row in rows
         if module.parse_marker_environment(row.name, row.definition)
-        and module.parse_build_packages(row.name, row.definition)
+        and module.parse_scenario_build_packages(row.name, row.definition)
     }
 
     assert set(marker_build_rows) == _MARKER_BUILD_SCENARIOS
+    assert sum("build_packages" in row.definition for row in rows) == 7
     assert all(
         row.definition.get("unsupported_reason") for row in marker_build_rows.values()
     )
@@ -2514,6 +2688,7 @@ python_version = "3.11"
 platform_system = "Linux"
 build_packages = ["demo"]
 requirements = ["demo"]
+requires_matching_host = "yes"
 """.lstrip(),
         encoding="utf-8",
     )
@@ -3534,6 +3709,16 @@ index_routes = "private"
 python_version = "3.11"
 requirements = []
 unsupported_reason = "not runnable"
+build_packages = "demo"
+""",
+            "other: build_packages must be a list of package names, got str",
+        ),
+        (
+            """
+[other]
+python_version = "3.11"
+requirements = []
+unsupported_reason = "not runnable"
 indexes = "private"
 project_name = "demo-project"
 project_extras = ["all"]
@@ -3564,6 +3749,7 @@ vcs_allowed_repos = { "https://example.test/repo" = false }
         "vcs-scheme-table",
         "indexes",
         "index-routes",
+        "build-packages",
         "project-before-indexes",
         "vcs-repo-table",
     ),
@@ -3670,6 +3856,11 @@ def test_profile_runner_accepts_an_explicit_strategy() -> None:
             "private",
             "example: index_routes must be an array of tables, got str",
         ),
+        (
+            "build_packages",
+            "demo",
+            "example: build_packages must be a list of package names, got str",
+        ),
     ],
     ids=(
         "pin",
@@ -3678,6 +3869,7 @@ def test_profile_runner_accepts_an_explicit_strategy() -> None:
         "repo-table",
         "indexes",
         "index-routes",
+        "build-packages",
     ),
 )
 def test_profile_main_validates_schema_before_host_capture(
@@ -3745,12 +3937,26 @@ def test_standard_canary_and_profile_build_the_same_project_config() -> None:
         {"name": "Demo_Pkg", "index": "private"},
         {"name": "Other.Package", "index": "private"},
     ]
+    assert standard_execution.expected_input["build_packages"] == [
+        "Zulu_Pkg",
+        "alpha.pkg",
+        "Demo-Pkg",
+    ]
     assert (
         standard_execution.config.indexes[0].serialization is SimpleSerialization.HTML
     )
     assert standard.index_routes_from_config(standard_execution.config) == [
         IndexRoute("demo-pkg", "private"),
         IndexRoute("other-package", "private"),
+    ]
+    assert [
+        (override.name, override.build_policy)
+        for override in standard_execution.config.package_overrides
+    ] == [
+        ("demo-pkg", standard.BuildPolicy.BUILD_REMOTE),
+        ("other-package", None),
+        ("zulu-pkg", standard.BuildPolicy.BUILD_REMOTE),
+        ("alpha-pkg", standard.BuildPolicy.BUILD_REMOTE),
     ]
 
     identity = canary.canary_v2_identity(
@@ -3761,6 +3967,11 @@ def test_standard_canary_and_profile_build_the_same_project_config() -> None:
     assert identity.definition["index_routes"] == [
         {"name": "Demo_Pkg", "index": "private"},
         {"name": "Other.Package", "index": "private"},
+    ]
+    assert identity.definition["build_packages"] == [
+        "Zulu_Pkg",
+        "alpha.pkg",
+        "Demo-Pkg",
     ]
 
     assert standard_execution.expected_input["requirements"] == [
@@ -3834,90 +4045,138 @@ def test_all_runners_validate_project_metadata_in_schema_order(
         profile.build_inputs("example", scenario, host=host)
 
 
-def test_all_runners_reject_malformed_indexes() -> None:
-    standard = _harness("scenarios")
-    canary = _harness("canary")
-    profile = _harness("_profile_runner")
+def test_all_runners_validate_indexes_before_index_routes() -> None:
     scenario = {
         "python_version": "3.11",
         "requirements": [],
         "indexes": [{"name": False, "url": 123}],
         "index_routes": "private",
     }
-    host = _linux_host(standard)
-    message = "example: indexes[0] name and url must be strings"
 
-    with pytest.raises(TypeError, match=re.escape(message)):
-        _prepare_standard_scenario(standard, scenario, host)
-
-    with pytest.raises(TypeError, match=re.escape(message)):
-        canary._prepare_canary_execution(
-            scenario,
-            scenario_name="example",
-            resolution_override=None,
-            host=host,
-        )
-
-    with pytest.raises(TypeError, match=re.escape(message)):
-        profile.build_inputs("example", scenario, host=host)
+    _assert_all_runners_reject_scenario(
+        scenario,
+        TypeError,
+        "example: indexes[0] name and url must be strings",
+    )
 
 
-def test_all_runners_reject_malformed_index_routes() -> None:
-    standard = _harness("scenarios")
-    canary = _harness("canary")
-    profile = _harness("_profile_runner")
+def test_all_runners_reject_invalid_index_route_names() -> None:
     scenario = {
         "python_version": "3.11",
         "requirements": [],
         "indexes": [{"name": "private", "url": "https://example.test/simple"}],
         "index_routes": [{"name": "demo>=1", "index": "private"}],
     }
-    host = _linux_host(standard)
     message = (
         "example: index_routes[0].name must be a valid distribution name, got 'demo>=1'"
     )
 
-    with pytest.raises(ValueError, match=re.escape(message)):
-        _prepare_standard_scenario(standard, scenario, host)
-
-    with pytest.raises(ValueError, match=re.escape(message)):
-        canary._prepare_canary_execution(
-            scenario,
-            scenario_name="example",
-            resolution_override=None,
-            host=host,
-        )
-
-    with pytest.raises(ValueError, match=re.escape(message)):
-        profile.build_inputs("example", scenario, host=host)
+    _assert_all_runners_reject_scenario(scenario, ValueError, message)
 
 
 def test_all_runners_validate_index_routes_before_build_packages() -> None:
-    standard = _harness("scenarios")
-    canary = _harness("canary")
-    profile = _harness("_profile_runner")
     scenario = {
         "python_version": "3.11",
         "requirements": [],
         "index_routes": [{"name": "demo", "index": 123}],
         "build_packages": "demo",
     }
-    host = _linux_host(standard)
-    message = "example: index_routes[0].index must be a string, got int"
 
-    with pytest.raises(TypeError, match=re.escape(message)):
-        _prepare_standard_scenario(standard, scenario, host)
+    _assert_all_runners_reject_scenario(
+        scenario,
+        TypeError,
+        "example: index_routes[0].index must be a string, got int",
+    )
 
-    with pytest.raises(TypeError, match=re.escape(message)):
+
+def test_all_runners_reject_invalid_build_package_names() -> None:
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        "build_packages": ["demo>=1"],
+    }
+    message = (
+        "example: build_packages[0] must be a valid distribution name, got 'demo>=1'"
+    )
+
+    _assert_all_runners_reject_scenario(scenario, ValueError, message)
+
+
+def test_all_runners_reject_non_list_build_packages() -> None:
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        "build_packages": "demo",
+    }
+
+    _assert_all_runners_reject_scenario(
+        scenario,
+        TypeError,
+        "example: build_packages must be a list of package names, got str",
+    )
+
+
+def test_all_runners_validate_marker_shape_before_build_packages() -> None:
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        "marker_environment": "Linux",
+        "build_packages": "demo",
+    }
+
+    _assert_all_runners_reject_scenario(
+        scenario,
+        TypeError,
+        "example: marker_environment must be a table of strings",
+    )
+
+
+def test_all_runners_validate_build_schema_before_compatibility() -> None:
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        "platform_system": "Linux",
+        "build_packages": ["Demo_Pkg", "demo-pkg"],
+    }
+
+    _assert_all_runners_reject_scenario(
+        scenario,
+        ValueError,
+        "example: duplicate build package 'demo-pkg'",
+    )
+
+
+def test_build_compatibility_precedes_resolution_and_host_validation() -> None:
+    canary = _harness("canary")
+    profile = _harness("_profile_runner")
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        "platform_system": "Linux",
+        "build_packages": ["demo"],
+        "resolution": "middle",
+        "requires_matching_host": "yes",
+    }
+    message = (
+        "example: build_packages cannot be combined with a marker environment overlay"
+    )
+
+    class UnusedHost:
+        """Fail if build-policy validation reaches target admission."""
+
+        def target_for(self, *_args: object, **_kwargs: object) -> object:
+            pytest.fail("build-policy validation reached host admission")
+
+    with pytest.raises(ValueError, match=re.escape(message)):
         canary._prepare_canary_execution(
             scenario,
             scenario_name="example",
             resolution_override=None,
-            host=host,
+            host=UnusedHost(),
         )
 
-    with pytest.raises(TypeError, match=re.escape(message)):
-        profile.build_inputs("example", scenario, host=host)
+    with pytest.raises(ValueError, match=re.escape(message)):
+        profile.build_inputs("example", scenario, host=UnusedHost())
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
A benchmark scenario with `build_packages = "demo"` became four canary overrides for `d`, `e`, `m`, and `o`, while the standard and profile runners rejected the same declaration. Requirement expressions such as `demo>=1` do not identify a package override, and normalization-equivalent entries such as `Demo_Pkg` and `demo-pkg` target the same package.

The three runners now share one parser that accepts only lists of bare distribution names and rejects malformed or duplicate declarations. Recorded inputs retain the declared spelling and order, while the effective configuration uses canonical package names. Each runner validates the field before host capture or result output.
