### PR TITLE
drop the look-ahead abort's skip marker

### DIFF
--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -683,9 +683,9 @@ def prefetch_walk_ahead(
 ) -> None:
     """Submit metadata for the next ``deep_count`` wheels of ``normalized``.
 
-    Called when the scan is about to walk past its ``PREFETCH_BATCH``
-    window.  Front-loading the rest of the walk lets ``_try_abort_skip``
-    and any restart hit cache instead of one RTT per visit.
+    Called at the top of the pipelined scan, so a walk that runs past the
+    first ``PREFETCH_BATCH`` window hits cache instead of paying one RTT
+    per visit.
 
     Takes each version's artifact from :func:`wheel_by_version`, so the
     sidecar it warms is the one the read asks for.  Skips already-cached

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -512,11 +512,10 @@ class Provider:
     # destabilised hard scenarios.
     PREFETCH_DEPTH: int = 1
 
-    # Once the first look-ahead candidate fails, the resolver walks
-    # versions one at a time via the abort-skip path.  Front-load
-    # metadata for the next K so the walk hits cache instead of one
-    # RTT per visit.  Only fires from _scan_candidates_pipelined, so
-    # scenarios that accept the first candidate pay nothing.
+    # Versions front-loaded at the top of the pipelined scan, so a walk
+    # that runs past the first ``PREFETCH_BATCH`` hits cache instead of one
+    # RTT per visit.  The scan only starts once the first candidate is
+    # rejected, so accepting that candidate costs nothing.
     DEEP_PREFETCH_COUNT: int = 64
 
     # Per-call cap on decision-aware look-ahead rejections so tight version
@@ -535,9 +534,7 @@ class Provider:
     #
     # Set low because the trigger is conservative: a unique
     # ``(blocker_pkg, blocker_version)`` repeating across every rejection
-    # is already a strong signal. Combined with the per-package skip
-    # below, subsequent calls for the same package skip look-ahead while
-    # the blocker decision is unchanged.
+    # is already a strong signal.
     _LOOKAHEAD_ABORT_THRESHOLD = 8
 
     # Max force-backtracks one blocker can drive per resolution.
@@ -806,14 +803,6 @@ class Provider:
         # Last NO_VERSIONS reason per package; consumed by resolve.py to
         # enrich ResolutionError messages.
         self._no_versions_reasons: dict[str, str] = {}
-
-        # Per-package record of "look-ahead aborted at this blocker decision".
-        # While the blocker is still decided to the recorded version, the next
-        # ``choose_version`` for this package skips look-ahead entirely and
-        # returns the first candidate; re-running the scan would just hit the
-        # same monolithic-rejection pattern and abort again.  Cleared per
-        # package when the blocker's decision changes (back-jump unblocks it).
-        self._lookahead_aborted: dict[str, tuple[str, Version]] = {}
 
         # Blocker packages queued for force back-track by the resolver after
         # the next ``choose_version`` returns.  Populated by the look-ahead
@@ -1300,10 +1289,6 @@ class Provider:
                 )
             return candidates[0] if candidates else None
 
-        skip = self._try_abort_skip(normalized, candidates[0])
-        if skip is not None:
-            return skip
-
         wheel_by_version = self._wheel_by_version(normalized, version_list)
         return self._run_full_scan(
             normalized, candidates, wheel_by_version, package, all_versions
@@ -1359,10 +1344,10 @@ class Provider:
 
         Runs the real ``choose_version`` over ``version_range`` so look-ahead
         rejections are honored, then rolls back the state it records: the queued
-        clauses and force-backtrack signal are drained, and the per-package abort
-        markers, force-backtrack budget, and no-versions reasons are restored to
-        their pre-probe values.  A failed-resolve attribution probe therefore
-        cannot alter a later decision.
+        clauses and force-backtrack signal are drained, and the force-backtrack
+        budget and no-versions reasons are restored to their pre-probe values.
+        A failed-resolve attribution probe therefore cannot alter a later
+        decision.
 
         The one exception is ``package``'s own no-versions reason.  When the
         un-narrowed range yields no version because a transitive conflict
@@ -1371,11 +1356,10 @@ class Provider:
         no-match the constraint-narrowed pass recorded.  The reason map only
         labels a ``NO_VERSIONS`` clause, so keeping it cannot alter a decision.
 
-        The probe also suppresses both look-ahead shortcuts, which could
-        otherwise report a version the decided blocker rejects: it hides the
-        abort markers (so neither a fresh abort nor a recorded skip fires) and
-        sets ``_probing_satisfiable`` to skip the abort and to keep checking
-        decisions past ``_BROAD_LA_REJECT_CAP``.
+        The probe also suppresses the two look-ahead shortcuts that could
+        otherwise report a version the decided blocker rejects:
+        ``_probing_satisfiable`` skips the abort and keeps checking decisions
+        past ``_BROAD_LA_REJECT_CAP``.
 
         The un-narrowed range spans versions the constraint clipped away, so
         look-ahead can reach one whose metadata raises a hard error the narrowed
@@ -1395,11 +1379,9 @@ class Provider:
         # Late import: config imports provider at module load.
         from .config import OverrideConflictError  # noqa: PLC0415
 
-        saved_aborted = dict(self._lookahead_aborted)
         saved_counts = dict(self._force_backtrack_counts)
         saved_reasons = dict(self._no_versions_reasons)
 
-        self._lookahead_aborted = {}
         self._probing_satisfiable = True
         try:
             return self.choose_version(package, version_range) is not None
@@ -1420,7 +1402,6 @@ class Provider:
             self._probing_satisfiable = False
             self.consume_pending_clauses()
             self.consume_force_backtrack_targets()
-            self._lookahead_aborted = saved_aborted
             self._force_backtrack_counts = saved_counts
 
             # Restore the snapshot but keep the probe's own blocker reason.
@@ -1428,29 +1409,6 @@ class Provider:
             self._no_versions_reasons = saved_reasons
             if probed_reason is not None:
                 self._no_versions_reasons[package] = probed_reason
-
-    def _try_abort_skip(self, normalized: str, first: Version) -> Version | None:
-        """Return the first candidate when a prior abort is still valid.
-
-        While the recorded blocker decision is unchanged, a re-run of
-        the full scan would just trip the abort again. A warm cache
-        hit returns directly; otherwise a non-decision look-ahead
-        guards against unreadable wheels. Returns None when no
-        recorded abort applies, or when the candidate fails the gate.
-        """
-        aborted = self._lookahead_aborted.get(normalized)
-        if aborted is None:
-            return None
-        blocker_pkg, blocker_version = aborted
-        if self.solution_decisions.get(blocker_pkg) != blocker_version:
-            del self._lookahead_aborted[normalized]
-            return None
-        if (normalized, first) in self.deps_cache:
-            return first
-        if self._look_ahead_ok(normalized, first, check_decisions=False):
-            self._flush_pending_blocks()
-            return first
-        return None
 
     def _run_full_scan(
         self,
@@ -1518,8 +1476,7 @@ class Provider:
         blocker on its own.  Sound because no clause is emitted by the
         abort path.
         """
