### PR TITLE
Pass the request URL to the probe transport's response

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -385,7 +385,7 @@ class _ConcurrencyProbeTransport:
             await asyncio.sleep(0)
 
         self._in_flight -= 1
-        return _SidecarResponse(self._payloads[url])
+        return _SidecarResponse(self._payloads[url], url)
 
     async def aclose(self) -> None:
         return None


### PR DESCRIPTION
`main` is red. `_SidecarResponse` gained a required `url` argument when relative index URLs started resolving against the redirect target, and `_ConcurrencyProbeTransport` still builds one from the body alone, so the three `--max-concurrency` tests raise `TypeError` before they assert anything. Each change was green on its own branch and neither touched the other's lines.

The probe now passes the URL it was asked for, which is what the real response carries.
