### PR TITLE
Add decision-order option for stable resolves

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -137,8 +137,9 @@ rejected in universal mode, where the matrix declares the Python axis.
 A project option can be overridden for one run with a `--project-<key>`
 flag: `--project-resolution`, `--project-mode`, `--project-requires-python`,
 `--project-uploaded-prior-to`, `--project-dist-policy`,
-`--project-build-policy`, `--project-build-requires-depth`, and the
-repeatable `--project-constraint` and `--project-default-group`. Every one
+`--project-build-policy`, `--project-build-requires-depth`,
+`--project-decision-order`, and the repeatable
+`--project-constraint` and `--project-default-group`. Every one
 of them replaces the file value outright; repeating `--project-constraint`
 builds up that run's whole constraint list rather than adding to the
 declared one. Each changes the resolved set, so passing one prints a

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -45,6 +45,12 @@ uploaded-prior-to = "2026-05-01T00:00:00Z"
 # Version selection within an allowed range.  Mirrors uv's --resolution.
 resolution = "highest"          # "highest" | "lowest" | "lowest-direct"
 
+# Whether listings that have already arrived may steer the decision
+# order.  "stable" waits for the listing instead, so the resolve does
+# not depend on how warm the HTTP cache was.  Costs wall time.  See
+# "Decision order" below.
+decision-order = "arrival"      # "arrival" | "stable"
+
 # Distribution policy.  See "Dist policy" below for details.
 dist-policy = "wheel-or-sdist"
 # "wheel-only" | "prefer-wheel" | "wheel-or-sdist" | "sdist-only" | "sdist-install"
@@ -552,6 +558,37 @@ dist-policy = "sdist-install"
 
 The same five values are accepted.  Package names are canonicalised, so
 `Foo-Bar`, `foo_bar`, and `foo-bar` name the same package.
+
+## Decision order
+
+`[tool.nab].decision-order` controls whether the listings that have
+arrived so far may steer which package the resolver decides next.
+
+nab fetches listings on a background thread while it resolves, and the
+decision scan prefers packages whose listing has already landed so the
+search keeps moving while the rest are in flight.  Which ones have
+landed depends on what the HTTP cache held, so one project resolved
+twice against one index can search differently, and on some inputs
+settle on a different valid answer.
+
+| Value | Behaviour |
+|---|---|
+| `arrival` (default) | Rank a package on the listings that have already landed. |
+| `stable` | Wait for the listing, then rank on its real version count. |
+
+Under `stable` nothing about fetch timing reaches the decision scan, so
+one project resolved twice against one index gives one lockfile.  This
+is the setting to reach for when `nab lock --locked` fails in CI on a
+commit nobody changed.
+
+It costs wall time: a few percent on nab's slower benchmark scenarios,
+with a wider run-to-run spread even though the answer stops moving.  The
+wait is usually on a fetch already in flight rather than one the scan
+issues, so fetching is not serialised.
+
+`stable` settles the resolver; the index can still move under you.  See
+"Reproducibility" in the [lockfile reference](lockfile.md) for the
+conditions that remain.
 
 ## VCS policy
 

--- a/docs/reference/lockfile.md
+++ b/docs/reference/lockfile.md
@@ -324,18 +324,44 @@ entries some other way if that is the workflow you need.
 
 ## Reproducibility
 
-Use `[tool.nab].uploaded-prior-to` to make the resolve
-time-bounded. Distributions uploaded after that timestamp are
-ignored, even if newer files exist on the index when you run.
-This pairs naturally with the lockfile: a fresh resolve with the
-same `uploaded-prior-to` produces the same pin set, so the
-lockfile is truly reproducible rather than "reproducible until
-upstream re-uploads".
+Two things have to hold for a lock to reproduce: the index has to
+give the same answer, and the resolver has to search the same
+way. They are separate settings.
 
