### PR TITLE
reject unknown benchmark scenario settings

### DIFF
--- a/nab-python/benchmarks/_profile_runner.py
+++ b/nab-python/benchmarks/_profile_runner.py
@@ -38,6 +38,7 @@ from benchmark_config import (
     parse_scenario_vcs_config,
     parse_trust_unverified_sdist_deps,
     validate_scenario_build_policy,
+    validate_scenario_settings,
 )
 
 
@@ -81,6 +82,7 @@ def build_inputs(
     resolution_override: sc.ResolutionStrategy | None = None,
     host: sc.BenchmarkHost | None = None,
 ) -> dict:
+    validate_scenario_settings(name, scenario)
     trust_unverified_sdist_deps = parse_trust_unverified_sdist_deps(name, scenario)
     requirement_inputs = parse_scenario_requirement_strings(name, scenario)
     vcs_config = parse_scenario_vcs_config(name, scenario)

--- a/nab-python/benchmarks/benchmark_config.py
+++ b/nab-python/benchmarks/benchmark_config.py
@@ -38,6 +38,30 @@ DEFAULT_INDEXES: tuple[IndexConfig, ...] = (
 )
 _INDEX_KEYS = frozenset({"name", "url", "serialization"})
 _INDEX_ROUTE_KEYS = frozenset({"name", "index"})
+_SCENARIO_SETTINGS = frozenset(
+    {
+        "requirements",
+        "constraints",
+        "project_name",
+        "project_extras",
+        "optional_dependencies",
+        "indexes",
+        "index_routes",
+        "build_packages",
+        "trust_unverified_sdist_deps",
+        "vcs_policy",
+        "vcs_allowed_schemes",
+        "vcs_allowed_repos",
+        "vcs_require_pin",
+        "python_version",
+        "marker_environment",
+        "platform_system",
+        "resolution",
+        "datetime",
+        "requires_matching_host",
+        "unsupported_reason",
+    }
+)
 
 
 class _BenchmarkResolveInputs(NamedTuple):
@@ -66,6 +90,19 @@ class ScenarioProjectMetadata(NamedTuple):
     project_name: str | None
     project_extras: list[str]
     optional_dependencies: dict[str, list[str]]
