### PR TITLE
Fix VCS URLs with credentials slipping past vcs.allowed-repos

### DIFF
--- a/nab-python/src/nab_python/_vcs_admission.py
+++ b/nab-python/src/nab_python/_vcs_admission.py
@@ -16,8 +16,9 @@ from __future__ import annotations
 
 import enum
 import posixpath
+import re
 from dataclasses import dataclass
-from urllib.parse import unquote, urlsplit, urlunsplit
+from urllib.parse import unquote, urlsplit
 
 from nab_index.vcs import FULL_GIT_SHA_RE
 
@@ -113,18 +114,26 @@ def split_vcs_scheme(url: str) -> tuple[str | None, str]:
     return (None, url)
 
 
+# The authority ends at the first "/", "?" or "#"; its userinfo ends at
+# the last "@" before that.
+_AUTHORITY_USERINFO_RE = re.compile(r"^([^/?#]*//)[^/?#]*@")
+
+
 def _without_userinfo(url: str) -> str:
     """Drop any authority ``user[:pass]@`` / SSH ``git@`` from ``url``.
 
     An ``allowed-repos`` prefix names a repo by scheme + host + path, not
     by credentials, so both the candidate URL and the prefix are stripped
     before the match. A URL with no userinfo is returned unchanged.
+
+    The cut is made on the raw string, since
+    :func:`urllib.parse.urlsplit` deletes every tab, CR and LF and does
+    not record an empty ``?``: a URL rebuilt from the parse is not the
+    one git is handed.
     """
-    parts = urlsplit(url)
-    if "@" not in parts.netloc:
+    if "@" not in urlsplit(url).netloc:
         return url
-    host = parts.netloc.rsplit("@", 1)[1]
-    return urlunsplit(parts._replace(netloc=host))
+    return _AUTHORITY_USERINFO_RE.sub(r"\1", url)
 
 
 def _drop_ref(remainder: str) -> str:

--- a/nab-python/tests/property_python/test_vcs_admission.py
+++ b/nab-python/tests/property_python/test_vcs_admission.py
@@ -28,7 +28,7 @@ Invariants:
 from __future__ import annotations
 
 import posixpath
-from urllib.parse import unquote, urlsplit, urlunsplit
+from urllib.parse import unquote, urlsplit
 
 import pytest
 from hypothesis import given
@@ -71,21 +71,18 @@ def _is_full_sha(ref: str) -> bool:
     return len(ref) == 40 and all(c in "0123456789abcdefABCDEF" for c in ref)
 
 
+ALLOWED_REPOS = [
+    "https://github.com/org",
+    "https://example.org/",
+    "ssh://git@github.com/org/repo.git",
+    "",
+]
+
 configs = st.builds(
     VcsConfig,
     policy=st.sampled_from([VcsPolicy.BLOCK, VcsPolicy.ALLOW]),
     allowed_schemes=st.frozensets(st.sampled_from(VALID_SCHEMES), max_size=5),
-    allowed_repos=st.lists(
-        st.sampled_from(
-            [
-                "https://github.com/org",
-                "https://example.org/",
-                "ssh://git@github.com/org/repo.git",
-                "",
-            ]
-        ),
-        max_size=2,
-    ).map(tuple),
+    allowed_repos=st.lists(st.sampled_from(ALLOWED_REPOS), max_size=2).map(tuple),
     require_pin=st.booleans(),
 )
 
@@ -139,6 +136,44 @@ def structured_urls(draw: st.DrawFn) -> str:
 
 
 @st.composite
+def boundary_cases(draw: st.DrawFn) -> tuple[str, VcsConfig]:
+    """A pinned URL continuing one ``allowed-repos`` entry, plus that config.
+
+    The candidate is built from the entry itself, since
+    ``structured_urls`` reaches the end of one only by chance: the drawn
+    tail is what the boundary rule has to judge, and the drawn login
+    sits in front of the authority.  A tail placed inside the authority
+    names a different host instead.
+    """
+    prefix = draw(st.sampled_from([entry for entry in ALLOWED_REPOS if entry]))
+    login = draw(st.sampled_from(["", "git@", "user:pw@"]))
+    tail = draw(
+        st.sampled_from(
+            ["", "\t", "\r", "\n", "?", "?x", "x", "/x", ".git", ".gitx", "#f"]
+        )
+    )
+    position = draw(st.sampled_from(["authority", "end"]))
+    require_pin = draw(st.booleans())
+
+    scheme, _, rest = prefix.partition("://")
+    if position == "authority":
+        authority, slash, path = rest.partition("/")
+        cut = len(authority) // 2
+        rest = f"{authority[:cut]}{tail}{authority[cut:]}{slash}{path}"
+    else:
+        rest = f"{rest}{tail}"
+
+    config = VcsConfig(
+        policy=VcsPolicy.ALLOW,
+        allowed_schemes=frozenset(VALID_SCHEMES),
+        allowed_repos=(prefix,),
+        require_pin=require_pin,
+    )
+
+    return (f"git+{scheme}://{login}{rest}@{SHA}", config)
+
+
+@st.composite
 def escaping_urls(draw: st.DrawFn) -> str:
     """A pinned URL whose path resolves one level above where it is written."""
     scheme = draw(st.sampled_from(VALID_SCHEMES))
@@ -156,11 +191,18 @@ def _decision(url: str, config: VcsConfig) -> tuple[str, str]:
 
 
 def _drop_login(url: str) -> str:
