### PR TITLE
add base-group to name the project's own dependencies

### DIFF
--- a/docs/how-to/workspaces.md
+++ b/docs/how-to/workspaces.md
@@ -95,13 +95,21 @@ locked: the workspace `members`, merged into `local-sources`. Everything
 else under `[tool.nab]` is scoped to the pyproject being locked: `conflicts`,
 `default-groups`, `constraints`, `matrix`, `mode`, `requires-python`,
 `uploaded-prior-to`, `build-policy` itself, `dist-policy`, `vcs`,
-`indexes`, and `environment`. Locking a member with `nab lock
+`indexes`, `base-group`, and `environment`. Locking a member with `nab lock
 packages/core/pyproject.toml` reads only that file's keys; the
 root's are ignored.
 
 Declare conflicts and default-groups on each member that needs them.
 The same applies to constraints: a root-level constraint table does
 not constrain a member resolve.
+
+`base-group` follows the same rule: the root's setting names the root's
+own dependencies in the root's lock, and a member's lock is unaffected.
+Members are ordinary packages there, so the gate covers everything the
+root's `[project.dependencies]` pull in, members and other local sources
+alike. An install asked for `dev` alone no longer gets them, and one
+that wants both asks for both. A root that declares members but has no
+dependencies of its own has nothing to name.
 
 ## Example layout
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -47,7 +47,8 @@ Dependency-group selection (PEP 735):
   group names land in the lockfile's top-level
   `dependency-groups` array. The separate `default-groups` array
   records the `[tool.nab].default-groups` project setting, not
-  this run's selection.
+  this run's selection, plus the group named by
+  `[tool.nab].base-group` when it is set.
 * `--all-groups` selects every group defined in the project.
 
 Extras selection:
@@ -138,11 +139,11 @@ A project option can be overridden for one run with a `--project-<key>`
 flag: `--project-resolution`, `--project-mode`, `--project-requires-python`,
 `--project-uploaded-prior-to`, `--project-dist-policy`,
 `--project-build-policy`, `--project-build-requires-depth`,
-`--project-decision-order`, and the repeatable
-`--project-constraint` and `--project-default-group`. Every one
+`--project-decision-order`, `--project-base-group`, and the
+repeatable `--project-constraint` and `--project-default-group`. Every one
 of them replaces the file value outright; repeating `--project-constraint`
 builds up that run's whole constraint list rather than adding to the
-declared one. Each changes the resolved set, so passing one prints a
+declared one. Each changes what the run writes, so passing one prints a
 reproducibility notice on stderr and records the override in the
 lockfile's `[tool.nab]` block, since the lock no longer derives from the
 committed files alone.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -28,6 +28,15 @@ constraints = ["urllib3<2"]
 # both be defaults.
 default-groups = ["dev"]
 
+# The group name a lock gives the project's own [project.dependencies],
+# recorded in both of the lockfile's group arrays.  Unset, they carry no
+# marker and install under every selection, so a lock offering groups
+# cannot be asked for one group without them.  The name must not be one
+# the file being locked declares in [dependency-groups].  It joins the
+# lockfile's default-groups only when default-groups above is unset;
+# declare it there too to keep it in the default selection.
+base-group = "base"
+
 # The Python range this project supports.  A declaration: it is
 # recorded in the lockfile and checked against the resolve target,
 # and it does not choose that target.  Falls back to

--- a/docs/reference/lockfile.md
+++ b/docs/reference/lockfile.md
@@ -120,13 +120,14 @@ version = "3.0.0"
 marker = "\"dev\" in dependency_groups"
 ```
 
-Reachability is what decides: a package the project's own
-dependencies pull in is unconditional even when a selected extra
-also asks for it, and a package that two selections reach disjoins
-both (`"cli" in extras or "dev" in dependency_groups`). A group
-named in `[tool.nab].default-groups` still installs by default,
-because PEP 751 seeds `dependency_groups` from `default-groups`
-when the installer is given no group selection.
+Reachability is what decides: unless `base-group` names them (below), a
+package the project's own dependencies pull in is unconditional even
+when a selected extra also asks for it, and a package that two
+selections reach disjoins both
+(`"cli" in extras or "dev" in dependency_groups`).
+A group named in `[tool.nab].default-groups` still installs by
+default, because PEP 751 seeds `dependency_groups` from
+`default-groups` when the installer is given no group selection.
 
 The gate is a property of the install context, not of the platform.
 A matrix folds the selection into every target, so an extra that
@@ -139,6 +140,49 @@ shape the pins of the packages it shares with the project. A
 conflict between two selections is a resolution failure, not two
 lockfiles, unless it is declared; see
 [Conflicting extras and groups](../explanation/conflicts.md).
+
+### Naming the project's own dependencies
+
+A package with no marker installs under every selection, so the project's
+own dependencies come with every group, and a lock offering groups cannot
+be asked for one group alone. Naming them fixes that:
+
+```toml
+[tool.nab]
+base-group = "base"
+```
+
+The lock carries that name in both group arrays and gates those packages
+on it:
+
+```toml
+dependency-groups = ["dev", "base"]
+default-groups = ["base"]
+
+[[packages]]
+name = "core"
+version = "1.0.0"
+marker = "\"base\" in dependency_groups"
+```
+
+An installer given no group selection still gets them, because PEP 751
+seeds `dependency_groups` from `default-groups`. One asked for `dev`
+alone gets that group and nothing else. One that asks for an empty group
+list gets no group at all, not even the project's own. A package both
+they and a group reach names both.
+
+The name joins `default-groups` only when the project declares none of
+its own. A declared `[tool.nab].default-groups` replaces the default
+selection rather than extending it, so a project that wants its
+dependencies installed alongside a group names them there too:
+`default-groups = ["dev", "base"]`.
+
+Unset, which is the default, they carry no marker. The name must not be
+one the project already declares in `[dependency-groups]`, since a
+marker naming it could not mean both. It is a name for the lock's
+consumers rather than a group of the project's own, so `--groups` does
+not accept it; `[tool.nab].default-groups` does, which is how it stays
+in the default selection.
 
 ### Portable paths
 

--- a/nab-python/src/nab_python/_lockfile/builder.py
+++ b/nab-python/src/nab_python/_lockfile/builder.py
@@ -27,6 +27,7 @@ from .._vendor.packaging.specifiers import SpecifierSet
 from .._vendor.packaging.utils import canonicalize_name
 from ..metadata import validate_specifier_versions
 from ..paths import path_state
+from .groups import BASE_MEMBER
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping, Sequence
@@ -276,7 +277,7 @@ def build_target_lock(
     install context requires directly: the project's own dependencies,
     and those of each selected extra and each selected group, keyed by
     its ``(kind, name)`` member.  :func:`_membership_gates` walks the
-    resolve from them to find the packages only a selection reaches.  An
+    resolve from each to find which contexts reach each package.  An
     empty ``base_roots`` is a project with no dependencies of its own, so
     it does not stand in for ``None``: omitting it while passing selector
     roots raises.
@@ -359,33 +360,34 @@ def _membership_gates(
     base_roots: Iterable[str],
     selector_roots: Mapping[tuple[str, str], Iterable[str]],
 ) -> dict[str, tuple[tuple[str, str], ...]]:
-    """Name the selections that gate each package no base dependency reaches.
+    """Name every install context that reaches each package.
 
     A selected extra or group is folded into the resolve that produces
     the lock, so its requirements pin packages a default install must not
-    receive.  PEP 751 defaults an install to no extras and to
-    ``default-groups``, and decides per package from ``packages.marker``,
-    so a package only a selection reaches has to name every selection
-    that reaches it; the writer turns each ``(kind, name)`` member into
-    ``'name' in extras`` / ``'name' in dependency_groups``.  A package
-    the project's own dependencies reach is unconditional.
+    receive.  PEP 751 decides per package from ``packages.marker``, so a
+    package has to name every context that reaches it; the writer turns
+    each ``(kind, name)`` member into ``'name' in extras`` /
+    ``'name' in dependency_groups``.  The project's own dependencies are
+    one such context, recorded as
+    :data:`~nab_python.lockfile.BASE_MEMBER` until the writer knows what to
+    call it, so a package both they and a group reach installs for either.
 
     Reachability is over this target's resolved graph, so an extras proxy
     (an extra requiring ``pkg[fancy]`` while the project requires plain
     ``pkg``) gates what ``fancy`` adds without gating ``pkg``.
+
+    Empty roots on both sides gate nothing, which is a lock with no
+    selection and no name for the project's own dependencies.
     """
-    if not selector_roots:
-        return {}
-
     pinned = {canonicalize_name(name): version for name, version in pins.items()}
-    base_reachable = _reachable_names(provider, pinned, base_roots)
 
-    gates: defaultdict[str, list[tuple[str, str]]] = defaultdict(list)
-    for member in sorted(selector_roots):
-        gated = _reachable_names(provider, pinned, selector_roots[member])
-        for name in gated - base_reachable:
-            gates[name].append(member)
-    return {name: tuple(members) for name, members in gates.items()}
+    reach: defaultdict[str, set[tuple[str, str]]] = defaultdict(set)
+    for name in _reachable_names(provider, pinned, base_roots):
+        reach[name].add(BASE_MEMBER)
+    for member, roots in selector_roots.items():
+        for name in _reachable_names(provider, pinned, roots):
+            reach[name].add(member)
+    return {name: tuple(sorted(members)) for name, members in reach.items()}
 
 
 def _reachable_names(

--- a/nab-python/src/nab_python/_lockfile/groups.py
+++ b/nab-python/src/nab_python/_lockfile/groups.py
@@ -1,0 +1,18 @@
+"""The group a lock can give the project's own dependencies.
+
+A leaf module, so the builder and the writer can both reach the member
+without importing each other.
+"""
+
+from __future__ import annotations
+
+from .._conflict_kind import KIND_GROUP
+
+BASE_MEMBER = (KIND_GROUP, "")
+"""Stands for the project's own dependencies in a gate.
+
+The builder records reachability before anything knows whether the lock
+will name them, so it records this and the writer substitutes the
+configured name or drops the gate. It is never rendered: the empty name
+belongs to no group.
+"""

--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import os
 from collections import Counter, defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from functools import reduce
 from itertools import product
 from pathlib import Path
@@ -22,7 +22,7 @@ import tomli_w
 
 from nab_index.atomic import atomic_write_text
 
-from .._conflict_kind import MARKER_VARIABLE_FOR_KIND
+from .._conflict_kind import KIND_GROUP, MARKER_VARIABLE_FOR_KIND
 from .._vendor.packaging.markers import Marker
 from .._vendor.packaging.markersets import (
     DecisionStore,
@@ -46,6 +46,7 @@ from ..config import conflict_exclusion_groups, conflict_member_groups
 from .builder import require_artifact_hashes
 from .coverage import validate_marker_coverage
 from .disjointness import validate_marker_disjointness
+from .groups import BASE_MEMBER
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping, Sequence
@@ -97,6 +98,17 @@ class _ForkAxes:
     env_signatures: Mapping[str, _EnvSignature]
     markers: Mapping[str, str]
     gates: Mapping[tuple[str, str], _Members]
+
+
+@dataclass(frozen=True, slots=True)
+class _GatedMarker:
+    """The environments one gate selects a package in.
+
+    ``marker`` is ``None`` when the gate holds on all of them.
+    """
+
+    marker: Marker | None
+    gate: tuple[tuple[str, str], ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -221,6 +233,8 @@ def build_pylock(lock_input: LockInput, *, lock_dir: Path | None = None) -> Pylo
     """
     from ..lockfile import LOCK_VERSION
 
+    lock_input = _name_base_group(lock_input)
+
     base = (lock_dir if lock_dir is not None else Path.cwd()).resolve()
     exclusion_groups = conflict_exclusion_groups(lock_input.conflicts)
     universe = _emission_universe(lock_input)
@@ -260,20 +274,63 @@ def build_pylock(lock_input: LockInput, *, lock_dir: Path | None = None) -> Pylo
             if lock_input.extras
             else None
         ),
