### PR TITLE
metadata ladder claims no sdist when a filter dropped one

### DIFF
--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -25,9 +25,11 @@ from .._vcs_admission import admit_vcs_url
 from .._vendor.packaging.ranges import VersionRange
 from .._vendor.packaging.specifiers import SpecifierSet
 from .._vendor.packaging.utils import canonicalize_name
+from .._vendor.packaging.version import InvalidVersion
 from ..metadata import (
     DEPENDENCY_FIELDS,
     WheelMetadata,
+    intern_version,
     metadata_deps_are_static,
     parse_metadata,
 )
@@ -176,11 +178,35 @@ def _ladder_failure(
     elif sdist is not None:
         # A fetched sdist with no PKG-INFO is distinct from no sdist at all.
         reason = "no PEP 658 metadata and the sdist has no readable PKG-INFO"
+    elif _index_published_sdist(index, normalized, version):
+        reason = (
+            "no PEP 658 metadata and the sdist was filtered by"
+            " requires-python, dist-policy, or upload-time"
+        )
     else:
         reason = "no PEP 658 metadata and no sdist available"
 
     msg = f"No metadata for {package}=={version}: {reason}"
     return MetadataError(msg)
+
+
+def _index_published_sdist(
+    index: InMemoryIndex, normalized: str, version: Version
+) -> bool:
+    """Whether the index served an sdist for ``version``.
+
+    The ladder only sees the post-filter listing, where an sdist the filter
+    dropped and one that was never published both read as absent.
+    """
+    for dist in index.get_listing(normalized) or ():
+        if not isinstance(dist, SdistFile):
+            continue
+        try:
+            if intern_version(dist.version) == version:
+                return True
+        except InvalidVersion:
+            continue
+    return False
 
 
 def _report_offline_skip(

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -7688,6 +7688,95 @@ class TestDistPolicy:
             provider.get_dependencies("pkg", V("1.0"))
 
 
+class TestLadderSdistAvailability:
+    """The metadata ladder tells a filtered sdist from one never published.
+
+    A filtered sdist comes back by loosening the cutoff or the policy that
+    dropped it; a release that published none has nothing to loosen.  So the
+    two failures must not read alike.
+    """
+
+    _FILTERED = (
+        "no PEP 658 metadata and the sdist was filtered by"
+        " requires-python, dist-policy, or upload-time"
+    )
+    _ABSENT = "no PEP 658 metadata and no sdist available"
+
+    def test_upload_cutoff_filtered_sdist_names_the_filter(self) -> None:
+        """A cutoff keeping the wheel and dropping the sdist names the filter."""
+        coordinator = make_coordinator(
+            [
+                make_wheel(
+                    "1.0", has_metadata=False, upload_time="2026-01-01T00:00:00Z"
+                ),
+                make_sdist("1.0", upload_time="2026-01-20T00:00:00Z"),
+            ]
+        )
+        provider = Provider(
+            coordinator,
+            target=_PY312,
+            uploaded_prior_to=datetime(2026, 1, 10, tzinfo=timezone.utc),
+        )
+
+        with pytest.raises(MetadataError) as excinfo:
+            provider.get_dependencies("pkg", V("1.0"))
+
+        assert self._FILTERED in str(excinfo.value)
+
+    def test_requires_python_filtered_sdist_names_the_filter(self) -> None:
+        """An sdist whose own Requires-Python excludes the target still exists."""
+        coordinator = make_coordinator(
+            [
+                make_wheel("1.0", has_metadata=False),
+                make_sdist("1.0", requires_python=">=3.13"),
+            ]
+        )
+        provider = Provider(coordinator, target=_PY312)
+
+        with pytest.raises(MetadataError) as excinfo:
+            provider.get_dependencies("pkg", V("1.0"))
+
+        assert self._FILTERED in str(excinfo.value)
+
+    def test_wheel_only_policy_filtered_sdist_names_the_filter(self) -> None:
+        """The sdist a wheel-only policy dropped is not reported as absent."""
+        coordinator = make_coordinator(
+            [make_wheel("1.0", has_metadata=False), make_sdist("1.0")]
+        )
+        provider = Provider(
+            coordinator, target=_PY312, dist_policy=DistPolicy.WHEEL_ONLY
+        )
+
+        with pytest.raises(MetadataError) as excinfo:
+            provider.get_dependencies("pkg", V("1.0"))
+
+        assert self._FILTERED in str(excinfo.value)
+
+    def test_sdist_of_another_release_is_reported_as_absent(self) -> None:
+        """Only this release's own sdist counts as one the filter dropped."""
+        coordinator = make_coordinator(
+            [make_wheel("1.0", has_metadata=False), make_sdist("2.0")]
+        )
+        provider = Provider(coordinator, target=_PY312)
+
+        with pytest.raises(MetadataError) as excinfo:
+            provider.get_dependencies("pkg", V("1.0"))
+
+        assert self._ABSENT in str(excinfo.value)
+
+    def test_unparseable_sdist_version_is_reported_as_absent(self) -> None:
+        """A version nab cannot parse cannot be this release's sdist."""
+        coordinator = make_coordinator(
+            [make_wheel("1.0", has_metadata=False), make_sdist("not-a-version")]
+        )
+        provider = Provider(coordinator, target=_PY312)
+
+        with pytest.raises(MetadataError) as excinfo:
+            provider.get_dependencies("pkg", V("1.0"))
+
+        assert self._ABSENT in str(excinfo.value)
+
+
 class TestFetchVersionsNotInIndex:
     def test_listing_not_in_index_blocks_on_request(self) -> None:
         """When listing is not in the index, request_listing + wait is used."""

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -13,7 +13,7 @@ import httpx
 import pytest
 import respx
 
-from nab_index.client import WheelFile
+from nab_index.client import SdistFile, WheelFile
 from nab_index.httpx_async_transport import HttpxAsyncTransport
 from nab_index.transport import HttpError
 from nab_python._testing.coordinator_fake import make_coordinator
@@ -3366,6 +3366,53 @@ class TestAugmentResolutionError:
             in diagnostics
         )
         assert "foo: no version matches the requirement" not in diagnostics
+
+    def test_cutoff_filtered_sdist_is_not_reported_as_never_published(
+        self, tmp_path: Path
+    ) -> None:
+        """An sdist the cutoff dropped is reported as filtered, not as absent.
+
+        ``foo`` 1.0 publishes a sidecar-less wheel and an sdist uploaded
+        after the cutoff, so the metadata ladder runs out of rungs.  Moving
+        the cutoff is the repair, so a line saying no sdist exists would send
+        the user to the index instead.
+        """
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "proj"\ndependencies = ["foo"]\n'
+            '[tool.nab]\nuploaded-prior-to = "2026-01-10T00:00:00Z"\n',
+            encoding="utf-8",
+        )
+
+        wheel = WheelFile(
+            filename="foo-1.0-py3-none-any.whl",
+            url="https://example.com/foo-1.0-py3-none-any.whl",
+            version="1.0",
+            requires_python=None,
+            has_metadata=False,
+            upload_time="2026-01-01T00:00:00Z",
+        )
+        sdist = SdistFile(
+            filename="foo-1.0.tar.gz",
+            url="https://example.com/foo-1.0.tar.gz",
+            version="1.0",
+            requires_python=None,
+            upload_time="2026-01-20T00:00:00Z",
+        )
+        coordinator = make_coordinator(listings={"foo": [wheel, sdist]})
+
+        with patch("nab_python.resolve.FetchCoordinator") as mock_coord_cls:
+            mock_coord_cls.return_value.__enter__ = lambda _self: coordinator
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            with pytest.raises(ResolutionError) as info:
+                _resolved(pyproject, _FAKE_TRANSPORT, python_version="3.12.0")
+
+        diagnostics = str(info.value).split("Diagnostics:")[1]
+        assert (
+            "foo: every version in range was rejected: No metadata for foo==1.0:"
+            " no PEP 658 metadata and the sdist was filtered by requires-python,"
+            " dist-policy, or upload-time" in diagnostics
+        )
 
 
 class TestConflictingRootRequirements:


### PR DESCRIPTION
A failed metadata ladder reports "No metadata for foo==1.0: no PEP 658 metadata and no sdist available" even when foo 1.0 published an sdist that the upload-time cutoff, the sdist's own Requires-Python, or the dist policy dropped. That points the reader the wrong way: a filtered sdist comes back by loosening the setting that dropped it, while a release that published none has nothing to loosen.

The ladder read availability off the post-filter listing, where a filtered sdist and one that was never published look alike. It now consults the raw listing and reports "the sdist was filtered by requires-python, dist-policy, or upload-time" when the index served one at that version.

The no-versions classifier drew the same distinction in #446.