-    """Strip any authority ``user[:pass]@`` / ``git@`` from ``url``."""
-    parts = urlsplit(url)
-    if "@" not in parts.netloc:
+    """Strip any authority ``user[:pass]@`` / ``git@`` from ``url``.
+
+    Cuts the raw string, since a URL rebuilt from :func:`urlsplit` has
+    lost every tab, CR and LF and any empty ``?``.
+    """
+    if "@" not in urlsplit(url).netloc:
         return url
-    return urlunsplit(parts._replace(netloc=parts.netloc.rsplit("@", 1)[1]))
+
+    head, _, rest = url.partition("//")
+    delimiters = [i for i in (rest.find(char) for char in "/?#") if i != -1]
+    end = min(delimiters, default=len(rest))
+    return f"{head}//{rest[:end].rpartition('@')[2]}{rest[end:]}"
 
 
 def _git_would_rewrite(path: str) -> bool:
@@ -249,6 +291,16 @@ def test_total_partition_and_determinism_arbitrary_text(
 @PROPERTY_SETTINGS
 @given(url=structured_urls(), config=configs)
 def test_matches_documented_oracle(url: str, config: VcsConfig) -> None:
+    assert _decision(url, config)[0] == _oracle(url, config)
+
+
+@PROPERTY_SETTINGS
+@given(case=boundary_cases())
+def test_prefix_boundary_matches_documented_oracle(
+    case: tuple[str, VcsConfig],
+) -> None:
+    """The character ending an entry decides the match, credentials or not."""
+    url, config = case
     assert _decision(url, config)[0] == _oracle(url, config)
 
 

--- a/nab-python/tests/test_vcs_admission.py
+++ b/nab-python/tests/test_vcs_admission.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import pytest
 
+from nab_index.vcs import VcsRequest
 from nab_python._vcs_admission import (
     UnsupportedVcsError,
     VcsConfig,
@@ -811,6 +812,71 @@ class TestAdmitVcsUrlUserinfoPosition:
         )
         with pytest.raises(UnsupportedVcsError, match="not in vcs.allowed-repos"):
             admit_vcs_url("git+https://github.com@elsewhere.example/foo", config)
+
+
+class TestAdmitVcsUrlRawBytes:
+    """A login in the URL does not change which bytes the prefix sees.
+
+    ``urlsplit`` deletes every tab, CR and LF and reports an empty ``?``
+    as no query, so the match runs on the raw URL rather than a rebuilt
+    one.
+    """
+
+    @pytest.mark.parametrize("login", ["", "git@"], ids=["anonymous", "login"])
+    @pytest.mark.parametrize("control", ["\t", "\r", "\n"], ids=["tab", "cr", "lf"])
+    def test_control_character_after_repo_refused(
+        self, control: str, login: str
+    ) -> None:
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+ssh"}),
+            allowed_repos=("ssh://git@github.com/myorg/repo",),
+        )
+        url = f"git+ssh://{login}github.com/myorg/repo{control}@{_FORTY}"
+        with pytest.raises(UnsupportedVcsError, match="not in vcs.allowed-repos"):
+            admit_vcs_url(url, config)
+
+    @pytest.mark.parametrize("control", ["\t", "\r", "\n"], ids=["tab", "cr", "lf"])
+    def test_control_character_inside_host_refused(self, control: str) -> None:
+        """The entry names github.com; git would be handed a different host."""
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+https"}),
+            allowed_repos=("https://github.com/myorg/repo",),
+        )
+        host = f"git{control}hub.com"
+        url = f"git+https://user@{host}/myorg/repo@{_FORTY}"
+        assert VcsRequest.parse(url).repo_url == f"https://user@{host}/myorg/repo"
+
+        with pytest.raises(UnsupportedVcsError, match="not in vcs.allowed-repos"):
+            admit_vcs_url(url, config)
+
+    @pytest.mark.parametrize("login", ["", "user@"], ids=["anonymous", "login"])
+    def test_empty_query_after_repo_refused(self, login: str) -> None:
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+https"}),
+            allowed_repos=("https://github.com/myorg/repo",),
+            require_pin=False,
+        )
+        with pytest.raises(UnsupportedVcsError, match="not in vcs.allowed-repos"):
+            admit_vcs_url(f"git+https://{login}github.com/myorg/repo?", config)
+
+    def test_control_character_reaches_the_clone_url(self) -> None:
+        """The tab survives into the clone URL, not just the admission check."""
+        request = VcsRequest.parse(f"git+ssh://git@github.com/myorg/repo\t@{_FORTY}")
+        assert request.repo_url == "ssh://git@github.com/myorg/repo\t"
+        assert request.ref == _FORTY
+
+    def test_prefix_naming_the_control_character_admits(self) -> None:
+        """Both sides keep their raw bytes, so an entry can name that path."""
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+ssh"}),
+            allowed_repos=("ssh://git@github.com/myorg/repo\t",),
+        )
+        url = f"git+ssh://git@github.com/myorg/repo\t@{_FORTY}"
+        assert admit_vcs_url(url, config) == "git+ssh"
 
 
 class TestAdmitVcsUrlMalformed:


### PR DESCRIPTION
`vcs.allowed-repos` was matched against a urlsplit/urlunsplit round trip of the candidate URL, but only when that URL carried credentials. The round trip deletes every tab, CR and LF and drops an empty `?`.

So `git+https://user@git<TAB>hub.com/myorg/repo@<sha>` matched an entry naming `https://github.com/myorg/repo` and was admitted, while git was handed the tabbed host. The same URL written without the `user@` skipped the round trip and was refused. Whether the allowlist saw the bytes git gets depended on whether credentials were present.

The credentials are now cut out of the raw string, so the candidate and the allowlist entry are compared as the URL that reaches the clone.
