### PR TITLE
Use nab's sdist metadata default in benchmark scenarios

### DIFF
--- a/nab-python/benchmarks/benchmark_config.py
+++ b/nab-python/benchmarks/benchmark_config.py
@@ -32,8 +32,9 @@ if TYPE_CHECKING:
     from nab_python.target import ResolveTarget
 
 
-# Search benchmarks trust pre-2.2 PKG-INFO dependency metadata by default.
-DEFAULT_SCENARIO_TRUST_UNVERIFIED_SDIST_DEPS = True
+DEFAULT_SCENARIO_TRUST_UNVERIFIED_SDIST_DEPS = (
+    NabProjectConfig().trust_unverified_sdist_deps
+)
 DEFAULT_INDEXES: tuple[IndexConfig, ...] = (
     IndexConfig(DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL),
 )
@@ -660,11 +661,11 @@ def _package_overrides(
 def build_benchmark_config(
     *,
     indexes: Sequence[IndexConfig],
+    trust_unverified_sdist_deps: bool,
     uploaded_prior_to: datetime | None = None,
     index_routes: Sequence[IndexRoute] = (),
     build_policy_overrides: Mapping[str, BuildPolicy] | None = None,
     resolution: ResolutionStrategy = ResolutionStrategy.HIGHEST,
-    trust_unverified_sdist_deps: bool = False,
     vcs: VcsConfig | None = None,
 ) -> NabProjectConfig:
     """Build the project config represented by one benchmark scenario."""

--- a/nab-python/benchmarks/compare.py
+++ b/nab-python/benchmarks/compare.py
@@ -173,7 +173,7 @@ def _validate_settings(value: object, run_dir: Path) -> None:
     if (
         value["dist_policy"] != "wheel-or-sdist"
         or value["build_policy"] != "never"
-        or value["trust_unverified_sdist_deps_default"] is not True
+        or value["trust_unverified_sdist_deps_default"] is not False
         or type(value["max_iterations"]) is not int
         or value["max_iterations"] <= 0
         or (timeout is not None and (type(timeout) is not int or timeout <= 0))

--- a/nab-python/tests/test_benchmark_canary.py
+++ b/nab-python/tests/test_benchmark_canary.py
@@ -512,6 +512,7 @@ def test_canary_configures_lowest_direct_roots(
             ),
         ),
         resolution=module.ResolutionStrategy.LOWEST_DIRECT,
+        trust_unverified_sdist_deps=False,
     )
     result = module.run_one(
         requirements,

--- a/nab-python/tests/test_benchmark_compare.py
+++ b/nab-python/tests/test_benchmark_compare.py
@@ -46,7 +46,7 @@ def _settings() -> dict[str, object]:
     return {
         "dist_policy": "wheel-or-sdist",
         "build_policy": "never",
-        "trust_unverified_sdist_deps_default": True,
+        "trust_unverified_sdist_deps_default": False,
         "max_iterations": 200_000,
         "wall_timeout_seconds": 120,
         "host": {
@@ -326,6 +326,30 @@ def test_load_run_rejects_invalid_settings(
     _rewrite_json(run_dir / module.MANIFEST_FILENAME, mutate)
 
     with pytest.raises(module.ComparisonError):
+        module.load_run(run_dir)
+
+
+def test_load_run_rejects_a_trusted_sdist_default(tmp_path: Path) -> None:
+    module = _harness()
+    run_dir = _write_run(module, tmp_path, "run", source_commit="a" * 40)
+    manifest_path = run_dir / module.MANIFEST_FILENAME
+    _rewrite_json(
+        manifest_path,
+        lambda data: data["settings"].update(trust_unverified_sdist_deps_default=True),
+    )
+
+    manifest = json.loads(manifest_path.read_text())
+    settings_hash = module._settings_hash(manifest["settings"])
+    # Keep the result identities valid so only the changed default is rejected.
+    for execution_key in manifest["completed_execution_keys"]:
+        _rewrite_json(
+            run_dir / execution_key,
+            lambda data: data["input"].update(settings_hash=settings_hash),
+        )
+
+    with pytest.raises(
+        module.ComparisonError, match="invalid standard benchmark settings"
+    ):
         module.load_run(run_dir)
 
 

--- a/nab-python/tests/test_benchmark_strategy_matrix.py
+++ b/nab-python/tests/test_benchmark_strategy_matrix.py
@@ -282,7 +282,6 @@ def _runner_parity_scenario() -> dict[str, object]:
         ],
         "build_packages": ["Zulu_Pkg", "alpha.pkg", "Demo-Pkg"],
         "resolution": "lowest-direct",
-        "trust_unverified_sdist_deps": False,
         "vcs_policy": "allow",
         "vcs_allowed_schemes": ["git+https"],
         "vcs_allowed_repos": ["https://example.test/project"],
@@ -1392,10 +1391,26 @@ def test_benchmark_config_combines_routing_and_build_policy() -> None:
     ]
 
 
+def test_benchmark_config_requires_an_explicit_sdist_trust_policy() -> None:
+    module = _harness("benchmark_config")
+
+    with pytest.raises(TypeError, match="trust_unverified_sdist_deps"):
+        module.build_benchmark_config(indexes=module.DEFAULT_INDEXES)
+
+
+def test_scenario_sdist_trust_default_matches_the_product_default() -> None:
+    module = _harness("benchmark_config")
+
+    assert (
+        module.DEFAULT_SCENARIO_TRUST_UNVERIFIED_SDIST_DEPS
+        is module.NabProjectConfig().trust_unverified_sdist_deps
+    )
+
+
 @pytest.mark.parametrize(
     ("scenario", "expected"),
     [
-        ({}, True),
+        ({}, False),
         ({"trust_unverified_sdist_deps": True}, True),
         ({"trust_unverified_sdist_deps": False}, False),
     ],
@@ -2577,6 +2592,7 @@ def test_benchmark_config_rejects_invalid_index_routes(
                 IndexConfig("private", "https://example.test/simple"),
             ],
             index_routes=[module.IndexRoute(*route) for route in routes],
+            trust_unverified_sdist_deps=False,
         )
 
 
@@ -2687,6 +2703,7 @@ def test_resolve_scenario_coordinates_config_target_and_constraints(
     config = module.build_benchmark_config(
         indexes=[IndexConfig("private", "https://example.test/simple")],
         index_routes=[module.IndexRoute("demo", "private")],
+        trust_unverified_sdist_deps=False,
     )
     coordinator = object()
     provider = SimpleNamespace(stats=_empty_provider_stats())
@@ -2815,7 +2832,10 @@ def test_resolve_scenario_records_no_pins_after_failure(
 
     result = module.resolve_scenario(
         module.parse_requirements(["demo"]),
-        config=module.build_benchmark_config(indexes=[]),
+        config=module.build_benchmark_config(
+            indexes=[],
+            trust_unverified_sdist_deps=False,
+        ),
         target=admission.target,
         host=host,
     )
@@ -2878,7 +2898,10 @@ def test_standard_runner_applies_root_extra_constraints(
     result = module.resolve_scenario(
         module.parse_requirements(["aaa[x]"]),
         module.parse_requirements([constraint]),
-        config=module.build_benchmark_config(indexes=module.DEFAULT_INDEXES),
+        config=module.build_benchmark_config(
+            indexes=module.DEFAULT_INDEXES,
+            trust_unverified_sdist_deps=False,
+        ),
         target=admission.target,
         host=host,
     )
@@ -4443,6 +4466,7 @@ def test_standard_canary_and_profile_build_the_same_project_config() -> None:
     assert (
         standard_execution.config == canary_execution.config == profile_inputs["config"]
     )
+    assert standard_execution.config.trust_unverified_sdist_deps is False
     assert standard_execution.config.constraints == ()
     assert standard_execution.constraint_strings == ["demo<2"]
 
@@ -5216,7 +5240,7 @@ def test_profile_runner_uses_scenario_sdist_trust_policy() -> None:
         "strict", {**base, "trust_unverified_sdist_deps": False}
     )
 
-    assert implicit["config"].trust_unverified_sdist_deps is True
+    assert implicit["config"].trust_unverified_sdist_deps is False
     assert trusted["config"].trust_unverified_sdist_deps is True
     assert strict["config"].trust_unverified_sdist_deps is False
 


### PR DESCRIPTION
Standard, canary and profile benchmarks trusted unverified sdist dependency metadata by default, while an ordinary nab resolve does not. `pip:copick` and `pip:langchain-ml-course` are the runs where that showed up.

Scenarios now inherit nab's project default unless they declare an override. A standard result recorded under the old trusted default is rejected rather than compared against a strict run.