-When `uploaded-prior-to` is an absolute timestamp, that timestamp
-also becomes the lockfile's `created-at`, so two locks from
-identical inputs are byte-for-byte identical. `--upgrade` is the
-exception: it stamps the run time instead.
+`[tool.nab].uploaded-prior-to` bounds the index view.
+Distributions uploaded after that timestamp are ignored, even if
+newer files exist on the index when you run, so the lockfile is
+truly reproducible rather than "reproducible until upstream
+re-uploads".
+
+`[tool.nab].decision-order = "stable"` bounds the search. On the
+default `arrival`, nab decides packages whose listing has already
+arrived ahead of ones still in flight, so a machine with a cold
+HTTP cache can search differently, and on some inputs pin
+differently, from one with a warm cache on the same inputs and
+the same frozen index. See "Decision order" in the
+[configuration reference](configuration.md) for what it costs.
+
+With both set, a fresh resolve produces the same pin set, and an
+absolute `uploaded-prior-to` also becomes the lockfile's
+`created-at`, so two locks from identical inputs are
+byte-for-byte identical. `--upgrade` is the exception: it stamps
+the run time instead.
+
+Both settings assume an index that does not move. Several things
+move it. Yanking is a property of the listing as it stands, not
+of the upload, so a file yanked after you locked changes the
+resolve and `uploaded-prior-to` does not bring it back. A deleted
+file cannot be resolved to at all.
+
+The cutoff also trusts the upload times the index reports. An
+index that rewrites them changes what a past cutoff admits, and
+nab does not detect that. A distribution reported without an
+upload time is excluded once a cutoff is set, so an index that
+reports none serves nothing at all. Local `file://` and
+find-links artifacts carry no upload time either, and those are
+kept rather than excluded, so a resolve mixing a wheelhouse with
+an index is only partly time-bounded.
 
 A relative `P<n>D` cutoff is measured back from `created-at`
 rather than from the clock, and a re-lock reuses the `created-at`
@@ -369,6 +395,12 @@ single-environment mode.
 Some mismatches are provable from your inputs without resolving, so
 `--locked` can fail fast with the reason before it re-resolves; see the
 [CLI reference](cli.md).
+
+`--locked` re-resolves, so it depends on everything the resolve
+depends on. On the default `decision-order = "arrival"` the check
+can fail on a commit nobody changed, when the CI runner's HTTP
+cache is colder than the machine that wrote the lock. Set
+`decision-order = "stable"` on any project that runs it.
 
 ## `nab download`
 

