### PR TITLE
keep the marker algebra's memos inside one operation

### DIFF
--- a/nab-python/src/nab_python/_vendor/packaging/_markersets.py
+++ b/nab-python/src/nab_python/_vendor/packaging/_markersets.py
@@ -165,26 +165,18 @@ def _oversized_numeric(text: str) -> bool:
 # ---------------------------------------------------------------------------- atoms
 
 
-# A value atom's denotation is memoised per atom, so the cache lives and dies
-# with the atom's tree. The bound stops a long-lived atom evaluated against
-# ever-new points from accumulating them. The oversized-value guards run
-# uncached before any ``holds`` call, so a warm cache never bypasses them.
-_HOLDS_CACHE_LIMIT = 1024
-
-
 class Atom:
     """A normalised leaf whose ``holds`` gives its denotation on one point.
 
-    Immutable once constructed, apart from two private caches minted lazily. A
-    value atom memoises ``holds`` per point text, since decisions re-evaluate
-    the same points across cell partitions; a version atom mints its pool
-    entries once. Equality and hashing run off a field tuple precomputed at
-    construction; the caches never take part.
+    Immutable once constructed, apart from the version pool a version atom mints
+    lazily from its own literal. Equality and hashing run off a field tuple
+    precomputed at construction. A decision re-reads the same atom on the same point
+    across partitions of one axis; that memo belongs to the operation, not here, so
+    ``holds`` recomputes.
     """
 
     __slots__ = (
         "_hash",
-        "_holds_cache",
         "_key",
         "_pool_entries",
         "derive_mm",
@@ -208,7 +200,6 @@ class Atom:
 
     _key: tuple[str, str, str, str, str, bool, bool, bool]
     _hash: int
-    _holds_cache: dict[str, bool]
     _pool_entries: tuple[tuple[Version, str], ...] | None
 
     def __init__(
@@ -233,7 +224,6 @@ class Atom:
         self.derive_mm = derive_mm
         self._key = (kind, variable, origin, op, literal, swapped, positive, derive_mm)
         self._hash = hash(self._key)
-        self._holds_cache = {}
         self._pool_entries = None
 
     def __eq__(self, other: object) -> bool:
@@ -269,14 +259,7 @@ class Atom:
     def holds(self, point: object) -> bool:
         """Return the atom's truth on one point of its axis."""
         if self.kind == AXIS_VALUE:
-            text = str(point)
-            cache = self._holds_cache
-            if text in cache:
-                return cache[text]
-            result = _holds_value(self, text)
-            if len(cache) < _HOLDS_CACHE_LIMIT:
-                cache[text] = result
-            return result
+            return _holds_value(self, str(point))
         if self.kind == AXIS_SET:
             member = self.literal in point  # type: ignore[operator]
             return member if self.positive else not member
@@ -644,6 +627,32 @@ class Cell(NamedTuple):
     vector: tuple[bool, ...]
 
 
+class Memo:
+    """One operation's scratch: the partitions and atom truths it re-reads.
+
+    A decision run re-partitions one axis for overlapping atom sets and re-reads one
+    atom on one point across those partitions. Both are memoised here, and the
+    operation that creates this drops it, so nothing accumulates between calls.
+    """
+
+    __slots__ = ("partitions", "truths")
+
+    def __init__(self) -> None:
+        self.partitions: dict[tuple, list[Cell]] = {}
+        self.truths: dict[tuple[Atom, str], bool] = {}
+
+
+def _truth(atom: Atom, point: object, memo: Memo) -> bool:
+    """Return an atom's truth on one point, memoised for the operation's span."""
+    if atom.kind != AXIS_VALUE:
+        return atom.holds(point)
+    key = (atom, str(point))
+    hit = memo.truths.get(key)
+    if hit is None:
+        hit = memo.truths[key] = atom.holds(point)
+    return hit
+
+
 def _substring_cost(text: str) -> int:
     """Return the iteration count of the quadratic substring loop over ``text``."""
     n = len(text)
@@ -930,7 +939,7 @@ def _value_candidates(
 
 
 def _reduce_cells(
-    points: Iterable[object], atoms: Sequence[Atom], max_cells: int
+    points: Iterable[object], atoms: Sequence[Atom], max_cells: int, memo: Memo
 ) -> list[Cell]:
     points = list(points)
 
@@ -944,7 +953,7 @@ def _reduce_cells(
 
     representatives: dict[tuple, object] = {}
     for point in points:
-        vector = tuple(atom.holds(point) for atom in atoms)
+        vector = tuple(_truth(atom, point, memo) for atom in atoms)
         representatives.setdefault(vector, point)
         # Every one of the 2**len(atoms) truth vectors now has a representative;
         # the remaining points can only repeat one.
@@ -964,15 +973,15 @@ def _mentioned_names(atoms: Sequence[Atom]) -> list[str]:
 
 
 def partition_value_axis(
-    variable: str, atoms: Sequence[Atom], max_cells: int
+    variable: str, atoms: Sequence[Atom], max_cells: int, memo: Memo
 ) -> list[Cell]:
     """Cells of a version/string value axis."""
     return _reduce_cells(
-        _value_candidates(variable, atoms, max_cells), atoms, max_cells
+        _value_candidates(variable, atoms, max_cells), atoms, max_cells, memo
     )
 
 
-def partition_set_axis(atoms: Sequence[Atom], max_cells: int) -> list[Cell]:
+def partition_set_axis(atoms: Sequence[Atom], max_cells: int, memo: Memo) -> list[Cell]:
     """Cells of a set axis: the powerset over the mentioned names (guarded)."""
     names = _mentioned_names(atoms)
     count = len(names)
@@ -983,27 +992,26 @@ def partition_set_axis(atoms: Sequence[Atom], max_cells: int) -> list[Cell]:
         frozenset(names[i] for i in range(count) if mask & (1 << i))
         for mask in range(1 << count)
     ]
-    return _reduce_cells(subsets, atoms, max_cells)
+    return _reduce_cells(subsets, atoms, max_cells, memo)
 
 
-def partition_boolean_axis(atoms: Sequence[Atom], max_cells: int) -> list[Cell]:
+def partition_boolean_axis(
+    atoms: Sequence[Atom], max_cells: int, memo: Memo
+) -> list[Cell]:
     """Cells of an opaque boolean (contains) axis: the two truth values."""
-    return _reduce_cells((False, True), atoms, max_cells)
+    return _reduce_cells((False, True), atoms, max_cells, memo)
 
 
-def _partition_axis(axis: tuple, atoms: Sequence[Atom], max_cells: int) -> list[Cell]:
+def _partition_axis(
+    axis: tuple, atoms: Sequence[Atom], max_cells: int, memo: Memo
+) -> list[Cell]:
     kind = axis[0]
     if kind == AXIS_VALUE:
-        return partition_value_axis(axis[1], atoms, max_cells)
+        return partition_value_axis(axis[1], atoms, max_cells, memo)
     if kind == AXIS_SET:
-        return partition_set_axis(atoms, max_cells)
-    return partition_boolean_axis(atoms, max_cells)
+        return partition_set_axis(atoms, max_cells, memo)
+    return partition_boolean_axis(atoms, max_cells, memo)
 
-
-# One simplify re-partitions the same axes with the same atoms over and over.
-# The cache lives only for that span and is thread-local, so a concurrent
-# simplify never shares a store.
-_partition_cache = threading.local()
 
 # ``max_cells`` bounds one decision, and the greedy fixpoint issues one per
 # clause and per atom per universe row, so the meter is what bounds the run:
@@ -1024,16 +1032,22 @@ def charge_work(units: int) -> None:
         raise IntractableMarkerSet(msg)
 
 
-def partition_axis(axis: tuple, atoms: Sequence[Atom], max_cells: int) -> list[Cell]:
-    """Partition one axis's domain into cells on which every atom is constant."""
-    store: dict | None = getattr(_partition_cache, "store", None)
-    if store is None:
-        return _partition_axis(axis, atoms, max_cells)
+def partition_axis(
+    axis: tuple, atoms: Sequence[Atom], max_cells: int, store: Memo
+) -> list[Cell]:
+    """Partition one axis's domain into cells on which every atom is constant.
+
+    ``store`` memoises the partition for the span of one operation; its owner decides
+    that span, and this keeps no state of its own.
+
+    The atoms are keyed in order, not as a set: :class:`Cell` vectors are aligned
+    positionally with the list a partition was built for.
+    """
     key = (axis, tuple(atoms), max_cells)
-    cached = store.get(key)
+    cached = store.partitions.get(key)
     if cached is None:
-        cached = _partition_axis(axis, atoms, max_cells)
-        store[key] = cached
+        cached = _partition_axis(axis, atoms, max_cells, store)
+        store.partitions[key] = cached
     return cached
 
 
@@ -1168,7 +1182,7 @@ def _eval_cell(node: Formula, truth: Mapping[Atom, bool]) -> bool:
 
 
 def _satisfying_cells(
-    node: Formula, max_cells: int
+    node: Formula, max_cells: int, store: Memo
 ) -> Iterator[dict[tuple[str, ...], Cell]]:
     atoms = collect_atoms(node)
     grouped = _atoms_by_axis(atoms)
@@ -1180,7 +1194,7 @@ def _satisfying_cells(
     axes = list(grouped)
     atomlists = [grouped[axis] for axis in axes]
     partitions = [
-        partition_axis(axis, atoms, max_cells)
+        partition_axis(axis, atoms, max_cells, store)
         for axis, atoms in zip(axes, atomlists, strict=True)
     ]
 
@@ -1204,9 +1218,15 @@ def _satisfying_cells(
             yield dict(zip(axes, combo, strict=True))
 
 
-def is_empty(node: Formula, max_cells: int) -> bool:
-    """Whether a tree denotes the empty set."""
-    return next(_satisfying_cells(node, max_cells), _MISSING) is _MISSING
+def is_empty(node: Formula, max_cells: int, store: Memo | None = None) -> bool:
+    """Whether a tree denotes the empty set.
+
+    ``store`` is the caller's partition memo when this decision is one of a run
+    over related trees; a lone decision partitions each axis once either way and
+    passes nothing.
+    """
+    cells = _satisfying_cells(node, max_cells, Memo() if store is None else store)
+    return next(cells, _MISSING) is _MISSING
 
 
 def witness(node: Formula, max_cells: int) -> dict[str, str | frozenset[str]] | None:
@@ -1220,7 +1240,7 @@ def witness(node: Formula, max_cells: int) -> dict[str, str | frozenset[str]] | 
     ``python_version`` and ``python_full_version`` share one axis, so those
     constraints can sit on different variables.
     """
-    for cell in _satisfying_cells(node, max_cells):
+    for cell in _satisfying_cells(node, max_cells, Memo()):
         env = _materialize(cell)
         if evaluate_tree(node, env):
             return env
@@ -1513,9 +1533,10 @@ def _equivalent_within(
     so it overruns ``max_cells`` on a wide multi-platform universe.
     :func:`equivalent_within_rows` decides the same verdict per row instead.
     """
+    store: Memo = Memo()
     return is_empty(
-        make_and((left, universe, make_not(right))), max_cells
-    ) and is_empty(make_and((right, universe, make_not(left))), max_cells)
+        make_and((left, universe, make_not(right))), max_cells, store
+    ) and is_empty(make_and((right, universe, make_not(left))), max_cells, store)
 
 
 class _Row(NamedTuple):
@@ -1576,17 +1597,23 @@ def _rows_equivalent(
     rows: Sequence[_Row],
     right_by_row: Sequence[Formula],
     max_cells: int,
+    store: Memo,
 ) -> bool:
     """Whether ``left`` agrees with the per-row restriction of the constant right.
 
     Restricting each operand to a row's pins complements over that row's residual
-    rather than the whole-matrix product.
+    rather than the whole-matrix product.  The rows of one universe differ on few
+    axes, so ``store`` carries each axis's partition across them.
     """
     for row, right in zip(rows, right_by_row, strict=True):
         left_r = restrict_tree(left, row.pins)
-        if not is_empty(make_and((left_r, row.bound, make_not(right))), max_cells):
+        if not is_empty(
+            make_and((left_r, row.bound, make_not(right))), max_cells, store
+        ):
             return False
-        if not is_empty(make_and((right, row.bound, make_not(left_r))), max_cells):
+        if not is_empty(
+            make_and((right, row.bound, make_not(left_r))), max_cells, store
+        ):
             return False
     return True
 
@@ -1599,7 +1626,8 @@ def universe_is_empty(universe: Formula, max_cells: int) -> bool:
     """
     nnf = universe if isinstance(universe, BoolConst) else to_nnf(universe)
     disjuncts = nnf.children if isinstance(nnf, OrNode) else (nnf,)
-    return all(is_empty(disjunct, max_cells) for disjunct in disjuncts)
+    store: Memo = Memo()
+    return all(is_empty(disjunct, max_cells, store) for disjunct in disjuncts)
 
 
 def equivalent_within_rows(
@@ -1613,7 +1641,8 @@ def equivalent_within_rows(
     """
     rows = _decompose_rows(universe)
     right_by_row = [restrict_tree(right, row.pins) for row in rows]
-    return _rows_equivalent(left, rows, right_by_row, max_cells)
+    store: Memo = Memo()
+    return _rows_equivalent(left, rows, right_by_row, max_cells, store)
 
 
 def _dedupe(clauses: list[frozenset[Atom]]) -> list[frozenset[Atom]]:
@@ -1631,11 +1660,14 @@ def _drop_clauses(
     rows: Sequence[_Row],
     original_by_row: Sequence[Formula],
     max_cells: int,
+    store: Memo,
 ) -> list[frozenset[Atom]]:
     kept = list(clauses)
     for clause in sorted(clauses, key=_clause_key):
         trial = [other for other in kept if other != clause]
-        if _rows_equivalent(_disjunction(trial), rows, original_by_row, max_cells):
+        if _rows_equivalent(
+            _disjunction(trial), rows, original_by_row, max_cells, store
+        ):
             kept = trial
     return kept
 
@@ -1645,13 +1677,14 @@ def _drop_atoms(
     rows: Sequence[_Row],
     original_by_row: Sequence[Formula],
     max_cells: int,
+    store: Memo,
 ) -> list[frozenset[Atom]]:
     working = [set(clause) for clause in clauses]
     for clause in working:
         for atom in sorted(clause, key=_atom_key):
             clause.discard(atom)
             trial = _disjunction(frozenset(current) for current in working)
-            if not _rows_equivalent(trial, rows, original_by_row, max_cells):
+            if not _rows_equivalent(trial, rows, original_by_row, max_cells, store):
                 clause.add(atom)
     return [frozenset(clause) for clause in working]
 
@@ -1682,19 +1715,19 @@ def simplify_within(
     original = _disjunction(clauses)
     rows = _decompose_rows(universe)
     original_by_row = [restrict_tree(original, row.pins) for row in rows]
-    previous_store = getattr(_partition_cache, "store", None)
+    store: Memo = Memo()
     previous_work = getattr(_work_meter, "remaining", None)
-    _partition_cache.store = {}
     _work_meter.remaining = max_work
     try:
         while True:
             before = _canonical(clauses)
-            clauses = _drop_clauses(clauses, rows, original_by_row, max_cells)
-            clauses = _dedupe(_drop_atoms(clauses, rows, original_by_row, max_cells))
+            clauses = _drop_clauses(clauses, rows, original_by_row, max_cells, store)
+            clauses = _dedupe(
+                _drop_atoms(clauses, rows, original_by_row, max_cells, store)
+            )
             if _canonical(clauses) == before:
                 break
     finally:
-        _partition_cache.store = previous_store
         _work_meter.remaining = previous_work
     if not clauses:
         return FALSE

--- a/nab-python/src/nab_python/_vendor/packaging/markersets.py
+++ b/nab-python/src/nab_python/_vendor/packaging/markersets.py
@@ -216,13 +216,18 @@ class MarkerSet:
         """Whether the two sets denote the same environments.
 
         The semantic equality ``==`` cannot cheaply provide, so it is a method.
+
+        Both containments read the same two trees, so they share one partition memo.
         """
+        store = _markersets.Memo()
         return _markersets.is_empty(
             _markersets.make_and((self._tree, _markersets.make_not(other._tree))),
             _MAX_CELLS,
+            store,
         ) and _markersets.is_empty(
             _markersets.make_and((other._tree, _markersets.make_not(self._tree))),
             _MAX_CELLS,
+            store,
         )
 
     @_bounded
@@ -324,9 +329,7 @@ class MarkerSet:
             msg = "within must not be the empty set"
             raise ValueError(msg)
         return self._wrap(
-            _markersets.simplify_within(
-                self._tree, within._tree, _MAX_CELLS, _MAX_WORK
-            )
+            _markersets.simplify_within(self._tree, within._tree, _MAX_CELLS, _MAX_WORK)
         )
 
     # ---- serialisation

--- a/nab-python/tests/test_markersets.py
+++ b/nab-python/tests/test_markersets.py
@@ -12,6 +12,7 @@ import importlib.util
 from collections import defaultdict
 from functools import reduce
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 from packaging.markers import Marker
@@ -22,6 +23,11 @@ from nab_python._vendor.packaging.markersets import (
     IntractableMarkerSet,
     MarkerSet,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+    from nab_python._vendor.packaging._markersets import Atom, Cell
 
 _spec = importlib.util.spec_from_file_location(
     "simplify_corpus_fixtures",
@@ -490,4 +496,182 @@ def test_work_meter_is_unset_outside_a_simplify() -> None:
     within = _narrow_universe()
     ms(_narrow_linux_span()).simplify(within=within)
     assert getattr(engine._work_meter, "remaining", None) is None
-    assert getattr(engine._partition_cache, "store", None) is None
+
+
+def _partition_counter(monkeypatch: pytest.MonkeyPatch) -> Callable[[], int]:
+    """Start counting axis partitions, and return a reader for the count.
+
+    Counts the calls that reach :func:`_partition_axis`, so a partition served
+    from an operation's store adds nothing.
+    """
+    calls = 0
+    real = engine._partition_axis
+
+    def counting(
+        axis: tuple, atoms: Sequence[Atom], max_cells: int, memo: engine.Memo
+    ) -> list[Cell]:
+        nonlocal calls
+        calls += 1
+        return real(axis, atoms, max_cells, memo)
+
+    monkeypatch.setattr(engine, "_partition_axis", counting)
+    return lambda: calls
+
+
+def _truth_counter(monkeypatch: pytest.MonkeyPatch) -> Callable[[], int]:
+    """Start counting atom-truth evaluations, and return a reader for the count.
+
+    Counts the calls that reach :func:`_holds_value`, so a truth served from an
+    operation's memo adds nothing.
+    """
+    calls = 0
+    real = engine._holds_value
+
+    def counting(atom: Atom, text: str) -> bool:
+        nonlocal calls
+        calls += 1
+        return real(atom, text)
+
+    monkeypatch.setattr(engine, "_holds_value", counting)
+    return lambda: calls
+
+
+def _row_universe() -> MarkerSet:
+    """Return a universe of six rows, each pinning a python minor and a platform."""
+    return union(
+        *(
+            f'python_version == "3.{minor}" and sys_platform == "{platform}"'
+            for minor in (10, 11, 12)
+            for platform in ("linux", "darwin")
+        )
+    )
+
+
+# Operands reaching all three axis kinds: a version axis, a set axis through
+# ``extra``, and an opaque contains axis. A universe row pins ``sys_platform`` away,
+# so a scenario without the last two would exercise the value axis alone.
+_SPREAD = ' and extra == "gpu" and "arm" in platform_machine'
+
+
+def test_one_operation_partitions_each_axis_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A within-universe decision partitions each axis once, not once per row.
+
+    The row walk issues two emptiness decisions for each of the six rows, so the
+    count is exact rather than bounded: 5 partitions here, against 36 with the store
+    ignored and 27 with a store that serves value axes only.
+    """
+    left = ms('python_version < "3.12"' + _SPREAD)
+    right = ms('python_version < "3.12" and sys_platform != "aix"' + _SPREAD)
+
+    partitions = _partition_counter(monkeypatch)
+    assert left.equivalent_within(right, _row_universe()) is True
+
+    assert partitions() == 5
+
+
+def test_simplify_keeps_its_partitions_to_one_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two identical simplifies each pay for their own partitions.
+
+    ``simplify_within`` creates the store its greedy fixpoint reuses, so a second
+    call repeats the whole cost. A store reaching past one call would make the repeat
+    nearly free, which is what this refuses.
+    """
+    universe = _row_universe()
+    marker = ms('python_version < "3.12"' + _SPREAD)
+
+    partitions = _partition_counter(monkeypatch)
+    marker.simplify(within=universe)
+    first = partitions()
+    marker.simplify(within=universe)
+
+    assert first > 0
+    assert partitions() == 2 * first
+
+
+def test_one_operation_reads_each_atom_truth_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An atom's truth on one point is evaluated once per operation.
+
+    Partitions of one axis over overlapping atom sets re-read the same atom on the
+    same point, which is why the memo pays. 156 evaluations here, against 208 with
+    the memo bypassed.
+    """
+    left = ms('python_version < "3.12"' + _SPREAD)
+    right = ms('python_version < "3.12" and sys_platform != "aix"' + _SPREAD)
+
+    truths = _truth_counter(monkeypatch)
+    assert left.equivalent_within(right, _row_universe()) is True
+
+    assert truths() == 156
+
+
+def test_atoms_keep_no_truths_between_operations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A second identical decision re-evaluates every atom truth.
+
+    The memo belongs to the operation, not to the atom, so an ``Atom`` that outlives
+    a decision carries nothing from it. A per-atom cache would make the repeat nearly
+    free, which is what this refuses.
+    """
+    universe = _row_universe()
+    left = ms('python_version < "3.12"' + _SPREAD)
+    right = ms('python_version < "3.12" and sys_platform != "aix"' + _SPREAD)
+
+    truths = _truth_counter(monkeypatch)
+    left.equivalent_within(right, universe)
+    first = truths()
+    left.equivalent_within(right, universe)
+
+    assert first > 0
+    assert truths() == 2 * first
+
+
+def test_partition_is_keyed_on_atom_order_not_just_the_set() -> None:
+    """A partition's cell vectors stay aligned with the atom list it was built for.
+
+    ``collect_atoms`` returns encounter order and nothing normalises it, while
+    ``_rows_equivalent`` builds its two halves with the operands in opposite
+    positions. So one operation can reach one axis with one atom set in two orders,
+    and keying on an unordered set would answer the second from the first's cells.
+    """
+    atoms = engine.collect_atoms(
+        engine.parse('python_version < "3.11" and python_version >= "3.10"')
+    )
+    axis = atoms[0].axis()
+    memo = engine.Memo()
+
+    forward = engine.partition_axis(axis, atoms, _MAX_CELLS, memo)
+    backward = engine.partition_axis(axis, list(reversed(atoms)), _MAX_CELLS, memo)
+
+    for cell in forward:
+        assert cell.vector == tuple(atom.holds(cell.point) for atom in atoms)
+    for cell in backward:
+        assert cell.vector == tuple(atom.holds(cell.point) for atom in reversed(atoms))
+
+
+def test_partitions_do_not_outlive_one_operation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A second identical decision pays for its partitions again.
+
+    The store belongs to one operation, so nothing carries between two of them.
+    A cache reaching further would make the repeat free, which is what this
+    refuses.
+    """
+    universe = _row_universe()
+    left = ms('python_version < "3.12"' + _SPREAD)
+    right = ms('python_version < "3.12" and sys_platform != "aix"' + _SPREAD)
+
+    partitions = _partition_counter(monkeypatch)
+    left.equivalent_within(right, universe)
+    first = partitions()
+    left.equivalent_within(right, universe)
+
+    assert first > 0
+    assert partitions() == 2 * first

--- a/tasks/vendoring/packaging.patch
+++ b/tasks/vendoring/packaging.patch
@@ -1,9 +1,9 @@
 diff --git a/nab-python/src/nab_python/_vendor/packaging/_markersets.py b/nab-python/src/nab_python/_vendor/packaging/_markersets.py
 new file mode 100644
-index 0000000..054dd73
+index 0000000..c6a193e
 --- /dev/null
 +++ b/nab-python/src/nab_python/_vendor/packaging/_markersets.py
-@@ -0,0 +1,1708 @@
+@@ -0,0 +1,1741 @@
 +"""Marker algebra engine: reason about PEP 508 markers as sets of environments.
 +
 +The private engine behind :class:`~packaging.markersets.MarkerSet`. Parses a
@@ -171,26 +171,18 @@ index 0000000..054dd73
 +# ---------------------------------------------------------------------------- atoms
 +
 +
-+# A value atom's denotation is memoised per atom, so the cache lives and dies
-+# with the atom's tree. The bound stops a long-lived atom evaluated against
-+# ever-new points from accumulating them. The oversized-value guards run
-+# uncached before any ``holds`` call, so a warm cache never bypasses them.
-+_HOLDS_CACHE_LIMIT = 1024
-+
-+
 +class Atom:
 +    """A normalised leaf whose ``holds`` gives its denotation on one point.
 +
-+    Immutable once constructed, apart from two private caches minted lazily. A
-+    value atom memoises ``holds`` per point text, since decisions re-evaluate
-+    the same points across cell partitions; a version atom mints its pool
-+    entries once. Equality and hashing run off a field tuple precomputed at
-+    construction; the caches never take part.
++    Immutable once constructed, apart from the version pool a version atom mints
++    lazily from its own literal. Equality and hashing run off a field tuple
++    precomputed at construction. A decision re-reads the same atom on the same point
++    across partitions of one axis; that memo belongs to the operation, not here, so
++    ``holds`` recomputes.
 +    """
 +
 +    __slots__ = (
 +        "_hash",
-+        "_holds_cache",
 +        "_key",
 +        "_pool_entries",
 +        "derive_mm",
@@ -214,7 +206,6 @@ index 0000000..054dd73
 +
 +    _key: tuple[str, str, str, str, str, bool, bool, bool]
 +    _hash: int
-+    _holds_cache: dict[str, bool]
 +    _pool_entries: tuple[tuple[Version, str], ...] | None
 +
 +    def __init__(
@@ -239,7 +230,6 @@ index 0000000..054dd73
 +        self.derive_mm = derive_mm
 +        self._key = (kind, variable, origin, op, literal, swapped, positive, derive_mm)
 +        self._hash = hash(self._key)
-+        self._holds_cache = {}
 +        self._pool_entries = None
 +
 +    def __eq__(self, other: object) -> bool:
@@ -275,14 +265,7 @@ index 0000000..054dd73
 +    def holds(self, point: object) -> bool:
 +        """Return the atom's truth on one point of its axis."""
 +        if self.kind == AXIS_VALUE:
-+            text = str(point)
-+            cache = self._holds_cache
-+            if text in cache:
-+                return cache[text]
-+            result = _holds_value(self, text)
-+            if len(cache) < _HOLDS_CACHE_LIMIT:
-+                cache[text] = result
-+            return result
++            return _holds_value(self, str(point))
 +        if self.kind == AXIS_SET:
 +            member = self.literal in point  # type: ignore[operator]
 +            return member if self.positive else not member
@@ -650,6 +633,32 @@ index 0000000..054dd73
 +    vector: tuple[bool, ...]
 +
 +
++class Memo:
++    """One operation's scratch: the partitions and atom truths it re-reads.
++
++    A decision run re-partitions one axis for overlapping atom sets and re-reads one
++    atom on one point across those partitions. Both are memoised here, and the
++    operation that creates this drops it, so nothing accumulates between calls.
++    """
++
++    __slots__ = ("partitions", "truths")
++
++    def __init__(self) -> None:
++        self.partitions: dict[tuple, list[Cell]] = {}
++        self.truths: dict[tuple[Atom, str], bool] = {}
++
++
++def _truth(atom: Atom, point: object, memo: Memo) -> bool:
++    """Return an atom's truth on one point, memoised for the operation's span."""
++    if atom.kind != AXIS_VALUE:
++        return atom.holds(point)
++    key = (atom, str(point))
++    hit = memo.truths.get(key)
++    if hit is None:
++        hit = memo.truths[key] = atom.holds(point)
++    return hit
++
++
 +def _substring_cost(text: str) -> int:
 +    """Return the iteration count of the quadratic substring loop over ``text``."""
 +    n = len(text)
@@ -936,7 +945,7 @@ index 0000000..054dd73
 +
 +
 +def _reduce_cells(
-+    points: Iterable[object], atoms: Sequence[Atom], max_cells: int
++    points: Iterable[object], atoms: Sequence[Atom], max_cells: int, memo: Memo
 +) -> list[Cell]:
 +    points = list(points)
 +
@@ -950,7 +959,7 @@ index 0000000..054dd73
 +
 +    representatives: dict[tuple, object] = {}
 +    for point in points:
-+        vector = tuple(atom.holds(point) for atom in atoms)
++        vector = tuple(_truth(atom, point, memo) for atom in atoms)
 +        representatives.setdefault(vector, point)
 +        # Every one of the 2**len(atoms) truth vectors now has a representative;
 +        # the remaining points can only repeat one.
@@ -970,15 +979,15 @@ index 0000000..054dd73
 +
 +
 +def partition_value_axis(
-+    variable: str, atoms: Sequence[Atom], max_cells: int
++    variable: str, atoms: Sequence[Atom], max_cells: int, memo: Memo
 +) -> list[Cell]:
 +    """Cells of a version/string value axis."""
 +    return _reduce_cells(
-+        _value_candidates(variable, atoms, max_cells), atoms, max_cells
++        _value_candidates(variable, atoms, max_cells), atoms, max_cells, memo
 +    )
 +
 +
-+def partition_set_axis(atoms: Sequence[Atom], max_cells: int) -> list[Cell]:
++def partition_set_axis(atoms: Sequence[Atom], max_cells: int, memo: Memo) -> list[Cell]:
 +    """Cells of a set axis: the powerset over the mentioned names (guarded)."""
 +    names = _mentioned_names(atoms)
 +    count = len(names)
@@ -989,27 +998,26 @@ index 0000000..054dd73
 +        frozenset(names[i] for i in range(count) if mask & (1 << i))
 +        for mask in range(1 << count)
 +    ]
-+    return _reduce_cells(subsets, atoms, max_cells)
++    return _reduce_cells(subsets, atoms, max_cells, memo)
 +
 +
-+def partition_boolean_axis(atoms: Sequence[Atom], max_cells: int) -> list[Cell]:
++def partition_boolean_axis(
++    atoms: Sequence[Atom], max_cells: int, memo: Memo
++) -> list[Cell]:
 +    """Cells of an opaque boolean (contains) axis: the two truth values."""
-+    return _reduce_cells((False, True), atoms, max_cells)
++    return _reduce_cells((False, True), atoms, max_cells, memo)
 +
 +
-+def _partition_axis(axis: tuple, atoms: Sequence[Atom], max_cells: int) -> list[Cell]:
++def _partition_axis(
++    axis: tuple, atoms: Sequence[Atom], max_cells: int, memo: Memo
++) -> list[Cell]:
 +    kind = axis[0]
 +    if kind == AXIS_VALUE:
-+        return partition_value_axis(axis[1], atoms, max_cells)
++        return partition_value_axis(axis[1], atoms, max_cells, memo)
 +    if kind == AXIS_SET:
-+        return partition_set_axis(atoms, max_cells)
-+    return partition_boolean_axis(atoms, max_cells)
++        return partition_set_axis(atoms, max_cells, memo)
++    return partition_boolean_axis(atoms, max_cells, memo)
 +
-+
-+# One simplify re-partitions the same axes with the same atoms over and over.
-+# The cache lives only for that span and is thread-local, so a concurrent
-+# simplify never shares a store.
-+_partition_cache = threading.local()
 +
 +# ``max_cells`` bounds one decision, and the greedy fixpoint issues one per
 +# clause and per atom per universe row, so the meter is what bounds the run:
@@ -1030,16 +1038,22 @@ index 0000000..054dd73
 +        raise IntractableMarkerSet(msg)
 +
 +
-+def partition_axis(axis: tuple, atoms: Sequence[Atom], max_cells: int) -> list[Cell]:
-+    """Partition one axis's domain into cells on which every atom is constant."""
-+    store: dict | None = getattr(_partition_cache, "store", None)
-+    if store is None:
-+        return _partition_axis(axis, atoms, max_cells)
++def partition_axis(
++    axis: tuple, atoms: Sequence[Atom], max_cells: int, store: Memo
++) -> list[Cell]:
++    """Partition one axis's domain into cells on which every atom is constant.
++
++    ``store`` memoises the partition for the span of one operation; its owner decides
++    that span, and this keeps no state of its own.
++
++    The atoms are keyed in order, not as a set: :class:`Cell` vectors are aligned
++    positionally with the list a partition was built for.
++    """
 +    key = (axis, tuple(atoms), max_cells)
-+    cached = store.get(key)
++    cached = store.partitions.get(key)
 +    if cached is None:
-+        cached = _partition_axis(axis, atoms, max_cells)
-+        store[key] = cached
++        cached = _partition_axis(axis, atoms, max_cells, store)
++        store.partitions[key] = cached
 +    return cached
 +
 +
@@ -1174,7 +1188,7 @@ index 0000000..054dd73
 +
 +
 +def _satisfying_cells(
-+    node: Formula, max_cells: int
++    node: Formula, max_cells: int, store: Memo
 +) -> Iterator[dict[tuple[str, ...], Cell]]:
 +    atoms = collect_atoms(node)
 +    grouped = _atoms_by_axis(atoms)
@@ -1186,7 +1200,7 @@ index 0000000..054dd73
 +    axes = list(grouped)
 +    atomlists = [grouped[axis] for axis in axes]
 +    partitions = [
-+        partition_axis(axis, atoms, max_cells)
++        partition_axis(axis, atoms, max_cells, store)
 +        for axis, atoms in zip(axes, atomlists, strict=True)
 +    ]
 +
@@ -1210,9 +1224,15 @@ index 0000000..054dd73
 +            yield dict(zip(axes, combo, strict=True))
 +
 +
-+def is_empty(node: Formula, max_cells: int) -> bool:
-+    """Whether a tree denotes the empty set."""
-+    return next(_satisfying_cells(node, max_cells), _MISSING) is _MISSING
++def is_empty(node: Formula, max_cells: int, store: Memo | None = None) -> bool:
++    """Whether a tree denotes the empty set.
++
++    ``store`` is the caller's partition memo when this decision is one of a run
++    over related trees; a lone decision partitions each axis once either way and
++    passes nothing.
++    """
++    cells = _satisfying_cells(node, max_cells, Memo() if store is None else store)
++    return next(cells, _MISSING) is _MISSING
 +
 +
 +def witness(node: Formula, max_cells: int) -> dict[str, str | frozenset[str]] | None:
@@ -1226,7 +1246,7 @@ index 0000000..054dd73
 +    ``python_version`` and ``python_full_version`` share one axis, so those
 +    constraints can sit on different variables.
 +    """
-+    for cell in _satisfying_cells(node, max_cells):
++    for cell in _satisfying_cells(node, max_cells, Memo()):
 +        env = _materialize(cell)
 +        if evaluate_tree(node, env):
 +            return env
@@ -1519,9 +1539,10 @@ index 0000000..054dd73
 +    so it overruns ``max_cells`` on a wide multi-platform universe.
 +    :func:`equivalent_within_rows` decides the same verdict per row instead.
 +    """
++    store: Memo = Memo()
 +    return is_empty(
-+        make_and((left, universe, make_not(right))), max_cells
-+    ) and is_empty(make_and((right, universe, make_not(left))), max_cells)
++        make_and((left, universe, make_not(right))), max_cells, store
++    ) and is_empty(make_and((right, universe, make_not(left))), max_cells, store)
 +
 +
 +class _Row(NamedTuple):
@@ -1582,17 +1603,23 @@ index 0000000..054dd73
 +    rows: Sequence[_Row],
 +    right_by_row: Sequence[Formula],
 +    max_cells: int,
++    store: Memo,
 +) -> bool:
 +    """Whether ``left`` agrees with the per-row restriction of the constant right.
 +
 +    Restricting each operand to a row's pins complements over that row's residual
-+    rather than the whole-matrix product.
++    rather than the whole-matrix product.  The rows of one universe differ on few
++    axes, so ``store`` carries each axis's partition across them.
 +    """
 +    for row, right in zip(rows, right_by_row, strict=True):
 +        left_r = restrict_tree(left, row.pins)
-+        if not is_empty(make_and((left_r, row.bound, make_not(right))), max_cells):
++        if not is_empty(
++            make_and((left_r, row.bound, make_not(right))), max_cells, store
++        ):
 +            return False
-+        if not is_empty(make_and((right, row.bound, make_not(left_r))), max_cells):
++        if not is_empty(
++            make_and((right, row.bound, make_not(left_r))), max_cells, store
++        ):
 +            return False
 +    return True
 +
@@ -1605,7 +1632,8 @@ index 0000000..054dd73
 +    """
 +    nnf = universe if isinstance(universe, BoolConst) else to_nnf(universe)
 +    disjuncts = nnf.children if isinstance(nnf, OrNode) else (nnf,)
-+    return all(is_empty(disjunct, max_cells) for disjunct in disjuncts)
++    store: Memo = Memo()
++    return all(is_empty(disjunct, max_cells, store) for disjunct in disjuncts)
 +
 +
 +def equivalent_within_rows(
@@ -1619,7 +1647,8 @@ index 0000000..054dd73
 +    """
 +    rows = _decompose_rows(universe)
 +    right_by_row = [restrict_tree(right, row.pins) for row in rows]
-+    return _rows_equivalent(left, rows, right_by_row, max_cells)
++    store: Memo = Memo()
++    return _rows_equivalent(left, rows, right_by_row, max_cells, store)
 +
 +
 +def _dedupe(clauses: list[frozenset[Atom]]) -> list[frozenset[Atom]]:
@@ -1637,11 +1666,14 @@ index 0000000..054dd73
 +    rows: Sequence[_Row],
 +    original_by_row: Sequence[Formula],
 +    max_cells: int,
++    store: Memo,
 +) -> list[frozenset[Atom]]:
 +    kept = list(clauses)
 +    for clause in sorted(clauses, key=_clause_key):
 +        trial = [other for other in kept if other != clause]
-+        if _rows_equivalent(_disjunction(trial), rows, original_by_row, max_cells):
++        if _rows_equivalent(
++            _disjunction(trial), rows, original_by_row, max_cells, store
++        ):
 +            kept = trial
 +    return kept
 +
@@ -1651,13 +1683,14 @@ index 0000000..054dd73
 +    rows: Sequence[_Row],
 +    original_by_row: Sequence[Formula],
 +    max_cells: int,
++    store: Memo,
 +) -> list[frozenset[Atom]]:
 +    working = [set(clause) for clause in clauses]
 +    for clause in working:
 +        for atom in sorted(clause, key=_atom_key):
 +            clause.discard(atom)
 +            trial = _disjunction(frozenset(current) for current in working)
-+            if not _rows_equivalent(trial, rows, original_by_row, max_cells):
++            if not _rows_equivalent(trial, rows, original_by_row, max_cells, store):
 +                clause.add(atom)
 +    return [frozenset(clause) for clause in working]
 +
@@ -1688,19 +1721,19 @@ index 0000000..054dd73
 +    original = _disjunction(clauses)
 +    rows = _decompose_rows(universe)
 +    original_by_row = [restrict_tree(original, row.pins) for row in rows]
-+    previous_store = getattr(_partition_cache, "store", None)
++    store: Memo = Memo()
 +    previous_work = getattr(_work_meter, "remaining", None)
-+    _partition_cache.store = {}
 +    _work_meter.remaining = max_work
 +    try:
 +        while True:
 +            before = _canonical(clauses)
-+            clauses = _drop_clauses(clauses, rows, original_by_row, max_cells)
-+            clauses = _dedupe(_drop_atoms(clauses, rows, original_by_row, max_cells))
++            clauses = _drop_clauses(clauses, rows, original_by_row, max_cells, store)
++            clauses = _dedupe(
++                _drop_atoms(clauses, rows, original_by_row, max_cells, store)
++            )
 +            if _canonical(clauses) == before:
 +                break
 +    finally:
-+        _partition_cache.store = previous_store
 +        _work_meter.remaining = previous_work
 +    if not clauses:
 +        return FALSE
@@ -1817,10 +1850,10 @@ index c78fd5d..0d7ee1d 100644
      """
 diff --git a/nab-python/src/nab_python/_vendor/packaging/markersets.py b/nab-python/src/nab_python/_vendor/packaging/markersets.py
 new file mode 100644
-index 0000000..74930e7
+index 0000000..3891398
 --- /dev/null
 +++ b/nab-python/src/nab_python/_vendor/packaging/markersets.py
-@@ -0,0 +1,359 @@
+@@ -0,0 +1,362 @@
 +"""The public :class:`MarkerSet`: a marker's denotation as a set of environments.
 +
 +A :class:`MarkerSet` is the denotation of a PEP 508 marker as a set of
@@ -2039,13 +2072,18 @@ index 0000000..74930e7
 +        """Whether the two sets denote the same environments.
 +
 +        The semantic equality ``==`` cannot cheaply provide, so it is a method.
++
++        Both containments read the same two trees, so they share one partition memo.
 +        """
++        store = _markersets.Memo()
 +        return _markersets.is_empty(
 +            _markersets.make_and((self._tree, _markersets.make_not(other._tree))),
 +            _MAX_CELLS,
++            store,
 +        ) and _markersets.is_empty(
 +            _markersets.make_and((other._tree, _markersets.make_not(self._tree))),
 +            _MAX_CELLS,
++            store,
 +        )
 +
 +    @_bounded
@@ -2147,9 +2185,7 @@ index 0000000..74930e7
 +            msg = "within must not be the empty set"
 +            raise ValueError(msg)
 +        return self._wrap(
-+            _markersets.simplify_within(
-+                self._tree, within._tree, _MAX_CELLS, _MAX_WORK
-+            )
++            _markersets.simplify_within(self._tree, within._tree, _MAX_CELLS, _MAX_WORK)
 +        )
 +
 +    # ---- serialisation


### PR DESCRIPTION
The marker algebra held two memos that outlived the work which filled them. `partition_axis` consulted a store installed on a thread-local, and only `simplify_within` ever installed one, so a decision over a wide universe re-partitioned the same axes once per row. Separately, every value atom carried its own truth cache, bounded at 1024 entries and alive as long as any tree referencing the atom.

Both now sit on a `Memo` that the operation creates and drops. Nothing in the module survives a call, and `Atom` is immutable apart from the version pool it mints from its own literal, so its docstring no longer has to except two caches.

Finalising the markers of one committed CI lock in a fresh process, min of three:

| lock | partitions computed | wall |
| --- | --- | --- |
| nox | 249 -> 86 | 0.198s -> 0.114s |
| dists | 249 -> 85 | 0.177s -> 0.109s |
| types | 412 -> 131 | 0.565s -> 0.384s |
| tests | 413 -> 146 | 0.521s -> 0.371s |

A lone decision is unchanged, since the memo it allocates is one object against a decision costing over a hundred microseconds.