-        # Front-load deep metadata before the scan: by the time the
-        # 8-batch trips the abort, the rest of the walk is in flight.
+        # Front-load deep metadata so a walk past the first batch hits cache.
         self.prefetch_walk_ahead(normalized)
 
         starts_iter = iter(range(0, len(remaining), self.PREFETCH_BATCH))
@@ -1588,17 +1545,15 @@ class Provider:
         return None, broad_rejections
 
     def _try_abort_lookahead(self, normalized: str) -> bool:
-        """Run the monolithic-rejection abort. Return True when fired.
+        """Run the monolithic-rejection abort. Return True when it fires.
 
-        Records the abort state, queues the blocker for force-backtrack
-        (up to the per-blocker cap), and returns True so the caller
-        falls back to its first candidate.
+        Firing queues the blocker for force-backtrack, up to the per-blocker
+        cap; the caller then falls back to its first candidate.
         """
         blocker = self._should_abort_lookahead(normalized)
         if blocker is None:
             return False
         self._discard_pending_decision_blocks(normalized)
-        self._lookahead_aborted[normalized] = blocker
         blocker_pkg, _ = blocker
         prior_fires = self._force_backtrack_counts.get(blocker_pkg, 0)
         if (

--- a/nab-python/tests/test_constraint_probe_hard_error.py
+++ b/nab-python/tests/test_constraint_probe_hard_error.py
@@ -6,7 +6,7 @@ That range includes the versions the constraint clipped away, so look-ahead can
 reach one whose metadata is a hard integrity error (a failed PEP 658 sidecar
 hash, or a bare wheel whose full body fails its published hash).  The probe only
 labels a ``NO_VERSIONS`` clause, so that error must not escape and abort the
-resolve, and the snapshot the probe restores must survive the failure path.
+resolve.
 
 What the probe contains is bounded by what the error says.  A fault of the one
 version is contained; a transient transport failure, which names the moment and
@@ -130,8 +130,8 @@ class TestConstraintProbeContainsHardError:
 
         assert pins == {"baz": V("1.0")}
 
-    def test_probe_contains_hard_error_and_restores_snapshot(self) -> None:
-        """A raising probe returns False and leaves the snapshot restored."""
+    def test_probe_contains_hard_error(self) -> None:
+        """A failed sidecar hash inside the probe returns False, it does not raise."""
         listings = {"foo": [_wheel("foo", "3.0")]}
         coordinator = make_coordinator(listings=listings)
         coordinator.index.store_metadata_error(
@@ -139,13 +139,8 @@ class TestConstraintProbeContainsHardError:
         )
         root_reqs = {"foo": VersionRange.full(admit_arbitrary=False)}
         provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
-        sentinel = {"sentinel-blocker": ("x", V("1.0"))}
-        provider._lookahead_aborted = dict(sentinel)
 
-        found = provider.has_satisfying_version("foo", VersionRange.full())
-
-        assert found is False
-        assert provider._lookahead_aborted == sentinel
+        assert provider.has_satisfying_version("foo", VersionRange.full()) is False
 
     @pytest.mark.parametrize(
         "error",
@@ -161,20 +156,15 @@ class TestConstraintProbeContainsHardError:
         or handed back a non-UTF-8 body for, is a fault of that one version.
         Over the un-narrowed probe range this is a version the constraint
         clipped away, so ``has_satisfying_version`` must return ``False`` rather
-        than abort the resolve, and the snapshot must survive.
+        than abort the resolve.
         """
         listings = {"foo": [_wheel("foo", "3.0")]}
         coordinator = make_coordinator(listings=listings)
         coordinator.index.store_metadata_error("foo", "3.0", error)
         root_reqs = {"foo": VersionRange.full(admit_arbitrary=False)}
         provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