+
+
+def validate_scenario_settings(
+    scenario_name: str,
+    scenario: Mapping[str, object],
+) -> None:
+    """Reject setting names that no live benchmark runner understands."""
+    unknown = sorted(
+        setting for setting in scenario if setting not in _SCENARIO_SETTINGS
+    )
+    if unknown:
+        msg = f"{scenario_name}: unknown scenario settings: {unknown!r}"
+        raise ValueError(msg)
 
 
 def _scenario_string_list(

--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -50,6 +50,7 @@ from benchmark_config import (
     parse_vcs_policy,
     parse_vcs_require_pin,
     validate_scenario_build_policy,
+    validate_scenario_settings,
 )
 from benchmark_host import (
     BenchmarkHost,
@@ -628,6 +629,9 @@ def select_scenarios(cases: list[CanaryCase]) -> list[CanaryCase]:
         )
         raise _SelectionError(msg)
 
+    for scenario_name, scenario in found_scenarios:
+        validate_scenario_settings(scenario_name, scenario)
+
     field_validators = (
         parse_trust_unverified_sdist_deps,
         parse_scenario_requirement_strings,
@@ -796,6 +800,7 @@ def _prepare_canary_execution(
     host: BenchmarkHost,
 ) -> CanaryPreparation:
     """Validate and prepare a supported canary scenario for this host."""
+    validate_scenario_settings(scenario_name, scenario)
     trust_unverified_sdist_deps = parse_trust_unverified_sdist_deps(
         scenario_name,
         scenario,

--- a/nab-python/benchmarks/scenarios.py
+++ b/nab-python/benchmarks/scenarios.py
@@ -48,6 +48,7 @@ from benchmark_config import (
     parse_scenario_vcs_config,
     parse_trust_unverified_sdist_deps,
     validate_scenario_build_policy,
+    validate_scenario_settings,
 )
 from benchmark_host import (
     HOST_TAG_MISMATCH_REASON,
@@ -580,6 +581,7 @@ def load_standard_corpus(files: list[Path]) -> list[StandardScenario]:
             for name, definition in scenarios.items()
         )
     for row in rows:
+        validate_scenario_settings(row.logical_key, row.definition)
         parse_trust_unverified_sdist_deps(row.logical_key, row.definition)
         parse_scenario_requirement_strings(row.logical_key, row.definition)
         parse_scenario_vcs_config(row.logical_key, row.definition)
@@ -1469,6 +1471,7 @@ def prepare_standard_execution(
     """Prepare and identify one execution without performing network work."""
     scenario_name = execution.scenario.name
     scenario = execution.scenario.definition
+    validate_scenario_settings(scenario_name, scenario)
     trust_unverified_sdist_deps = parse_trust_unverified_sdist_deps(
         scenario_name,
         scenario,

--- a/nab-python/tests/test_benchmark_canary_selection.py
+++ b/nab-python/tests/test_benchmark_canary_selection.py
@@ -551,6 +551,46 @@ def test_selection_validates_requirement_lists_before_vcs_pin_settings(
 
 
 @pytest.mark.parametrize(
+    "unsupported_reason",
+    [None, "not runnable"],
+    ids=("supported", "unsupported"),
+)
+def test_selection_validates_unknown_settings_across_the_whole_selection(
+    monkeypatch: pytest.MonkeyPatch,
+    unsupported_reason: str | None,
+) -> None:
+    module = _harness()
+    second: dict[str, object] = {
+        "requirements": [],
+        "trust_unverified_sdist_dependencies": False,
+    }
+    if unsupported_reason is not None:
+        second["unsupported_reason"] = unsupported_reason
+    scenarios = {
+        "quick:first": {
+            "requirements": [],
+            "trust_unverified_sdist_deps": "false",
+        },
+        "quick:second": second,
+    }
+    monkeypatch.setattr(module, "find_scenario", scenarios.get)
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "quick:second: unknown scenario settings: "
+            "['trust_unverified_sdist_dependencies']"
+        ),
+    ):
+        module.select_scenarios(
+            [
+                module.CanaryCase("quick:first", None),
+                module.CanaryCase("quick:second", None),
+            ]
+        )
+
+
+@pytest.mark.parametrize(
     ("vcs_settings", "message"),
     [
         (
@@ -843,6 +883,14 @@ def test_selection_rejects_unknown_marker_variables_on_unsupported_rows(
     ("scenario", "message"),
     [
         (
+            {
+                "requirements": [],
+                "trust_unverified_sdist_deps": "false",
+                "trust_unverified_sdist_dependencies": False,
+            },
+            "unknown scenario settings: ['trust_unverified_sdist_dependencies']",
+        ),
+        (
             {"requirements": [], "build_packages": "demo"},
             "build_packages must be a list of package names",
         ),
@@ -862,7 +910,13 @@ def test_selection_rejects_unknown_marker_variables_on_unsupported_rows(
             "unknown marker_environment variables: ['platform_codename']",
         ),
     ],
-    ids=("build-packages", "resolution", "host-requirement", "marker-variable"),
+    ids=(
+        "unknown-setting",
+        "build-packages",
+        "resolution",
+        "host-requirement",
+        "marker-variable",
+    ),
 )
 def test_selected_scenario_preflight_fails_before_host_and_output(
     tmp_path: Path,

--- a/nab-python/tests/test_benchmark_strategy_matrix.py
+++ b/nab-python/tests/test_benchmark_strategy_matrix.py
@@ -32,6 +32,29 @@ _STANDARD_SCENARIOS = 558
 _RUNNABLE_SCENARIOS = 536
 _UNSUPPORTED_SCENARIOS = 22
 _TOTAL_EXECUTION_IDENTITIES = 1_674
+# Keep the expected vocabulary independent of the validator's private set.
+_LIVE_SCENARIO_SETTINGS = {
+    "requirements",
+    "constraints",
+    "project_name",
+    "project_extras",
+    "optional_dependencies",
+    "indexes",
+    "index_routes",
+    "build_packages",
+    "trust_unverified_sdist_deps",
+    "vcs_policy",
+    "vcs_allowed_schemes",
+    "vcs_allowed_repos",
+    "vcs_require_pin",
+    "python_version",
+    "marker_environment",
+    "platform_system",
+    "resolution",
+    "datetime",
+    "requires_matching_host",
+    "unsupported_reason",
+}
 _MARKER_BUILD_SCENARIOS = {
     "ai-stack:llama-index-experimental-gpt5",
     "ai-stack:open-r1",
@@ -405,6 +428,32 @@ def _harness(name: str) -> ModuleType:
     finally:
         sys.path.remove(str(_BENCHMARKS))
     return module
+
+
+def test_scenario_setting_validator_accepts_the_complete_live_vocabulary() -> None:
+    module = _harness("benchmark_config")
+
+    module.validate_scenario_settings(
+        "example",
+        dict.fromkeys(_LIVE_SCENARIO_SETTINGS),
+    )
+
+
+def test_scenario_setting_validator_sorts_unknown_names() -> None:
+    module = _harness("benchmark_config")
+    scenario = {
+        "trust_unverified_sdist_dependencies": False,
+        "output_directory": "results",
+    }
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "example: unknown scenario settings: "
+            "['output_directory', 'trust_unverified_sdist_dependencies']"
+        ),
+    ):
+        module.validate_scenario_settings("example", scenario)
 
 
 def _matching_host_rows(module: ModuleType) -> dict[str, object]:
@@ -2862,6 +2911,44 @@ requires_matching_host = "yes"
     [None, "not runnable"],
     ids=("supported", "unsupported"),
 )
+def test_standard_corpus_rejects_unknown_settings_before_other_fields(
+    tmp_path: Path,
+    unsupported_reason: str | None,
+) -> None:
+    module = _harness("scenarios")
+    path = tmp_path / "quick.toml"
+    unsupported_declaration = (
+        f'unsupported_reason = "{unsupported_reason}"'
+        if unsupported_reason is not None
+        else ""
+    )
+    path.write_text(
+        f"""
+[example]
+python_version = "3.11"
+requirements = []
+{unsupported_declaration}
+trust_unverified_sdist_deps = "false"
+trust_unverified_sdist_dependencies = false
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "quick:example: unknown scenario settings: "
+            "['trust_unverified_sdist_dependencies']"
+        ),
+    ):
+        module.load_standard_corpus([path])
+
+
+@pytest.mark.parametrize(
+    "unsupported_reason",
+    [None, "not runnable"],
+    ids=("supported", "unsupported"),
+)
 def test_standard_corpus_rejects_unknown_marker_variables(
     tmp_path: Path,
     unsupported_reason: str | None,
@@ -3771,6 +3858,20 @@ python_version = "3.11"
 requirements = []
 unsupported_reason = "not runnable"
 trust_unverified_sdist_deps = "false"
+trust_unverified_sdist_dependencies = false
+""",
+            (
+                "other:other: unknown scenario settings: "
+                "['trust_unverified_sdist_dependencies']"
+            ),
+        ),
+        (
+            """
+[other]
+python_version = "3.11"
+requirements = []
+unsupported_reason = "not runnable"
+trust_unverified_sdist_deps = "false"
 """,
             "other:other: trust_unverified_sdist_deps must be a boolean, got str",
         ),
@@ -3909,6 +4010,7 @@ vcs_allowed_repos = { "https://example.test/repo" = false }
         ),
     ],
     ids=(
+        "unknown-setting",
         "sdist-trust",
         "requirements",
         "project-metadata",
@@ -3997,6 +4099,14 @@ def test_profile_runner_accepts_an_explicit_strategy() -> None:
     ("field", "value", "message"),
     [
         (
+            "trust_unverified_sdist_dependencies",
+            False,
+            (
+                "example: unknown scenario settings: "
+                "['trust_unverified_sdist_dependencies']"
+            ),
+        ),
+        (
             "vcs_require_pin",
             "false",
             "example: vcs_require_pin must be a boolean, got str",
@@ -4033,6 +4143,7 @@ def test_profile_runner_accepts_an_explicit_strategy() -> None:
         ),
     ],
     ids=(
+        "unknown-setting",
         "pin",
         "policy",
         "scheme-table",
@@ -4315,6 +4426,50 @@ def test_unknown_marker_variables_fail_before_runner_host_admission() -> None:
 
     with pytest.raises(ValueError, match=re.escape(message)):
         _prepare_standard_scenario(standard, scenario, host)
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        canary._prepare_canary_execution(
+            scenario,
+            scenario_name="example",
+            resolution_override=None,
+            host=host,
+        )
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        profile.build_inputs("example", scenario, host=host)
+
+    host.target_for.assert_not_called()
+
+
+def test_unknown_scenario_settings_fail_at_every_direct_runner_boundary() -> None:
+    standard = _harness("scenarios")
+    canary = _harness("canary")
+    profile = _harness("_profile_runner")
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        "trust_unverified_sdist_deps": "false",
+        "trust_unverified_sdist_dependencies": False,
+    }
+    message = (
+        "example: unknown scenario settings: ['trust_unverified_sdist_dependencies']"
+    )
+    execution = standard.StandardExecution(
+        standard.StandardScenario("quick", "example", scenario),
+        standard.ResolutionStrategy.HIGHEST,
+    )
+    target = _linux_host(standard).target
+    host = MagicMock()
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        standard.prepare_standard_execution(
+            execution,
+            target,
+            commit="run",
+            source=dict(_CLEAN_SOURCE),
+            corpus_hash="f" * 64,
+            settings_digest="settings",
+        )
 
     with pytest.raises(ValueError, match=re.escape(message)):
         canary._prepare_canary_execution(


### PR DESCRIPTION
A scenario with `trust_unverified_sdist_dependencies = false` was accepted by the standard, canary, and profile runners even though each runner prepared resolver inputs with `trust_unverified_sdist_deps = true`.

The benchmark runners now reject unknown scenario setting names before host admission or output. Unsupported scenarios keep their existing exception for combining `marker_environment` with `build_packages`, but their setting names are still validated.
