### PR TITLE
Add Range.from_versions bulk constructor

### DIFF
--- a/nab-resolver/src/nab_resolver/ranges.py
+++ b/nab-resolver/src/nab_resolver/ranges.py
@@ -12,10 +12,13 @@ provider uses int; the Python provider uses packaging.version.Version.
 
 from __future__ import annotations
 
-from typing import Any, Generic, TypeAlias
+from typing import TYPE_CHECKING, Any, Generic, TypeAlias, cast
 
 from ._compat import override
 from .types import RangeRelation, VersionType
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 # Bound once so the hot return paths load a module global instead of a class
 # attribute.
@@ -185,8 +188,24 @@ class Range(Generic[VersionType]):
         """Create a range containing exactly one version.
 
         Mirrors :meth:`packaging.ranges.VersionRange.singleton`.
+        For a set of versions use :meth:`from_versions`.
         """
         return cls(((version, True, version, True),))
+
+    @classmethod
+    def from_versions(cls, versions: Iterable[VersionType]) -> Range[VersionType]:
+        """Create a range holding exactly the given versions.
+
+        The iterable is consumed once and equal versions collapse.
+        Distinct versions never merge: a range has no notion of one
+        version following another, so the result still excludes
+        everything strictly between them.
+
+        Cheaper than folding :meth:`singleton` with ``|``.
+        """
+        # sorted() needs an ordering bound, which VersionType does not declare.
+        distinct = sorted(set(cast("Iterable[Any]", versions)))
+        return cls(tuple((version, True, version, True) for version in distinct))
 
     @classmethod
     def at_least(cls, version: VersionType) -> Range[VersionType]:

--- a/nab-resolver/tests/property/test_ranges_set_algebra.py
+++ b/nab-resolver/tests/property/test_ranges_set_algebra.py
@@ -62,6 +62,38 @@ class TestSingleton:
         assert (version + 1) not in singleton
 
 
+class TestFromVersions:
+    """``from_versions`` builds the canonical range over a finite version set.
+
+    The oracles are a Python ``set`` and a sorted interval tuple, not a
+    fold of ``singleton`` with ``|``, so a fault in the union machinery
+    cannot cancel out against the constructor.
+    """
+
+    @given(versions=st.lists(st.sampled_from(VERSION_RANGE), max_size=8))
+    @DEEP_SETTINGS
+    def test_contains_exactly_the_given_versions(self, versions: list[int]) -> None:
+        """``v in from_versions(vs)`` iff ``v`` appears in ``vs``."""
+        built = Range.from_versions(versions)
+        wanted = set(versions)
+        for version in VERSION_RANGE:
+            assert (version in built) == (version in wanted)
+
+    @given(versions=st.lists(st.sampled_from(VERSION_RANGE), max_size=8))
+    @DEEP_SETTINGS
+    def test_intervals_are_the_distinct_versions_in_order(
+        self, versions: list[int]
+    ) -> None:
+        """One inclusive singleton per distinct version, ascending.
+
+        Membership alone would let an unsorted or repeating interval list
+        through, and equality and hashing both read that list.
+        """
+        assert Range.from_versions(versions)._intervals == tuple(
+            (version, True, version, True) for version in sorted(set(versions))
+        )
+
+
 class TestComplement:
     """The complement of ``R`` is ``Universe \\ R``: it contains exactly
     those versions ``v`` for which ``v not in R``.

--- a/nab-resolver/tests/test_ranges.py
+++ b/nab-resolver/tests/test_ranges.py
@@ -6,8 +6,27 @@ We use int as the version type for simplicity.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
+import pytest
+
 from nab_resolver.ranges import Range
 from nab_resolver.types import RangeRelation
+
+
+@dataclass(frozen=True, order=True)
+class Release:
+    """A version type whose equal values are separate objects, unlike small ints."""
+
+    number: int
+
+
+def fold_singletons(versions: list[int]) -> Range[int]:
+    """Build a range the way a caller without a bulk constructor has to."""
+    folded: Range[int] = Range.empty()
+    for version in versions:
+        folded = folded | Range.singleton(version)
+    return folded
 
 
 class TestRangeConstruction:
@@ -58,6 +77,45 @@ class TestRangeConstruction:
         assert r.is_empty
         assert r == Range.empty()
         assert ~~r == r
+
+
+class TestRangeFromVersions:
+    def test_no_versions_is_the_empty_range(self) -> None:
+        assert Range.from_versions([]) == Range.empty()
+
+    def test_one_version_is_a_singleton(self) -> None:
+        assert Range.from_versions([5]) == Range.singleton(5)
+
+    def test_versions_are_sorted(self) -> None:
+        assert Range.from_versions([5, 1, 3]) == fold_singletons([1, 3, 5])
+
+    def test_repeats_collapse(self) -> None:
+        assert Range.from_versions([2, 2, 2]) == Range.singleton(2)
+
+    def test_equal_but_separate_version_objects_collapse(self) -> None:
+        """Repeats are found by comparing versions, not by identity."""
+        first, second = Release(1), Release(1)
+
+        assert first is not second
+        assert Range.from_versions([first, second]) == Range.singleton(first)
+
+    def test_neighbouring_versions_stay_apart(self) -> None:
+        """Nothing merges: a range cannot know that 2 follows 1."""
+        built = Range.from_versions([1, 2])
+
+        assert 1 in built
+        assert 2 in built
+        assert 1.5 not in built
+
+    def test_an_iterator_is_consumed_once(self) -> None:
+        versions = iter([3, 1, 2])
+
+        assert Range.from_versions(versions) == fold_singletons([1, 2, 3])
+        assert list(versions) == []
+
+    @pytest.mark.parametrize("versions", [[1, 2, 3, 4], [10, 1, 10, 5, 1]])
+    def test_matches_folding_singletons(self, versions: list[int]) -> None:
+        assert Range.from_versions(versions) == fold_singletons(versions)
 
 
 class TestRangeOperations:


### PR DESCRIPTION
`Range` is the default `range_type` on `Resolver`, so any host that vendors nab-resolver and writes its own provider gets it. Such a host has no specifier-to-range conversion, so it enumerates the versions a requirement matches and folds `Range.singleton` with `|`. Every step of that fold concatenates both interval lists and re-sorts the result, so the cost roughly quadruples for each doubling of the version count. The only alternative was handing the interval tuple to `Range(...)`, a raw structure whose invariants nothing validates.

`Range.from_versions(versions)` does the same job in one pass: sort, drop equal versions, emit one inclusive singleton each. At a few hundred versions that is hundreds of times faster than the fold, and it gives a caller a name to reach for instead of the bare constructor. Nothing beyond equal versions merges, since a range has no notion of one version following another, so two distinct singletons still exclude everything strictly between them.

The fold is what core-experiments/core-pip ended up writing when they vendored nab-resolver: their provider builds a range that way for every root requirement and for every dependency of every decided package.
