### PR TITLE
Parallelize CI tests and split out the benchmark harness

### DIFF
--- a/.github/requirements/pylock.crosshair.toml
+++ b/.github/requirements/pylock.crosshair.toml
@@ -211,6 +211,9 @@ name = "coverage"
 version = "7.15.2"
 marker = "\"crosshair\" in dependency_groups"
 requires-python = ">=3.10"
+dependencies = [
+    { name = "tomli" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -757,6 +760,31 @@ size = 16740
 
 [packages.wheels.hashes]
 sha256 = "a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598"
+
+[[packages]]
+name = "execnet"
+version = "2.1.2"
+marker = "\"crosshair\" in dependency_groups"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "execnet-2.1.2.tar.gz"
+upload-time = 2025-11-12 09:56:37.750774+00:00
+url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz"
+size = 166622
+
+[packages.sdist.hashes]
+sha256 = "63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd"
+
+[[packages.wheels]]
+name = "execnet-2.1.2-py3-none-any.whl"
+upload-time = 2025-11-12 09:56:36.333212+00:00
+url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl"
+size = 40708
+
+[packages.wheels.hashes]
+sha256 = "67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec"
 
 [[packages]]
 name = "h11"
@@ -1586,6 +1614,36 @@ size = 386536
 sha256 = "37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c"
 
 [[packages]]
+name = "pytest-cov"
+version = "7.1.0"
+marker = "\"crosshair\" in dependency_groups"
+requires-python = ">=3.9"
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "pytest_cov-7.1.0.tar.gz"
+upload-time = 2026-03-21 20:11:16.284275+00:00
+url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz"
+size = 55592
+
+[packages.sdist.hashes]
+sha256 = "30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2"
+
+[[packages.wheels]]
+name = "pytest_cov-7.1.0-py3-none-any.whl"
+upload-time = 2026-03-21 20:11:14.438324+00:00
+url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl"
+size = 22876
+
+[packages.wheels.hashes]
+sha256 = "a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678"
+
+[[packages]]
 name = "pytest-timeout"
 version = "2.4.0"
 marker = "\"crosshair\" in dependency_groups"
@@ -1612,6 +1670,35 @@ size = 14382
 
 [packages.wheels.hashes]
 sha256 = "c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2"
+
+[[packages]]
+name = "pytest-xdist"
+version = "3.8.0"
+marker = "\"crosshair\" in dependency_groups"
+requires-python = ">=3.9"
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "pytest_xdist-3.8.0.tar.gz"
+upload-time = 2025-07-01 13:30:59.346894+00:00
+url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz"
+size = 88069
+
+[packages.sdist.hashes]
+sha256 = "7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1"
+
+[[packages.wheels]]
+name = "pytest_xdist-3.8.0-py3-none-any.whl"
+upload-time = 2025-07-01 13:30:56.632054+00:00
+url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl"
+size = 46396
+
+[packages.wheels.hashes]
+sha256 = "202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88"
 
 [[packages]]
 name = "respx"

--- a/.github/requirements/pylock.tests.toml
+++ b/.github/requirements/pylock.tests.toml
@@ -156,6 +156,9 @@ name = "coverage"
 version = "7.15.2"
 marker = "\"tests\" in dependency_groups"
 requires-python = ">=3.10"
+dependencies = [
+    { name = "tomli" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -452,6 +455,31 @@ size = 16740
 
 [packages.wheels.hashes]
 sha256 = "a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598"
+
+[[packages]]
+name = "execnet"
+version = "2.1.2"
+marker = "\"tests\" in dependency_groups"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "execnet-2.1.2.tar.gz"
+upload-time = 2025-11-12 09:56:37.750774+00:00
+url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz"
+size = 166622
+
+[packages.sdist.hashes]
+sha256 = "63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd"
+
+[[packages.wheels]]
+name = "execnet-2.1.2-py3-none-any.whl"
+upload-time = 2025-11-12 09:56:36.333212+00:00
+url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl"
+size = 40708
+
+[packages.wheels.hashes]
+sha256 = "67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec"
 
 [[packages]]
 name = "h11"
@@ -1143,6 +1171,36 @@ size = 386536
 sha256 = "37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c"
 
 [[packages]]
+name = "pytest-cov"
+version = "7.1.0"
+marker = "\"tests\" in dependency_groups"
+requires-python = ">=3.9"
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "pytest_cov-7.1.0.tar.gz"
+upload-time = 2026-03-21 20:11:16.284275+00:00
+url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz"
+size = 55592
+
+[packages.sdist.hashes]
+sha256 = "30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2"
+
+[[packages.wheels]]
+name = "pytest_cov-7.1.0-py3-none-any.whl"
+upload-time = 2026-03-21 20:11:14.438324+00:00
+url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl"
+size = 22876
+
+[packages.wheels.hashes]
+sha256 = "a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678"
+
+[[packages]]
 name = "pytest-timeout"
 version = "2.4.0"
 marker = "\"tests\" in dependency_groups"
@@ -1169,6 +1227,35 @@ size = 14382
 
 [packages.wheels.hashes]
 sha256 = "c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2"
+
+[[packages]]
+name = "pytest-xdist"
+version = "3.8.0"
+marker = "\"tests\" in dependency_groups"
+requires-python = ">=3.9"
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "pytest_xdist-3.8.0.tar.gz"
+upload-time = 2025-07-01 13:30:59.346894+00:00
+url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz"
+size = 88069
+
+[packages.sdist.hashes]
+sha256 = "7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1"
+
+[[packages.wheels]]
+name = "pytest_xdist-3.8.0-py3-none-any.whl"
+upload-time = 2025-07-01 13:30:56.632054+00:00
+url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl"
+size = 46396
+
+[packages.wheels.hashes]
+sha256 = "202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88"
 
 [[packages]]
 name = "respx"

--- a/.github/requirements/pylock.types.toml
+++ b/.github/requirements/pylock.types.toml
@@ -217,6 +217,9 @@ name = "coverage"
 version = "7.15.2"
 marker = "\"types\" in dependency_groups"
 requires-python = ">=3.10"
+dependencies = [
+    { name = "tomli" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -513,6 +516,31 @@ size = 16740
 
 [packages.wheels.hashes]
 sha256 = "a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598"
+
+[[packages]]
+name = "execnet"
+version = "2.1.2"
+marker = "\"types\" in dependency_groups"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "execnet-2.1.2.tar.gz"
+upload-time = 2025-11-12 09:56:37.750774+00:00
+url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz"
+size = 166622
+
+[packages.sdist.hashes]
+sha256 = "63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd"
+
+[[packages.wheels]]
+name = "execnet-2.1.2-py3-none-any.whl"
+upload-time = 2025-11-12 09:56:36.333212+00:00
+url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl"
+size = 40708
+
+[packages.wheels.hashes]
+sha256 = "67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec"
 
 [[packages]]
 name = "h11"
@@ -1868,6 +1896,36 @@ size = 386536
 sha256 = "37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c"
 
 [[packages]]
+name = "pytest-cov"
+version = "7.1.0"
+marker = "\"types\" in dependency_groups"
+requires-python = ">=3.9"
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "pytest_cov-7.1.0.tar.gz"
+upload-time = 2026-03-21 20:11:16.284275+00:00
+url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz"
+size = 55592
+
+[packages.sdist.hashes]
+sha256 = "30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2"
+
+[[packages.wheels]]
+name = "pytest_cov-7.1.0-py3-none-any.whl"
+upload-time = 2026-03-21 20:11:14.438324+00:00
+url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl"
+size = 22876
+
+[packages.wheels.hashes]
+sha256 = "a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678"
+
+[[packages]]
 name = "pytest-timeout"
 version = "2.4.0"
 marker = "\"types\" in dependency_groups"
@@ -1894,6 +1952,35 @@ size = 14382
 
 [packages.wheels.hashes]
 sha256 = "c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2"
+
+[[packages]]
+name = "pytest-xdist"
+version = "3.8.0"
+marker = "\"types\" in dependency_groups"
+requires-python = ">=3.9"
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "pytest_xdist-3.8.0.tar.gz"
+upload-time = 2025-07-01 13:30:59.346894+00:00
+url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz"
+size = 88069
+
+[packages.sdist.hashes]
+sha256 = "7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1"
+
+[[packages.wheels]]
+name = "pytest_xdist-3.8.0-py3-none-any.whl"
+upload-time = 2025-07-01 13:30:56.632054+00:00
+url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl"
+size = 46396
+
+[packages.wheels.hashes]
+sha256 = "202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88"
 
 [[packages]]
 name = "respx"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,50 @@ jobs:
         env:
           WORKSPACE: ${{ matrix.workspace }}
 
+  benchmarks:
+    name: benchmark harness / ${{ matrix.os }} / ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      # These cover nab-python/benchmarks, which is developer tooling rather
+      # than shipped code, so they run on the ends of the supported range
+      # instead of the full matrix. Windows earns its cell because the
+      # harness builds output paths and the tests pin its device-name rules.
+      matrix:
+        include:
+          - os: ubuntu
+            python-version: "3.10"
+          - os: ubuntu
+            python-version: "3.14"
+          - os: windows
+            python-version: "3.14"
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        name: Install Python ${{ matrix.python-version }}
+        with:
+          python-version: ${{ matrix.python-version }}
+          check-latest: true
+          cache: pip
+          cache-dependency-path: |
+            .github/requirements/pylock.nox.toml
+            .github/requirements/pylock.tests.toml
+          allow-prereleases: true
+
+      - name: Upgrade pip to PEP 751 install support
+        run: python -m pip install --upgrade "pip>=26.1"
+
+      - name: Install nox
+        run: pip install -r .github/requirements/pylock.nox.toml
+
+      - name: Run the benchmark-harness tests
+        run: nox -s benchmarks
+
   property-tests:
     name: Property tests
     runs-on: ubuntu-latest
@@ -153,6 +197,7 @@ jobs:
     if: always()
     needs:
       - test
+      - benchmarks
       - property-tests
       - crosshair-tests
       - dists

--- a/nab-python/tests/test_benchmark_canary.py
+++ b/nab-python/tests/test_benchmark_canary.py
@@ -16,6 +16,8 @@ from typing_extensions import Self
 
 from nab_python.target import ResolveTarget
 
+pytestmark = pytest.mark.benchmark
+
 _CANARY = Path(__file__).resolve().parents[1] / "benchmarks" / "canary.py"
 
 

--- a/nab-python/tests/test_benchmark_canary_selection.py
+++ b/nab-python/tests/test_benchmark_canary_selection.py
@@ -9,6 +9,8 @@ from types import ModuleType
 
 import pytest
 
+pytestmark = pytest.mark.benchmark
+
 _CANARY = Path(__file__).resolve().parents[1] / "benchmarks" / "canary.py"
 _EXPECTED_CANARY_CASES = 19
 _EXPECTED_V2_INPUT_HASHES = {

--- a/nab-python/tests/test_benchmark_compare.py
+++ b/nab-python/tests/test_benchmark_compare.py
@@ -10,6 +10,8 @@ from types import ModuleType
 
 import pytest
 
+pytestmark = pytest.mark.benchmark
+
 _BENCHMARKS = Path(__file__).resolve().parents[1] / "benchmarks"
 _STRATEGIES = ("highest", "lowest", "lowest-direct")
 _COMPLETED_LOGICAL = ("cases:done",)

--- a/nab-python/tests/test_benchmark_datetime.py
+++ b/nab-python/tests/test_benchmark_datetime.py
@@ -10,6 +10,8 @@ from types import ModuleType
 
 import pytest
 
+pytestmark = pytest.mark.benchmark
+
 _BENCHMARKS = Path(__file__).resolve().parents[1] / "benchmarks"
 _FRACTION_WIDTHS = [
     ("", 0),

--- a/nab-python/tests/test_benchmark_parse_requirements.py
+++ b/nab-python/tests/test_benchmark_parse_requirements.py
@@ -25,6 +25,8 @@ from nab_python._vendor.packaging.version import Version
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+pytestmark = pytest.mark.benchmark
+
 _BENCH = Path(__file__).resolve().parents[1] / "benchmarks"
 
 

--- a/nab-python/tests/test_benchmark_strategy_matrix.py
+++ b/nab-python/tests/test_benchmark_strategy_matrix.py
@@ -18,6 +18,8 @@ import pytest
 from nab_python._vendor.packaging.tags import Tag
 from nab_python.target import ResolveTarget
 
+pytestmark = pytest.mark.benchmark
+
 _BENCHMARKS = Path(__file__).resolve().parents[1] / "benchmarks"
 _STANDARD_FILES = 14
 _STANDARD_SCENARIOS = 557

--- a/nab-python/tests/test_deterministic_smoke_core.py
+++ b/nab-python/tests/test_deterministic_smoke_core.py
@@ -20,6 +20,8 @@ from nab_python.config import NabProjectConfig
 from nab_python.lockfile import IndexPin, TargetLock, WheelArtifact
 from nab_python.resolve import ResolveResult, TargetResult
 
+pytestmark = pytest.mark.benchmark
+
 _BENCHMARKS = Path(__file__).resolve().parents[1] / "benchmarks"
 
 

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -60,14 +60,16 @@ def _coord(**kwargs: object) -> FetchCoordinator:
 def _wait_until(predicate: Callable[[], bool], timeout: float = 5) -> bool:
     """Poll ``predicate`` until it holds, and report whether it did.
 
-    For work the coordinator finishes without setting a waiter's event, where
-    waiting on the event itself would only burn the whole timeout.
+    The coordinator finishes some work without setting the waiter's event, so
+    waiting on the event itself would just spend the whole timeout.
     """
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         if predicate():
             return True
         time.sleep(0.01)
+
+    # One last look, in case the work landed during the final sleep.
     return predicate()
 
 
@@ -1367,8 +1369,8 @@ class TestFetchCoordinator:
             )
             event = coord.request_metadata("pkg", "1.0", "https://f.com/m")
 
-            # Handing back the pending's own event is what marks it deduplicated;
-            # nothing was submitted, so no one ever sets it.
+            # Deduplicating means handing back the pending's own event. Nothing
+            # was submitted for it, so nothing ever sets it.
             assert event is pending.event
             assert not event.is_set()
 

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -57,6 +57,20 @@ def _coord(**kwargs: object) -> FetchCoordinator:
     return FetchCoordinator(transport=HttpxAsyncTransport(), **kwargs)  # type: ignore[arg-type]
 
 
+def _wait_until(predicate: Callable[[], bool], timeout: float = 5) -> bool:
+    """Poll ``predicate`` until it holds, and report whether it did.
+
+    For work the coordinator finishes without setting a waiter's event, where
+    waiting on the event itself would only burn the whole timeout.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return predicate()
+
+
 class _FetcherDeath(BaseException):
     """A BaseException that is not an Exception, as asyncio.CancelledError is."""
 
@@ -589,14 +603,14 @@ class TestFetchCoordinator:
             # Put a request with None url directly on the queue
             from nab_python.fetch import FetchKind, FetchRequest
 
-            pending, _ = coord.index.get_or_create_pending("metadata:pkg:1.0")
+            coord.index.get_or_create_pending("metadata:pkg:1.0")
             coord._submit(
                 FetchRequest(
                     kind=FetchKind.METADATA, package="pkg", version="1.0", url=None
                 )
             )
-            pending.event.wait(timeout=5)
-            assert coord.index.has_metadata("pkg", "1.0")
+
+            assert _wait_until(lambda: coord.index.has_metadata("pkg", "1.0"))
             assert coord.index.get_metadata("pkg", "1.0") is None
 
     @respx.mock
@@ -1348,11 +1362,15 @@ class TestFetchCoordinator:
         """Second request_metadata for the same key reuses the pending."""
         respx.get(url__regex=r".*").mock(return_value=httpx.Response(200, text="meta"))
         with _coord() as coord:
-            # Pre-create a pending so the second request finds it.
-            coord.index.get_or_create_pending("metadata:pkg:1.0:https://f.com/m")
-            e = coord.request_metadata("pkg", "1.0", "https://f.com/m")
-            # Should reuse the existing pending (existed=True path).
-            e.wait(timeout=5)
+            pending, _ = coord.index.get_or_create_pending(
+                "metadata:pkg:1.0:https://f.com/m"
+            )
+            event = coord.request_metadata("pkg", "1.0", "https://f.com/m")
+
+            # Handing back the pending's own event is what marks it deduplicated;
+            # nothing was submitted, so no one ever sets it.
+            assert event is pending.event
+            assert not event.is_set()
 
     @respx.mock
     def test_request_sdist(self) -> None:
@@ -1552,9 +1570,11 @@ class TestFetchCoordinator:
             return_value=httpx.Response(200, content=buf.getvalue())
         )
         with _coord() as coord:
-            coord.index.get_or_create_pending("sdist:pkg:1.0")
-            e = coord.request_sdist("pkg", "1.0", "https://f.com/pkg-1.0.tar.gz")
-            e.wait(timeout=5)
+            pending, _ = coord.index.get_or_create_pending("sdist:pkg:1.0")
+            event = coord.request_sdist("pkg", "1.0", "https://f.com/pkg-1.0.tar.gz")
+
+            assert event is pending.event
+            assert not event.is_set()
 
     @respx.mock
     def test_request_sdist_archive_stores_bytes(self) -> None:
@@ -1616,11 +1636,13 @@ class TestFetchCoordinator:
             return_value=httpx.Response(200, content=b"archive"),
         )
         with _coord() as coord:
-            coord.index.get_or_create_pending("sdist-archive:pkg:1.0")
+            pending, _ = coord.index.get_or_create_pending("sdist-archive:pkg:1.0")
             event = coord.request_sdist_archive(
                 "pkg", "1.0", "https://f.com/pkg-1.0.tar.gz"
             )
-            event.wait(timeout=5)
+
+            assert event is pending.event
+            assert not event.is_set()
 
     @respx.mock
     def test_request_sdist_archive_404_records_error(self) -> None:
@@ -1715,16 +1737,23 @@ class TestFetchCoordinator:
         """Batch request skips items with existing pending."""
         respx.get(url__regex=r".*").mock(return_value=httpx.Response(200, text="meta"))
         with _coord() as coord:
-            # Pre-create a pending for one of the batch items.
-            coord.index.get_or_create_pending("metadata:a:1.0:https://f.com/a")
+            pending, _ = coord.index.get_or_create_pending(
+                "metadata:a:1.0:https://f.com/a"
+            )
             results = coord.request_metadata_batch(
                 [
                     ("a", "1.0", "https://f.com/a", None),
                     ("b", "1.0", "https://f.com/b", None),
                 ]
             )
-            for _, _, ev in results:
-                ev.wait(timeout=5)
+            events = {package: event for package, _version, event in results}
+
+            assert events["a"] is pending.event
+            assert not events["a"].is_set()
+
+            # The item without a pending is still fetched.
+            assert events["b"].wait(timeout=5)
+            assert coord.index.get_metadata("b", "1.0", "https://f.com/b") == "meta"
 
 
 class TestFetchCoordinatorCache:

--- a/nab-python/tests/test_universal_benchmark.py
+++ b/nab-python/tests/test_universal_benchmark.py
@@ -19,6 +19,8 @@ from nab_python.resolve import ResolveResult, TargetResult
 from nab_python.tags import PlatformSpec
 from nab_python.target import ResolveTarget
 
+pytestmark = pytest.mark.benchmark
+
 _BENCHMARK = (
     Path(__file__).resolve().parents[1] / "benchmarks" / "universal_scenarios.py"
 )

--- a/noxfile.py
+++ b/noxfile.py
@@ -4,9 +4,11 @@
 percent. ``fail_under`` and the ``[tool.coverage.paths]`` remaps live in
 ``pyproject.toml``; the per-package ``--include`` globs are built here.
 ``types`` runs one type-checker over the source trees in ``TYPED_TREES``.
-``dists`` builds every distribution and installs each sdist and wheel to
-catch packaging regressions that building alone misses. All take their
-pinned dependencies from ``.github/requirements``.
+``benchmarks`` runs the benchmark-harness tests, which carry the ``benchmark``
+marker and so sit outside every workspace run. ``dists`` builds every
+distribution and installs each sdist and wheel to catch packaging regressions
+that building alone misses. All take their pinned dependencies from
+``.github/requirements``.
 
 The Python version comes from whoever launches nox, so CI drives the matrix
 through ``actions/setup-python`` and stays off the per-OS versioned-binary
@@ -14,6 +16,7 @@ lookup. Run a single cell locally, for example::
 
     nox -s "tests(workspace='python')"
     nox -s "types(checker='mypy')"
+    nox -s benchmarks
     nox -s dists
 """
 
@@ -84,10 +87,34 @@ def tests(session: nox.Session, workspace: str) -> None:
     _install(session, TESTS_LOCK, editables)
 
     session.run("coverage", "erase")
-    session.run("coverage", "run", "-m", "pytest", *paths)
-    session.run("coverage", "combine")
+
+    # pytest-cov measures the xdist workers, which a bare `coverage run` cannot
+    # see, and combines their data files when the session ends. Its own gate is
+    # off because it scores every source package at once, and a workspace only
+    # imports the ones it owns; the per-package reports below are the gate.
+    session.run(
+        "python",
+        "-m",
+        "pytest",
+        "-n",
+        "auto",
+        "--cov",
+        "--cov-report=",
+        "--cov-fail-under=0",
+        *paths,
+    )
+
     for package in packages:
         session.run("coverage", "report", f"--include=*/{package}/*")
+
+
+@nox.session
+def benchmarks(session: nox.Session) -> None:
+    """Run the benchmark-harness tests the workspace sessions deselect."""
+    # These cover scripts under nab-python/benchmarks, which no coverage gate
+    # owns, so this session only has to prove they still pass.
+    _install(session, TESTS_LOCK, ["nab-resolver", "nab-index", "nab-python"])
+    session.run("python", "-m", "pytest", "-m", "benchmark", "nab-python/tests")
 
 
 @nox.session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,9 @@ exclude = [
 [dependency-groups]
 tests = [
     "pytest>=9",
+    "pytest-cov>=7",
     "pytest-timeout>=2.3",
+    "pytest-xdist>=3.8",
     "coverage>=7",
     "hypothesis>=6.100",
     "respx>=0.22",
@@ -159,7 +161,7 @@ addopts = [
     "--import-mode=importlib",
     "--showlocals",
     "-m",
-    "not property and not crosshair and not network",
+    "not property and not crosshair and not network and not benchmark",
 ]
 testpaths = [
     "nab-resolver/tests",
@@ -174,6 +176,7 @@ markers = [
     "network: hits a real network endpoint (skipped by default in CI)",
     "property: Hypothesis property tests (opt-in; run with -m property)",
     "crosshair: CrossHair-backed property tests (opt-in; very slow; -m crosshair)",
+    "benchmark: covers the benchmark harness, not the resolver (opt-in; -m benchmark)",
 ]
 
 # https://coverage.readthedocs.io/en/latest/config.html#run


### PR DESCRIPTION
The workspace test jobs run everything serially, and the `python` workspace is now big enough to account for about 70% of a run's total job time, roughly 4650s of 6690s, with its slowest cell taking over seven minutes. Under pytest-xdist that cell goes from about 300s of pytest to about 75s.

The 100% branch gate is unchanged. pytest-cov measures the xdist workers, which a bare `coverage run` cannot see, and the per-package reports still decide pass or fail.

The benchmark-harness tests now carry a `benchmark` marker and run in their own job rather than on all fifteen OS and Python cells. They cover scripts under `nab-python/benchmarks`, which no coverage gate owns, so the job takes the ends of the supported range plus Windows, the platform whose device-name rules `test_universal_benchmark.py` pins.

Four of the `FetchCoordinator` deduplication tests waited five seconds each on an event that nothing submits and so nothing ever sets, then asserted nothing at all. They cost 25s per job and could not fail. They now assert what their docstrings already claimed, that a second request hands back the pending's own event, and the batch case also checks that the item without a pending is still fetched.
