### PR TITLE
Add a Range benchmark to nab-resolver

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,9 +65,9 @@ jobs:
     timeout-minutes: 20
     strategy:
       fail-fast: false
-      # These cover nab-python/benchmarks, which is developer tooling rather
-      # than shipped code, so they run on the ends of the supported range
-      # instead of the full matrix. Windows earns its cell because the
+      # These cover the benchmarks directories, which are developer tooling
+      # rather than shipped code, so they run on the ends of the supported
+      # range instead of the full matrix. Windows earns its cell because the
       # harness builds output paths and the tests pin its device-name rules.
       matrix:
         include:

--- a/nab-resolver/benchmarks/README.md
+++ b/nab-resolver/benchmarks/README.md
@@ -1,0 +1,44 @@
+# Benchmarks
+
+`range_scenarios.py` resolves two graph shapes through `nab_resolver.Resolver` with every
+constructor argument left at its default, so the range type under test is this package's
+`Range`. nab-python's benchmark suites all pass packaging's `VersionRange`, which leaves
+`Range` unmeasured everywhere else even though it is what a consumer that supplies no
+`range_type` gets.
+
+```bash
+python nab-resolver/benchmarks/range_scenarios.py
+python nab-resolver/benchmarks/range_scenarios.py --scenario conflict-free-fanout
+python nab-resolver/benchmarks/range_scenarios.py --repeats 9 --json out.json
+```
+
+`wrong-package-backtracking` builds 64 releases of a graph whose roots pin disagreeing
+versions of one shared package. It backtracks, so it drives the set predicates and the
+differences and intersections that fragment a range.
+
+`conflict-free-fanout` builds one root over 120 leaf packages of 50 releases each. Nothing
+conflicts, no range ever gains a second interval, and nearly all the work is membership
+tests during prioritization.
+
+A change to `Range` can win on one of those and lose on the other, so compare both. Each
+scenario prints its Range call counts, `hash_misses` for the calls that found the hash memo
+empty, `intervals_max` and `intervals_mean` over the intervals per range that membership was
+tested against, a digest of the solution it reached, and process CPU. Everything but the
+`__hash__` count and the timing survives a change of machine. `__hash__` follows how often
+CPython's dicts ask a key for its hash and so differs between versions, which is why
+`hash_misses` is reported beside it. Quote a CPU number only from a serialized run, and read
+two runs whose digests differ as two different questions rather than as a comparison.
+
+Three things those numbers do not say. The digest identifies the solution, not the workload,
+and `wrong-package-backtracking` always resolves to the same four pins, so on that scenario
+the search counters and the interval census are what separate two runs. The interval census
+is a function of that scenario's size rather than a sample of anything: `intervals_max` is
+always the size. And every membership test in either scenario comes from `GraphProvider`
+scanning its own release lists, so a provider that indexed or cached its candidates would
+show almost none. All of it compares `Range` implementations against each other on a fixed
+workload; none of it sizes `Range`'s share of a real resolve.
+
+Versions here are `int`, so a comparison inside `Range` costs a C-level int compare, while a
+consumer holding packaging `Version` objects pays a Python-level `__lt__`. A change that
+spends allocations to save comparisons is worth at least what it measures here, and more to
+that consumer.

