### PR TITLE
stop re-deciding the same atom on the same point

### DIFF
--- a/nab-python/src/nab_python/_vendor/packaging/_markersets.py
+++ b/nab-python/src/nab_python/_vendor/packaging/_markersets.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import re
 import sys
 import threading
+from functools import lru_cache
 from itertools import pairwise, product
 from typing import TYPE_CHECKING, NamedTuple, cast
 
@@ -111,7 +112,16 @@ def is_pure_version(variable: str) -> bool:
     return DOMAIN_REGISTRY[variable] == DOMAIN_VERSION
 
 
+@lru_cache(maxsize=8192)
 def _apply(lhs: str, op: str, rhs: str, key: str) -> bool:
+    """Evaluate one atom against one point, memoised on the four strings.
+
+    A decision re-reads the same atom on the same point across the cells of
+    one axis, and the operations of one lock re-read the same few hundred
+    pairs thousands of times.  ``Memo`` spans a single operation, so it
+    cannot see that; this key is four strings and holds no reference to any
+    tree or atom, so caching it across operations keeps nothing alive.
+    """
     return _eval_op(lhs, Op(op), rhs, key=key)
 
 

--- a/tasks/vendoring/packaging.patch
+++ b/tasks/vendoring/packaging.patch
@@ -1,9 +1,9 @@
 diff --git a/nab-python/src/nab_python/_vendor/packaging/_markersets.py b/nab-python/src/nab_python/_vendor/packaging/_markersets.py
 new file mode 100644
-index 0000000..a4847ee
+index 0000000..c870260
 --- /dev/null
 +++ b/nab-python/src/nab_python/_vendor/packaging/_markersets.py
-@@ -0,0 +1,1794 @@
+@@ -0,0 +1,1804 @@
 +"""Marker algebra engine: reason about PEP 508 markers as sets of environments.
 +
 +The private engine behind :class:`~packaging.markersets.MarkerSet`. Parses a
@@ -23,6 +23,7 @@ index 0000000..a4847ee
 +import re
 +import sys
 +import threading
++from functools import lru_cache
 +from itertools import pairwise, product
 +from typing import TYPE_CHECKING, NamedTuple, cast
 +
@@ -117,7 +118,16 @@ index 0000000..a4847ee
 +    return DOMAIN_REGISTRY[variable] == DOMAIN_VERSION
 +
 +
++@lru_cache(maxsize=8192)
 +def _apply(lhs: str, op: str, rhs: str, key: str) -> bool:
++    """Evaluate one atom against one point, memoised on the four strings.
++
++    A decision re-reads the same atom on the same point across the cells of
++    one axis, and the operations of one lock re-read the same few hundred
++    pairs thousands of times.  ``Memo`` spans a single operation, so it
++    cannot see that; this key is four strings and holds no reference to any
++    tree or atom, so caching it across operations keeps nothing alive.
++    """
 +    return _eval_op(lhs, Op(op), rhs, key=key)
 +
 +


### PR DESCRIPTION
Deciding a marker set re-reads one atom on one point across the cells of an axis, which `Memo` already caches for the span of one operation. The operations of one lock then re-read the same pairs again: emitting nab's own 30-target tests lock evaluates atoms tens of thousands of times over 433 distinct (value, operator, literal, variable) tuples, rebuilding a `Specifier` and parsing versions each time. The evaluation is a pure function of those four strings, so it is now memoised on them. The key holds no reference to a tree or an atom, so unlike the per-atom truth cache that moved into `Memo` it keeps nothing alive, and it is bounded.

nab's own 30-target locks, min of three: tests 539 to 334ms, types 505 to 355ms, crosshair 712 to 567ms, release 873 to 661ms. Regenerating all eight leaves every marker byte-identical.