-        sentinel = {"sentinel-blocker": ("x", V("1.0"))}
-        provider._lookahead_aborted = dict(sentinel)
 
-        found = provider.has_satisfying_version("foo", VersionRange.full())
-
-        assert found is False
-        assert provider._lookahead_aborted == sentinel
+        assert provider.has_satisfying_version("foo", VersionRange.full()) is False
 
     def test_transient_transport_failure_propagates_out_of_probe(self) -> None:
         """A 5xx that outlived the retry budget aborts, it is not absorbed.
@@ -182,7 +172,6 @@ class TestConstraintProbeContainsHardError:
         A bare ``HttpError`` names the moment, not the version.  Reading it as
         "this version has no satisfying candidate" would let the resolve carry
         on and pin a different-but-valid answer, so it must escape the probe.
-        The snapshot is still restored on the way out.
         """
         listings = {"foo": [_wheel("foo", "3.0")]}
         coordinator = make_coordinator(listings=listings)
@@ -191,13 +180,9 @@ class TestConstraintProbeContainsHardError:
         )
         root_reqs = {"foo": VersionRange.full(admit_arbitrary=False)}
         provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
-        sentinel = {"sentinel-blocker": ("x", V("1.0"))}
-        provider._lookahead_aborted = dict(sentinel)
 
         with pytest.raises(HttpError, match="HTTP 503"):
             provider.has_satisfying_version("foo", VersionRange.full())
