### PR TITLE
reject unknown benchmark marker environment variables

### DIFF
--- a/nab-python/benchmarks/benchmark_host.py
+++ b/nab-python/benchmarks/benchmark_host.py
@@ -10,7 +10,12 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from nab_python.target import IMPLEMENTATION_MARKERS, PLATFORM_MARKERS, ResolveTarget
+from nab_python.target import (
+    IMPLEMENTATION_MARKERS,
+    PEP508_MARKER_VARIABLES,
+    PLATFORM_MARKERS,
+    ResolveTarget,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Mapping
@@ -71,6 +76,11 @@ def parse_target_marker_environment(
         raise TypeError(msg)
 
     marker_environment = dict(raw)
+    unknown = sorted(set(marker_environment) - PEP508_MARKER_VARIABLES)
+    if unknown:
+        msg = f"{scenario_name}: unknown marker_environment variables: {unknown!r}"
+        raise ValueError(msg)
+
     platform_system = scenario.get("platform_system")
     if platform_system is not None:
         if type(platform_system) is not str or not platform_system:

--- a/nab-python/tests/test_benchmark_canary_selection.py
+++ b/nab-python/tests/test_benchmark_canary_selection.py
@@ -715,11 +715,12 @@ def test_selection_validates_all_indexes_before_any_index_routes(
 
 
 @pytest.mark.parametrize(
-    ("first", "second", "message"),
+    ("first", "second", "error", "message"),
     [
         (
             {"build_packages": "demo"},
             {"marker_environment": "Linux"},
+            TypeError,
             "quick:second: marker_environment must be a table of strings",
         ),
         (
@@ -728,15 +729,29 @@ def test_selection_validates_all_indexes_before_any_index_routes(
                 "build_packages": ["demo"],
             },
             {"build_packages": "demo"},
+            TypeError,
             ("quick:second: build_packages must be a list of package names, got str"),
         ),
+        (
+            {"build_packages": "demo"},
+            {"marker_environment": {"platform_codename": "Windows"}},
+            ValueError,
+            (
+                "quick:second: unknown marker_environment variables: ['platform_codename']"
+            ),
+        ),
     ],
-    ids=("markers-before-build", "build-shapes-before-compatibility"),
+    ids=(
+        "marker-shapes-before-build",
+        "build-shapes-before-compatibility",
+        "marker-names-before-build",
+    ),
 )
 def test_selection_validates_field_phases_across_the_whole_selection(
     monkeypatch: pytest.MonkeyPatch,
     first: dict[str, object],
     second: dict[str, object],
+    error: type[Exception],
     message: str,
 ) -> None:
     module = _harness()
@@ -746,7 +761,7 @@ def test_selection_validates_field_phases_across_the_whole_selection(
     }
     monkeypatch.setattr(module, "find_scenario", scenarios.get)
 
-    with pytest.raises(TypeError, match=re.escape(message)):
+    with pytest.raises(error, match=re.escape(message)):
         module.select_scenarios(
             [
                 module.CanaryCase("quick:first", None),
@@ -804,6 +819,26 @@ def test_selection_validates_unsupported_build_shape_but_not_compatibility(
         module.select_scenarios(selected)
 
 
+def test_selection_rejects_unknown_marker_variables_on_unsupported_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    scenario = {
+        "requirements": [],
+        "unsupported_reason": "not runnable",
+        "marker_environment": {"platform_codename": "Windows"},
+    }
+    monkeypatch.setattr(module, "find_scenario", lambda _name: scenario)
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "quick:example: unknown marker_environment variables: ['platform_codename']"
+        ),
+    ):
+        module.select_scenarios([module.CanaryCase("quick:example", None)])
+
+
 @pytest.mark.parametrize(
     ("scenario", "message"),
     [
@@ -819,8 +854,15 @@ def test_selection_validates_unsupported_build_shape_but_not_compatibility(
             {"requirements": [], "requires_matching_host": "yes"},
             "requires_matching_host must be a boolean",
         ),
+        (
+            {
+                "requirements": [],
+                "marker_environment": {"platform_codename": "Windows"},
+            },
+            "unknown marker_environment variables: ['platform_codename']",
+        ),
     ],
-    ids=("build-packages", "resolution", "host-requirement"),
+    ids=("build-packages", "resolution", "host-requirement", "marker-variable"),
 )
 def test_selected_scenario_preflight_fails_before_host_and_output(
     tmp_path: Path,

--- a/nab-python/tests/test_benchmark_strategy_matrix.py
+++ b/nab-python/tests/test_benchmark_strategy_matrix.py
@@ -918,6 +918,140 @@ def test_target_marker_declarations_require_string_values(
 
 
 @pytest.mark.parametrize(
+    ("marker_environment", "unknown"),
+    [
+        ({"platform_codename": "Windows"}, ["platform_codename"]),
+        (
+            {"zulu_marker": "z", "platform_system": "Linux", "alpha_marker": "a"},
+            ["alpha_marker", "zulu_marker"],
+        ),
+    ],
+    ids=("single", "multiple-sorted"),
+)
+def test_target_marker_declarations_reject_unknown_variables(
+    marker_environment: dict[str, str],
+    unknown: list[str],
+) -> None:
+    module = _harness("scenarios")
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(f"invalid: unknown marker_environment variables: {unknown!r}"),
+    ):
+        module.parse_marker_environment(
+            "invalid",
+            {"marker_environment": marker_environment},
+        )
+
+
+def test_target_marker_shape_precedes_unknown_variables() -> None:
+    module = _harness("scenarios")
+    definition = {"marker_environment": {"platform_codename": 1}}
+
+    with pytest.raises(
+        TypeError,
+        match="invalid: marker_environment must be a table of strings",
+    ):
+        module.parse_marker_environment("invalid", definition)
+
+
+@pytest.mark.parametrize(
+    "platform_system",
+    ["Linux", 1],
+    ids=("conflict", "invalid-type"),
+)
+def test_unknown_marker_variables_precede_platform_shorthand_validation(
+    platform_system: object,
+) -> None:
+    module = _harness("scenarios")
+    definition = {
+        "platform_system": platform_system,
+        "marker_environment": {
+            "platform_system": "Windows",
+            "platform_codename": "Windows",
+        },
+    }
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "invalid: unknown marker_environment variables: ['platform_codename']"
+        ),
+    ):
+        module.parse_marker_environment("invalid", definition)
+
+
+@pytest.mark.parametrize(
+    "target_markers",
+    [
+        {"platform_system": "Darwin", "sys_platform": "win32"},
+        {
+            "implementation_name": "cpython",
+            "platform_python_implementation": "PyPy",
+        },
+    ],
+    ids=("platform", "interpreter"),
+)
+def test_unknown_marker_variables_precede_supported_target_validation(
+    target_markers: dict[str, str],
+) -> None:
+    module = _harness("scenarios")
+    definition = {
+        "marker_environment": {
+            "platform_codename": "stable",
+            **target_markers,
+        }
+    }
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "invalid: unknown marker_environment variables: ['platform_codename']"
+        ),
+    ):
+        module.parse_marker_environment("invalid", definition)
+
+
+def test_target_marker_declarations_accept_every_pep508_variable() -> None:
+    module = _harness("scenarios")
+    # Nonalphabetical order makes an accidental sort visible.
+    declared = {
+        "platform_system": "Linux",
+        "python_version": "3.12.5",
+        "implementation_name": "cpython",
+        "sys_platform": "linux",
+        "platform_release": "test-release",
+        "os_name": "posix",
+        "python_full_version": "3.12.5",
+        "platform_machine": "x86_64",
+        "implementation_version": "3.12.5",
+        "platform_version": "test-version",
+        "platform_python_implementation": "CPython",
+    }
+
+    parsed = module.parse_marker_environment(
+        "valid",
+        {"marker_environment": declared},
+    )
+
+    assert parsed == declared
+    assert list(parsed) == list(declared)
+
+
+def test_target_marker_declarations_accept_partial_known_overlays() -> None:
+    module = _harness("scenarios")
+    declared = {"platform_release": "test-release"}
+
+    assert (
+        module.parse_marker_environment(
+            "valid",
+            {"marker_environment": declared},
+        )
+        == declared
+    )
+
+
+@pytest.mark.parametrize(
     ("definition", "expected"),
     [
         ({}, False),
@@ -2723,6 +2857,42 @@ requires_matching_host = "yes"
         module.load_standard_corpus([path])
 
 
+@pytest.mark.parametrize(
+    "unsupported_reason",
+    [None, "not runnable"],
+    ids=("supported", "unsupported"),
+)
+def test_standard_corpus_rejects_unknown_marker_variables(
+    tmp_path: Path,
+    unsupported_reason: str | None,
+) -> None:
+    module = _harness("scenarios")
+    path = tmp_path / "quick.toml"
+    unsupported_declaration = (
+        f'unsupported_reason = "{unsupported_reason}"'
+        if unsupported_reason is not None
+        else ""
+    )
+    path.write_text(
+        f"""
+[example]
+python_version = "3.11"
+requirements = []
+{unsupported_declaration}
+marker_environment = {{ platform_codename = "Windows" }}
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "example: unknown marker_environment variables: ['platform_codename']"
+        ),
+    ):
+        module.load_standard_corpus([path])
+
+
 def test_standard_corpus_rejects_a_strategy_clone(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -4129,6 +4299,35 @@ def test_all_runners_validate_marker_shape_before_build_packages() -> None:
         TypeError,
         "example: marker_environment must be a table of strings",
     )
+
+
+def test_unknown_marker_variables_fail_before_runner_host_admission() -> None:
+    standard = _harness("scenarios")
+    canary = _harness("canary")
+    profile = _harness("_profile_runner")
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        "marker_environment": {"platform_codename": "Windows"},
+    }
+    message = "example: unknown marker_environment variables: ['platform_codename']"
+    host = MagicMock()
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        _prepare_standard_scenario(standard, scenario, host)
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        canary._prepare_canary_execution(
+            scenario,
+            scenario_name="example",
+            resolution_override=None,
+            host=host,
+        )
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        profile.build_inputs("example", scenario, host=host)
+
+    host.target_for.assert_not_called()
 
 
 def test_all_runners_validate_build_schema_before_compatibility() -> None:


### PR DESCRIPTION
A scenario with `marker_environment = { platform_systme = "Windows" }` was accepted by the standard, canary, and profile runners. The standard and canary runners recorded the misspelled name, but every runner still used the Linux host's `platform_system` value.

The benchmark runners now reject unknown names in `marker_environment` before host admission or result output. Valid partial overlays remain accepted.
