### PR TITLE
mark two trust-dependent benchmarks unsupported

### DIFF
--- a/nab-python/benchmarks/scenarios/ai-stack.toml
+++ b/nab-python/benchmarks/scenarios/ai-stack.toml
@@ -531,9 +531,7 @@ requirements = ["pyautogen[long-context]", "PyMuPDF"]
 python_version = "3.11"
 platform_system = "Linux"
 datetime = "2025-06-01 10:00:00"
-# Resolves only by trusting a pre-2.2 sdist's PKG-INFO deps, which the
-# strict PEP 643 default routes to a build (BuildPolicy.NEVER fails).
-trust_unverified_sdist_deps = true
+unsupported_reason = "requires unverified sdist dependency metadata"
 requirements = [
     "streamlit",
     "langchain",
@@ -554,9 +552,7 @@ requirements = [
 python_version = "3.10"
 platform_system = "Linux"
 datetime = "2025-01-16 13:37:05"
-# Resolves only by trusting a pre-2.2 sdist's PKG-INFO deps, which the
-# strict PEP 643 default routes to a build (BuildPolicy.NEVER fails).
-trust_unverified_sdist_deps = true
+unsupported_reason = "requires unverified sdist dependency metadata"
 requirements = [
     "langchain",
     "langchain-community",

--- a/nab-python/tests/test_benchmark_canary_selection.py
+++ b/nab-python/tests/test_benchmark_canary_selection.py
@@ -30,8 +30,8 @@ _EXPECTED_V2_INPUT_HASHES = {
     "forums-lowest-direct:so-dbt-core-snowflake-79744735": "2f409a250216abc0c5f89f74bf752db4c2b6b1564264d2df2d22dbb8f3a8d541",
     "uv-lowest:uv-issue-16601-xinference": "a6aa7fbec8e1291349a311745800095e4ed52c02805180da8517299860fb5476",
     "uv-lowest:uv-issue-16601-xinference-fixed": "109bb4cd7dd756a96f5b04edd007f3312fe5853c442ea7ee1b64ae6ea234903f",
-    "ai-stack:rag-chroma-langchain": "7dfda04a2fb704451afd48ee66d3fb617955535138f663dc7926ce397a304722",
-    "ai-stack:streamlit-langchain": "906384169268c46027f15ddead1f021edbc2f20589bd165ebf5ddc1e521fe338",
+    "ai-stack:rag-chroma-langchain": "0aeb86e88d6f7410ef858b51c4104d1f5c79349b9c25a1b71e7b59e053b642fe",
+    "ai-stack:streamlit-langchain": "145f34978276b96146e589c080ece06229d3b4817e619f2dfbf7ae95b247f784",
 }
 
 

--- a/nab-python/tests/test_benchmark_strategy_matrix.py
+++ b/nab-python/tests/test_benchmark_strategy_matrix.py
@@ -29,8 +29,8 @@ from nab_python.target import ResolveTarget
 _BENCHMARKS = Path(__file__).resolve().parents[1] / "benchmarks"
 _STANDARD_FILES = 14
 _STANDARD_SCENARIOS = 558
-_RUNNABLE_SCENARIOS = 536
-_UNSUPPORTED_SCENARIOS = 22
+_RUNNABLE_SCENARIOS = 534
+_UNSUPPORTED_SCENARIOS = 24
 _TOTAL_EXECUTION_IDENTITIES = 1_674
 # Keep the expected vocabulary independent of the validator's private set.
 _LIVE_SCENARIO_SETTINGS = {
@@ -64,6 +64,11 @@ _MARKER_BUILD_SCENARIOS = {
     "pip:pip-9572-textract-pypdf2",
     "uv:uv-issue-13321-axolotl-stack",
 }
+_UNVERIFIED_SDIST_METADATA_SCENARIOS = {
+    "ai-stack:rag-chroma-langchain",
+    "ai-stack:streamlit-langchain",
+}
+_UNVERIFIED_SDIST_METADATA_REASON = "requires unverified sdist dependency metadata"
 _MATCHING_HOST_MARKERS = {
     "uv:uv-tensorflow-macos": {
         "implementation_name": "cpython",
@@ -2789,6 +2794,22 @@ def test_marker_build_scenarios_are_explicitly_unsupported() -> None:
     assert sum("build_packages" in row.definition for row in rows) == 7
     assert all(
         row.definition.get("unsupported_reason") for row in marker_build_rows.values()
+    )
+
+
+def test_unverified_sdist_metadata_scenarios_are_explicitly_unsupported() -> None:
+    module = _harness("scenarios")
+    rows = module.load_standard_corpus(module.standard_scenario_files())
+    definitions = {row.logical_key: row.definition for row in rows}
+    affected = {
+        key
+        for key, definition in definitions.items()
+        if definition.get("unsupported_reason") == _UNVERIFIED_SDIST_METADATA_REASON
+    }
+
+    assert affected == _UNVERIFIED_SDIST_METADATA_SCENARIOS
+    assert all(
+        "trust_unverified_sdist_deps" not in definitions[key] for key in affected
     )
 
 


### PR DESCRIPTION
The `streamlit-langchain` and `rag-chroma-langchain` scenarios resolve only when the benchmark accepts unverified dependency metadata from legacy sdists. Their definitions remain in the corpus but are now marked unsupported, so those trust-dependent results are no longer counted as successful benchmark runs.