-
-        assert provider._lookahead_aborted == sentinel
 
     def test_tie_divergence_on_probed_version_returns_false(self) -> None:
         """A tie divergence reached only by the probe returns False, not crash.

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -812,24 +812,13 @@ class TestHasSatisfyingVersion:
         )
         assert provider.get_no_versions_reason("foo") == "sentinel"
 
-    def test_preserves_prior_abort_state(self) -> None:
-        """Abort markers and force-backtrack counts survive the probe."""
-        coordinator = make_coordinator([make_wheel("1.0")], package="foo")
-        provider = Provider(coordinator)
-        provider._lookahead_aborted["bar"] = ("baz", V("1.0"))
-        provider._force_backtrack_counts["baz"] = 2
-        provider.has_satisfying_version("foo", VersionRange.full())
-        assert provider._lookahead_aborted == {"bar": ("baz", V("1.0"))}
-        assert provider._force_backtrack_counts == {"baz": 2}
-
     def test_false_when_every_candidate_hits_the_abort_blocker(self) -> None:
         """The look-ahead abort's optimistic pick is not a satisfying version.
 
         Every candidate in range is rejected by one decided blocker, tripping
         ``choose_version``'s monolithic-rejection abort, which returns the first
         candidate for the resolver to decide and back-jump.  The probe must
-        report that no usable version exists, both when the abort
-        fires fresh and when a prior abort is already recorded.
+        report that no usable version exists.
         """
         versions = [f"{n}.0" for n in range(8, 0, -1)]
         wheels = [make_wheel(v) for v in versions]
@@ -842,11 +831,9 @@ class TestHasSatisfyingVersion:
         root_reqs = {"foo": VersionRange.full(admit_arbitrary=False)}
         provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         provider.receive_partial_solution_hint({}, {"bar": V("5.0")})
-        # choose_version takes the abort shortcut: returns the first pick and
-        # records the skip state a later call would reuse.
+        # choose_version takes the abort shortcut and returns the first pick.
         assert provider.choose_version("foo", VersionRange.full()) == V("8.0")
-        assert provider._lookahead_aborted == {"foo": ("bar", V("5.0"))}
-        # The probe ignores both the recorded skip and a fresh abort.
+
         assert not provider.has_satisfying_version("foo", VersionRange.full())
 
     def test_true_when_a_usable_version_sits_past_the_abort_threshold(self) -> None:
@@ -4474,28 +4461,6 @@ class TestLookAheadAbort:
         clauses = provider.consume_pending_clauses()
         assert len(clauses) == 1
 
-    def test_abort_records_state_for_per_package_skip(self) -> None:
-        """When the abort fires, ``_lookahead_aborted`` records the blocker so
-        the next ``choose_version`` for this package can short-circuit
-        look-ahead while the blocker decision is unchanged.
-        """
-        versions = ["3.0", "2.0", "1.0"]
-        wheels = [make_wheel(v) for v in versions]
-        meta_template = (
-            "Metadata-Version: 2.1\nName: foo\nVersion: {ver}\nRequires-Dist: bar<2.0\n"
-        )
-        coordinator = make_coordinator(
-            wheels,
-            metadata_by_version={v: meta_template.format(ver=v) for v in versions},
-            package="foo",
-        )
-        root_reqs = {"foo": VersionRange.full(admit_arbitrary=False)}
-        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
-        provider.receive_partial_solution_hint({}, {"bar": V("3.0")})
-        provider._LOOKAHEAD_ABORT_THRESHOLD = 2  # type: ignore[misc]
-        assert provider.choose_version("foo", VersionRange.full()) == V("3.0")
-        assert provider._lookahead_aborted == {"foo": ("bar", V("3.0"))}
-
     def test_abort_queues_force_backtrack_target(self) -> None:
         """The abort path queues the blocker package on
         ``_force_backtrack_targets`` so the resolver can pick it up via
