### PR TITLE
Remove four out-of-scope ecosystem benchmarks

### DIFF
--- a/nab-python/benchmarks/scenarios/ecosystem.toml
+++ b/nab-python/benchmarks/scenarios/ecosystem.toml
@@ -54,26 +54,12 @@ platform_system = "Linux"
 datetime = "2026-03-19 16:03:38"
 requirements = ["ray[llm]==2.54.0"]
 
-[ray-llm-native-libs]
-# https://github.com/ray-project/ray/issues/62111
-python_version = "3.11"
-platform_system = "Linux"
-datetime = "2026-03-26 21:21:01"
-requirements = ["ray[llm]==2.55"]
-
 [ray-tune-sklearn]
 # https://github.com/ray-project/ray/issues/47266
 python_version = "3.12"
 platform_system = "Linux"
 datetime = "2024-08-22 00:31:58"
 requirements = ["tune-sklearn", "ray[tune]"]
-
-[ray-train-tune-import]
-# https://github.com/ray-project/ray/issues/58280
-python_version = "3.13"
-platform_system = "Linux"
-datetime = "2025-10-29 11:00:46"
-requirements = ["ray[tune]==2.51.0"]
 
 [ray-full]
 # "ray" with all extras -> huge dependency fanout.
@@ -119,16 +105,6 @@ requirements = [
     "gradio_leaderboard",
 ]
 
-[gradio-client-sync]
-# https://github.com/gradio-app/gradio/issues/12844
-python_version = "3.11"
-platform_system = "Linux"
-datetime = "2026-01-29 08:24:15"
-requirements = [
-    "gradio==6.5.0",
-    "gradio-client==2.0.3",
-]
-
 # -----------------------------------------------------------------------
 # Dask / Modin
 # -----------------------------------------------------------------------
@@ -141,18 +117,6 @@ datetime = "2025-11-21 16:49:04"
 requirements = [
     "dask==2025.11.0",
     "distributed==2025.11.0",
-]
-
-[dask-bottleneck-2024]
-# https://github.com/dask/dask/issues/12198
-python_version = "3.11"
-platform_system = "Linux"
-datetime = "2025-12-16 10:55:07"
-requirements = [
-    "dask>=2024.11.0",
-    "bottleneck",
-    "pandas",
-    "numpy",
 ]
 
 # -----------------------------------------------------------------------

--- a/nab-python/tests/test_benchmark_strategy_matrix.py
+++ b/nab-python/tests/test_benchmark_strategy_matrix.py
@@ -31,10 +31,16 @@ pytestmark = pytest.mark.benchmark
 
 _BENCHMARKS = Path(__file__).resolve().parents[1] / "benchmarks"
 _STANDARD_FILES = 14
-_STANDARD_SCENARIOS = 557
-_RUNNABLE_SCENARIOS = 533
+_STANDARD_SCENARIOS = 553
+_RUNNABLE_SCENARIOS = 529
 _UNSUPPORTED_SCENARIOS = 24
-_TOTAL_EXECUTION_IDENTITIES = 1_671
+_TOTAL_EXECUTION_IDENTITIES = 1_659
+_OUT_OF_SCOPE_ECOSYSTEM_SCENARIOS = {
+    "ecosystem:dask-bottleneck-2024",
+    "ecosystem:gradio-client-sync",
+    "ecosystem:ray-llm-native-libs",
+    "ecosystem:ray-train-tune-import",
+}
 # Keep the expected vocabulary independent of the validator's private set.
 _LIVE_SCENARIO_SETTINGS = {
     "requirements",
@@ -655,6 +661,7 @@ def test_standard_corpus_is_one_canonical_definition_per_scenario() -> None:
     assert runnable == _RUNNABLE_SCENARIOS
     assert len(rows) - runnable == _UNSUPPORTED_SCENARIOS
     assert all("resolution" not in row.definition for row in rows)
+    assert _OUT_OF_SCOPE_ECOSYSTEM_SCENARIOS.isdisjoint(row.logical_key for row in rows)
 
 
 def _scenario_input_key(definition: dict[str, object]) -> str:


### PR DESCRIPTION
Four ecosystem rows cite import or runtime failures, but the benchmark only resolves their requirements, so none of them can reproduce its cited report through dependency resolution:

- `ray-llm-native-libs`, which also uses a cutoff from before its pinned Ray release existed on PyPI
- `ray-train-tune-import`
- `gradio-client-sync`
- `dask-bottleneck-2024`

All four are removed.