-        dependency_groups=(
-            tuple(canonicalize_name(g) for g in lock_input.dependency_groups)
-            if lock_input.dependency_groups
-            else None
+        dependency_groups=_group_array(
+            lock_input.dependency_groups, lock_input.base_group
         ),
-        default_groups=(
-            tuple(canonicalize_name(g) for g in lock_input.default_groups)
-            if lock_input.default_groups
-            else None
+        default_groups=_group_array(
+            lock_input.default_groups,
+            lock_input.base_group if not lock_input.default_groups else None,
         ),
         created_by=lock_input.created_by,
         packages=package_records,
         tool=tool,
     )
+
+
+def _name_base_group(lock_input: LockInput) -> LockInput:
+    """Return ``lock_input`` with the base member named, or cut from every gate.
+
+    The builder records :data:`~nab_python.lockfile.BASE_MEMBER` on every
+    package the project's own dependencies reach.  With ``base-group``
+    unset there is no name to give it, so those packages lose their gate
+    and stay unconditional.
+    """
+    name = lock_input.base_group
+    member = (KIND_GROUP, name)
+    targets = {
+        label: replace(
+            lock,
+            package_gates={
+                gated: tuple(
+                    member if gate_member == BASE_MEMBER else gate_member
+                    for gate_member in gate
+                )
+                for gated, gate in lock.package_gates.items()
+                if name is not None or BASE_MEMBER not in gate
+            },
+        )
+        for label, lock in lock_input.targets.items()
+    }
+    return replace(lock_input, targets=targets)
+
+
+def _group_array(
+    groups: Sequence[str], base_group: str | None
+) -> tuple[str, ...] | None:
+    """Render one of the lock's group arrays, or ``None`` when it is empty.
+
+    ``base_group`` is appended when given.  It always joins
+    ``dependency-groups``, since an installer that offers only those
+    names would otherwise never reach it.  It joins ``default-groups``
+    only when the project declares none of its own: a declared
+    ``default-groups`` replaces the default selection rather than
+    extending it, so a project that wants its own dependencies installed
+    by default alongside a group names them there itself.
+    """
+    names = dict.fromkeys(str(canonicalize_name(group)) for group in groups)
+    if base_group is not None:
+        names[str(canonicalize_name(base_group))] = None
+    return tuple(names) or None
 
 
 def _relativize_path(target: str | os.PathLike[str], lock_dir: Path) -> str:
@@ -567,10 +624,9 @@ def _build_packages(
     Each emitted marker is finalised to its shortest form equivalent over
     the declared environments (:func:`_finalize_marker`).
 
-    A package a selected extra or group reaches while the project's own
-    dependencies do not is gated on that selection, so a default install
-    (no extras, the default groups) leaves it out.  See
-    :func:`_build_marker`.
+    A package carries the gate of every install context that reaches it,
+    which with ``[tool.nab].base-group`` set includes the project's own
+    dependencies.  See :func:`_build_marker`.
 
     A conflict fork injects a membership clause into every target's
     marker, including the forks' base dependencies.  A base dependency
@@ -632,7 +688,7 @@ def _build_packages(
         )
 
         for pins, labels in groups:
-            marker = _build_marker(
+            parts = _build_marker(
                 canonical_name,
                 labels,
                 env_fork_counts,
@@ -640,9 +696,7 @@ def _build_packages(
                 axes,
                 projections,
             )
-            marker = _finalize_cached(
-                marker, universe, canonical_name, shortened, store
-            )
+            marker = _finalize_parts(parts, universe, canonical_name, shortened, store)
             out.append(
                 _pin_to_package(
                     _merge_pins_in_group(pins),
@@ -884,8 +938,8 @@ def _build_marker(
     env_base_names: Mapping[tuple[tuple[str, str], ...], frozenset[str]],
     axes: _ForkAxes,
     projections: Mapping[tuple[str, str], _Projection],
-) -> Marker | None:
-    """Return the marker selecting ``labels``, or ``None`` if unconditional.
+) -> tuple[_GatedMarker, ...]:
+    """Return the marker selecting ``labels``, split by gate.
 
     For each environment the package appears in, the contribution is
     the membership-free env-only marker when the package is present in
@@ -916,10 +970,9 @@ def _build_marker(
     :func:`_fork_projections`.  The projection makes several forks render
     the same contribution, which is emitted once.
 
-    A package a selected extra or group reaches while the project's own
-    dependencies do not carries that selection's gate (see
-    :attr:`~nab_python.lockfile.TargetLock.package_gates`), which is
-    joined by ``and`` onto each contribution.  A fork whose gate names
+    A package carries the gate of every install context that reaches it
+    (see :attr:`~nab_python.lockfile.TargetLock.package_gates`), joined
+    by ``and`` onto each contribution.  A fork whose gate names
     its own selection needs no gate: its marker already asserts that
     member.  An env collapses only when its forks agree on the rest of
     the gate, and the collapsed entry carries their union, so a package
@@ -941,8 +994,8 @@ def _build_marker(
     # every environment collapsed to its env-only marker. A member-only
     # dep present in all forks of an env keeps the membership OR, so it
     # is not unconditional even at full coverage.
-    contributions: list[Marker] = []
-    collapsed_gates: set[tuple[tuple[str, str], ...]] = set()
+    by_gate: defaultdict[tuple[tuple[str, str], ...], list[Marker]] = defaultdict(list)
+    loose: list[Marker] = []
     unconditional = len(labels) >= len(targets)
     for signature, env_labels in by_env.items():
         is_base = _is_base(name, signature, env_fork_counts, env_base_names)
@@ -951,31 +1004,45 @@ def _build_marker(
             == 1
         )
 
-        if len(env_labels) >= env_fork_counts[signature] and is_base and agreed_gate:
-            head = targets[env_labels[0]].target
-            merged = _merge_gates(gates[label] for label in env_labels)
-            collapsed_gates.add(merged)
-            contributions.append(
-                Marker(_with_gate(head.environment_marker_string, merged))
-            )
-        else:
-            contributions.extend(
-                Marker(text)
-                for text in _fork_contributions(axes, projections, name, env_labels)
-            )
-            unconditional = False
+        collapses = len(env_labels) >= env_fork_counts[signature] and is_base
+        head = targets[env_labels[0]].target
 
+        if collapses and agreed_gate:
+            merged = _merge_gates(gates[label] for label in env_labels)
+            by_gate[merged].append(Marker(head.environment_marker_string))
+            continue
+
+        # Forks that disagree on the gate still agree on what they share,
+        # and a base dep is present in all of them, so the shared part
+        # holds whichever fork the install context picks, including none.
+        if collapses:
+            shared = _common_gate(gates[label] for label in env_labels)
+            if shared:
+                by_gate[shared].append(Marker(head.environment_marker_string))
+
+        loose.extend(
+            Marker(text)
+            for text in _fork_contributions(axes, projections, name, env_labels)
+        )
+        unconditional = False
+
+    parts = tuple(
+        _GatedMarker(_or_markers(environments), gate)
+        for gate, environments in by_gate.items()
+    )
+    if loose:
+        parts += (_GatedMarker(_or_markers(loose), ()),)
     if not unconditional:
-        return _or_markers(contributions)
+        return parts
 
     # Every env collapsed at full coverage: the environment is not what
     # selects this package, so only the gate can, and only when every
     # env agrees on it.
-    if collapsed_gates == {()}:
-        return None
-    if len(collapsed_gates) == 1:
-        return Marker(_gate_clause(next(iter(collapsed_gates))))
-    return _or_markers(contributions)
+    if set(by_gate) == {()}:
+        return (_GatedMarker(None, ()),)
+    if len(by_gate) == 1:
+        return (_GatedMarker(None, next(iter(by_gate))),)
+    return parts
 
 
 def _fork_contributions(
@@ -1220,6 +1287,21 @@ def _fork_gate(
     return tuple(sorted(gate))
 
 
+def _common_gate(
+    gates: Iterable[tuple[tuple[str, str], ...]],
+) -> tuple[tuple[str, str], ...]:
+    """Return the members every fork of one environment gates a package on.
+
+    A gate is a disjunction, so a member every fork names implies every
+    fork's gate: the package is reached under that member whichever fork
+    the install context selects.
+    """
+    common: set[tuple[str, str]] | None = None
+    for gate in gates:
+        common = set(gate) if common is None else common & set(gate)
+    return tuple(sorted(common or ()))
+
+
 def _merge_gates(
     gates: Iterable[tuple[tuple[str, str], ...]],
 ) -> tuple[tuple[str, str], ...]:
@@ -1284,6 +1366,47 @@ def _gate_clause(gate: Sequence[tuple[str, str]]) -> str:
     return " or ".join(
         f'"{name}" in {MARKER_VARIABLE_FOR_KIND[kind]}' for kind, name in sorted(gate)
     )
+
+
+def _finalize_parts(
+    parts: Sequence[_GatedMarker],
+    universe: MarkerSet,
+    name: str,
+    memo: dict[str, Marker | None],
+    store: DecisionStore,
+) -> Marker | None:
+    """Simplify each gate's environments, then the marker they assemble into.
+
+    Simplifying the whole marker in one pass walks a cell space the
+    membership variables multiply.  Each gate's environments carry no
+    membership variable, so they shrink first, and the marker they
+    assemble into is small by the time the second pass canonicalises it.
+    """
+    assembled: list[Marker] = []
+    for part in parts:
+        simplified = _finalize_cached(part.marker, universe, name, memo, store)
+        if not part.gate:
+            if simplified is None:
+                return None
+            assembled.append(simplified)
+            continue
+        assembled.append(_gated_marker(simplified, part.gate))
+
+    # One ungated part is already what the second pass would return.
+    if len(parts) == 1 and not parts[0].gate:
+        return assembled[0]
+    return _finalize_cached(_or_markers(assembled), universe, name, memo, store)
+
+
+def _gated_marker(marker: Marker | None, gate: Sequence[tuple[str, str]]) -> Marker:
+    """Conjoin a gate onto the simplified environments it selects in.
+
+    With no environments the gate is the whole marker.  Otherwise they
+    are parenthesised, since they may disjoin and ``and`` binds tighter.
+    """
+    if marker is None:
+        return Marker(_gate_clause(gate))
+    return Marker(_with_gate(f"({marker})", gate))
 
 
 def _with_gate(marker: str, gate: Sequence[tuple[str, str]]) -> str:

--- a/nab-python/src/nab_python/_lockfile/validate.py
+++ b/nab-python/src/nab_python/_lockfile/validate.py
@@ -92,6 +92,7 @@ def check_envelope(
     extras: tuple[str, ...],
     dependency_groups: tuple[str, ...],
     default_groups: tuple[str, ...],
+    base_group: str | None = None,
 ) -> LockDisqualification | None:
     """Compare the current envelope against the committed lock.
 
@@ -99,6 +100,11 @@ def check_envelope(
     selection as a set of normalized names, so reformatting or reordering
     does not fire and an empty selection matches the ``None`` the writer
     commits. Returns the first difference, or ``None`` when every field agrees.
+
+    ``base_group`` is the name this run would give the project's own
+    dependencies. No run selects it, so it is checked before the arrays are
+    compared and then dropped from them, and a run that sets it gets a
+    reason naming only groups the caller asked for.
     """
     requires_python_result = _check_requires_python(
         committed.requires_python, requires_python
@@ -106,16 +112,63 @@ def check_envelope(
     if requires_python_result is not None:
         return requires_python_result
 
+    base_group_result = _check_base_group(committed, base_group)
+    if base_group_result is not None:
+        return base_group_result
+
     for kind, committed_names, current_names in (
         ("extras", committed.extras, extras),
-        ("dependency-groups", committed.dependency_groups, dependency_groups),
-        ("default-groups", committed.default_groups, default_groups),
+        (
+            "dependency-groups",
+            _without(committed.dependency_groups, base_group),
+            dependency_groups,
+        ),
+        (
+            "default-groups",
+            _without(committed.default_groups, base_group),
+            default_groups,
+        ),
     ):
         result = _check_name_set(kind, committed_names, current_names)
         if result is not None:
             return result
 
     return None
+
+
+def _without(names: Sequence[str] | None, dropped: str | None) -> list[str]:
+    """Return ``names`` without ``dropped``, comparing canonical names."""
+    if dropped is None:
+        return list(names or ())
+    return [
+        name
+        for name in names or ()
+        if canonicalize_name(name) != canonicalize_name(dropped)
+    ]
+
+
+def _check_base_group(
+    committed: Pylock, base_group: str | None
+) -> LockDisqualification | None:
+    """Whether the lock names the project's own dependencies as this run does.
+
+    A committed name looks like any other group, so which one an earlier
+    run gave them cannot be read back.  The reason says only what this
+    run would write and the lock does not have.
+    """
+    if base_group is None:
+        return None
+    if any(
+        canonicalize_name(name) == canonicalize_name(base_group)
+        for name in committed.dependency_groups or ()
+    ):
+        return None
+    return LockDisqualification(
+        reason=(
+            f"the lockfile does not name {base_group!r} for the project's"
+            f" own dependencies, which this run does"
+        )
+    )
 
 
 def _check_requires_python(
@@ -343,6 +396,7 @@ def check_locked(  # noqa: PLR0913 - the envelope fields and the validity inputs
     extras: tuple[str, ...],
     dependency_groups: tuple[str, ...],
     default_groups: tuple[str, ...],
+    base_group: str | None = None,
     roots: Iterable[RootRequirement] | None = None,
     constraints: Iterable[str] = (),
     resolve_target: ResolveTarget | None = None,
@@ -366,6 +420,7 @@ def check_locked(  # noqa: PLR0913 - the envelope fields and the validity inputs
         extras=extras,
         dependency_groups=dependency_groups,
         default_groups=default_groups,
+        base_group=base_group,
     )
     if disqualification is not None or roots is None or resolve_target is None:
         return disqualification

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -435,6 +435,7 @@ class NabProjectConfig:
     mode: ResolveMode = ResolveMode.SPECIFIC
     constraints: tuple[str, ...] = ()
     default_groups: tuple[str, ...] = ()
+    base_group: str | None = None
     # The project's declared Python support range: recorded as the lock's
     # top-level ``requires-python`` and checked against the resolve target.
     # It does not choose the target; ``environment`` does.
@@ -656,6 +657,7 @@ def read_pyproject_config(
         pyproject_dir=pyproject_dir,
         project_requires_python=project_requires_python,
     )
+    _validate_base_group_is_free(effective["base-group"], path)
     if discover_workspace:
         config = _apply_workspace_discovery(
             path, config, declared_in=effective["workspace"].origin.label
@@ -774,6 +776,7 @@ def _config_from_effective(
         mode=mode,
         constraints=effective["constraints"].value,
         default_groups=default_groups,
+        base_group=effective["base-group"].value,
         requires_python=requires_python,
         requires_python_source=requires_python_source,
         uploaded_prior_to=effective["uploaded-prior-to"].value,
@@ -1306,6 +1309,22 @@ def _parse_string_value(key: str, value: object) -> str:
     return value
 
 
+def _parse_base_group(value: object) -> str | None:
+    """Parse ``[tool.nab].base-group`` as a PEP 735 group name.
+
+    Names the group a lock gives the project's own dependencies, so an
+    installer can ask for one group without them.  Unset leaves them
+    unconditional.
+    """
+    raw = _parse_string_value("base-group", value)
+    try:
+        canonical = canonicalize_name(raw, validate=True)
+    except InvalidName as e:
+        msg = f"base-group {raw!r} is not a valid group name: {e}"
+        raise ConfigError(msg) from e
+    return str(canonical)
+
+
 def _parse_requires_python(value: object) -> str | None:
     """Parse ``[tool.nab].requires-python`` as a PEP 440 specifier.
 
@@ -1329,6 +1348,39 @@ def _parse_requires_python(value: object) -> str | None:
         )
         raise ConfigError(msg) from exc
     return raw
+
+
+def _validate_base_group_is_free(base_group: EffectiveValue, path: Path) -> None:
+    """Reject a ``base-group`` the project already declares as a group.
+
+    Both would emit ``'name' in dependency_groups`` and no marker could
+    say which was meant.  Checked as the file is read rather than at
+    emission, so it costs no resolve and holds for every output format.
+    """
+    name: str | None = base_group.value
+    if name is None:
+        return
+    with path.open("rb") as f:
+        data = tomli.load(f)
+    groups = data.get("dependency-groups")
+    if not isinstance(groups, dict):
+        return
+    taken = sorted(
+        declared for declared in groups if canonicalize_name(declared) == name
+    )
+    if not taken:
+        return
+    names = ", ".join(repr(declared) for declared in taken)
+    key = (
+        "--project-base-group"
+        if base_group.origin.kind is SourceKind.CLI
+        else "base-group"
+    )
+    msg = (
+        f"{key} {name!r} and [dependency-groups] {names} are the same name;"
+        " one marker cannot mean both"
+    )
+    raise ConfigError(msg)
 
 
 def _read_project_requires_python(path: Path) -> str | None:

--- a/nab-python/src/nab_python/config_sources.py
+++ b/nab-python/src/nab_python/config_sources.py
@@ -549,6 +549,15 @@ def _parse_default_groups(value: Any, where: str) -> tuple[str, ...]:
     return _delegate(lambda: _impl("default-groups", value))
 
 
+def _parse_base_group(value: Any, where: str) -> str | None:
+    del where
+    from .config import (  # noqa: PLC0415 (config import cycle)
+        _parse_base_group as _impl,
+    )
+
+    return _delegate(lambda: _impl(value))
+
+
 def _parse_indexes(value: Any, where: str) -> tuple[IndexConfig, ...]:
     # One file's array-of-tables: config._parse_indexes validates shape,
     # keys, and the same-name check into IndexConfig entries.
@@ -872,6 +881,17 @@ OPTIONS: tuple[OptionSpec, ...] = (
         cli_param="project_default_group",
         parse=_parse_default_groups,
         render=_render_string_tuple,
+    ),
+    OptionSpec(
+        key="base-group",
+        scope=Scope.PROJECT,
+        type_label="group",
+        default=None,
+        env_var=None,
+        cli_flag="--project-base-group",
+        cli_param="project_base_group",
+        parse=_parse_base_group,
+        render=lambda v: "<none>" if v is None else v,
     ),
     OptionSpec(
         key="requires-python",

--- a/nab-python/src/nab_python/lockfile.py
+++ b/nab-python/src/nab_python/lockfile.py
@@ -25,6 +25,7 @@ from ._lockfile.builder import (
     read_lockfile_packages,
 )
 from ._lockfile.disjointness import DisjointnessError
+from ._lockfile.groups import BASE_MEMBER
 from ._lockfile.pylock import (
     DivergentBaseDependencyError,
     build_pylock,
@@ -58,6 +59,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "ACCEPTED_HASH_ALGORITHMS",
+    "BASE_MEMBER",
     "LOCK_VERSION",
     "ArchivePin",
     "DisjointnessError",
@@ -371,14 +373,16 @@ class TargetLock:
     handed a projection of them, so a lock entry and the environment it
     was resolved for cannot drift apart.
 
-    ``package_gates`` maps a package this target locked to the selected
-    extras and groups that reach it while the project's own dependencies
-    do not, as ``(kind, name)`` members, including the conflict fork's
-    own selection.  The writer emits each one as a
-    ``'name' in extras`` / ``'name' in dependency_groups`` clause on that
-    package's marker, so a default install (no extras, the default
-    groups) leaves it out.  A package the project's dependencies reach is
-    absent from the map and stays unconditional.
+    ``package_gates`` maps a package this target locked to every install
+    context that reaches it, as ``(kind, name)`` members: each selected
+    extra and group, including the conflict fork's own selection, and
+    :data:`BASE_MEMBER` for the project's own dependencies, which the
+    writer renames to ``[tool.nab].base-group``.  The writer disjoins
+    them into ``'name' in extras`` / ``'name' in dependency_groups``
+    clauses on that package's marker.  With no ``base-group`` set there
+    is no name to give the project's own dependencies, so the writer
+    drops the gate of every package they reach and it stays
+    unconditional.
     """
 
     target: ResolveTarget
@@ -442,6 +446,9 @@ class LockInput:
     """Declared ``[tool.nab].conflicts``.  Prunes the disjointness
     validator's install-context universe so a per-fork lock (one entry
     per mutually-exclusive extra/group) validates."""
+    base_group: str | None = None
+    """``[tool.nab].base-group``: the group name the lock gives
+    the project's own dependencies, or ``None`` to leave them unconditional."""
 
     @property
     def active_groups(self) -> tuple[str, ...]:
@@ -450,9 +457,13 @@ class LockInput:
         PEP 751 keeps the ``default-groups`` names out of
         ``dependency-groups``, and an installer that selects nothing
         still activates the defaults, so the group axis of an install
-        context is the union of the two arrays.
+        context is the union of the two arrays, plus the name the lock
+        gives the project's own dependencies.
         """
-        return tuple(dict.fromkeys((*self.dependency_groups, *self.default_groups)))
+        names = dict.fromkeys((*self.dependency_groups, *self.default_groups))
+        if self.base_group is not None:
+            names[self.base_group] = None
+        return tuple(names)
 
     @property
     def marker_envs(self) -> dict[str, Mapping[str, str]]:

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -106,6 +106,7 @@ __all__ = [
     "ResolveFork",
     "ResolveResult",
     "TargetResult",
+    "active_group_names",
     "build_lock_input",
     "resolve_for_targets",
     "resolve_with_coordinator",
@@ -165,19 +166,25 @@ class InstallContexts:
     ``project`` is the project's own dependencies, and ``selectors``
     holds one requirement list per active extra and group, keyed by its
     ``(kind, name)`` member.  The lock writer walks the resolved graph
-    from each of them, so a package only a selection reaches is gated on
-    it (see :attr:`~nab_python.lockfile.TargetLock.package_gates`) and a
-    default install leaves it out.
+    from each of them, so each package is gated on the contexts that
+    reach it (see :attr:`~nab_python.lockfile.TargetLock.package_gates`)
+    and a default install leaves out what only a selection brings.
 
     The fork's own ``selection`` is one of those selectors, so a package
     it shares with another active selection names both members and
     installs for either.
+
+    ``name_project`` is set when ``[tool.nab].base-group`` names the
+    project's own dependencies.  They are then walked even with nothing
+    selected, since the name has to mean the same thing in every lock it
+    appears in.
     """
 
     project: tuple[Requirement, ...] = ()
     selectors: Mapping[tuple[str, str], tuple[Requirement, ...]] = field(
         default_factory=dict
     )
+    name_project: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -327,7 +334,9 @@ def resolve_for_targets(  # noqa: PLR0913 - the surface mirrors the CLI; bundlin
     # activates them, so the conflict checks, the fork plan, and the
     # resolves all fold them into the active group set alongside the CLI
     # selection.
-    effective_groups = tuple(dict.fromkeys((*groups, *config.default_groups)))
+    effective_groups = active_group_names(
+        groups, config.default_groups, config.base_group
+    )
 
     forks, base_requirements = _plan_forks(
         path,
@@ -719,6 +728,28 @@ def _base_pass(
     return results, env_base_names
 
 
+def active_group_names(
+    groups: Sequence[str],
+    default_groups: Sequence[str],
+    base_group: str | None,
+) -> tuple[str, ...]:
+    """Return the ``[dependency-groups]`` names this run activates, in order.
+
+    ``base-group`` may be named in ``default-groups`` to keep the
+    project's own dependencies in the default selection.  Its
+    requirements are ``[project].dependencies``, which are roots already,
+    so it is dropped here rather than looked up as a declared group.
+    ``groups`` is this run's ``--groups`` selection and keeps the name, so
+    selecting a group the project does not declare still raises.
+    """
+    policy = tuple(
+        name
+        for name in default_groups
+        if base_group is None or canonicalize_name(name) != base_group
+    )
+    return tuple(dict.fromkeys((*groups, *policy)))
+
+
 def build_lock_input(
     result: ResolveResult,
     *,
@@ -736,8 +767,9 @@ def build_lock_input(
     ``result.success`` first.
 
     ``extras`` and ``dependency_groups`` are this run's selection, which
-    the lock records at the top level;  ``default-groups`` and the
-    declared conflicts are project policy and come from ``config``.
+    the lock records at the top level;  ``default-groups``, the declared
+    conflicts, and ``base-group`` are project policy and come from
+    ``config``.
     """
     effective = config if config is not None else NabProjectConfig()
     targets: dict[str, TargetLock] = {}
@@ -769,6 +801,7 @@ def build_lock_input(
         dependency_groups=tuple(dependency_groups),
         default_groups=effective.default_groups,
         conflicts=effective.conflicts,
+        base_group=effective.base_group,
     )
 
 
@@ -1026,12 +1059,13 @@ def _install_context_roots(
 ) -> tuple[frozenset[str] | None, dict[tuple[str, str], frozenset[str]] | None]:
     """Return the lock writer's install-context roots for one target.
 
-    ``(None, None)`` when there is no selection to attribute packages to,
-    which leaves every package unconditional.  A requirement whose marker
-    this target's environment fails is dropped, exactly as the resolve
-    dropped it, so it gates nothing.
+    ``(None, None)`` when nothing needs attributing, which leaves every
+    package unconditional: no selection to name, and no name for the
+    project's own dependencies either.  A requirement whose marker this
+    target's environment fails is dropped, exactly as the resolve dropped
+    it, so it gates nothing.
     """
-    if contexts is None or not contexts.selectors:
+    if contexts is None or not (contexts.selectors or contexts.name_project):
         return None, None
     return (
         _root_keys(contexts.project, environment),
@@ -1161,6 +1195,7 @@ def _plan_forks(
                 contexts=InstallContexts(
                     project=tuple(tables.dependencies),
                     selectors=_selector_requirements(path, tables, fork),
+                    name_project=config.base_group is not None,
                 ),
             )
         )

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -888,6 +888,31 @@ class TestDefaultGroups:
         assert any(word in comment for word in ("resolve", "activat")), comment
 
 
+class TestMainGroup:
+    """``base-group`` names the project's own dependencies in a lock."""
+
+    def test_base_group_is_normalised(self, tmp_path: Path) -> None:
+        path = write(tmp_path, '[tool.nab]\nbase-group = "Runtime_Deps"\n')
+        assert read_pyproject_config(path).base_group == "runtime-deps"
+
+    def test_base_group_names_every_declaration_it_collides_with(
+        self, tmp_path: Path
+    ) -> None:
+        """Two spellings of one group name, so the message reads in order."""
+        path = write(
+            tmp_path,
+            "[dependency-groups]\nDefault = []\nDEFAULT = []\n"
+            '[tool.nab]\nbase-group = "default"\n',
+        )
+        with pytest.raises(ConfigError, match="'DEFAULT', 'Default' are the same"):
+            read_pyproject_config(path)
+
+    def test_base_group_rejects_a_non_name(self, tmp_path: Path) -> None:
+        path = write(tmp_path, '[tool.nab]\nbase-group = "-nope-"\n')
+        with pytest.raises(ConfigError, match="not a valid group name"):
+            read_pyproject_config(path)
+
+
 class TestRequiresPython:
     """``requires-python`` declares the supported range; it is not a target.
 
@@ -4779,6 +4804,60 @@ class TestWorkspaceDiscoveryIntegration:
         )
         config = read_pyproject_config(member)
         assert config.build_policy is BuildPolicy.BUILD_LOCAL
+
+    def test_discovery_carries_members_and_not_the_root_base_group(
+        self, tmp_path: Path
+    ) -> None:
+        """A member takes the root's sources, never the name it gives its own.
+
+        Discovery reads the root's ``members`` list and nothing else from
+        it, so the two files each name their own dependencies.
+        """
+        member = self._ws(tmp_path)
+        root = tmp_path / "pyproject.toml"
+        root.write_text(
+            root.read_text(encoding="utf-8") + '[tool.nab]\nbase-group = "root"\n',
+            encoding="utf-8",
+        )
+
+        assert read_pyproject_config(root).base_group == "root"
+
+        config = read_pyproject_config(member)
+        assert config.base_group is None
+        assert config.local_sources == (
+            LocalSource(name="alpha", path=str(member.parent), editable=True),
+        )
+
+    def test_a_member_group_may_take_the_root_base_group_name(
+        self, tmp_path: Path
+    ) -> None:
+        """A member's groups are not selectable in the root's lock.
+
+        They are in a different marker namespace, so the name the root
+        gives its own dependencies does not collide with them.  The same
+        name on the member's own file does.
+        """
+        member = self._ws(tmp_path)
+        member.write_text(
+            member.read_text(encoding="utf-8")
+            + '[dependency-groups]\nroot = ["iniconfig"]\n',
+            encoding="utf-8",
+        )
+        root = tmp_path / "pyproject.toml"
+        root.write_text(
+            root.read_text(encoding="utf-8") + '[tool.nab]\nbase-group = "root"\n',
+            encoding="utf-8",
+        )
+
+        assert read_pyproject_config(root).base_group == "root"
+        assert read_pyproject_config(member).base_group is None
+
+        member.write_text(
+            member.read_text(encoding="utf-8") + '[tool.nab]\nbase-group = "root"\n',
+            encoding="utf-8",
+        )
+        with pytest.raises(ConfigError, match=r"^base-group 'root' and"):
+            read_pyproject_config(member)
 
     def test_no_discovery_skips_walk(self, tmp_path: Path) -> None:
         member = self._ws(tmp_path)

--- a/nab-python/tests/test_config_sources.py
+++ b/nab-python/tests/test_config_sources.py
@@ -917,6 +917,7 @@ class TestReproducibilityNotice:
                 "project_build_policy": None,
                 "project_build_requires_depth": None,
                 "project_decision_order": None,
+                "project_base_group": None,
                 "project_constraint": (),
                 "project_default_group": ("dev",),
             }
@@ -938,6 +939,7 @@ class TestParserFoldHelpers:
             {
                 "resolution",
                 "decision-order",
+                "base-group",
                 "mode",
                 "constraints",
                 "default-groups",

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -9,6 +9,7 @@ import re
 import sys
 from collections.abc import Callable, Mapping, Sequence
 from contextlib import AbstractContextManager
+from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import ClassVar
@@ -55,6 +56,7 @@ from nab_python.config import (
     conflict_member_groups,
 )
 from nab_python.lockfile import (
+    BASE_MEMBER,
     LOCK_VERSION,
     ArchivePin,
     DisjointnessError,
@@ -868,6 +870,120 @@ class TestConflictForkBaseDepMarkers:
         pylock = build_pylock(self._lock_input())
         universal = next(p for p in pylock.packages if str(p.name) == "universal")
         assert universal.marker is None
+
+    def test_base_dep_of_a_fork_gates_on_the_base_group(self) -> None:
+        """A fork's base deps take the base group, and only it.
+
+        The conflict members stay out of the clause: the package installs
+        whichever of them the installer picks, and when it picks none.
+        """
+        base = self._lock_input()
+        lock_input = replace(
+            base,
+            targets={
+                label: replace(
+                    lock,
+                    package_gates=dict.fromkeys(lock.pins, (BASE_MEMBER,)),
+                )
+                for label, lock in base.targets.items()
+            },
+            dependency_groups=("dev",),
+            base_group="default",
+        )
+        pylock = build_pylock(lock_input)
+        base_marker = next(
+            p.marker for p in pylock.packages if str(p.name) == "basepkg"
+        )
+
+        assert base_marker is not None
+        assert "in extras" not in str(base_marker)
+
+        linux = self._LINUX.env_with_membership()
+        assert not base_marker.evaluate(linux)
+        assert base_marker.evaluate({**linux, "dependency_groups": {"default"}})
+
+    def test_a_fork_reaching_a_base_dep_by_extra_keeps_the_shared_gate(self) -> None:
+        """One fork also reaching it through an extra must not narrow it.
+
+        The forks then disagree on the gate, but both still name the main
+        group, and a base dep is in every fork, so it installs under that
+        group with no member selected.
+        """
+        base = self._lock_input()
+        extra_reaches = {(("extra", "cpu"),): (("extra", "cli"), BASE_MEMBER)}
+        lock_input = replace(
+            base,
+            targets={
+                label: replace(
+                    lock,
+                    package_gates={
+                        pin: extra_reaches.get(lock.target.selection, (BASE_MEMBER,))
+                        for pin in lock.pins
+                    },
+                )
+                for label, lock in base.targets.items()
+            },
+            extras=("cpu", "gpu", "cli"),
+            base_group="default",
+        )
+        pylock = build_pylock(lock_input)
+        base_marker = next(
+            p.marker for p in pylock.packages if str(p.name) == "basepkg"
+        )
+
+        assert base_marker is not None
+        linux = self._LINUX.env_with_membership()
+        assert base_marker.evaluate({**linux, "dependency_groups": {"default"}})
+        assert base_marker.evaluate(
+            {**linux, "extras": {"cli", "cpu"}, "dependency_groups": set()}
+        )
+        assert not base_marker.evaluate(
+            {**linux, "extras": {"cli", "gpu"}, "dependency_groups": set()}
+        )
+
+    def test_forks_sharing_no_gate_member_stay_fork_conditional(self) -> None:
+        """Nothing holds across every fork, so there is no shared part.
+
+        Each fork reaches the package through a selection of its own, and
+        an install context that picks no member reaches it through
+        neither.
+        """
+        base = self._lock_input()
+        by_fork = {
+            self._CPU: (("extra", "cli"),),
+            self._GPU: (("group", "dev"),),
+        }
+        lock_input = replace(
+            base,
+            targets={
+                label: replace(
+                    lock,
+                    package_gates=dict.fromkeys(
+                        lock.pins, by_fork[lock.target.selection]
+                    ),
+                )
+                for label, lock in base.targets.items()
+            },
+            extras=("cpu", "gpu", "cli"),
+            dependency_groups=("dev",),
+            base_group="default",
+        )
+        pylock = build_pylock(lock_input)
+        base_marker = next(
+            p.marker for p in pylock.packages if str(p.name) == "basepkg"
+        )
+
+        assert base_marker is not None
+        linux = self._LINUX.env_with_membership()
+        assert base_marker.evaluate(
+            {**linux, "extras": {"cli", "cpu"}, "dependency_groups": set()}
+        )
+        assert base_marker.evaluate(
+            {**linux, "extras": {"gpu"}, "dependency_groups": {"dev"}}
+        )
+        assert not base_marker.evaluate(
+            {**linux, "extras": {"cli"}, "dependency_groups": {"dev", "default"}}
+        )
 
 
 class TestConflictForkGateMerge:
@@ -1846,6 +1962,54 @@ class TestDependencyGroups:
         assert data["dependency-groups"] == ["dev", "docs"]
         assert data["default-groups"] == ["dev"]
 
+    def test_a_declared_default_groups_is_not_extended(self) -> None:
+        """The base name joins ``default-groups`` only when none is declared.
+
+        A declared ``default-groups`` replaces the default selection, so
+        a project that wants its own dependencies installed alongside a
+        group names them there itself.
+        """
+        text = write_lock(
+            LockInput(
+                targets=_one({"foo": _index_pin()}),
+                default_groups=("dev",),
+                base_group="base",
+            )
+        )
+        data = tomllib.loads(text)
+        assert data["dependency-groups"] == ["base"]
+        assert data["default-groups"] == ["dev"]
+
+    def test_naming_it_in_default_groups_installs_it_by_default(self) -> None:
+        """Named there, it is back in the default selection."""
+        text = write_lock(
+            LockInput(
+                targets=_one({"foo": _index_pin()}),
+                default_groups=("dev", "base"),
+                base_group="base",
+            )
+        )
+        data = tomllib.loads(text)
+        assert tomllib.loads(text)["default-groups"] == ["dev", "base"]
+        assert data["dependency-groups"] == ["base"]
+
+    def test_base_group_joins_both_arrays(self) -> None:
+        """An installer may read the offered groups from either array.
+
+        Naming it in ``default-groups`` alone leaves one that reads
+        ``dependency-groups`` with nothing to activate.
+        """
+        text = write_lock(
+            LockInput(
+                targets=_one({"foo": _index_pin()}),
+                dependency_groups=("dev",),
+                base_group="default",
+            )
+        )
+        data = tomllib.loads(text)
+        assert data["dependency-groups"] == ["dev", "default"]
+        assert data["default-groups"] == ["default"]
+
     def test_omits_arrays_when_empty(self) -> None:
         text = write_lock(LockInput(targets=_one({"foo": _index_pin()})))
         data = tomllib.loads(text)
@@ -1859,6 +2023,14 @@ class TestDependencyGroups:
             default_groups=("dev", "lint"),
         )
         assert lock_input.active_groups == ("docs", "dev", "lint")
+
+    def test_active_groups_includes_the_base_group(self) -> None:
+        lock_input = LockInput(
+            targets=_one({"foo": _index_pin()}),
+            dependency_groups=("docs",),
+            base_group="default",
+        )
+        assert lock_input.active_groups == ("docs", "default")
 
     def test_group_names_normalized(self) -> None:
         text = write_lock(
@@ -4711,6 +4883,94 @@ class TestDependencyGraph:
         assert by_name["foo"]["dependencies"] == [{"name": "bar"}, {"name": "baz"}]
 
 
+class TestMainGroupAcrossTargets:
+    """One package, reached by the project on one target and a group on another.
+
+    The gate is per target, so each environment contributes its own
+    clause.  Pairing every environment with every gate instead would
+    install the package on Windows for a default install.
+    """
+
+    _LINUX: ClassVar[ResolveTarget] = _target(platform="linux_x86_64")
+    _WINDOWS: ClassVar[ResolveTarget] = _target(platform="windows_amd64")
+
+    def test_each_target_carries_its_own_gate(self) -> None:
+        pin = {"iniconfig": _index_pin(name="iniconfig")}
+        targets = {
+            self._LINUX.label: TargetLock(
+                target=self._LINUX,
+                pins=pin,
+                package_gates={"iniconfig": (BASE_MEMBER,)},
+            ),
+            self._WINDOWS.label: TargetLock(
+                target=self._WINDOWS,
+                pins=pin,
+                package_gates={"iniconfig": (("group", "dev"),)},
+            ),
+        }
+        pylock = build_pylock(
+            LockInput(targets=targets, dependency_groups=("dev",), base_group="default")
+        )
+        (package,) = pylock.packages
+        assert package.marker is not None
+
+        def installs(target: ResolveTarget, group: str) -> bool:
+            assert package.marker is not None
+            return package.marker.evaluate(
+                {
+                    **target.marker_env,
+                    "extras": frozenset(),
+                    "dependency_groups": frozenset({group}),
+                }
+            )
+
+        assert installs(self._LINUX, "default")
+        assert installs(self._WINDOWS, "dev")
+
+        assert not installs(self._LINUX, "dev")
+        assert not installs(self._WINDOWS, "default")
+
+    def test_one_gate_over_several_environments_binds_them_all(self) -> None:
+        """The gate holds over the disjunction, not over its first clause.
+
+        Two targets share a gate and two more lock nothing, so the gate's
+        environments come out as an ``or``.  Conjoining the gate without
+        parenthesising them would leave the second environment ungated.
+        """
+        gated = (_target(), _target(python_version="3.12", platform="windows_amd64"))
+        ungated = (
+            _target(platform="windows_amd64"),
+            _target(python_version="3.12"),
+        )
+        pin = {"iniconfig": _index_pin(name="iniconfig")}
+        targets = {
+            **{
+                target.label: TargetLock(
+                    target=target,
+                    pins=pin,
+                    package_gates={"iniconfig": (BASE_MEMBER,)},
+                )
+                for target in gated
+            },
+            **{
+                target.label: TargetLock(target=target, pins={}, package_gates={})
+                for target in ungated
+            },
+        }
+        pylock = build_pylock(LockInput(targets=targets, base_group="default"))
+        (package,) = pylock.packages
+        assert package.marker is not None
+
+        for target in gated:
+            env = {**target.marker_env, "extras": frozenset()}
+            assert package.marker.evaluate(
+                {**env, "dependency_groups": frozenset({"default"})}
+            )
+            assert not package.marker.evaluate(
+                {**env, "dependency_groups": frozenset()}
+            )
+
+
 class TestMembershipGates:
     """Only-an-extra / only-a-group packages carry a membership marker.
 
@@ -4750,6 +5010,7 @@ class TestMembershipGates:
             selector_roots={("extra", "cli"): frozenset({"mytool"})},
         )
         assert lock.package_gates == {
+            "core": (BASE_MEMBER,),
             "mytool": (("extra", "cli"),),
             "subtool": (("extra", "cli"),),
         }
@@ -4797,8 +5058,9 @@ class TestMembershipGates:
     def test_extras_proxy_gates_only_what_the_extra_adds(self) -> None:
         """The project requires ``foo``; the extra requires ``foo[fancy]``.
 
-        ``foo`` itself installs unconditionally; only what ``fancy``
-        adds on top of it is gated.
+        ``foo`` is the project's own, so it carries the base member the
+        extra's proxy adds to; only what ``fancy`` brings is the extra's
+        alone.
         """
         provider = self._provider(
             ("foo", "fancy-lib"),
@@ -4817,9 +5079,12 @@ class TestMembershipGates:
             base_roots=frozenset({"foo"}),
             selector_roots={("extra", "cli"): frozenset({"foo", "foo[fancy]"})},
         )
-        assert lock.package_gates == {"fancy-lib": (("extra", "cli"),)}
+        assert lock.package_gates == {
+            "foo": (("extra", "cli"), BASE_MEMBER),
+            "fancy-lib": (("extra", "cli"),),
+        }
 
-    def test_base_dependency_reached_through_a_cycle_is_not_gated(self) -> None:
+    def test_base_dependency_reached_through_a_cycle_is_gated_as_base(self) -> None:
         """A dependency cycle in the base closure terminates the walk."""
         provider = self._provider(
             ("core", "loop", "mytool"),
@@ -4836,7 +5101,11 @@ class TestMembershipGates:
             base_roots=frozenset({"core"}),
             selector_roots={("extra", "cli"): frozenset({"mytool"})},
         )
-        assert lock.package_gates == {"mytool": (("extra", "cli"),)}
+        assert lock.package_gates == {
+            "core": (("extra", "cli"), BASE_MEMBER),
+            "loop": (("extra", "cli"), BASE_MEMBER),
+            "mytool": (("extra", "cli"),),
+        }
 
     def test_unpinned_dependency_is_skipped(self) -> None:
         """A dep name the resolve did not pin cannot be gated."""
@@ -4853,11 +5122,21 @@ class TestMembershipGates:
         )
         assert set(lock.package_gates) == {"mytool"}
 
-    def test_no_selection_leaves_the_map_empty(self) -> None:
+    def test_base_roots_alone_still_record_the_base_member(self) -> None:
+        """Given base roots and no selector, the base reach is still recorded.
+
+        The writer needs it whenever the lock names the project's own
+        dependencies, which it can do with no group selected at all.
+        """
         provider = self._provider(("core",), deps_cache={("core", Version("1.0")): {}})
         lock = build_target_lock(
             provider, _HOST, {"core": Version("1.0")}, base_roots=frozenset({"core"})
         )
+        assert lock.package_gates == {"core": (BASE_MEMBER,)}
+
+    def test_no_roots_at_all_leave_the_map_empty(self) -> None:
+        provider = self._provider(("core",), deps_cache={("core", Version("1.0")): {}})
+        lock = build_target_lock(provider, _HOST, {"core": Version("1.0")})
         assert lock.package_gates == {}
 
     def test_selector_roots_without_base_roots_are_refused(self) -> None:

--- a/nab-python/tests/test_lockfile_locked.py
+++ b/nab-python/tests/test_lockfile_locked.py
@@ -10,6 +10,7 @@ import pytest
 from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.version import Version
 from nab_python.lockfile import (
+    BASE_MEMBER,
     IndexPin,
     InvalidLockfileError,
     LockfileSyntaxError,
@@ -17,6 +18,7 @@ from nab_python.lockfile import (
     RootRequirement,
     TargetLock,
     WheelArtifact,
+    build_pylock,
     check_locked,
     drop_workspace_pins,
     read_lockfile_packages,
@@ -56,6 +58,8 @@ def _lock_input(
     *,
     dependencies: Mapping[str, tuple[str, ...]] | None = None,
     base_dependencies: Mapping[str, tuple[str, ...]] | None = None,
+    package_gates: Mapping[str, tuple[tuple[str, str], ...]] | None = None,
+    base_group: str | None = None,
 ) -> LockInput:
     return LockInput(
         targets={
@@ -64,8 +68,10 @@ def _lock_input(
                 pins=dict(pins),
                 dependencies=dict(dependencies or {}),
                 base_dependencies=dict(base_dependencies or {}),
+                package_gates=dict(package_gates or {}),
             )
-        }
+        },
+        base_group=base_group,
     )
 
 
@@ -420,6 +426,34 @@ class TestDropWorkspacePins:
 
         dropped = drop_workspace_pins(lock_input, frozenset({"alpha"}))
         assert dropped.targets[TARGET.label].base_dependencies == edges
+
+    def test_a_surviving_package_keeps_its_whole_gate(self) -> None:
+        """Dropping a member cannot narrow what still installs.
+
+        A gate names install contexts, never packages, so nothing a
+        dropped member reached can leave a gate behind that no longer
+        resolves.
+        """
+        lock_input = _lock_input(
+            {"foo": _pin("foo", "1.0"), "alpha": _pin("alpha", "2.0")},
+            dependencies={"alpha": ("foo",)},
+            package_gates={
+                "foo": (BASE_MEMBER, ("group", "dev")),
+                "alpha": (BASE_MEMBER,),
+            },
+            base_group="default",
+        )
+
+        dropped = drop_workspace_pins(lock_input, frozenset({"alpha"}))
+
+        assert dropped.targets[TARGET.label].package_gates == {
+            "foo": (BASE_MEMBER, ("group", "dev"))
+        }
+        marker = next(p.marker for p in build_pylock(dropped).packages)
+        assert marker is not None
+        assert str(marker) == (
+            '"default" in dependency_groups or "dev" in dependency_groups'
+        )
 
 
 class TestSummarizeLock:

--- a/nab-python/tests/test_lockfile_validate.py
+++ b/nab-python/tests/test_lockfile_validate.py
@@ -57,6 +57,7 @@ def envelope(
     extras: tuple[str, ...] = (),
     dependency_groups: tuple[str, ...] = (),
     default_groups: tuple[str, ...] = (),
+    base_group: str | None = None,
 ) -> LockDisqualification | None:
     return check_envelope(
         committed,
@@ -64,6 +65,7 @@ def envelope(
         extras=extras,
         dependency_groups=dependency_groups,
         default_groups=default_groups,
+        base_group=base_group,
     )
 
 
@@ -186,6 +188,55 @@ def test_default_groups_removed_fires() -> None:
 def test_default_groups_reordered_does_not_fire() -> None:
     committed = make_pylock(default_groups=("main", "extra"))
     assert envelope(committed, default_groups=("extra", "main")) is None
+
+
+def test_the_named_base_group_does_not_fire() -> None:
+    """The writer adds it to both arrays and no run selects it."""
+    committed = make_pylock(
+        dependency_groups=("dev", "default"),
+        default_groups=("main", "default"),
+    )
+    assert (
+        envelope(
+            committed,
+            dependency_groups=("dev",),
+            default_groups=("main",),
+            base_group="default",
+        )
+        is None
+    )
+
+
+def test_the_name_is_looked_for_in_dependency_groups() -> None:
+    """``default-groups`` alone is a lock no installer can activate it from."""
+    committed = make_pylock(dependency_groups=("dev",), default_groups=("default",))
+    result = envelope(committed, dependency_groups=("dev",), base_group="default")
+    assert result is not None
+    assert "does not name 'default'" in result.reason
+
+
+def test_a_lock_predating_the_option_fires_on_the_missing_name() -> None:
+    """A lock written before ``base-group`` was set names no group at all."""
+    committed = make_pylock(dependency_groups=None, default_groups=None)
+    result = envelope(committed, default_groups=("test",), base_group="default")
+    assert result is not None
+    assert "does not name 'default'" in result.reason
+
+
+def test_a_lock_naming_a_different_base_group_fires() -> None:
+    """The option was renamed since, so the committed name is stale."""
+    committed = make_pylock(
+        dependency_groups=("dev", "default"),
+        default_groups=("main", "default"),
+    )
+    result = envelope(
+        committed,
+        dependency_groups=("dev",),
+        default_groups=("main",),
+        base_group="default-1",
+    )
+    assert result is not None
+    assert "does not name 'default-1'" in result.reason
 
 
 def test_all_envelope_fields_matching_returns_none() -> None:

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -4312,6 +4312,9 @@ class TestLockDeclaresItsEnvironment:
         assert not Marker(rows["above"]).evaluate(low)
 
 
+_BASE_GROUP = '[tool.nab]\nbase-group = "default"\n'
+
+
 class TestExtraAndGroupMembershipMarkers:
     """A selected extra or group gates the packages only it reaches.
 
@@ -4422,6 +4425,49 @@ class TestExtraAndGroupMembershipMarkers:
             "subtool",
         }
 
+    def test_a_group_can_be_selected_without_the_project_dependencies(
+        self, tmp_path: Path
+    ) -> None:
+        """What naming them buys: a lock can be asked for one group.
+
+        The project's own dependencies answer to their own group name, so
+        an installer asked for ``dev`` alone gets the group and nothing
+        else.  Naming groups replaces the defaults rather than adding to
+        them, so an install that wants both asks for both.
+        """
+        pylock = self._lock(
+            tmp_path, extras=("cli",), groups=("dev",), root=self._ROOT + _BASE_GROUP
+        )
+
+        assert self._markers(pylock) == {
+            "core": '"default" in dependency_groups',
+            "mydev": '"dev" in dependency_groups',
+            "mytool": '"cli" in extras',
+            "subtool": '"cli" in extras',
+        }
+
+        assert self._selected(pylock, dependency_groups=["dev"]) == {"mydev"}
+        assert self._selected(pylock, dependency_groups=["default", "dev"]) == {
+            "core",
+            "mydev",
+        }
+
+    def test_package_reached_by_base_and_group_installs_for_either(
+        self, tmp_path: Path
+    ) -> None:
+        """A group that re-requires a project dependency still gets it.
+
+        The package answers to both names, so selecting the group alone
+        installs it even though the project's own dependencies are out.
+        """
+        root = self._ROOT.replace('dev = ["mydev"]', 'dev = ["mydev", "core"]')
+        pylock = self._lock(tmp_path, groups=("dev",), root=root + _BASE_GROUP)
+
+        assert self._markers(pylock)["core"] == (
+            '"default" in dependency_groups or "dev" in dependency_groups'
+        )
+        assert self._selected(pylock, dependency_groups=["dev"]) == {"core", "mydev"}
+
     def test_package_reached_by_base_and_extra_is_unconditional(
         self, tmp_path: Path
     ) -> None:
@@ -4445,6 +4491,95 @@ class TestExtraAndGroupMembershipMarkers:
         assert pylock.default_groups == ("dev",)
         assert self._selected(pylock) == {"core", "mydev"}
         assert self._selected(pylock, dependency_groups=[]) == {"core"}
+
+    def test_declared_default_groups_replace_rather_than_extend(
+        self, tmp_path: Path
+    ) -> None:
+        """Declaring ``default-groups`` drops the base group from them.
+
+        The project chose that selection, so nab does not add to it; the
+        name goes back in by being declared there.
+        """
+        root = self._ROOT + '[tool.nab]\ndefault-groups = ["dev"]\n'
+        replaced = self._lock(tmp_path, root=root + 'base-group = "base"\n')
+
+        assert replaced.default_groups == ("dev",)
+        assert self._selected(replaced) == {"mydev"}
+
+    def test_naming_the_base_group_in_default_groups_keeps_it(
+        self, tmp_path: Path
+    ) -> None:
+        """It is not a declared group, but ``default-groups`` accepts it."""
+        root = self._ROOT + '[tool.nab]\ndefault-groups = ["dev", "base"]\n'
+        pylock = self._lock(tmp_path, root=root + 'base-group = "base"\n')
+
+        assert pylock.default_groups == ("dev", "base")
+        assert self._selected(pylock) == {"core", "mydev"}
+
+    def test_selecting_the_base_group_by_name_refuses(self, tmp_path: Path) -> None:
+        """It is project policy, not a per-run selection.
+
+        ``default-groups`` takes the name; ``--groups`` does not, and
+        being silently accepted there would make the flag a no-op.
+        """
+        with pytest.raises(LookupError, match="'default' not found"):
+            self._lock(tmp_path, groups=("default",), root=self._ROOT + _BASE_GROUP)
+
+    def test_a_declared_group_of_that_name_refuses(self, tmp_path: Path) -> None:
+        """One marker cannot mean both the project's own and a declared group."""
+        root = self._ROOT.replace(
+            '[dependency-groups]\ndev = ["mydev"]',
+            '[dependency-groups]\nDefault = ["mydev"]',
+        )
+        with pytest.raises(ConfigError, match=r"^base-group 'default' and"):
+            self._lock(tmp_path, groups=("default",), root=root + _BASE_GROUP)
+
+    def test_a_name_merely_resembling_it_is_allowed(self, tmp_path: Path) -> None:
+        """``de_fault`` normalises to ``de-fault``, which collides with nothing."""
+        root = self._ROOT.replace(
+            '[dependency-groups]\ndev = ["mydev"]',
+            '[dependency-groups]\nde_fault = ["mydev"]',
+        )
+        pylock = self._lock(tmp_path, groups=("de_fault",), root=root + _BASE_GROUP)
+
+        assert pylock.dependency_groups == ("de-fault", "default")
+        assert self._selected(pylock, dependency_groups=["de-fault"]) == {"mydev"}
+
+    def test_no_group_offered_names_nothing(self, tmp_path: Path) -> None:
+        """With no group to select, nothing needs a name for the project's own."""
+        root = self._ROOT.replace(
+            '[dependency-groups]\ndev = ["mydev"]',
+            '[dependency-groups]\ndefault = ["mydev"]',
+        )
+        pylock = self._lock(tmp_path, root=root)
+
+        assert pylock.default_groups is None
+        assert self._markers(pylock) == {"core": None}
+
+    def test_naming_them_gates_them_with_nothing_selected(self, tmp_path: Path) -> None:
+        """The name means one thing whether or not the run selects a group.
+
+        A lock written with no selection still gates the project's own
+        dependencies, so an installer reading two locks of the same
+        project does not get two answers to the same request.
+        """
+        pylock = self._lock(tmp_path, root=self._ROOT + _BASE_GROUP)
+
+        assert self._markers(pylock) == {"core": '"default" in dependency_groups'}
+        assert self._selected(pylock) == {"core"}
+        assert self._selected(pylock, dependency_groups=[]) == set()
+
+    def test_dynamic_project_dependencies_still_refuse(self, tmp_path: Path) -> None:
+        """Setting the option does not open a path around the refusal.
+
+        There is nothing to name when the project's own dependencies need
+        a build to compute, and this run stops before that matters.
+        """
+        root = self._ROOT.replace(
+            'dependencies = ["core"]', 'dynamic = ["dependencies"]'
+        )
+        with pytest.raises(InvalidProjectRequirementError, match="declared dynamic"):
+            self._lock(tmp_path, groups=("dev",), root=root + _BASE_GROUP)
 
     def test_no_selection_leaves_every_package_unmarked(self, tmp_path: Path) -> None:
         pylock = self._lock(tmp_path)

--- a/src/nab/_config_cmd.py
+++ b/src/nab/_config_cmd.py
@@ -66,6 +66,7 @@ def config_command(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag
     project_decision_order: DecisionOrderFlag | None = None,
     project_constraint: Annotated[tuple[str, ...], tyro.conf.UseAppendAction] = (),
     project_default_group: Annotated[tuple[str, ...], tyro.conf.UseAppendAction] = (),
+    project_base_group: str | None = None,
     include_rejected: bool = False,
 ) -> None:
     """Inspect the effective layered configuration.
@@ -110,6 +111,7 @@ def config_command(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag
         cli_decision_order=project_decision_order,
         cli_constraint=project_constraint,
         cli_default_group=project_default_group,
+        cli_base_group=project_base_group,
     )
 
     rejected: list[RejectedLayer] = []

--- a/src/nab/_download.py
+++ b/src/nab/_download.py
@@ -63,6 +63,7 @@ def download(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config 
     project_decision_order: DecisionOrderFlag | None = None,
     project_constraint: Annotated[tuple[str, ...], tyro.conf.UseAppendAction] = (),
     project_default_group: Annotated[tuple[str, ...], tyro.conf.UseAppendAction] = (),
+    project_base_group: str | None = None,
 ) -> None:
     """Resolve and download every wheel, sdist, and direct-URL archive.
 
@@ -106,6 +107,7 @@ def download(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config 
         cli_decision_order=project_decision_order,
         cli_constraint=project_constraint,
         cli_default_group=project_default_group,
+        cli_base_group=project_base_group,
     )
     project_overrides = _cli.project_config_overrides(overrides)
     _cli._project_cli_overrides_or_exit(project_overrides)  # noqa: SLF001

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -68,7 +68,7 @@ from nab_python.requirements_file import (
     read_pyproject_optional_dependencies,
     resolve_groups_to_requirements,
 )
-from nab_python.resolve import build_lock_input
+from nab_python.resolve import active_group_names, build_lock_input
 from nab_python.target import UnevaluableMarkerError
 
 from . import cli as _cli
@@ -128,6 +128,7 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
     project_decision_order: DecisionOrderFlag | None = None,
     project_constraint: Annotated[tuple[str, ...], tyro.conf.UseAppendAction] = (),
     project_default_group: Annotated[tuple[str, ...], tyro.conf.UseAppendAction] = (),
+    project_base_group: str | None = None,
     upgrade: bool = False,
     locked: bool = False,
 ) -> None:
@@ -190,6 +191,7 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
         cli_decision_order=project_decision_order,
         cli_constraint=project_constraint,
         cli_default_group=project_default_group,
+        cli_base_group=project_base_group,
     )
     project_overrides = _cli.project_config_overrides(overrides)
     _cli._project_cli_overrides_or_exit(project_overrides)  # noqa: SLF001
@@ -344,6 +346,7 @@ def _fast_fail_locked(
             extras=extras,
             groups=groups,
             default_groups=config.default_groups,
+            base_group=config.base_group,
         )
     except (
         InvalidProjectTableError,
@@ -362,6 +365,7 @@ def _fast_fail_locked(
             extras=extras,
             dependency_groups=groups,
             default_groups=config.default_groups,
+            base_group=config.base_group,
             roots=roots,
             constraints=config.constraints,
             resolve_target=resolve_target,
@@ -413,6 +417,7 @@ def _active_root_requirements(
     extras: tuple[str, ...],
     groups: tuple[str, ...],
     default_groups: tuple[str, ...],
+    base_group: str | None = None,
 ) -> list[RootRequirement]:
     """Collect this run's active direct requirements with their source clause.
 
@@ -435,7 +440,9 @@ def _active_root_requirements(
                 for req in expand_extra_requirements(optional, project_name, [extra])
             )
 
-    effective_groups = dict.fromkeys((*groups, *default_groups))
+    effective_groups = dict.fromkeys(
+        active_group_names(groups, default_groups, base_group)
+    )
     if effective_groups:
         table = read_pyproject_groups(path)
         for group in effective_groups:

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -321,6 +321,7 @@ def _cli_overrides(  # noqa: PLR0913 - one keyword per CLI flag it maps to a reg
     cli_decision_order: str | None = None,
     cli_constraint: tuple[str, ...] = (),
     cli_default_group: tuple[str, ...] = (),
+    cli_base_group: str | None = None,
 ) -> dict[str, object]:
     """Build the registry-keyed CLI override dict from the named flags.
 
@@ -347,6 +348,7 @@ def _cli_overrides(  # noqa: PLR0913 - one keyword per CLI flag it maps to a reg
             "project_decision_order": cli_decision_order,
             "project_constraint": cli_constraint,
             "project_default_group": cli_default_group,
+            "project_base_group": cli_base_group,
         }
     )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2045,6 +2045,45 @@ class TestLockCommandUniversal:
         err = capsys.readouterr().err
         assert f"error: {hint}\n" in err
 
+    def test_base_group_naming_a_declared_group_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The configured name is already a group of the project's own.
+
+        Refused as the config is read, so nothing here has to stand in
+        for a resolve.
+        """
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\ndependencies = ["foo"]\n'
+            '[dependency-groups]\ndev = ["foo"]\ndefault = ["foo"]\n'
+            '[tool.nab]\nbase-group = "default"\n',
+        )
+        with pytest.raises(SystemExit, match="1"):
+            lock(pyproject, output=tmp_path / "pylock.toml", groups=("dev",))
+        err = capsys.readouterr().err
+        assert "error: in [tool.nab]: base-group 'default' and" in err
+        assert "--project-base-group" not in err
+        assert "Traceback" not in err
+
+    def test_the_flag_naming_a_declared_group_names_the_flag(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The project file may not hold the value the run is refusing."""
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\ndependencies = ["foo"]\n[dependency-groups]\ndev = ["foo"]\n',
+        )
+        with pytest.raises(SystemExit, match="1"):
+            lock(
+                pyproject,
+                output=tmp_path / "pylock.toml",
+                groups=("dev",),
+                project_base_group="dev",
+            )
+
+        assert "--project-base-group 'dev' and" in capsys.readouterr().err
+
     def test_pylock_divergent_base_dep_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
@@ -3815,6 +3854,55 @@ class TestLockedFlag:
         self._run_locked(pyproject, out, _stub_resolve_result(pins={"foo": V("1.0")}))
         assert "is up to date" in capsys.readouterr().err
         assert out.read_bytes() == before
+
+    def test_lock_offering_groups_is_up_to_date(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The name lands in ``default-groups`` while no run selects it.
+
+        A checker comparing that array as it stands would call every lock
+        that names the project's own dependencies out of date.
+        """
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\ndependencies = ["foo"]\n[dependency-groups]\ndev = ["foo"]\n'
+            '[tool.nab]\nbase-group = "default"\n',
+        )
+        out = tmp_path / "pylock.toml"
+        result = _stub_resolve_result(pins={"foo": V("1.0")})
+        self._write_lock(pyproject, out, result, "--groups", "dev")
+        capsys.readouterr()
+        assert "default" in tomli.loads(out.read_text())["default-groups"]
+
+        self._run_locked(pyproject, out, result, "--groups", "dev")
+        assert "is up to date" in capsys.readouterr().err
+
+    def test_a_renamed_base_group_is_out_of_date(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Renaming the group renames a marker on every package it gates.
+
+        Nothing else about the lock changes, so only the name the writer
+        would now use can tell the checker it is stale.
+        """
+        body = (
+            '[project]\ndependencies = ["foo"]\n'
+            '[dependency-groups]\ndev = ["foo"]\n'
+            "[tool.nab]\n"
+        )
+        pyproject = _make_pyproject(tmp_path, body + 'base-group = "default"\n')
+        out = tmp_path / "pylock.toml"
+        result = _stub_resolve_result(pins={"foo": V("1.0")})
+        self._write_lock(pyproject, out, result, "--groups", "dev")
+        capsys.readouterr()
+        assert tomli.loads(out.read_text())["default-groups"] == ["default"]
+
+        pyproject.write_text(body + 'base-group = "base"\n', encoding="utf-8")
+        with pytest.raises(SystemExit) as exc:
+            self._run_locked(pyproject, out, result, "--groups", "dev")
+
+        assert exc.value.code == 1
+        assert "out of date" in capsys.readouterr().err
 
     def test_out_of_date_version_exits_one_without_writing(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
Fixes #790.

A lock that offers dependency groups gives no way to install one group on its own: the project's own dependencies carry no marker, and a package with no marker installs under every selection, so `pylock.select(dependency_groups=["build"])` returns the project's whole tree along with the build group.

```toml
[tool.nab]
base-group = "default"
```

names them, so they answer to that group and an installer can ask for another without them. A package both they and a group reach names both. The name must not be one `[dependency-groups]` declares, since a marker naming it could not mean both.

Unset, which is the default, nab's own locks regenerate byte for byte. Naming them puts a marker on every package, which the emitter did not have to produce before: rendering nab's 30-target locks goes 250 to 525ms (tests) and 520 to 640ms (release).