--- a/nab-resolver/benchmarks/range_scenarios.py
+++ b/nab-resolver/benchmarks/range_scenarios.py
@@ -1,0 +1,434 @@
+"""Benchmark ``nab_resolver.Range`` through the resolver that defaults to it.
+
+Usage:
+    python nab-resolver/benchmarks/range_scenarios.py
+    python nab-resolver/benchmarks/range_scenarios.py --scenario conflict-free-fanout
+    python nab-resolver/benchmarks/range_scenarios.py --repeats 9 --json out.json
+
+``Range`` is what ``Resolver`` and ``PartialSolution`` fall back to when a
+consumer passes no ``range_type``, and nab-python always passes packaging's
+``VersionRange``, so nothing in nab's other benchmark suites runs it. A change
+to Range's algebra can win on one graph shape and lose on another, so both
+regimes run here: ``wrong-package-backtracking`` drives the set predicates and
+the differences that fragment a range, and ``conflict-free-fanout`` is almost
+all membership tests against single-interval ranges.
+
+Every scenario reports its Range call counts, how many ``__hash__`` calls found
+the memo empty, the intervals per range that membership was tested against, and
+a digest of the solution it reached. All of it holds across machines and
+interpreters except the ``__hash__`` count, which follows how often CPython's
+dicts ask a key for its hash and so differs between versions. The memo misses
+beside it are what a change to hashing shows up in. Timing holds on no machine,
+so quote a CPU number only from a serialized run, and read two runs whose
+digests differ as two different questions.
+
+``README.md`` next to this script covers what the numbers do and do not settle.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import platform
+import statistics
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from nab_resolver.ranges import Range
+from nab_resolver.resolver import BaseProvider, Resolver
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping, Sequence
+
+    from nab_resolver.resolver import ResolverStats
+    from nab_resolver.types import RangeProtocol
+
+# package -> version -> dependency -> required range.
+Graph = dict[str, dict[int, dict[str, Range[int]]]]
+
+FANOUT_RELEASES = 50
+DEFAULT_REPEATS = 5
+
+# The Range methods worth counting: the set predicates, the operators an
+# implementation might answer them with, and the equality and hash a dict keyed
+# by ranges calls.
+COUNTED_METHODS = (
+    "__and__",
+    "__contains__",
+    "__eq__",
+    "__hash__",
+    "__invert__",
+    "__or__",
+    "__sub__",
+    "is_disjoint",
+    "is_subset",
+    "relation",
+)
+
+
+def wrong_package_backtracking_graph(releases: int) -> Graph:
+    """Build the graph where every root but the oldest is unsatisfiable.
+
+    Root ``k`` wants ``left k`` and ``right k-1``, which pin different versions
+    of one shared package, so the resolver works its way down from the newest
+    root and conflicts on the way.
+    """
+    graph: Graph = {"root": {}, "left": {}, "right": {}, "shared": {}}
+    for index in range(1, releases + 1):
+        lagging = max(1, index - 1)
+        graph["shared"][index] = {}
+        graph["left"][index] = {"shared": Range.singleton(index)}
+        graph["right"][lagging] = {"shared": Range.singleton(lagging)}
+        graph["root"][index] = {
+            "left": Range.singleton(index),
+            "right": Range.singleton(lagging),
+        }
+    return graph
+
+
+def conflict_free_fanout_graph(packages: int) -> Graph:
+    """Build one root depending on ``packages`` leaves of ``FANOUT_RELEASES`` each.
+
+    Nothing depends on anything else, so no range ever gains a second interval
+    and the resolve is dominated by membership tests during prioritization.
+    """
+    root: dict[str, Range[int]] = {}
+    graph: Graph = {"root": {1: root}}
+    for index in range(packages):
+        name = f"p{index}"
+        graph[name] = {version: {} for version in range(1, FANOUT_RELEASES + 1)}
+        root[name] = Range.at_least(2)
+    return graph
+
+
+@dataclass(frozen=True)
+class Scenario:
+    """One graph shape and the size the standard run builds it at."""
+
+    id: str
+    size: int
+    build: Callable[[int], Graph]
+
+
+SCENARIOS = (
+    Scenario("wrong-package-backtracking", 64, wrong_package_backtracking_graph),
+    Scenario("conflict-free-fanout", 120, conflict_free_fanout_graph),
+)
+
+
+class GraphProvider(BaseProvider[str, int]):
+    """Answer from an in-memory graph, newest release first."""
+
+    def __init__(self, graph: Graph) -> None:
+        """Index ``graph``'s releases newest first for the version scans."""
+        self._graph = graph
+        self._newest_first = {
+            package: sorted(releases, reverse=True)
+            for package, releases in graph.items()
+        }
+
+    def choose_version(
+        self, package: str, version_range: RangeProtocol[int]
+    ) -> int | None:
+        """Return the newest release of ``package`` inside ``version_range``."""
+        for version in self._newest_first.get(package, ()):
+            if version in version_range:
+                return version
+        return None
+
+    def has_satisfying_version(
+        self, package: str, version_range: RangeProtocol[int]
+    ) -> bool:
+        """Report whether any release of ``package`` is inside ``version_range``.
+
+        Owed to ``ResolverProvider`` and not supplied by ``BaseProvider``. No
+        scenario here reaches it.
+        """
+        return any(v in version_range for v in self._newest_first.get(package, ()))
+
+    def get_dependencies(self, package: str, version: int) -> Mapping[str, Range[int]]:
+        """Return the recorded dependency ranges for one release."""
+        return self._graph.get(package, {}).get(version, {})
+
+    def prioritize(
+        self,
+        package: str,
+        version_range: RangeProtocol[int],
+        conflict_counts: Mapping[str, int],
+        culprit_counts: Mapping[str, int] | None = None,
+    ) -> int:
+        """Decide the package with the fewest releases still in range first."""
+        del conflict_counts, culprit_counts
+        return sum(1 for v in self._newest_first.get(package, ()) if v in version_range)
+
+    def widen_decision(self, package: str, version: int) -> None:
+        """Keep the exact singleton: nothing here widens a decision."""
+        del package, version
+
+
+def solution_digest(solution: Mapping[str, int]) -> str:
+    """Identify a solution by its contents, so two separate runs can be compared.
+
+    A change to ``Range`` that reaches a different answer agrees with itself on
+    every repeat, so nothing inside one run can see it.
+    """
+    lines = "\n".join(
+        f"{package} {version}" for package, version in sorted(solution.items())
+    )
+    return hashlib.sha256(lines.encode("utf-8")).hexdigest()[:12]
+
+
+@dataclass(frozen=True)
+class Resolution:
+    """One resolve: the solution, the search counters, and the range type used."""
+
+    solution: dict[str, int]
+    stats: ResolverStats[str]
+    range_type: str
+
+    @property
+    def digest(self) -> str:
+        """Short stable identity for the solution this resolve reached."""
+        return solution_digest(self.solution)
+
+
+def resolve_once(graph: Graph) -> Resolution:
+    """Resolve ``graph`` with every ``Resolver`` argument left at its default.
+
+    The range type is read back off the resolver rather than declared, so a
+    report cannot claim to have exercised ``Range`` when it did not.
+    """
+    resolver: Resolver[str, int] = Resolver(GraphProvider(graph))
+    solution = resolver.resolve({"root": Range.full()})
+    range_type = resolver.range_type
+    return Resolution(
+        solution=solution,
+        stats=resolver.stats,
+        range_type=f"{range_type.__module__}.{range_type.__qualname__}",
+    )
+
+
+@dataclass
+class IntervalCensus:
+    """Intervals per receiver, counted over every membership test."""
+
+    tests: int = 0
+    intervals: int = 0
+    largest: int = 0
+
+    def record(self, count: int) -> None:
+        """Fold in one membership test against a range of ``count`` intervals."""
+        self.tests += 1
+        self.intervals += count
+        self.largest = max(self.largest, count)
+
+    @property
+    def mean(self) -> float:
+        """Mean intervals per membership test, or zero when none ran."""
+        return self.intervals / self.tests if self.tests else 0.0
+
+
+@dataclass
+class RangeTraffic:
+    """What one resolve asked of ``Range``."""
+
+    counts: dict[str, int] = field(
+        default_factory=lambda: dict.fromkeys(COUNTED_METHODS, 0)
+    )
+    census: IntervalCensus = field(default_factory=IntervalCensus)
+    # Calls that found the hash memo empty and so walked the intervals.
+    hash_misses: int = 0
+
+
+def count_range_traffic(graph: Graph) -> RangeTraffic:
+    """Resolve ``graph`` once with ``Range``'s methods wrapped in counters.
+
+    The wrappers are far too expensive to leave in place while timing, so this
+    is its own resolve and the timed repeats run against the untouched class.
+    """
+    traffic = RangeTraffic()
+    originals = {name: getattr(Range, name) for name in COUNTED_METHODS}
+
+    def counter(name: str, original: Any) -> Any:
+        """Wrap one Range method so every call to it is tallied."""
+
+        def counted(self: Range[int], *args: Any, **kwargs: Any) -> Any:
+            traffic.counts[name] += 1
+            return original(self, *args, **kwargs)
+
+        return counted
+
+    def membership_counter(original: Any) -> Any:
+        """Wrap ``__contains__``, which also censuses its receiver's intervals."""
+
+        def counted(self: Range[int], version: object) -> bool:
+            traffic.counts["__contains__"] += 1
+            traffic.census.record(len(self._intervals))
+            return bool(original(self, version))
+
+        return counted
+
+    def hash_counter(original: Any) -> Any:
+        """Wrap ``__hash__``, separating the calls the memo already answers."""
+
+        def counted(self: Range[int]) -> int:
+            traffic.counts["__hash__"] += 1
+            if self._hash == 0:
+                traffic.hash_misses += 1
+            return int(original(self))
+
+        return counted
+
+    for name, original in originals.items():
+        if name == "__contains__":
+            setattr(Range, name, membership_counter(original))
+        elif name == "__hash__":
+            setattr(Range, name, hash_counter(original))
+        else:
+            setattr(Range, name, counter(name, original))
+
+    try:
+        resolve_once(graph)
+    finally:
+        for name, original in originals.items():
+            setattr(Range, name, original)
+
+    return traffic
+
+
+@dataclass(frozen=True)
+class Measurement:
+    """One scenario's resolve, its Range traffic, and its CPU samples."""
+
+    scenario: Scenario
+    resolution: Resolution
+    traffic: RangeTraffic
+    cpu_seconds: list[float]
+
+    @property
+    def median_cpu(self) -> float:
+        """Median process CPU seconds across the timed repeats."""
+        return statistics.median(self.cpu_seconds)
+
+
+def measure(scenario: Scenario, repeats: int) -> Measurement:
+    """Run one scenario: once for its counters, then ``repeats`` times for CPU.
+
+    The counted resolve is not the first against this graph, so the hash misses
+    it reports come from the ranges a resolve builds rather than from the
+    graph's own literals.
+
+    The repeats are checked against the first resolve's solution, which catches
+    a resolve that is not reproducible within a run. Comparing answers across
+    runs is what the reported digest is for.
+    """
+    graph = scenario.build(scenario.size)
+    resolution = resolve_once(graph)
+    traffic = count_range_traffic(graph)
+
+    cpu_seconds = []
+    for _ in range(repeats):
+        start = time.process_time()
+        repeated = resolve_once(graph)
+        cpu_seconds.append(time.process_time() - start)
+        if repeated.solution != resolution.solution:
+            msg = f"{scenario.id}: repeated resolve selected a different solution"
+            raise RuntimeError(msg)
+
+    return Measurement(scenario, resolution, traffic, cpu_seconds)
+
+
+def build_report(measurements: Sequence[Measurement], repeats: int) -> dict[str, Any]:
+    """Assemble the JSON report for a finished run."""
+    return {
+        "schema": 1,
+        "python": platform.python_version(),
+        "repeats": repeats,
+        "scenarios": [
+            {
+                "id": measurement.scenario.id,
+                "size": measurement.scenario.size,
+                "range_type": measurement.resolution.range_type,
+                "digest": measurement.resolution.digest,
+                "search": {
+                    "rounds": measurement.resolution.stats.rounds,
+                    "decisions": measurement.resolution.stats.decisions,
+                    "conflicts": measurement.resolution.stats.conflicts,
+                },
+                "range_calls": measurement.traffic.counts,
+                "hash_misses": measurement.traffic.hash_misses,
+                "intervals": {
+                    "max": measurement.traffic.census.largest,
+                    "mean": measurement.traffic.census.mean,
+                },
+                "cpu_seconds": measurement.cpu_seconds,
+            }
+            for measurement in measurements
+        ],
+    }
+
+
+def _print_summary(measurements: Sequence[Measurement]) -> None:
+    """Print one row per scenario, then the Range calls behind each row."""
+    print(
+        "scenario                   size digest       rounds decisions conflicts"
+        " intervals_max intervals_mean median_ms"
+    )
+    for measurement in measurements:
+        stats = measurement.resolution.stats
+        census = measurement.traffic.census
+        print(
+            f"{measurement.scenario.id:<26}"
+            f" {measurement.scenario.size:>4}"
+            f" {measurement.resolution.digest:<12}"
+            f" {stats.rounds:>6}"
+            f" {stats.decisions:>9}"
+            f" {stats.conflicts:>9}"
+            f" {census.largest:>13}"
+            f" {census.mean:>14.2f}"
+            f" {measurement.median_cpu * 1000:>9.2f}"
+        )
+
+    print()
+    for measurement in measurements:
+        calls = " ".join(
+            f"{name}={count}"
+            for name, count in sorted(measurement.traffic.counts.items())
+        )
+        misses = measurement.traffic.hash_misses
+        print(f"{measurement.scenario.id}: {calls} hash_misses={misses}")
+
+
+def main() -> None:
+    """Run the selected scenarios against the resolver's default range type."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scenario", action="append", default=[])
+    parser.add_argument("--repeats", type=int, default=DEFAULT_REPEATS)
+    parser.add_argument("--json", type=Path)
+    args = parser.parse_args()
+    if args.repeats < 1:
+        parser.error("--repeats must be at least 1")
+
+    requested = set(args.scenario)
+    unknown = requested - {scenario.id for scenario in SCENARIOS}
+    if unknown:
+        parser.error(f"unknown --scenario values: {sorted(unknown)}")
+
+    selected = [
+        scenario for scenario in SCENARIOS if not requested or scenario.id in requested
+    ]
+    measurements = [measure(scenario, args.repeats) for scenario in selected]
+
+    _print_summary(measurements)
+    if args.json is not None:
+        report = build_report(measurements, args.repeats)
+        args.json.write_text(
+            json.dumps(report, indent=2) + "\n", encoding="utf-8", newline="\n"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/nab-resolver/pyproject.toml
+++ b/nab-resolver/pyproject.toml
@@ -31,3 +31,8 @@ Changelog = "https://github.com/notatallshaw/nab/releases"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+# Benchmarks are development tooling, not part of the shipped package, so the
+# sdist carries only the source and tests.
+[tool.hatch.build.targets.sdist]
+exclude = ["/benchmarks"]

--- a/nab-resolver/tests/test_range_benchmark.py
+++ b/nab-resolver/tests/test_range_benchmark.py
@@ -1,0 +1,332 @@
+"""Tests for the Range benchmark under ``nab-resolver/benchmarks``.
+
+The benchmark exists to catch a change to ``Range`` that helps a backtracking
+resolve and hurts a wide one, so what has to hold is that its two scenarios
+really are those two regimes, that both go through the resolver's default range
+type, and that the traffic each reports is the traffic it reported before. Each
+scenario runs here shrunk to ``SUITE_SIZES``; the sizes the standard run
+declares are pinned on their own.
+
+These carry the ``benchmark`` marker, so they run under ``nox -s benchmarks``
+rather than in the resolver workspace.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import itertools
+import json
+import sys
+from collections.abc import Iterator
+from dataclasses import replace
+from pathlib import Path
+from types import ModuleType
+from typing import Any, NamedTuple
+
+import pytest
+
+from nab_resolver.ranges import Range
+
+pytestmark = pytest.mark.benchmark
+
+BENCHMARK = Path(__file__).resolve().parents[1] / "benchmarks" / "range_scenarios.py"
+MODULE_NAME = "_nab_range_scenarios"
+
+# Small enough to run in a fraction of a second, large enough to backtrack and
+# to fan out.
+SUITE_SIZES = {"wrong-package-backtracking": 8, "conflict-free-fanout": 6}
+
+
+class Profile(NamedTuple):
+    """What one scenario asks of the resolver and of Range at its suite size.
+
+    The ``__hash__`` call count is left out because it is the one reported
+    number that differs between interpreters. ``hash_misses`` is the part of it
+    a change to hashing shows up in, and that part is the same on 3.10 through
+    3.14.
+    """
+
+    rounds: int
+    decisions: int
+    conflicts: int
+    membership_tests: int
+    intervals_seen: int
+    largest_range: int
+    hash_misses: int
+    equality_calls: int
+
+
+SUITE_PROFILE = {
+    "wrong-package-backtracking": Profile(
+        rounds=41,
+        decisions=27,
+        conflicts=14,
+        membership_tests=448,
+        intervals_seen=892,
+        largest_range=8,
+        hash_misses=116,
+        equality_calls=436,
+    ),
+    "conflict-free-fanout": Profile(
+        rounds=8,
+        decisions=8,
+        conflicts=0,
+        membership_tests=1058,
+        intervals_seen=1058,
+        largest_range=1,
+        hash_misses=12,
+        equality_calls=41,
+    ),
+}
+
+
+@pytest.fixture(scope="module")
+def benchmark() -> Iterator[ModuleType]:
+    """Import the benchmark script, which lives outside any package.
+
+    The module has to be in ``sys.modules`` before it executes, or the
+    dataclasses in it cannot resolve their own annotations.
+    """
+    spec = importlib.util.spec_from_file_location(MODULE_NAME, BENCHMARK)
+    assert spec is not None
+    assert spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[MODULE_NAME] = module
+    try:
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        del sys.modules[MODULE_NAME]
+
+
+def scenario_of(benchmark: ModuleType, scenario_id: str) -> Any:
+    """Look one declared scenario up by id rather than by position."""
+    return next(s for s in benchmark.SCENARIOS if s.id == scenario_id)
+
+
+def measure_small(benchmark: ModuleType, scenario_id: str) -> Any:
+    """Run one declared scenario shrunk to the size the suite runs it at."""
+    scenario = scenario_of(benchmark, scenario_id)
+    return benchmark.measure(
+        replace(scenario, size=SUITE_SIZES[scenario_id]), repeats=1
+    )
+
+
+def test_standard_run_declares_the_full_scale_sizes(benchmark: ModuleType) -> None:
+    assert {s.id: s.size for s in benchmark.SCENARIOS} == {
+        "wrong-package-backtracking": 64,
+        "conflict-free-fanout": 120,
+    }
+    assert benchmark.FANOUT_RELEASES == 50
+    assert benchmark.DEFAULT_REPEATS == 5
+
+
+@pytest.mark.parametrize("scenario_id", list(SUITE_SIZES))
+def test_scenario_resolves_through_the_default_range_type(
+    benchmark: ModuleType, scenario_id: str
+) -> None:
+    measurement = measure_small(benchmark, scenario_id)
+
+    assert measurement.resolution.range_type == "nab_resolver.ranges.Range"
+    assert measurement.traffic.counts["__contains__"] > 0
+    assert len(measurement.cpu_seconds) == 1
+
+
+def test_backtracking_scenario_works_the_set_predicates(benchmark: ModuleType) -> None:
+    measurement = measure_small(benchmark, "wrong-package-backtracking")
+    counts = measurement.traffic.counts
+
+    assert measurement.resolution.stats.conflicts > 0
+    assert counts["is_subset"] > 0
+    assert counts["is_disjoint"] > 0
+    assert counts["__sub__"] > 0
+
+    # Carving a negative term out of a positive one splits an interval in two,
+    # so the ranges under test stop carrying a single one.
+    assert measurement.traffic.census.largest > 1
+
+
+def test_fanout_scenario_stays_conflict_free_and_single_interval(
+    benchmark: ModuleType,
+) -> None:
+    measurement = measure_small(benchmark, "conflict-free-fanout")
+    counts = measurement.traffic.counts
+
+    assert measurement.resolution.stats.conflicts == 0
+    assert counts["is_disjoint"] == 0
+    assert counts["__sub__"] == 0
+
+    assert measurement.traffic.census.largest == 1
+    assert measurement.traffic.census.mean == 1.0
+
+
+@pytest.mark.parametrize("scenario_id", list(SUITE_SIZES))
+def test_scenario_pins_its_search_and_membership_profile(
+    benchmark: ModuleType, scenario_id: str
+) -> None:
+    """Hold each scenario to the workload the report says it measured.
+
+    The regime assertions pass on any graph that merely conflicts or merely
+    fans out, and most of the membership tests come from ``GraphProvider``
+    scanning its own release lists rather than from the resolver. An edit that
+    leaves the answer correct can still move what a comparison between two
+    ``Range`` implementations is read off, so these numbers change deliberately
+    or not at all.
+    """
+    measurement = measure_small(benchmark, scenario_id)
+    stats = measurement.resolution.stats
+    census = measurement.traffic.census
+
+    assert (
+        Profile(
+            rounds=stats.rounds,
+            decisions=stats.decisions,
+            conflicts=stats.conflicts,
+            membership_tests=census.tests,
+            intervals_seen=census.intervals,
+            largest_range=census.largest,
+            hash_misses=measurement.traffic.hash_misses,
+            equality_calls=measurement.traffic.counts["__eq__"],
+        )
+        == SUITE_PROFILE[scenario_id]
+    )
+
+
+def test_digest_separates_two_runs_that_each_agree_with_themselves(
+    benchmark: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Cross-run solution identity, which the repeat guard cannot supply.
+
+    A ``Range`` change that deterministically resolves to different pins agrees
+    with itself on every repeat, so ``measure`` stays quiet and the digest is
+    the only thing separating the two runs. It therefore has to reach the JSON
+    report, which is what an A/B actually diffs.
+    """
+    baseline = measure_small(benchmark, "conflict-free-fanout")
+
+    def oldest_in_range(_self: Any, _package: str, version_range: Any) -> int | None:
+        for version in range(1, benchmark.FANOUT_RELEASES + 1):
+            if version in version_range:
+                return version
+        return None
+
+    monkeypatch.setattr(benchmark.GraphProvider, "choose_version", oldest_in_range)
+    drifted = measure_small(benchmark, "conflict-free-fanout")
+
+    assert drifted.resolution.solution != baseline.resolution.solution
+    assert drifted.resolution.digest != baseline.resolution.digest
+
+    report = benchmark.build_report([baseline, drifted], repeats=1)
+    assert [scenario["digest"] for scenario in report["scenarios"]] == [
+        baseline.resolution.digest,
+        drifted.resolution.digest,
+    ]
+
+
+def test_counting_leaves_range_as_it_found_it(benchmark: ModuleType) -> None:
+    """Counting patches a shipped class, so it has to put every method back."""
+    original = {name: getattr(Range, name) for name in benchmark.COUNTED_METHODS}
+
+    scenario = scenario_of(benchmark, "wrong-package-backtracking")
+    benchmark.count_range_traffic(scenario.build(4))
+
+    assert {
+        name: getattr(Range, name) for name in benchmark.COUNTED_METHODS
+    } == original
+
+
+def test_repeat_that_selects_another_solution_is_reported(
+    benchmark: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The guard that stops one run being averaged over two different answers."""
+    real_resolve = benchmark.resolve_once
+    resolves = itertools.count()
+
+    def drifting(graph: Any) -> Any:
+        resolution = real_resolve(graph)
+        if next(resolves) == 0:
+            return resolution
+        return replace(resolution, solution={**resolution.solution, "root": -1})
+
+    monkeypatch.setattr(benchmark, "resolve_once", drifting)
+
+    scenario = replace(scenario_of(benchmark, "wrong-package-backtracking"), size=4)
+    with pytest.raises(RuntimeError, match="different solution"):
+        benchmark.measure(scenario, repeats=1)
+
+
+def test_command_line_run_prints_and_writes_one_scenario(
+    benchmark: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The invocation the README documents, shrunk to a size the suite affords.
+
+    The JSON is what an A/B diffs, so the digest has to survive the round trip
+    to the file and agree with the same scenario measured directly.
+    """
+    monkeypatch.setattr(
+        benchmark,
+        "SCENARIOS",
+        tuple(
+            replace(scenario, size=SUITE_SIZES[scenario.id])
+            for scenario in benchmark.SCENARIOS
+        ),
+    )
+    report_path = tmp_path / "report.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "range_scenarios.py",
+            "--scenario",
+            "conflict-free-fanout",
+            "--repeats",
+            "1",
+            "--json",
+            str(report_path),
+        ],
+    )
+
+    benchmark.main()
+
+    printed = capsys.readouterr().out
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    (scenario_report,) = report["scenarios"]
+
+    assert report["repeats"] == 1
+    assert scenario_report["id"] == "conflict-free-fanout"
+    assert (
+        scenario_report["digest"]
+        == measure_small(benchmark, "conflict-free-fanout").resolution.digest
+    )
+
+    # The table row carries the digest and the block under it the call counts.
+    assert scenario_report["digest"] in printed
+    calls = scenario_report["range_calls"]
+    assert f"conflict-free-fanout: __and__={calls['__and__']}" in printed
+
+
+@pytest.mark.parametrize(
+    ("argument", "complaint"),
+    [
+        (["--repeats", "0"], "--repeats must be at least 1"),
+        (["--scenario", "no-such-shape"], "unknown --scenario values"),
+    ],
+)
+def test_command_line_refuses_a_run_it_cannot_make(
+    benchmark: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    argument: list[str],
+    complaint: str,
+) -> None:
+    """Both arguments the parser turns away before any scenario is built."""
+    monkeypatch.setattr(sys, "argv", ["range_scenarios.py", *argument])
+
+    with pytest.raises(SystemExit):
+        benchmark.main()
+
+    assert complaint in capsys.readouterr().err

--- a/noxfile.py
+++ b/noxfile.py
@@ -112,10 +112,19 @@ def tests(session: nox.Session, workspace: str) -> None:
 @nox.session
 def benchmarks(session: nox.Session) -> None:
     """Run the benchmark-harness tests the workspace sessions deselect."""
-    # These cover scripts under nab-python/benchmarks, which no coverage gate
-    # owns, so this session only has to prove they still pass.
+    # These cover the scripts under nab-resolver/benchmarks and
+    # nab-python/benchmarks, which no coverage gate owns, so this session only
+    # has to prove they still pass.
     _install(session, TESTS_LOCK, ["nab-resolver", "nab-index", "nab-python"])
-    session.run("python", "-m", "pytest", "-m", "benchmark", "nab-python/tests")
+    session.run(
+        "python",
+        "-m",
+        "pytest",
+        "-m",
+        "benchmark",
+        "nab-resolver/tests",
+        "nab-python/tests",
+    )
 
 
 @nox.session


### PR DESCRIPTION
`nab_resolver.Range` is what a consumer gets who passes no `range_type` to `Resolver` or `PartialSolution`, and nothing measures it. nab-python's benchmark suites all hand the resolver packaging's `VersionRange`, so a change to `Range`'s algebra moves no number in this repo even when it changes a standalone consumer's resolve time. That gap surfaced when core-pip vendored nab-resolver, patched only `ranges.py`, and found a win on its own integration that none of nab's benchmarks could have seen.

`nab-resolver/benchmarks/range_scenarios.py` resolves through `Resolver` with every constructor argument left at its default and reads the range type back off the resolver, so a report cannot claim to have exercised `Range` when it did not. It runs two shapes, because a change to the algebra can win on one and lose on the other:

| scenario | graph | Range traffic |
|---|---|---|
| `wrong-package-backtracking` | 64 releases of a graph whose roots pin disagreeing versions of one shared package | set predicates, plus the differences and intersections that fragment a range |
| `conflict-free-fanout` | one root over 120 leaf packages of 50 releases each, where no range gains a second interval | almost entirely `__contains__` |

Alongside process CPU, each scenario reports its `Range` call counts, how many `__hash__` calls found the memo empty, the intervals per range that membership was tested against, and a digest of the solution it reached. All of that holds across machines and interpreters except the `__hash__` count itself, which follows how often CPython's dicts ask a key for its hash. So a comparison taken on a loaded machine still has something to rest on, and an arm that reached a different answer is visible instead of passing as a win.

Both graphs use `int` versions, so a change that spends allocations to save comparisons is worth at least what it measures here, and more to a consumer holding packaging `Version` objects. The benchmarks directory stays out of the sdist.