@@ -4524,8 +4489,8 @@ class TestLookAheadAbort:
     def test_force_backtrack_refires_up_to_cap(self) -> None:
         """A blocker can drive at most ``_MAX_FORCE_BACKTRACKS_PER_PKG``
         force-backtracks, mirroring uv's repeated ConflictTracker fires.
-        After the cap the abort path still records the skip but does not
-        re-queue the force-backtrack target.
+        After the cap the abort still fires but does not re-queue the
+        force-backtrack target.
         """
         versions = ["3.0", "2.0", "1.0"]
         wheels = [make_wheel(v) for v in versions]
@@ -4545,111 +4510,10 @@ class TestLookAheadAbort:
         for _ in range(3):
             provider.choose_version("foo", VersionRange.full())
             assert provider.consume_force_backtrack_targets() == ["bar"]
-            provider._lookahead_aborted.pop("foo", None)
+
         # Fourth abort blaming the same blocker is past the cap; no re-queue.
         provider.choose_version("foo", VersionRange.full())
         assert provider.consume_force_backtrack_targets() == []
-
-    def test_per_package_skip_short_circuits_while_blocker_decided(self) -> None:
-        """A recorded abort makes ``choose_version`` skip the full scan
-        when the blocker decision is unchanged.  If the first candidate's
-        metadata is already cached (warm path), it is returned without
-        running look-ahead at all.  If not cached (cold path), a non
-        -decision look-ahead gate runs to guard against unreadable
-        wheels.
-        """
-        meta = (
-            "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\nRequires-Dist: bar<2.0\n"
-        )
-        coordinator = make_coordinator(
-            [make_wheel("1.0")], metadata_text=meta, package="foo"
-        )
-        root_reqs = {"foo": VersionRange.full(admit_arbitrary=False)}
-        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
-        # bar=3.0 conflicts with foo's bar<2.0 dep, the same
-        # state that would have triggered the abort in the first place.
-        provider.receive_partial_solution_hint({}, {"bar": V("3.0")})
-        # Pre-record the abort state as if a prior scan had populated it.
-        provider._lookahead_aborted["foo"] = ("bar", V("3.0"))
-        # Pre-warm the deps_cache so the skip path takes the cache fast
-        # path (no look-ahead invocation).
-        provider.get_dependencies("foo", V("1.0"))
-        before_rejections = provider.stats.look_ahead_rejections
-        chosen = provider.choose_version("foo", VersionRange.full())
-        assert chosen == V("1.0")
-        # Cache hit, no extra look-ahead rejections recorded.
-        assert provider.stats.look_ahead_rejections == before_rejections
-
-    def test_per_package_skip_cold_runs_safety_check(self) -> None:
-        """Cold cache: the skip path runs ``_look_ahead_ok`` with
-        ``check_decisions=False`` to catch unreadable wheels before the
-        resolver decides them.
-        """
-        meta = (
-            "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\nRequires-Dist: bar<2.0\n"
-        )
-        coordinator = make_coordinator(
-            [make_wheel("1.0")], metadata_text=meta, package="foo"
-        )
-        root_reqs = {"foo": VersionRange.full(admit_arbitrary=False)}
-        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
-        provider.receive_partial_solution_hint({}, {"bar": V("3.0")})
-        provider._lookahead_aborted["foo"] = ("bar", V("3.0"))
-        # No pre-warm; cold cache. The safety look-ahead fetches the
-        # metadata and the skip path returns the candidate.
-        chosen = provider.choose_version("foo", VersionRange.full())
-        assert chosen == V("1.0")
-
-    def test_per_package_skip_falls_through_on_metadata_error(self) -> None:
-        """If the first candidate has unreadable metadata, the safety
-        check rejects it and the normal scan path runs.  Prevents the
-        resolver from deciding a broken candidate and crashing with
-        ``MetadataError``.
-        """
-        wheels = [make_wheel("1.0"), make_wheel("0.9")]
-        meta_v1_broken = "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\nRequires-Dist: bar(invalid\n"
-        meta_v09 = (
-            "Metadata-Version: 2.1\nName: foo\nVersion: 0.9\nRequires-Dist: bar>=1.0\n"
-        )
-        coordinator = make_coordinator(
-            wheels,
-            metadata_by_version={"1.0": meta_v1_broken, "0.9": meta_v09},
-            package="foo",
-        )
-        root_reqs = {"foo": VersionRange.full(admit_arbitrary=False)}
-        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
-        provider.receive_partial_solution_hint({}, {"bar": V("3.0")})
-        # Skip is recorded, but foo==1.0 has bad metadata so the
-        # safety check rejects and the scan proceeds.
-        provider._lookahead_aborted["foo"] = ("bar", V("3.0"))
-        chosen = provider.choose_version("foo", VersionRange.full())
-        # The broken candidate is rejected via the metadata-block path;
-        # the scan continues to ``0.9`` which does *not* conflict with
-        # bar=3.0 (its dep is bar>=1.0).  Returning ``0.9`` shows the
-        # safety check successfully kept the resolver from crashing.
-        assert chosen == V("0.9")
-
-    def test_per_package_skip_invalidated_when_blocker_changes(self) -> None:
-        """A recorded abort is dropped once the blocker decision changes,
-        and the normal look-ahead path runs again.
-        """
-        wheels = [make_wheel("1.0")]
-        meta = (
-            "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\nRequires-Dist: bar>=5.0\n"
-        )
-        coordinator = make_coordinator(wheels, metadata_text=meta, package="foo")
-        root_reqs = {"foo": VersionRange.full(admit_arbitrary=False)}
-        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
-        # Recorded state names bar==3.0, but the current decisions have
-        # bar==2.0, so the recorded state is stale.
-        provider.receive_partial_solution_hint({}, {"bar": V("2.0")})
-        provider._lookahead_aborted["foo"] = ("bar", V("3.0"))
-        chosen = provider.choose_version("foo", VersionRange.full())
-        # Look-ahead ran normally: foo==1.0 rejects because bar==2.0
-        # doesn't match its >=5.0 dep.
-        assert chosen is None
-        # Stale record was dropped.
-        assert "foo" not in provider._lookahead_aborted
 
 
 class TestConstraintNotBlamedWhenProbeAborts:
@@ -7765,7 +7629,7 @@ class TestSpeculativePrefetchBatchLimit:
 
 
 class TestPrefetchWalkAhead:
-    """``prefetch_walk_ahead`` covers the abort-skip walk after the scan.
+    """``prefetch_walk_ahead`` covers the walk past the first batch.
 
     Fired from ``_scan_candidates_pipelined``; submits up to
     ``DEEP_PREFETCH_COUNT`` wheel metadata requests in scan order over


### PR DESCRIPTION
`choose_version`'s look-ahead abort leaves a per-package note of the blocker decision it gave up on, so a later call for that package can return its first candidate without re-running the scan. The note does get used, usually by one package in a long resolve, but it saves nothing measurable: the abort front-loads metadata for the versions ahead, so the scan it skips is served from cache and ends in the same abort.

What it does change is the force-backtrack budget. Skipping the scan skips the abort, so the blocker never spends the rest of its per-blocker force-backtracks. `rip-apache-airflow-all-modern` runs out of iterations on main and reaches an unsat derivation without the note.

This drops the note and its skip path, along with the snapshot `has_satisfying_version` kept so a probe could not leak it into a later decision. The abort is unchanged: it still discards the pending decision blocks, queues the blocker under the per-blocker cap, and hands back the first candidate.
