### PR TITLE
Answer Range's set predicates in one walk

### DIFF
--- a/nab-resolver/src/nab_resolver/ranges.py
+++ b/nab-resolver/src/nab_resolver/ranges.py
@@ -137,6 +137,33 @@ def _min_upper_bound(left: Interval, right: Interval) -> tuple[Bound, bool]:
     return left_upper, left_upper_inc
 
 
+def _ends_before(interval: Interval, other: Interval) -> bool:
+    """Return whether ``interval`` finishes below everything in ``other``."""
+    upper, upper_inclusive = interval[2], interval[3]
+    lower, lower_inclusive = other[0], other[1]
+    if upper is POSITIVE_INFINITY or lower is NEGATIVE_INFINITY:
+        return False
+    if upper == lower:
+        # They meet at a point, which they share only if both ends include it.
+        return not (upper_inclusive and lower_inclusive)
+    return bool(upper < lower)
+
+
+def _advance_left(left: Interval, right: Interval) -> bool:
+    """Return whether a walk over two interval lists should step ``left``.
+
+    Whichever interval ends first cannot meet anything further along the other
+    list, so it is the one to retire.
+    """
+    left_upper = left[2]
+    right_upper = right[2]
+    if left_upper is POSITIVE_INFINITY:
+        return right_upper is POSITIVE_INFINITY
+    if right_upper is POSITIVE_INFINITY:
+        return True
+    return bool(left_upper <= right_upper)
+
+
 def _interval_is_empty(
     lower: Bound,
     *,
@@ -350,31 +377,156 @@ class Range(Generic[VersionType]):
         return Range(tuple(result))
 
     def __sub__(self, other: object) -> Range[VersionType]:
-        """Set difference: versions in self but not in other."""
+        """Set difference: versions in self but not in other.
+
+        Carves each of this range's intervals against ``other``'s in a single
+        walk of both lists, so the complement of ``other`` is never built.
+        """
         if not isinstance(other, Range):
             return NotImplemented
-        return self & ~other
+
+        right_intervals = other._intervals
+        right_count = len(right_intervals)
+        result: list[Interval] = []
+        right_index = 0
+
+        for left in self._intervals:
+            lower, lower_inclusive, upper, upper_inclusive = left
+
+            # A right interval below this one is below every later one too.
+            while right_index < right_count and _ends_before(
+                right_intervals[right_index], left
+            ):
+                right_index += 1
+
+            fully_covered = False
+            scan = right_index
+
+            while scan < right_count:
+                right = right_intervals[scan]
+
+                # Carving moves the remainder's lower end only, so its upper end
+                # is still left's and this comparison can read left directly.
+                if _ends_before(left, right):
+                    break
+
+                right_lower, right_lower_inc, right_upper, right_upper_inc = right
+
+                # Whatever of the remainder sits below this right interval survives.
+                if right_lower is not NEGATIVE_INFINITY and not _interval_is_empty(
+                    lower,
+                    lower_inclusive=lower_inclusive,
+                    upper=right_lower,
+                    upper_inclusive=not right_lower_inc,
+                ):
+                    result.append(
+                        (lower, lower_inclusive, right_lower, not right_lower_inc)
+                    )
+
+                if right_upper is POSITIVE_INFINITY:
+                    fully_covered = True
+                    break
+
+                # Resume above this right interval.
+                lower, lower_inclusive = right_upper, not right_upper_inc
+                if _interval_is_empty(
+                    lower,
+                    lower_inclusive=lower_inclusive,
+                    upper=upper,
+                    upper_inclusive=upper_inclusive,
+                ):
+                    fully_covered = True
+                    break
+
+                scan += 1
+
+            if not fully_covered and not _interval_is_empty(
+                lower,
+                lower_inclusive=lower_inclusive,
+                upper=upper,
+                upper_inclusive=upper_inclusive,
+            ):
+                result.append((lower, lower_inclusive, upper, upper_inclusive))
+
+        return Range(tuple(result))
 
     def is_subset(self, other: Range[VersionType]) -> bool:
-        """Return whether every version in self is also in other."""
-        return (self - other).is_empty
+        """Return whether every version in self is also in other.
+
+        Walks both interval lists once and stops at the first uncovered
+        interval.  This leans on the invariant: consecutive intervals in
+        ``other`` always leave a gap, so an interval of self is covered only
+        when a single interval of other holds all of it.
+        """
+        right_intervals = other._intervals
+        right_count = len(right_intervals)
+        right_index = 0
+
+        for left in self._intervals:
+            while right_index < right_count and _ends_before(
+                right_intervals[right_index], left
+            ):
+                right_index += 1
+
+            if right_index >= right_count:
+                return False
+
+            right = right_intervals[right_index]
+            lower, lower_inclusive = _max_lower_bound(left, right)
+            upper, upper_inclusive = _min_upper_bound(left, right)
+
+            if (lower, lower_inclusive, upper, upper_inclusive) != left:
+                return False
+
+        return True
 
     def is_superset(self, other: Range[VersionType]) -> bool:
         """Return whether every version in other is also in self."""
         return other.is_subset(self)
 
     def is_disjoint(self, other: Range[VersionType]) -> bool:
-        """Return whether self and other share no version."""
-        return (self & other).is_empty
+        """Return whether self and other share no version.
+
+        Stops at the first shared version rather than building the whole
+        intersection.
+        """
+        left_intervals = self._intervals
+        right_intervals = other._intervals
+        left_count = len(left_intervals)
+        right_count = len(right_intervals)
+        left_index = right_index = 0
+
+        while left_index < left_count and right_index < right_count:
+            left = left_intervals[left_index]
+            right = right_intervals[right_index]
+
+            lower, lower_inclusive = _max_lower_bound(left, right)
+            upper, upper_inclusive = _min_upper_bound(left, right)
+
+            if not _interval_is_empty(
+                lower,
+                lower_inclusive=lower_inclusive,
+                upper=upper,
+                upper_inclusive=upper_inclusive,
+            ):
+                return False
+
+            if _advance_left(left, right):
+                left_index += 1
+            else:
+                right_index += 1
+
+        return True
 
     def relation(self, other: Range[VersionType]) -> RangeRelation:
         """Return how self's members sit against other's.
 
-        Asked separately here; an implementation may answer both in one walk.
+        The empty range is both a subset and disjoint, so it is answered ahead
+        of the walks instead of by running both of them.
         """
+        if self.is_empty:
+            return _EMPTY_REL
         if self.is_subset(other):
-            if self.is_disjoint(other):
-                return _EMPTY_REL
             return _SUBSET_REL
         if self.is_disjoint(other):
             return _DISJOINT_REL

--- a/nab-resolver/src/nab_resolver/ranges.py
+++ b/nab-resolver/src/nab_resolver/ranges.py
@@ -189,7 +189,7 @@ class Range(Generic[VersionType]):
     See :meth:`__init__` for the invariant the interval list must satisfy.
     """
 
-    __slots__ = ("_intervals",)
+    __slots__ = ("_hash", "_intervals")
 
     def __init__(self, intervals: tuple[Interval, ...] = ()) -> None:
         """Create a range from intervals that already satisfy the invariant.
@@ -207,6 +207,7 @@ class Range(Generic[VersionType]):
         write ``[1, 3]``.
         """
         self._intervals = intervals
+        self._hash = 0
 
     @classmethod
     def empty(cls) -> Range[VersionType]:
@@ -541,8 +542,33 @@ class Range(Generic[VersionType]):
 
     @override
     def __hash__(self) -> int:
-        """Hash based on interval tuples."""
-        return hash(self._intervals)
+        """Hash the interval tuple once and keep the answer.
+
+        A range is immutable and is hashed over and over as a cache key, and
+        each hash walks every interval and every bound in it.  Zero marks "not
+        computed yet", so a tuple that really hashes to zero is stored as one.
+        """
+        cached = self._hash
+        if cached == 0:
+            cached = hash(self._intervals) or 1
+            self._hash = cached
+        return cached
+
+    def __getstate__(self) -> tuple[tuple[Interval, ...]]:
+        """Return the intervals alone, keeping the memo out of the pickle.
+
+        The infinity sentinels hash as plain strings, so a memo computed in
+        one process is wrong in a process running a different
+        ``PYTHONHASHSEED``.  The wrapping tuple is what makes the empty range
+        survive: protocols 0 and 1 discard a pickle state that is falsy, and
+        an empty range's intervals are ``()``.
+        """
+        return (self._intervals,)
+
+    def __setstate__(self, state: tuple[tuple[Interval, ...]]) -> None:
+        """Restore from :meth:`__getstate__`, leaving the hash to be recomputed."""
+        (self._intervals,) = state
+        self._hash = 0
 
     @override
     def __repr__(self) -> str:

--- a/nab-resolver/src/nab_resolver/ranges.py
+++ b/nab-resolver/src/nab_resolver/ranges.py
@@ -1,7 +1,8 @@
 """Generic version range with interval operations.
 
-A Range represents a set of versions as a sorted list of non-overlapping
-intervals. Supports intersection, union, complement, and containment.
+A Range represents a set of versions as a canonical list of intervals; see
+``Range.__init__`` for what makes a list canonical. Supports intersection,
+union, complement, and containment.
 
 This is equivalent to pubgrub-rs's ``version_ranges::Ranges<V>``:
 https://github.com/pubgrub-rs/pubgrub/tree/release/version-ranges
@@ -152,19 +153,32 @@ def _interval_is_empty(
 
 
 class Range(Generic[VersionType]):
-    """A set of versions represented as sorted, non-overlapping intervals.
+    """A set of versions represented as a canonical list of intervals.
 
     Modeled after pubgrub-rs ``version_ranges::Ranges<V>``:
     https://docs.rs/version-ranges/latest/version_ranges/struct.Ranges.html
 
     Each interval is ``(lower, lower_inclusive, upper, upper_inclusive)``.
-    The list is sorted by lower bound and intervals do not overlap or touch.
+    See :meth:`__init__` for the invariant the interval list must satisfy.
     """
 
     __slots__ = ("_intervals",)
 
     def __init__(self, intervals: tuple[Interval, ...] = ()) -> None:
-        """Create a range from pre-sorted, non-overlapping intervals."""
+        """Create a range from intervals that already satisfy the invariant.
+
+        The intervals must be sorted by lower bound, must not overlap or
+        touch, must each hold at least one version, and must be exclusive at
+        ``NEGATIVE_INFINITY`` and ``POSITIVE_INFINITY``.  Every operator
+        returns through here, so this neither checks nor normalizes: the
+        classmethods and the operators maintain the invariant, and a caller
+        that assembles its own tuple owns it.
+
+        Equality and hashing compare interval tuples, so two lists denoting
+        the same set must be the same list, and
+        ``((1, True, 2, False), (2, True, 3, True))`` is not a legal way to
+        write ``[1, 3]``.
+        """
         self._intervals = intervals
 
     @classmethod
@@ -406,7 +420,13 @@ class Range(Generic[VersionType]):
 
 
 def _normalize_intervals(intervals: list[Interval]) -> tuple[Interval, ...]:
-    """Sort intervals by lower bound and merge overlapping or adjacent ones."""
+    """Sort intervals by lower bound and merge overlapping or adjacent ones.
+
+    Order, overlap and touching are all it repairs.  An empty interval, a
+    reversed one or an inclusive infinity bound comes through untouched unless
+    a merge happens to absorb or rebuild it, so this is not a way to normalize
+    a list that breaks the ``Range`` invariant.
+    """
     if not intervals:
         return ()
 

--- a/nab-resolver/tests/test_ranges.py
+++ b/nab-resolver/tests/test_ranges.py
@@ -308,13 +308,15 @@ class TestRangeComplementEdgeCases:
         assert 1 not in complement
         assert 2 in complement
 
-    def test_complement_of_touching_intervals(self) -> None:
-        """Complement of [1,2) | [2,3) has no gap at 2."""
-        r = Range(((1, True, 2, False), (2, True, 3, False)))
+    def test_complement_of_a_merged_touch(self) -> None:
+        """[1,2) | [2,3) merges to [1,3), so the complement has no gap at 2."""
+        r = Range.between(1, 2) | Range.between(2, 3)
+        assert r == Range.between(1, 3)
+
         complement = ~r
         assert 0 in complement
         assert 1 not in complement
-        assert 2 not in complement  # 2 is in [2,3)
+        assert 2 not in complement
         assert 3 in complement
 
 

--- a/nab-resolver/tests/test_ranges_contract.py
+++ b/nab-resolver/tests/test_ranges_contract.py
@@ -1,0 +1,266 @@
+"""Tests for the interval-list invariant that ``Range.__init__`` documents.
+
+``Range.__init__`` neither checks nor normalizes, so the invariant is only
+worth stating if the promised surface upholds it.  The census here builds a
+range from every classmethod and closes the result under every operator, then
+checks each one against a restatement of the invariant that does not share a
+line with the implementation.
+
+The rest pins what ``_normalize_intervals`` repairs, which is less than the
+invariant asks for, and what ``Range`` does with hand-built lists that break
+it.
+"""
+
+from __future__ import annotations
+
+import collections
+import itertools
+from functools import cache
+
+from nab_resolver.ranges import (
+    NEGATIVE_INFINITY,
+    POSITIVE_INFINITY,
+    Interval,
+    Range,
+    _normalize_intervals,
+)
+
+VERSIONS = (1, 2, 3, 5, 8)
+"""Version pool for the generated ranges.  The gaps make touching reachable."""
+
+PROBES = tuple(range(10))
+"""Membership probes, wide enough to straddle every bound built from VERSIONS."""
+
+SECOND_ROUND_SAMPLE = 60
+"""How many first-round ranges get run through the operators a second time."""
+
+
+def holds_no_version(interval: Interval) -> bool:
+    """Return whether ``interval`` denotes the empty set."""
+    lower, lower_inclusive, upper, upper_inclusive = interval
+    if lower is NEGATIVE_INFINITY or upper is POSITIVE_INFINITY:
+        return False
+    if lower > upper:
+        return True
+    return lower == upper and not (lower_inclusive and upper_inclusive)
+
+
+def leaves_a_gap_before(left: Interval, right: Interval) -> bool:
+    """Return whether ``left`` ends below ``right`` sharing neither a version nor a bound."""
+    upper, upper_inclusive = left[2], left[3]
+    lower, lower_inclusive = right[0], right[1]
+    if upper is POSITIVE_INFINITY or lower is NEGATIVE_INFINITY:
+        return False
+    if upper == lower:
+        return not upper_inclusive and not lower_inclusive
+    return bool(upper < lower)
+
+
+def invariant_violations(intervals: tuple[Interval, ...]) -> list[str]:
+    """Return one message per way ``intervals`` breaks the documented invariant."""
+    problems: list[str] = []
+
+    for interval in intervals:
+        lower, lower_inclusive, upper, upper_inclusive = interval
+        if lower is NEGATIVE_INFINITY and lower_inclusive:
+            problems.append(f"inclusive -inf: {interval!r}")
+        if upper is POSITIVE_INFINITY and upper_inclusive:
+            problems.append(f"inclusive +inf: {interval!r}")
+        if holds_no_version(interval):
+            problems.append(f"empty interval: {interval!r}")
+
+    for left, right in itertools.pairwise(intervals):
+        if not leaves_a_gap_before(left, right):
+            problems.append(f"{left!r} leaves no gap before {right!r}")
+
+    return problems
+
+
+def constructed_ranges() -> list[Range[int]]:
+    """Return every range the public classmethods build over ``VERSIONS``."""
+    ranges = [Range.empty(), Range.full()]
+    for version in VERSIONS:
+        ranges += [
+            Range.singleton(version),
+            Range.at_least(version),
+            Range.greater_than(version),
+            Range.at_most(version),
+            Range.less_than(version),
+        ]
+    ranges += [
+        Range.between(lower, upper)
+        for lower, upper in itertools.product(VERSIONS, repeat=2)
+    ]
+    return ranges
+
+
+def combined(ranges: list[Range[int]]) -> list[Range[int]]:
+    """Return every ``~`` of one range and every ``&``, ``|`` and ``-`` of a pair."""
+    results = [~range_ for range_ in ranges]
+    for left, right in itertools.product(ranges, repeat=2):
+        results += [left & right, left | right, left - right]
+    return results
+
+
+@cache
+def public_surface_ranges() -> tuple[Range[int], ...]:
+    """Return the ranges reachable from the classmethods through two operator rounds.
+
+    The second round runs a stride sample of the first: the full product is
+    tens of millions of ranges, and the shapes stop changing well before that.
+    """
+    first = constructed_ranges()
+    second = combined(first)
+    sample = second[:: len(second) // SECOND_ROUND_SAMPLE][:SECOND_ROUND_SAMPLE]
+    return tuple(first + second + combined(sample))
+
+
+@cache
+def distinct_pool_ranges() -> tuple[Range[int], ...]:
+    """Return the pool with duplicates dropped, in the order they were built."""
+    return tuple(dict.fromkeys(public_surface_ranges()))
+
+
+class TestPublicSurfaceUpholdsTheInvariant:
+    """Nothing reachable from the promised API produces a non-canonical list.
+
+    This is what lets ``__init__`` state a precondition and check nothing.  It
+    is also the answer to whether an inclusive infinity bound needs a runtime
+    guard: no constructor and no operator emits one.
+    """
+
+    def test_the_pool_reaches_the_shapes_the_invariant_is_about(self) -> None:
+        """A pool of nothing but empty and single-interval ranges passes vacuously.
+
+        Order, touching and gaps are only expressible from two intervals up, so
+        the multi-interval counts are what say the census means anything.  The
+        operators build the same range over and over, so the number of
+        constructions is far larger and says much less.
+        """
+        shapes = collections.Counter(
+            len(range_._intervals) for range_ in distinct_pool_ranges()
+        )
+
+        assert shapes[1] > 50
+        assert shapes[2] > 200
+        assert shapes[3] > 20
+
+    def test_no_generated_range_breaks_the_invariant(self) -> None:
+        """Sorted, non-overlapping, non-touching, non-empty, exclusive at infinity."""
+        violations = [
+            f"{range_!r}: {problems}"
+            for range_ in public_surface_ranges()
+            if (problems := invariant_violations(range_._intervals))
+        ]
+        assert not violations, violations[:5]
+
+    def test_the_checker_can_fail(self) -> None:
+        """Each clause of the invariant rejects a list that breaks only that clause."""
+        assert invariant_violations(((NEGATIVE_INFINITY, True, 5, False),))
+        assert invariant_violations(((1, True, POSITIVE_INFINITY, True),))
+        assert invariant_violations(((3, False, 3, False),))
+        assert invariant_violations(((5, True, 6, False), (1, True, 2, False)))
+        assert invariant_violations(((1, True, 2, False), (2, True, 3, False)))
+        assert invariant_violations(((1, True, 4, False), (2, True, 6, False)))
+
+
+class TestNormalizeIntervals:
+    """What the only repairing path repairs, and what it passes through.
+
+    ``__or__`` runs every union through ``_normalize_intervals``, which makes
+    it the closest thing to a normalizing entry point.  How far it goes decides
+    whether a caller can repair a bad list by unioning it with a good one.
+    """
+
+    def test_sorts_by_lower_bound(self) -> None:
+        assert _normalize_intervals([(5, True, 6, False), (1, True, 2, False)]) == (
+            (1, True, 2, False),
+            (5, True, 6, False),
+        )
+
+    def test_merges_overlapping_intervals(self) -> None:
+        assert _normalize_intervals([(1, True, 4, False), (2, True, 6, False)]) == (
+            (1, True, 6, False),
+        )
+
+    def test_merges_touching_intervals(self) -> None:
+        assert _normalize_intervals([(1, True, 2, False), (2, True, 3, False)]) == (
+            (1, True, 3, False),
+        )
+
+    def test_keeps_an_empty_interval(self) -> None:
+        assert _normalize_intervals([(3, False, 3, False)]) == ((3, False, 3, False),)
+
+    def test_keeps_a_reversed_interval(self) -> None:
+        assert _normalize_intervals([(5, True, 4, True)]) == ((5, True, 4, True),)
+
+    def test_a_merge_absorbs_an_empty_interval(self) -> None:
+        """Survival is only survival of what no merge reaches."""
+        assert _normalize_intervals([(1, True, 5, False), (3, False, 3, False)]) == (
+            (1, True, 5, False),
+        )
+
+    def test_a_merge_absorbs_a_reversed_interval(self) -> None:
+        assert _normalize_intervals([(1, True, 9, False), (5, True, 4, True)]) == (
+            (1, True, 9, False),
+        )
+
+    def test_keeps_an_inclusive_negative_infinity(self) -> None:
+        assert _normalize_intervals([(NEGATIVE_INFINITY, True, 5, False)]) == (
+            (NEGATIVE_INFINITY, True, 5, False),
+        )
+
+    def test_keeps_a_lone_inclusive_positive_infinity(self) -> None:
+        assert _normalize_intervals([(1, True, POSITIVE_INFINITY, True)]) == (
+            (1, True, POSITIVE_INFINITY, True),
+        )
+
+    def test_merging_two_positive_infinities_drops_the_flag(self) -> None:
+        """The merge arm rebuilds the upper bound, which is the one place it is fixed."""
+        assert _normalize_intervals(
+            [(1, True, POSITIVE_INFINITY, True), (2, True, POSITIVE_INFINITY, True)]
+        ) == ((1, True, POSITIVE_INFINITY, False),)
+
+    def test_union_carries_a_hand_built_flag_through(self) -> None:
+        """Unioning with a canonical range does not canonicalize the other side."""
+        hand_built: Range[int] = Range(((NEGATIVE_INFINITY, True, 5, False),))
+        assert (hand_built | Range.full())._intervals == (
+            (NEGATIVE_INFINITY, True, POSITIVE_INFINITY, False),
+        )
+
+
+class TestOutOfContractInputs:
+    """Hand-built lists that break the invariant, and what ``Range`` does with them.
+
+    None of these is reachable from the classmethods or the operators, which
+    the census above pins.  The assertions record where the implementation
+    parts from set algebra, so that widening or narrowing the invariant shows
+    up as a failing test rather than as a silent behaviour change.
+    """
+
+    def test_inclusive_infinity_splits_equality_from_membership(self) -> None:
+        """Two lists denoting ``(-inf, 5)`` compare unequal because their flags differ."""
+        exclusive: Range[int] = Range(((NEGATIVE_INFINITY, False, 5, False),))
+        inclusive: Range[int] = Range(((NEGATIVE_INFINITY, True, 5, False),))
+
+        assert all((probe in exclusive) == (probe in inclusive) for probe in PROBES)
+
+        assert exclusive != inclusive
+        assert {exclusive: "value"}.get(inclusive) is None
+        assert len({exclusive, inclusive}) == 2
+
+    def test_touching_intervals_compare_unequal_to_the_merged_form(self) -> None:
+        """``[1, 2) | [2, 3]`` and ``[1, 3]`` hold the same versions and compare unequal."""
+        touching: Range[int] = Range(((1, True, 2, False), (2, True, 3, True)))
+        merged: Range[int] = Range(((1, True, 3, True),))
+
+        assert all((probe in touching) == (probe in merged) for probe in PROBES)
+        assert touching != merged
+
+    def test_an_empty_interval_makes_a_range_that_is_not_is_empty(self) -> None:
+        """``is_empty`` counts intervals, so a list of empty ones reports non-empty."""
+        degenerate: Range[int] = Range(((3, False, 3, False),))
+
+        assert all(probe not in degenerate for probe in PROBES)
+        assert not degenerate.is_empty
+        assert bool(degenerate)

--- a/nab-resolver/tests/test_ranges_contract.py
+++ b/nab-resolver/tests/test_ranges_contract.py
@@ -6,6 +6,11 @@ range from every classmethod and closes the result under every operator, then
 checks each one against a restatement of the invariant that does not share a
 line with the implementation.
 
+The same pool feeds a differential over the set predicates.  Its oracle is each
+predicate's set-algebra definition, written out below rather than called
+through ``Range``, so a fault in a helper the predicates share cannot move the
+expected answer along with the result.
+
 The rest pins what ``_normalize_intervals`` repairs, which is less than the
 invariant asks for, and what ``Range`` does with hand-built lists that break
 it.
@@ -24,6 +29,7 @@ from nab_resolver.ranges import (
     Range,
     _normalize_intervals,
 )
+from nab_resolver.types import RangeRelation
 
 VERSIONS = (1, 2, 3, 5, 8)
 """Version pool for the generated ranges.  The gaps make touching reachable."""
@@ -33,6 +39,32 @@ PROBES = tuple(range(10))
 
 SECOND_ROUND_SAMPLE = 60
 """How many first-round ranges get run through the operators a second time."""
+
+DIFFERENTIAL_POPULATION = 180
+"""How many distinct pool ranges the differential draws its pairs from.  Capping
+the count rather than striding the whole list is what bounds the work: pairing is
+quadratic, and a ``__hash__`` that stopped deduplicating would otherwise take the
+pool from a few hundred ranges to nineteen thousand."""
+
+WIDENING_CHANGES_THIS = (
+    "This input breaks the Range invariant, so set algebra does not decide it. "
+    "A change that makes the walks total over any interval list should update "
+    "this assertion rather than be reverted for failing it."
+)
+"""Failure message for the assertions that pin behaviour on illegal input."""
+
+OUT_OF_CONTRACT_LISTS: tuple[tuple[Interval, ...], ...] = (
+    ((5, True, 8, False), (1, True, 3, False)),
+    ((1, True, 5, False), (2, True, 8, False)),
+    ((1, True, 2, False), (2, True, 3, False)),
+    ((3, False, 3, False),),
+    ((5, True, 4, True),),
+    ((NEGATIVE_INFINITY, True, 3, False),),
+    ((1, True, POSITIVE_INFINITY, True),),
+    ((8, True, 9, False), (3, False, 3, False), (1, True, 2, True)),
+)
+"""One list per way the invariant can break: order, overlap, touch, empty,
+reversed, either inclusive infinity, and all of them at once."""
 
 
 def holds_no_version(interval: Interval) -> bool:
@@ -121,6 +153,46 @@ def distinct_pool_ranges() -> tuple[Range[int], ...]:
     return tuple(dict.fromkeys(public_surface_ranges()))
 
 
+@cache
+def differential_pairs() -> tuple[tuple[Range[int], Range[int]], ...]:
+    """Return every ordered pair from an even sample of the distinct pool ranges.
+
+    Deduplicating first is what makes the pairs worth running: the raw pool is
+    mostly repeats of the empty range and of single intervals, and the walks
+    can only part from set algebra on the multi-interval shapes.
+    """
+    distinct = distinct_pool_ranges()
+    stride = max(1, len(distinct) // DIFFERENTIAL_POPULATION)
+    sample = distinct[::stride][:DIFFERENTIAL_POPULATION]
+    return tuple((left, right) for left in sample for right in sample)
+
+
+def oracle_difference(left: Range[int], right: Range[int]) -> Range[int]:
+    """Return ``left - right`` by set algebra: meet ``left`` with the complement."""
+    return left & ~right
+
+
+def oracle_is_subset(left: Range[int], right: Range[int]) -> bool:
+    """Return whether ``left`` is a subset by set algebra: an empty difference."""
+    return (left & ~right).is_empty
+
+
+def oracle_is_disjoint(left: Range[int], right: Range[int]) -> bool:
+    """Return whether the two are disjoint by set algebra: an empty meet."""
+    return (left & right).is_empty
+
+
+def oracle_relation(left: Range[int], right: Range[int]) -> RangeRelation:
+    """Return the relation from the two oracle predicates, asking each in turn."""
+    if oracle_is_subset(left, right):
+        if oracle_is_disjoint(left, right):
+            return RangeRelation.EMPTY
+        return RangeRelation.SUBSET
+    if oracle_is_disjoint(left, right):
+        return RangeRelation.DISJOINT
+    return RangeRelation.OVERLAPPING
+
+
 class TestPublicSurfaceUpholdsTheInvariant:
     """Nothing reachable from the promised API produces a non-canonical list.
 
@@ -162,6 +234,81 @@ class TestPublicSurfaceUpholdsTheInvariant:
         assert invariant_violations(((5, True, 6, False), (1, True, 2, False)))
         assert invariant_violations(((1, True, 2, False), (2, True, 3, False)))
         assert invariant_violations(((1, True, 4, False), (2, True, 6, False)))
+
+
+class TestPredicatesMatchSetAlgebra:
+    """The one-pass walks answer what the set-algebra formulations answer.
+
+    Every pair comes from the census pool, so every input satisfies the
+    invariant the walks require.
+    """
+
+    def test_pairs_are_numerous_enough_to_mean_something(self) -> None:
+        """A thin pair set, or one of nothing but single intervals, agrees with anything.
+
+        The upper bound is the other half: pairing is quadratic, so it holds the
+        module to a bounded run even if the sample stops being deduplicated.
+        """
+        pairs = differential_pairs()
+
+        assert 30_000 < len(pairs) <= DIFFERENTIAL_POPULATION**2
+        assert max(len(left._intervals) for left, _ in pairs) >= 3
+
+    def test_is_subset(self) -> None:
+        mismatches = [
+            (left, right)
+            for left, right in differential_pairs()
+            if left.is_subset(right) != oracle_is_subset(left, right)
+        ]
+        assert not mismatches, mismatches[:3]
+
+    def test_is_disjoint(self) -> None:
+        mismatches = [
+            (left, right)
+            for left, right in differential_pairs()
+            if left.is_disjoint(right) != oracle_is_disjoint(left, right)
+        ]
+        assert not mismatches, mismatches[:3]
+
+    def test_difference(self) -> None:
+        mismatches = [
+            (left, right)
+            for left, right in differential_pairs()
+            if (left - right) != oracle_difference(left, right)
+        ]
+        assert not mismatches, mismatches[:3]
+
+    def test_relation(self) -> None:
+        mismatches = [
+            (left, right)
+            for left, right in differential_pairs()
+            if left.relation(right) is not oracle_relation(left, right)
+        ]
+        assert not mismatches, mismatches[:3]
+
+
+class TestPredicatesMatchMembership:
+    """A version one range holds and the other does not settles the predicate.
+
+    This shares no code with the oracle above, which is built from ``__and__``
+    and ``__invert__``; these read only ``__contains__``.
+    """
+
+    def test_a_version_only_left_holds_denies_is_subset(self) -> None:
+        for left, right in differential_pairs():
+            if any(probe in left and probe not in right for probe in PROBES):
+                assert not left.is_subset(right)
+
+    def test_a_version_both_hold_denies_is_disjoint(self) -> None:
+        for left, right in differential_pairs():
+            if any(probe in left and probe in right for probe in PROBES):
+                assert not left.is_disjoint(right)
+
+    def test_difference_holds_exactly_the_versions_only_left_holds(self) -> None:
+        for left, right in differential_pairs():
+            difference = left - right
+            for probe in PROBES:
+                assert (probe in difference) == (probe in left and probe not in right)
 
 
 class TestNormalizeIntervals:
@@ -264,3 +411,47 @@ class TestOutOfContractInputs:
         assert all(probe not in degenerate for probe in PROBES)
         assert not degenerate.is_empty
         assert bool(degenerate)
+
+    def test_touching_intervals_defeat_the_subset_walk(self) -> None:
+        """``[1, 3]`` sits inside ``[1, 2) | [2, 3]``, and the walk answers False.
+
+        The walk asks one interval of the right side to hold a whole interval
+        of the left, which matches coverage only when the right side leaves a
+        gap between its own intervals.
+        """
+        whole: Range[int] = Range(((1, True, 3, True),))
+        split: Range[int] = Range(((1, True, 2, False), (2, True, 3, True)))
+
+        assert oracle_is_subset(whole, split)
+        assert not whole.is_subset(split), WIDENING_CHANGES_THIS
+        assert whole.relation(split) is RangeRelation.OVERLAPPING, WIDENING_CHANGES_THIS
+
+    def test_an_inclusive_infinity_defeats_the_subset_walk(self) -> None:
+        """The walk compares a rebuilt tuple against the left interval, flags included."""
+        below_one: Range[int] = Range(((NEGATIVE_INFINITY, True, 1, False),))
+
+        assert oracle_is_subset(below_one, Range.full())
+        assert not below_one.is_subset(Range.full()), WIDENING_CHANGES_THIS
+
+    def test_an_empty_interval_defeats_the_relation_short_circuit(self) -> None:
+        """``relation`` reads ``is_empty`` off the interval count, not off the versions."""
+        degenerate: Range[int] = Range(((3, False, 3, False),))
+        other: Range[int] = Range(((1, True, 5, False),))
+
+        assert oracle_relation(degenerate, other) is RangeRelation.EMPTY
+        assert degenerate.relation(other) is RangeRelation.SUBSET, WIDENING_CHANGES_THIS
+
+
+class TestMembershipDoesNotNeedTheInvariant:
+    """``__contains__`` scans every interval, so it defines membership on any list.
+
+    That asymmetry is why the walks take a precondition and the scan does not.
+    """
+
+    def test_membership_decomposes_over_intervals(self) -> None:
+        """``v in Range(intervals)`` is ``v`` in any one of them, however they are ordered."""
+        for intervals in OUT_OF_CONTRACT_LISTS:
+            whole: Range[int] = Range(intervals)
+            parts: list[Range[int]] = [Range((interval,)) for interval in intervals]
+            for probe in PROBES:
+                assert (probe in whole) == any(probe in part for part in parts)

--- a/nab-resolver/tests/test_ranges_hash.py
+++ b/nab-resolver/tests/test_ranges_hash.py
@@ -1,0 +1,172 @@
+"""Tests for ``Range``'s memoized hash and the pickle state that goes with it.
+
+The memo lives in a slot, and slots land in the default pickle state, so an
+unpickled range would otherwise carry a hash its own process never computed.
+``NEGATIVE_INFINITY`` and ``POSITIVE_INFINITY`` hash as plain strings, which
+makes that hash depend on the writing process's ``PYTHONHASHSEED``.  The
+cross-process test at the bottom is the one that would catch a regression;
+the rest stay in process, where the same behaviour is easier to read.
+"""
+
+from __future__ import annotations
+
+import os
+import pickle
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from nab_resolver.ranges import Interval, Range
+
+PROTOCOLS = tuple(range(pickle.HIGHEST_PROTOCOL + 1))
+"""Protocols 0 and 1 route through ``copyreg`` and drop a falsy pickle state,
+which is a different code path from the one the default protocol takes."""
+
+WRITER = """
+import pickle
+import sys
+
+from nab_resolver.ranges import Range
+
+value = Range.at_least(3)
+hash(value)
+with open(sys.argv[1], "wb") as handle:
+    pickle.dump(value, handle)
+
+sys.stdout.write(str(hash("_PositiveInfinity")))
+"""
+
+READER = """
+import pickle
+import sys
+
+from nab_resolver.ranges import Range
+
+with open(sys.argv[1], "rb") as handle:
+    restored = pickle.load(handle)
+
+fresh = Range.at_least(3)
+index = {restored: "restored"}
+
+sys.stdout.write(
+    f'{hash("_PositiveInfinity")}'
+    f' {hash(restored) == hash(fresh)}'
+    f' {index.get(fresh)}'
+    f' {len({restored, fresh})}'
+)
+"""
+
+
+def round_trip(
+    value: Range[int], protocol: int = pickle.DEFAULT_PROTOCOL
+) -> Range[int]:
+    """Pickle and unpickle ``value`` inside this process."""
+    return pickle.loads(pickle.dumps(value, protocol))  # noqa: S301
+
+
+def run_at_seed(source: str, seed: int, *args: str) -> str:
+    """Run ``source`` in a child interpreter at a fixed ``PYTHONHASHSEED``.
+
+    The child inherits this process's ``sys.path`` so it imports the same
+    ``nab_resolver`` the test does, editable install or not.
+    """
+    environment = dict(
+        os.environ,
+        PYTHONHASHSEED=str(seed),
+        PYTHONPATH=os.pathsep.join(sys.path),
+    )
+    completed = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", source, *args],
+        capture_output=True,
+        text=True,
+        env=environment,
+        check=True,
+    )
+    return completed.stdout
+
+
+class TestHashMemo:
+    def test_the_first_hash_is_the_one_that_is_kept(self) -> None:
+        value = Range.between(2, 9)
+        assert value._hash == 0
+
+        first = hash(value)
+
+        assert value._hash == first
+        assert hash(value) == first
+
+    def test_equal_ranges_hash_alike(self) -> None:
+        assert hash(Range.at_least(4)) == hash(Range.at_least(4))
+
+    def test_an_interval_tuple_hashing_to_zero_memoizes_as_one(self) -> None:
+        """Zero is the "not computed" marker, so a real zero is stored as one instead."""
+
+        class ZeroHashing(tuple[Interval, ...]):
+            """An interval tuple whose hash collides with the marker."""
+
+            __slots__ = ()
+
+            def __hash__(self) -> int:
+                return 0
+
+        value: Range[int] = Range(ZeroHashing([(1, True, 1, True)]))
+
+        assert hash(value) == 1
+        assert value._hash == 1
+        assert hash(value) == 1
+
+
+class TestPickle:
+    @pytest.mark.parametrize("protocol", PROTOCOLS)
+    def test_a_round_trip_restores_an_equal_range(self, protocol: int) -> None:
+        original = Range.at_least(3) | Range.singleton(1)
+        restored = round_trip(original, protocol)
+
+        assert restored == original
+        assert 3 in restored
+        assert 2 not in restored
+
+    @pytest.mark.parametrize("protocol", PROTOCOLS)
+    def test_the_empty_range_round_trips(self, protocol: int) -> None:
+        """Its intervals are ``()``, which the older protocols drop as a state."""
+        restored = round_trip(Range.empty(), protocol)
+
+        assert restored == Range.empty()
+        assert restored.is_empty
+        assert hash(restored) == hash(Range.empty())
+        assert 1 not in restored
+
+    def test_the_memo_does_not_travel_with_the_pickle(self) -> None:
+        """The restored range has to compute its own hash, not inherit one."""
+        original = Range.at_least(3)
+        hash(original)
+
+        restored = round_trip(original)
+
+        assert restored._hash == 0
+        assert hash(restored) == hash(original)
+
+    def test_an_unpickled_range_hashes_under_the_reading_process_seed(
+        self, tmp_path: Path
+    ) -> None:
+        """A range written at one hash seed indexes correctly when read at another.
+
+        Without the state methods the writer's memo rides along in the pickle,
+        the restored range disagrees with an equal one built locally, and a
+        dict keyed by the restored range misses.
+        """
+        pickle_path = str(tmp_path / "range.pickle")
+
+        writer_sentinel = run_at_seed(WRITER, 1, pickle_path).strip()
+        reader_sentinel, hashes_agree, index_hit, distinct = run_at_seed(
+            READER, 2, pickle_path
+        ).split()
+
+        # A test where both seeds hashed the sentinel alike would prove nothing.
+        assert writer_sentinel != reader_sentinel
+
+        assert hashes_agree == "True"
+        assert index_hit == "restored"
+        assert distinct == "1"


### PR DESCRIPTION
`nab_resolver.Range` is the default `range_type` on both `Resolver` and `PartialSolution`, so it is what any consumer gets who does not supply one. core-pip vendored nab-resolver and patched exactly one of its files, `ranges.py`, which is how all of this surfaced in someone else's integration rather than in ours.

`is_subset` was `(self - other).is_empty` and `__sub__` was `self & ~other`, so a subset test over a single interval built two whole ranges and a `relation()` call built three. All three now answer from one walk of the two interval lists, and `relation` settles the empty range before it walks anything. On a 64-release backtracking graph resolved through `nab_resolver.Resolver` with the default range type that is 44 percent less wall time and process CPU, with `Range.__and__` going from 11,945 calls to 598 and `__invert__` from 6,754 to none. A graph with no conflicts, where every range holds one interval, is unchanged.

`__hash__` now keeps its answer in a slot. A range is immutable and gets hashed over and over as a cache key, while each hash walks every interval and every bound in it. The memo stays out of the pickle: the infinity sentinels hash as plain strings, so a range written under one `PYTHONHASHSEED` would otherwise come back holding a hash the reading process disagrees with and miss its own key in a dict.

The walks want a stricter interval list than `Range.__init__` was documenting. The class docstring already said intervals must not overlap or touch; the constructor docstring said only sorted and non-overlapping. `__init__` now carries the whole precondition, including exclusive bounds at the infinity sentinels and no empty intervals. That is a real narrowing against released 0.0.12's wording, and it is worth a release note: on a list whose intervals touch, or one that puts an inclusive flag on an infinity sentinel, `is_subset` and `relation` now answer the way the class docstring always implied rather than the way set algebra would. Nothing reachable from the classmethods or the operators builds such a list, and the constructor still neither checks nor normalizes.

None of this reverses #750. That deleted two-pointer walks from packaging's `VersionRange`, which already answers both predicates from a bounds-only fast path, on nab-python resolves where index work dominates the profile. `nab_resolver.Range` has no fast path and this workload is entirely resolver CPU. nab-python passes `VersionRange` as its `range_type` and nothing under `nab-python/src`, `nab-index/src` or `src/nab` imports `nab_resolver.ranges`, so this is worth nothing on nab's own benchmarks. The case is library surface quality for standalone consumers.