--- a/nab-python/src/nab_python/_provider/priority.py
+++ b/nab-python/src/nab_python/_provider/priority.py
@@ -72,6 +72,10 @@ def compute_matching(
     :data:`_NO_LISTING_PRIOR` while the listing is still in flight, reading
     arrival through ``arrived_listing`` so it agrees with ``is_ready`` for the
     whole decision scan.
+
+    Under :attr:`~nab_python.provider.DecisionOrder.STABLE` it waits for the
+    listing instead, so the count is the real one and this sentinel is only
+    reached by a package with no listing to count.
     """
     per_pkg = provider.matching_cache.get(normalized)
     if per_pkg is not None:
@@ -87,7 +91,11 @@ def compute_matching(
         or normalized in provider.archive_sources
     )
     if normalized not in provider.versions_cache and not has_local_source:
-        files = provider.arrived_listing(normalized)
+        files = (
+            provider.settled_listing(normalized)
+            if provider.settle_listings
+            else provider.arrived_listing(normalized)
+        )
         if files is not None:
             versions = provider.filter_distributions(normalized, files)
             provider.versions_cache[normalized] = versions
@@ -155,7 +163,9 @@ def prioritize(
     their base at equal tier so they pin the base version directly (avoids
     the backtrack storm when the base is decided before the extras proxy).
 
-    Never blocks on I/O.
+    Blocks on I/O only under
+    :attr:`~nab_python.provider.DecisionOrder.STABLE`, which waits for a
+    listing rather than ranking its absence.
     """
     provider.stats.prioritize_calls += 1
     _, extra, normalized = provider.split_and_normalize(package)

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -53,6 +53,7 @@ from .paths import resolve_path
 from .provider import (
     ArchiveSource,
     BuildPolicy,
+    DecisionOrder,
     DistPolicy,
     LocalSource,
     ResolutionStrategy,
@@ -456,6 +457,7 @@ class NabProjectConfig:
     archive_sources: tuple[ArchiveSource, ...] = ()
     matrix: MatrixConfig | None = None
     resolution: ResolutionStrategy = ResolutionStrategy.HIGHEST
+    decision_order: DecisionOrder = DecisionOrder.ARRIVAL
     workspace: WorkspaceConfig | None = None
     conflicts: tuple[ConflictSet, ...] = ()
     # Per-package overrides from ``[tool.nab.packages.<name>]`` and
@@ -783,6 +785,7 @@ def _config_from_effective(
         archive_sources=archive_sources,
         matrix=matrix,
         resolution=effective["resolution"].value,
+        decision_order=effective["decision-order"].value,
         workspace=effective["workspace"].value,
         conflicts=conflicts,
         package_overrides=package_overrides,

--- a/nab-python/src/nab_python/config_sources.py
+++ b/nab-python/src/nab_python/config_sources.py
@@ -48,6 +48,7 @@ from .paths import PathState, is_usable_path_name, path_state
 from .provider import (
     ArchiveSource,
     BuildPolicy,
+    DecisionOrder,
     DistPolicy,
     LocalSource,
     ResolutionStrategy,
@@ -436,6 +437,15 @@ def _parse_build_policy(value: Any, where: str) -> BuildPolicy:
     )
 
 
+def _parse_decision_order(value: Any, where: str) -> DecisionOrder:
+    del where
+    from .config import _parse_enum as _impl  # noqa: PLC0415 (config import cycle)
+
+    return _delegate(
+        lambda: _impl("decision-order", value, DecisionOrder, DecisionOrder.ARRIVAL)
+    )
+
+
 def _parse_uploaded_prior_to(value: Any, where: str) -> Any:
     """Parse ``uploaded-prior-to`` without re-anchoring relative durations.
 
@@ -817,6 +827,17 @@ OPTIONS: tuple[OptionSpec, ...] = (
         cli_flag="--project-resolution",
         cli_param="project_resolution",
         parse=_parse_resolution,
+        render=lambda v: v.value,
+    ),
+    OptionSpec(
+        key="decision-order",
+        scope=Scope.PROJECT,
+        type_label=f"enum({'|'.join(o.value for o in DecisionOrder)})",
+        default=DecisionOrder.ARRIVAL,
+        env_var=None,
+        cli_flag="--project-decision-order",
+        cli_param="project_decision_order",
+        parse=_parse_decision_order,
         render=lambda v: v.value,
     ),
     OptionSpec(

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -63,6 +63,7 @@ if TYPE_CHECKING:
 __all__ = [
     "ArchiveSource",
     "BuildPolicy",
+    "DecisionOrder",
     "DistFile",
     "DistPolicy",
     "ExtrasMode",
@@ -230,6 +231,16 @@ class ResolutionStrategy(enum.Enum):
 
     LOWEST_DIRECT = "lowest-direct"
     """Oldest for direct deps; newest for transitive deps."""
+
+
+class DecisionOrder(enum.Enum):
+    """Whether arrived listings may steer which package is decided next."""
+
+    ARRIVAL = "arrival"
+    """Rank on what has already landed, so the search keeps moving (default)."""
+
+    STABLE = "stable"
+    """Wait for each listing, so the sort key cannot see which had arrived."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -496,6 +507,10 @@ class Provider:
     ``listing_filter_cache`` shares the platform-independent half of the
     listing filter with the other targets of the same resolve; see
     :class:`ListingFilterCache`.
+
+    ``decision_order`` chooses whether the decision scan may rank a
+    package on whether its listing has landed yet.  See
+    :meth:`settled_listing`.
     """
 
     # Drives two prefetch paths: the speculative root-batch prefetch
@@ -577,6 +592,7 @@ class Provider:
         *,
         constraints: Mapping[str, VersionRange] | None = None,
         trust_unverified_sdist_deps: bool = False,
+        decision_order: DecisionOrder = DecisionOrder.ARRIVAL,
     ) -> None:
         """Construct the provider; see the class docstring for parameters."""
         if isinstance(resolution_strategy, str):
@@ -612,6 +628,8 @@ class Provider:
             build_config is not None and build_config.trust_unverified_sdist_deps
         )
         self._resolution_strategy = resolution_strategy
+        # The scan asks this once per package, so keep the answer.
+        self.settle_listings = decision_order is DecisionOrder.STABLE
         self._direct_packages: frozenset[str] = direct_packages or frozenset()
         # Versions another target already decided, tried first when they are
         # usable here: uv-style cross-target alignment ("target A picked numpy
@@ -2257,11 +2275,38 @@ class Provider:
             self._absent_listing_scan[normalized] = self._scan_generation
         return listing
 
+    def settled_listing(self, normalized: str) -> list[DistFile] | None:
+        """Return ``normalized``'s listing, waiting once for it to land.
+
+        The blocking counterpart of :meth:`arrived_listing`, used by the
+        decision scan under :attr:`DecisionOrder.STABLE`: waiting for the
+        fetch gives the scan the same version count whatever the HTTP
+        cache held, where reading what has arrived so far does not.
+
+        A listing that already failed is not re-requested, and one wait is
+        enough because every terminal path in the fetcher sets the event.
+        ``None`` still means there is no listing to count, so a caller must
+        not spin on it.
+        """
+        listing = self.coordinator.index.get_listing(normalized)
+        if listing is not None:
+            return listing
+        if self.coordinator.index.get_listing_error(normalized) is not None:
+            return None
+        self.coordinator.request_listing(normalized).wait()
+        return self.coordinator.index.get_listing(normalized)
+
     def is_ready(self, package: str) -> bool:
         """Check if a package's listing is available without blocking.
 
         Used by the resolver to prefer packages with cached data,
         letting it make progress while other listings are in flight.
+
+        Under :attr:`DecisionOrder.STABLE` it needs no blocking half of its
+        own.  ``prioritize`` runs first in the same sort key and has already
+        settled the listing into ``versions_cache``; what is left is a
+        failed listing or a package served from a local, VCS, or archive
+        source, and no listing is ever requested for those.
         """
         _, extra, normalized = self.split_and_normalize(package)
         if extra is not None:

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -878,6 +878,7 @@ def _resolve_one_target(
             source_root / ARCHIVE_BUCKET if source_root is not None else None
         ),
         build_config=config,
+        decision_order=config.decision_order,
         resolution_strategy=settings.resolution,
         direct_packages=frozenset(
             name for name in resolver_requirements if split_extra(name)[1] is None

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -51,6 +51,7 @@ from nab_python.config_sources import (
 from nab_python.fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL, IndexRoute
 from nab_python.provider import (
     BuildPolicy,
+    DecisionOrder,
     DistPolicy,
     LocalSource,
     ResolutionStrategy,
@@ -1379,6 +1380,19 @@ class TestPolicies:
     def test_build_requires_depth_reaches_the_config(self, tmp_path: Path) -> None:
         path = write(tmp_path, "[tool.nab]\nbuild-requires-depth = 2\n")
         assert read_pyproject_config(path).build_requires_depth == 2
+
+    def test_invalid_decision_order(self, tmp_path: Path) -> None:
+        path = write(tmp_path, '[tool.nab]\ndecision-order = "eventually"\n')
+        with pytest.raises(ConfigError, match="decision-order must be one of"):
+            read_pyproject_config(path)
+
+    def test_decision_order_reaches_the_config(self, tmp_path: Path) -> None:
+        path = write(tmp_path, '[tool.nab]\ndecision-order = "stable"\n')
+        assert read_pyproject_config(path).decision_order is DecisionOrder.STABLE
+
+    def test_decision_order_defaults_to_arrival(self, tmp_path: Path) -> None:
+        path = write(tmp_path, "[tool.nab]\n")
+        assert read_pyproject_config(path).decision_order is DecisionOrder.ARRIVAL
 
 
 _UNIVERSAL_MATRIX = (

--- a/nab-python/tests/test_config_sources.py
+++ b/nab-python/tests/test_config_sources.py
@@ -59,6 +59,7 @@ from nab_python.config_sources import (
 from nab_python.provider import (
     ArchiveSource,
     BuildPolicy,
+    DecisionOrder,
     DistPolicy,
     ResolutionStrategy,
     ResolveMode,
@@ -177,6 +178,54 @@ class TestResolutionLadder:
 
     def test_resolution_non_string_errors(self, tmp_path: Path) -> None:
         _project(tmp_path, "resolution = 3\n")
+        with pytest.raises(SourceConfigError, match="must be a string"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+
+class TestDecisionOrderLadder:
+    def test_default_is_arrival(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["decision-order"].value is DecisionOrder.ARRIVAL
+        assert eff["decision-order"].origin.kind is SourceKind.DEFAULT
+
+    def test_pyproject_sets_decision_order(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'decision-order = "stable"\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["decision-order"].value is DecisionOrder.STABLE
+        assert eff["decision-order"].origin.kind is SourceKind.PYPROJECT
+
+    def test_project_nab_toml_sets_decision_order(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        _write(tmp_path / "nab.toml", 'decision-order = "stable"\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["decision-order"].value is DecisionOrder.STABLE
+        assert eff["decision-order"].origin.kind is SourceKind.PROJECT_TOML
+
+    def test_cli_project_decision_order_wins(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'decision-order = "stable"\n')
+        eff = _resolve(
+            SourceRoots(project_dir=tmp_path), cli={"decision-order": "arrival"}
+        )
+        assert eff["decision-order"].value is DecisionOrder.ARRIVAL
+        assert eff["decision-order"].origin.kind is SourceKind.CLI
+
+    def test_decision_order_in_user_nab_toml_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        user = _write(
+            tmp_path / "usr" / "nab" / "nab.toml", 'decision-order = "stable"\n'
+        )
+        roots = SourceRoots(user_toml=user, project_dir=tmp_path)
+        with pytest.raises(SourceConfigError, match="project-scope option"):
+            _resolve(roots)
+
+    def test_bad_decision_order_value_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'decision-order = "whenever"\n')
+        with pytest.raises(SourceConfigError, match="must be one of"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_decision_order_non_string_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path, "decision-order = 3\n")
         with pytest.raises(SourceConfigError, match="must be a string"):
             _resolve(SourceRoots(project_dir=tmp_path))
 
@@ -867,6 +916,7 @@ class TestReproducibilityNotice:
                 "project_dist_policy": "sdist-only",
                 "project_build_policy": None,
                 "project_build_requires_depth": None,
+                "project_decision_order": None,
                 "project_constraint": (),
                 "project_default_group": ("dev",),
             }
@@ -887,6 +937,7 @@ class TestParserFoldHelpers:
         assert pyproject_registry_keys() == frozenset(
             {
                 "resolution",
+                "decision-order",
                 "mode",
                 "constraints",
                 "default-groups",

--- a/nab-python/tests/test_decision_scan.py
+++ b/nab-python/tests/test_decision_scan.py
@@ -9,10 +9,16 @@ compared against each other, can answer from different moments.
 The index double below lands a listing on the first read that asks for it,
 which is the race a traced resolve caught: the listing arrives between
 ``prioritize`` and ``is_ready`` for one package.
+
+Freezing that view keeps one scan consistent with itself, but the scans
+of two runs can still disagree: what had landed when each scan opened is
+a fact about the HTTP cache.  ``decision-order = "stable"`` closes that,
+and the last class here varies only which listings were already resident.
 """
 
 from __future__ import annotations
 
+import threading
 from typing import TYPE_CHECKING
 
 from nab_index.client import WheelFile
@@ -21,7 +27,7 @@ from nab_python._testing.coordinator_fake import make_coordinator
 from nab_python._vendor.packaging.ranges import VersionRange
 from nab_python._vendor.packaging.version import Version
 from nab_python.fetch import InMemoryIndex
-from nab_python.provider import Provider
+from nab_python.provider import DecisionOrder, Provider
 from nab_resolver import decide
 from nab_resolver.resolver import Resolver
 from nab_resolver.types import Incompatibility, IncompatibilityCause, Term
@@ -69,8 +75,12 @@ class _ArrivesOnReadIndex(InMemoryIndex):
 class _ScanRecordingProvider(Provider):
     """Records both halves of every sort key a scan builds, in scan order."""
 
-    def __init__(self, coordinator: MagicMock) -> None:
-        super().__init__(coordinator)
+    def __init__(
+        self,
+        coordinator: MagicMock,
+        decision_order: DecisionOrder = DecisionOrder.ARRIVAL,
+    ) -> None:
+        super().__init__(coordinator, decision_order=decision_order)
         self.scan_reads: list[tuple[str, int, bool]] = []
         self._matching: dict[str, int] = {}
 
@@ -104,6 +114,95 @@ def _coordinator(
         index.store_listing(package, files)
     coordinator.index = index
     return coordinator
+
+
+class _LandsOnWait(threading.Event):
+    """The fetcher's event, carrying the store it does just before setting it.
+
+    A synchronous double cannot race its reader, so the arrival hangs off
+    ``wait`` itself.  A caller that does not wait then sees no listing, which
+    is what it would see against a fetcher that had not finished.
+    """
+
+    def __init__(
+        self,
+        index: InMemoryIndex,
+        package: str,
+        files: Sequence[WheelFile | SdistFile],
+    ) -> None:
+        super().__init__()
+        self._index = index
+        self._package = package
+        self._files = files
+
+    def wait(self, timeout: float | None = None) -> bool:
+        self._index.store_listing(self._package, self._files)
+        self.set()
+        return super().wait(timeout)
+
+
+def _fetching_coordinator(
+    pending: Mapping[str, Sequence[WheelFile | SdistFile]],
+) -> MagicMock:
+    """Coordinator whose listings land only for a caller that waits."""
+    coordinator = make_coordinator(None)
+    index = InMemoryIndex()
+    coordinator.index = index
+    coordinator.request_listing.side_effect = lambda package: _LandsOnWait(
+        index, package, pending[package]
+    )
+    return coordinator
+
+
+def _two_package_resolver(
+    *, resident: bool, decision_order: DecisionOrder
+) -> tuple[Resolver[str, Version], _ScanRecordingProvider]:
+    """Resolver over a three-version ``alpha`` and a one-version ``beta``.
+
+    ``resident`` is the only thing that differs between two runs of this
+    project against this index: whether ``beta``'s listing had already
+    landed when the scan opened, or lands during it.
+    """
+    beta = [_wheel("beta")]
+    resident_listings: dict[str, Sequence[WheelFile | SdistFile]] = {
+        "alpha": [_wheel("alpha", version) for version in ("1.0", "2.0", "3.0")]
+    }
+    arrivals: dict[str, Sequence[WheelFile | SdistFile]] = {}
+    if resident:
+        resident_listings["beta"] = beta
+    else:
+        arrivals["beta"] = beta
+
+    provider = _ScanRecordingProvider(
+        _coordinator(arrivals, resident_listings), decision_order
+    )
+    resolver: Resolver[str, Version] = Resolver(
+        provider, range_type=VersionRange, root_version="0"
+    )
+    for package in ("alpha", "beta"):
+        resolver.solution.derive(
+            package, VersionRange.full(), positive=True, cause=_cause()
+        )
+    return resolver, provider
+
+
+def _scan_keys(*, resident: bool, decision_order: DecisionOrder) -> dict[str, object]:
+    """Return one scan's ``package -> (matching, ready)`` map."""
+    resolver, provider = _two_package_resolver(
+        resident=resident, decision_order=decision_order
+    )
+    decide.choose_package_to_decide(resolver)
+    return {
+        package: (matching, ready) for package, matching, ready in provider.scan_reads
+    }
+
+
+def _decided_first(*, resident: bool, decision_order: DecisionOrder) -> str | None:
+    """Return the package the scan would decide next."""
+    resolver, _ = _two_package_resolver(
+        resident=resident, decision_order=decision_order
+    )
+    return decide.choose_package_to_decide(resolver)
 
 
 def _cause() -> Incompatibility[str, Version]:
@@ -208,3 +307,89 @@ class TestScanKeysShareOneView:
         decide.choose_package_to_decide(resolver)
 
         assert all(ready for _, _, ready in provider.scan_reads)
+
+
+class TestStableOrderIgnoresArrival:
+    """Under ``stable`` the scan settles a listing rather than ranking its absence."""
+
+    def test_a_listing_that_lands_mid_scan_is_counted_now(self) -> None:
+        """The count is the real one, not the in-flight sentinel."""
+        provider = Provider(
+            _coordinator({"foo": [_wheel("foo")]}),
+            decision_order=DecisionOrder.STABLE,
+        )
+
+        provider.begin_decision_scan()
+
+        assert provider.prioritize("foo", VersionRange.full(), {})[1] == 1
+        assert provider.is_ready("foo") is True
+
+    def test_settling_waits_for_the_fetch(self) -> None:
+        """The count comes from the wait, not from a second look at the index."""
+        provider = Provider(
+            _fetching_coordinator({"foo": [_wheel("foo")]}),
+            decision_order=DecisionOrder.STABLE,
+        )
+
+        provider.begin_decision_scan()
+
+        assert provider.prioritize("foo", VersionRange.full(), {})[1] == 1
+        assert provider.is_ready("foo") is True
+
+    def test_a_resident_listing_is_read_without_a_request(self) -> None:
+        """Settling costs nothing once the listing is in the index."""
+        coordinator = _coordinator({}, {"foo": [_wheel("foo")]})
+        provider = Provider(coordinator, decision_order=DecisionOrder.STABLE)
+
+        listing = provider.settled_listing("foo")
+
+        assert listing is not None
+        assert [file.filename for file in listing] == ["foo-1.0-py3-none-any.whl"]
+        coordinator.request_listing.assert_not_called()
+
+    def test_a_failed_listing_is_not_requested_again(self) -> None:
+        """A fetch that already failed has settled; asking again would not help."""
+        coordinator = _coordinator({})
+        coordinator.index.store_listing_error("foo", RuntimeError("index is down"))
+        provider = Provider(coordinator, decision_order=DecisionOrder.STABLE)
+
+        provider.begin_decision_scan()
+
+        assert (
+            provider.prioritize("foo", VersionRange.full(), {})[1] == _NO_LISTING_PRIOR
+        )
+        assert provider.is_ready("foo") is False
+        coordinator.request_listing.assert_not_called()
+
+    def test_a_listing_that_never_lands_leaves_the_package_in_flight(self) -> None:
+        """One wait, then the sentinel: the scan must not spin on a dead fetch."""
+        provider = Provider(_coordinator({}), decision_order=DecisionOrder.STABLE)
+
+        provider.begin_decision_scan()
+
+        assert (
+            provider.prioritize("foo", VersionRange.full(), {})[1] == _NO_LISTING_PRIOR
+        )
+        assert provider.is_ready("foo") is False
+
+    def test_the_scan_builds_the_same_keys_whatever_had_landed(self) -> None:
+        """Cache warmth is invisible to the sort key."""
+        warm = _scan_keys(resident=True, decision_order=DecisionOrder.STABLE)
+        cold = _scan_keys(resident=False, decision_order=DecisionOrder.STABLE)
+
+        assert warm == cold == {"alpha": (3, True), "beta": (1, True)}
+
+    def test_the_same_package_is_decided_whatever_had_landed(self) -> None:
+        """The package with fewer candidates decides first either way."""
+        warm = _decided_first(resident=True, decision_order=DecisionOrder.STABLE)
+        cold = _decided_first(resident=False, decision_order=DecisionOrder.STABLE)
+
+        assert warm == cold == "beta"
+
+    def test_the_default_decides_on_what_happened_to_have_landed(self) -> None:
+        """The default decides on cache warmth, which is what the option closes."""
+        warm = _decided_first(resident=True, decision_order=DecisionOrder.ARRIVAL)
+        cold = _decided_first(resident=False, decision_order=DecisionOrder.ARRIVAL)
+
+        assert warm == "beta"
+        assert cold == "alpha"

--- a/src/nab/_config_cmd.py
+++ b/src/nab/_config_cmd.py
@@ -28,6 +28,7 @@ from nab_python.config_sources import (
 
 from .cli import (
     BuildPolicyFlag,
+    DecisionOrderFlag,
     DistPolicyFlag,
     HttpBackend,
     ModeFlag,
@@ -62,6 +63,7 @@ def config_command(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag
     project_dist_policy: DistPolicyFlag | None = None,
     project_build_policy: BuildPolicyFlag | None = None,
     project_build_requires_depth: int | None = None,
+    project_decision_order: DecisionOrderFlag | None = None,
     project_constraint: Annotated[tuple[str, ...], tyro.conf.UseAppendAction] = (),
     project_default_group: Annotated[tuple[str, ...], tyro.conf.UseAppendAction] = (),
     include_rejected: bool = False,
@@ -105,6 +107,7 @@ def config_command(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag
         cli_dist_policy=project_dist_policy,
         cli_build_policy=project_build_policy,
         cli_build_requires_depth=project_build_requires_depth,
+        cli_decision_order=project_decision_order,
         cli_constraint=project_constraint,
         cli_default_group=project_default_group,
     )

--- a/src/nab/_download.py
+++ b/src/nab/_download.py
@@ -25,6 +25,7 @@ from . import cli as _cli
 from ._lock import resolve_extra_selection, resolve_group_selection
 from .cli import (
     BuildPolicyFlag,
+    DecisionOrderFlag,
     DistPolicyFlag,
     HttpBackend,
     ModeFlag,
@@ -59,6 +60,7 @@ def download(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config 
     project_dist_policy: DistPolicyFlag | None = None,
     project_build_policy: BuildPolicyFlag | None = None,
     project_build_requires_depth: int | None = None,
+    project_decision_order: DecisionOrderFlag | None = None,
     project_constraint: Annotated[tuple[str, ...], tyro.conf.UseAppendAction] = (),
     project_default_group: Annotated[tuple[str, ...], tyro.conf.UseAppendAction] = (),
 ) -> None:
@@ -101,6 +103,7 @@ def download(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config 
         cli_dist_policy=project_dist_policy,
         cli_build_policy=project_build_policy,
         cli_build_requires_depth=project_build_requires_depth,
+        cli_decision_order=project_decision_order,
         cli_constraint=project_constraint,
         cli_default_group=project_default_group,
     )

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -74,6 +74,7 @@ from nab_python.target import UnevaluableMarkerError
 from . import cli as _cli
 from .cli import (
     BuildPolicyFlag,
+    DecisionOrderFlag,
     DistPolicyFlag,
     HttpBackend,
     LockFormat,
@@ -124,6 +125,7 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
     project_dist_policy: DistPolicyFlag | None = None,
     project_build_policy: BuildPolicyFlag | None = None,
     project_build_requires_depth: int | None = None,
+    project_decision_order: DecisionOrderFlag | None = None,
     project_constraint: Annotated[tuple[str, ...], tyro.conf.UseAppendAction] = (),
     project_default_group: Annotated[tuple[str, ...], tyro.conf.UseAppendAction] = (),
     upgrade: bool = False,
@@ -185,6 +187,7 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
         cli_dist_policy=project_dist_policy,
         cli_build_policy=project_build_policy,
         cli_build_requires_depth=project_build_requires_depth,
+        cli_decision_order=project_decision_order,
         cli_constraint=project_constraint,
         cli_default_group=project_default_group,
     )

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -110,6 +110,7 @@ DistPolicyFlag = Literal[
     "wheel-only", "prefer-wheel", "wheel-or-sdist", "sdist-only", "sdist-install"
 ]
 BuildPolicyFlag = Literal["never", "build-local", "build-remote"]
+DecisionOrderFlag = Literal["arrival", "stable"]
 
 # --offline is layered (an nab.toml or NAB_OFFLINE may set it), so it stays
 # tri-state: an explicit value overrides the lower layers while an absent flag
@@ -317,6 +318,7 @@ def _cli_overrides(  # noqa: PLR0913 - one keyword per CLI flag it maps to a reg
     cli_dist_policy: str | None = None,
     cli_build_policy: str | None = None,
     cli_build_requires_depth: int | None = None,
+    cli_decision_order: str | None = None,
     cli_constraint: tuple[str, ...] = (),
     cli_default_group: tuple[str, ...] = (),
 ) -> dict[str, object]:
@@ -342,6 +344,7 @@ def _cli_overrides(  # noqa: PLR0913 - one keyword per CLI flag it maps to a reg
             "project_dist_policy": cli_dist_policy,
             "project_build_policy": cli_build_policy,
             "project_build_requires_depth": cli_build_requires_depth,
+            "project_decision_order": cli_decision_order,
             "project_constraint": cli_constraint,
             "project_default_group": cli_default_group,
         }

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -44,7 +44,7 @@ from nab_python.lockfile import (
     WheelArtifact,
     read_lockfile_anchor,
 )
-from nab_python.provider import DistPolicy, ResolutionStrategy
+from nab_python.provider import DecisionOrder, DistPolicy, ResolutionStrategy
 from nab_python.resolve import ResolveResult, TargetResult
 from nab_python.target import ResolveTarget
 
@@ -999,6 +999,16 @@ class TestProjectCliOverrides:
             ["--project-build-requires-depth", "3"],
         )
         assert config.build_requires_depth == 3
+
+    def test_project_decision_order_reaches_resolve(self, hermetic_roots: Path) -> None:
+        # The file declares stable, so a resolve seeing arrival read the flag.
+        proj = _project(hermetic_roots, 'decision-order = "stable"\n')
+        config, _ = self._lock_config(
+            proj,
+            hermetic_roots / "pylock.toml",
+            ["--project-decision-order", "arrival"],
+        )
+        assert config.decision_order is DecisionOrder.ARRIVAL
 
     def test_project_constraint_repeats_replace_the_file_list(
         self, hermetic_roots: Path


### PR DESCRIPTION
nab decides packages whose index listing has already arrived ahead of ones still in flight, so which fetches happened to finish first reaches the decision order. One project resolved twice against a single frozen index can then search differently and return a different valid pin set.

On an unchanged `autogluon==1.1.1` project bounded with `uploaded-prior-to`, a cold HTTP cache swaps requests 2.28.2 for 2.32.3 and urllib3 1.26.20 for 2.2.3, drops oss2 entirely, and `nab lock --locked` fails on a commit nobody changed.

`decision-order = "stable"` waits for the listing instead of ranking a package on its absence, so the same inputs against the same index give the same lockfile. The wait is usually on a fetch already in flight rather than one the scan issues, so fetching is not serialised. It costs a few percent of wall time, so the default stays `arrival`.

The lockfile reference promised byte-for-byte identical locks from identical inputs with no qualification. It now says what that rests on, including the ways an index moves that no resolver setting can fix.
