### PR TITLE
let a caller share one decision's scratch with the next

### DIFF
--- a/nab-python/src/nab_python/_lockfile/coverage.py
+++ b/nab-python/src/nab_python/_lockfile/coverage.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 from functools import reduce
 from typing import TYPE_CHECKING
 
-from .._vendor.packaging.markersets import MarkerSet, variable_names
+from .._vendor.packaging.markersets import DecisionStore, MarkerSet, variable_names
 from ..target import UNBOUNDABLE_MARKER_VARIABLES, declared_range_marker
 
 if TYPE_CHECKING:
@@ -69,6 +69,7 @@ def validate_marker_coverage(
     targets: Sequence[ResolveTarget],
     *,
     environments: Sequence[Marker],
+    store: DecisionStore | None = None,
 ) -> None:
     """Confirm the emitted rows cover every target the resolve ran.
 
@@ -99,7 +100,7 @@ def validate_marker_coverage(
             (MarkerSet.from_marker(marker) for marker in references),
             MarkerSet.empty(),
         )
-        witness = (asked & ~covered_here).witness()
+        witness = (asked & ~covered_here).witness(store=store)
         if witness is not None:
             raise CoverageError(_coverage_message(witness))
 

--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -25,6 +25,7 @@ from nab_index.atomic import atomic_write_text
 from .._conflict_kind import MARKER_VARIABLE_FOR_KIND
 from .._vendor.packaging.markers import Marker
 from .._vendor.packaging.markersets import (
+    DecisionStore,
     IntractableMarkerSet,
     MarkerSet,
     UnserializableMarkerSet,
@@ -223,7 +224,10 @@ def build_pylock(lock_input: LockInput, *, lock_dir: Path | None = None) -> Pylo
     base = (lock_dir if lock_dir is not None else Path.cwd()).resolve()
     exclusion_groups = conflict_exclusion_groups(lock_input.conflicts)
     universe = _emission_universe(lock_input)
-    package_records = _build_packages(lock_input, base, exclusion_groups, universe)
+    store = DecisionStore()
+    package_records = _build_packages(
+        lock_input, base, exclusion_groups, universe, store
+    )
     package_records.sort(key=_package_sort_key)
     validate_marker_disjointness(
         package_records,
@@ -236,6 +240,7 @@ def build_pylock(lock_input: LockInput, *, lock_dir: Path | None = None) -> Pylo
     validate_marker_coverage(
         [lock.target for lock in lock_input.targets.values()],
         environments=lock_input.environments,
+        store=store,
     )
     tool: dict[str, Any] | None = (
         {"nab": lock_input.provenance.to_block()}
@@ -462,7 +467,10 @@ def _emission_universe(lock_input: LockInput) -> MarkerSet:
 
 
 def _finalize_marker(
-    raw: Marker | None, within: MarkerSet, name: str = ""
+    raw: Marker | None,
+    within: MarkerSet,
+    name: str = "",
+    store: DecisionStore | None = None,
 ) -> Marker | None:
     """Return ``raw`` in its shortest form equivalent over ``within``.
 
@@ -481,14 +489,14 @@ def _finalize_marker(
     if raw is None:
         return None
     try:
-        simplified = MarkerSet.from_marker(raw).simplify(within=within)
+        simplified = MarkerSet.from_marker(raw).simplify(within=within, store=store)
         text = simplified.to_marker_string()
         rebuilt = None if text is None else Marker(text)
         emitted = (
             MarkerSet.full() if rebuilt is None else MarkerSet.from_marker(rebuilt)
         )
         shown = "no marker" if rebuilt is None else str(rebuilt)
-        sound = _sound_within_universe(raw, emitted, within)
+        sound = _sound_within_universe(raw, emitted, within, store)
     except (IntractableMarkerSet, UnserializableMarkerSet):
         return raw
     if not sound:
@@ -505,6 +513,7 @@ def _finalize_cached(
     within: MarkerSet,
     name: str,
     memo: dict[str, Marker | None],
+    store: DecisionStore,
 ) -> Marker | None:
     """:func:`_finalize_marker` memoised for the span of one lock.
 
@@ -516,18 +525,23 @@ def _finalize_cached(
         return None
     key = str(raw)
     if key not in memo:
-        memo[key] = _finalize_marker(raw, within, name)
+        memo[key] = _finalize_marker(raw, within, name, store)
     return memo[key]
 
 
-def _sound_within_universe(raw: Marker, emitted: MarkerSet, within: MarkerSet) -> bool:
+def _sound_within_universe(
+    raw: Marker,
+    emitted: MarkerSet,
+    within: MarkerSet,
+    store: DecisionStore | None = None,
+) -> bool:
     """Whether ``emitted`` and ``raw`` agree on every environment in ``within``.
 
     ``emitted`` is what the lock ships: the reparsed marker bytes, or
     :meth:`MarkerSet.full` when no marker field is emitted.  Decided per universe
     row, under the same budget as the operator it checks.
     """
-    return MarkerSet.from_marker(raw).equivalent_within(emitted, within)
+    return MarkerSet.from_marker(raw).equivalent_within(emitted, within, store=store)
 
 
 def _build_packages(
@@ -535,6 +549,7 @@ def _build_packages(
     lock_dir: Path,
     exclusion_groups: Sequence[AbstractSet[tuple[str, str]]],
     universe: MarkerSet,
+    store: DecisionStore,
 ) -> list[Package]:
     """Collapse the per-target pins into Package entries with markers.
 
@@ -625,7 +640,9 @@ def _build_packages(
                 axes,
                 projections,
             )
-            marker = _finalize_cached(marker, universe, canonical_name, shortened)
+            marker = _finalize_cached(
+                marker, universe, canonical_name, shortened, store
+            )
             out.append(
                 _pin_to_package(
                     _merge_pins_in_group(pins),

--- a/nab-python/src/nab_python/_vendor/packaging/_markersets.py
+++ b/nab-python/src/nab_python/_vendor/packaging/_markersets.py
@@ -628,11 +628,12 @@ class Cell(NamedTuple):
 
 
 class Memo:
-    """One operation's scratch: the partitions and atom truths it re-reads.
+    """The partitions and atom truths a decision re-reads.
 
-    A decision run re-partitions one axis for overlapping atom sets and re-reads one
-    atom on one point across those partitions. Both are memoised here, and the
-    operation that creates this drops it, so nothing accumulates between calls.
+    A decision re-partitions one axis for overlapping atom sets and re-reads one
+    atom on one point across those partitions. Both are memoised here. One
+    decision makes its own unless the caller passes one to share; see
+    :class:`~packaging.markersets.DecisionStore` for the sharing contract.
     """
 
     __slots__ = ("partitions", "truths")
@@ -1229,7 +1230,9 @@ def is_empty(node: Formula, max_cells: int, store: Memo | None = None) -> bool:
     return next(cells, _MISSING) is _MISSING
 
 
-def witness(node: Formula, max_cells: int) -> dict[str, str | frozenset[str]] | None:
+def witness(
+    node: Formula, max_cells: int, store: Memo | None = None
+) -> dict[str, str | frozenset[str]] | None:
     """Return a concrete environment satisfying a tree, or ``None`` if none is found.
 
     The returned environment is verified against the tree before it is returned.
@@ -1240,7 +1243,7 @@ def witness(node: Formula, max_cells: int) -> dict[str, str | frozenset[str]] | 
     ``python_version`` and ``python_full_version`` share one axis, so those
     constraints can sit on different variables.
     """
-    for cell in _satisfying_cells(node, max_cells, Memo()):
+    for cell in _satisfying_cells(node, max_cells, Memo() if store is None else store):
         env = _materialize(cell)
         if evaluate_tree(node, env):
             return env
@@ -1618,7 +1621,9 @@ def _rows_equivalent(
     return True
 
 
-def universe_is_empty(universe: Formula, max_cells: int) -> bool:
+def universe_is_empty(
+    universe: Formula, max_cells: int, store: Memo | None = None
+) -> bool:
     """Whether a universe admits no environment, decided per row.
 
     A union is empty iff every top-level disjunct is, so each is tested alone,
@@ -1626,23 +1631,30 @@ def universe_is_empty(universe: Formula, max_cells: int) -> bool:
     """
     nnf = universe if isinstance(universe, BoolConst) else to_nnf(universe)
     disjuncts = nnf.children if isinstance(nnf, OrNode) else (nnf,)
-    store: Memo = Memo()
-    return all(is_empty(disjunct, max_cells, store) for disjunct in disjuncts)
+    shared = Memo() if store is None else store
+    return all(is_empty(disjunct, max_cells, shared) for disjunct in disjuncts)
 
 
 def equivalent_within_rows(
-    left: Formula, right: Formula, universe: Formula, max_cells: int
+    left: Formula,
+    right: Formula,
+    universe: Formula,
+    max_cells: int,
+    store: Memo | None = None,
 ) -> bool:
     """Whether two trees agree on every point of ``universe``, decided per row.
 
     The row-restricted dual of :func:`_equivalent_within`, deciding the same
     verdict but staying decidable on wide multi-platform universes. A universe of
     ``TRUE`` reduces it to plain global equivalence.
+
+    ``store`` is the caller's scratch when this decision is one of a run.
     """
     rows = _decompose_rows(universe)
     right_by_row = [restrict_tree(right, row.pins) for row in rows]
-    store: Memo = Memo()
-    return _rows_equivalent(left, rows, right_by_row, max_cells, store)
+    return _rows_equivalent(
+        left, rows, right_by_row, max_cells, Memo() if store is None else store
+    )
 
 
 def _dedupe(clauses: list[frozenset[Atom]]) -> list[frozenset[Atom]]:
@@ -1747,7 +1759,11 @@ def _canonical(clauses: list[frozenset[Atom]]) -> tuple:
 
 
 def simplify_within(
-    node: Formula, universe: Formula, max_cells: int, max_work: int
+    node: Formula,
+    universe: Formula,
+    max_cells: int,
+    max_work: int,
+    store: Memo | None = None,
 ) -> Formula:
     """Return the smallest tree equivalent to ``node`` on every point of ``universe``.
 
@@ -1768,7 +1784,8 @@ def simplify_within(
     original = _disjunction(clauses)
     rows = _decompose_rows(universe)
     original_by_row = [restrict_tree(original, row.pins) for row in rows]
-    store: Memo = Memo()
+    if store is None:
+        store = Memo()
     previous_work = getattr(_work_meter, "remaining", None)
     _work_meter.remaining = max_work
     try:

--- a/nab-python/src/nab_python/_vendor/packaging/markersets.py
+++ b/nab-python/src/nab_python/_vendor/packaging/markersets.py
@@ -48,6 +48,7 @@ _MAX_CELLS = 100_000
 _MAX_WORK = 100_000_000
 
 __all__ = [
+    "DecisionStore",
     "IntractableMarkerSet",
     "MarkerSet",
     "UnserializableMarkerSet",
@@ -81,6 +82,21 @@ def _bounded(method: Callable[_P, _R]) -> Callable[_P, _R]:
             raise IntractableMarkerSet(msg) from exc
 
     return wrapper
+
+
+DecisionStore = _markersets.Memo
+"""Scratch that several decisions can share.
+
+Each decision partitions the axes its atoms sit on and reads those atoms on
+the points of the resulting cells. Two decisions over the same universe
+mostly repeat that, so passing one store to both keeps the work; passing
+none is correct and starts each cold.
+
+Answers do not depend on it: the partitions and truths it holds are
+functions of their keys alone. It grows with the atoms it has read, and
+holds them, so give one to the decisions of a single piece of work and drop
+it after. Not safe to share across threads.
+"""
 
 
 class MarkerSet:
@@ -231,16 +247,20 @@ class MarkerSet:
         )
 
     @_bounded
-    def equivalent_within(self, other: MarkerSet, within: MarkerSet) -> bool:
+    def equivalent_within(
+        self, other: MarkerSet, within: MarkerSet, *, store: DecisionStore | None = None
+    ) -> bool:
         """Whether the two sets denote the same environments on every point of ``within``.
 
         The row-restricted counterpart of :meth:`equivalent`, deciding each of
         ``within``'s rows under its pins so it stays decidable on wide
         multi-platform universes. A universe of :meth:`full` reduces it to plain
         :meth:`equivalent`.
+
+        ``store`` shares scratch with other decisions (:class:`DecisionStore`).
         """
         return _markersets.equivalent_within_rows(
-            self._tree, other._tree, within._tree, _MAX_CELLS
+            self._tree, other._tree, within._tree, _MAX_CELLS, store
         )
 
     # ---- restriction and projection
@@ -297,7 +317,9 @@ class MarkerSet:
         return _markersets.evaluate_tree(self._tree, env)
 
     @_bounded
-    def witness(self) -> dict[str, str | frozenset[str]] | None:
+    def witness(
+        self, *, store: DecisionStore | None = None
+    ) -> dict[str, str | frozenset[str]] | None:
         """Return a satisfying environment, or ``None`` when none is found.
 
         ``None`` is returned for the empty set. The search over ``contains``
@@ -306,18 +328,24 @@ class MarkerSet:
         or more ``contains`` atoms, or a mix) have no jointly realisable cell
         representative. ``python_version`` and ``python_full_version`` share one
         axis, so those constraints can sit on different variables.
+
+        ``store`` shares scratch with other decisions (:class:`DecisionStore`).
         """
-        return _markersets.witness(self._tree, _MAX_CELLS)
+        return _markersets.witness(self._tree, _MAX_CELLS, store)
 
     # ---- simplification
 
     @_bounded
-    def simplify(self, *, within: MarkerSet) -> MarkerSet:
+    def simplify(
+        self, *, within: MarkerSet, store: DecisionStore | None = None
+    ) -> MarkerSet:
         """Return the smallest set equivalent to this one on every point of ``within``.
 
         ``within`` is the universe the result must agree with this set over: pass
         the union of a lock's declared environments for universe-aware
         simplification, or :meth:`full` for a context-free factoring.
+
+        ``store`` shares scratch with other decisions (:class:`DecisionStore`).
 
         :raises ValueError: if ``within`` is the empty set, which makes every set
             vacuously equivalent.
@@ -325,11 +353,13 @@ class MarkerSet:
             cell budget, if the whole run exceeds the internal work budget, or
             if the marker nests past the stack.
         """
-        if _markersets.universe_is_empty(within._tree, _MAX_CELLS):
+        if _markersets.universe_is_empty(within._tree, _MAX_CELLS, store):
             msg = "within must not be the empty set"
             raise ValueError(msg)
         return self._wrap(
-            _markersets.simplify_within(self._tree, within._tree, _MAX_CELLS, _MAX_WORK)
+            _markersets.simplify_within(
+                self._tree, within._tree, _MAX_CELLS, _MAX_WORK, store
+            )
         )
 
     # ---- serialisation

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -6046,7 +6046,7 @@ class TestMarkerCoverage:
             validate_marker_coverage([linux, windows], environments=[self._row(linux)])
 
     def test_intractable_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        def boom(self: MarkerSet) -> None:
+        def boom(self: MarkerSet, *, store: object | None = None) -> None:
             raise IntractableMarkerSet("patched")
 
         monkeypatch.setattr(MarkerSet, "witness", boom)

--- a/nab-python/tests/test_markersets.py
+++ b/nab-python/tests/test_markersets.py
@@ -20,6 +20,8 @@ from packaging.markers import Marker
 from nab_python._vendor.packaging import _markersets as engine
 from nab_python._vendor.packaging.markersets import (
     _MAX_CELLS,
+    _MAX_WORK,
+    DecisionStore,
     IntractableMarkerSet,
     MarkerSet,
 )
@@ -615,9 +617,10 @@ def test_atoms_keep_no_truths_between_operations(
 ) -> None:
     """A second identical decision re-evaluates every atom truth.
 
-    The memo belongs to the operation, not to the atom, so an ``Atom`` that outlives
-    a decision carries nothing from it. A per-atom cache would make the repeat nearly
-    free, which is what this refuses.
+    The memo belongs to the decision, not to the atom, so an ``Atom`` that
+    outlives one carries nothing from it. A per-atom cache would make the
+    repeat nearly free, which is what this refuses; a caller wanting the reuse
+    passes a store instead.
     """
     universe = _row_universe()
     left = ms('python_version < "3.12"' + _SPREAD)
@@ -660,9 +663,9 @@ def test_partitions_do_not_outlive_one_operation(
 ) -> None:
     """A second identical decision pays for its partitions again.
 
-    The store belongs to one operation, so nothing carries between two of them.
-    A cache reaching further would make the repeat free, which is what this
-    refuses.
+    A decision handed no store makes its own, so nothing carries to the next.
+    Reuse is the caller's to ask for, not something the module keeps on its
+    own; :func:`test_a_shared_store_serves_the_next_decision` is the other half.
     """
     universe = _row_universe()
     left = ms('python_version < "3.12"' + _SPREAD)
@@ -675,3 +678,134 @@ def test_partitions_do_not_outlive_one_operation(
 
     assert first > 0
     assert partitions() == 2 * first
+
+
+def test_a_shared_store_serves_the_next_decision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A decision handed the previous one's store partitions no axis again.
+
+    The mirror of :func:`test_partitions_do_not_outlive_one_operation`: without a
+    store the repeat pays 5 partitions again, with one it pays none. An ignored
+    ``store`` argument leaves the two counts equal to that test's.
+    """
+    universe = _row_universe()
+    left = ms('python_version < "3.12"' + _SPREAD)
+    right = ms('python_version < "3.12" and sys_platform != "aix"' + _SPREAD)
+    store = DecisionStore()
+
+    partitions = _partition_counter(monkeypatch)
+    assert left.equivalent_within(right, universe, store=store) is True
+    first = partitions()
+    assert left.equivalent_within(right, universe, store=store) is True
+
+    assert first == 5
+    assert partitions() == first
+
+
+def test_a_shared_store_serves_the_next_decision_its_truths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A decision handed the previous one's store re-reads no stored atom truth.
+
+    Only restriction repeats, one read for each of the six rows' two operands,
+    against 156 for the decision itself.
+    """
+    universe = _row_universe()
+    left = ms('python_version < "3.12"' + _SPREAD)
+    right = ms('python_version < "3.12" and sys_platform != "aix"' + _SPREAD)
+    store = DecisionStore()
+
+    truths = _truth_counter(monkeypatch)
+    left.equivalent_within(right, universe, store=store)
+    first = truths()
+    left.equivalent_within(right, universe, store=store)
+
+    assert first == 156
+    assert truths() - first == 12
+
+
+def test_a_shared_store_serves_a_repeated_simplify(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A simplify handed the previous one's store partitions no axis again.
+
+    Driven at the engine because :meth:`MarkerSet.simplify` guards the empty
+    universe on a store of its own, which the next test measures.
+    """
+    universe = _row_universe()
+    tree = engine.parse('python_version < "3.12"' + _SPREAD)
+    store = engine.Memo()
+
+    partitions = _partition_counter(monkeypatch)
+    engine.simplify_within(tree, universe._tree, _MAX_CELLS, _MAX_WORK, store)
+    first = partitions()
+    engine.simplify_within(tree, universe._tree, _MAX_CELLS, _MAX_WORK, store)
+
+    assert first > 0
+    assert partitions() == first
+
+
+def test_the_store_reaches_the_engine_from_simplify(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The store :meth:`MarkerSet.simplify` is handed reaches every decision under it.
+
+    Including the empty-universe guard, so a repeat partitions nothing again.
+    :func:`test_simplify_keeps_its_partitions_to_one_call` measures the doubled
+    count when no store is passed.
+    """
+    universe = _row_universe()
+    marker = ms('python_version < "3.12"' + _SPREAD)
+    store = DecisionStore()
+
+    partitions = _partition_counter(monkeypatch)
+    marker.simplify(within=universe, store=store)
+    first = partitions()
+    marker.simplify(within=universe, store=store)
+
+    assert first > 0
+    assert partitions() == first
+
+
+def test_a_shared_store_answers_what_fresh_stores_answer() -> None:
+    """One store across a run of decisions answers as a fresh store per decision.
+
+    Soundness rather than speed: what a decision reads back was stored by a
+    decision over a different tree.
+    """
+    universe = _row_universe()
+    texts = [
+        'python_version < "3.12"' + _SPREAD,
+        'python_version >= "3.11" and sys_platform == "linux"',
+        'sys_platform == "linux" or sys_platform == "darwin"',
+        'python_version < "3.12" and sys_platform != "aix"' + _SPREAD,
+    ]
+    store = DecisionStore()
+
+    for text in texts:
+        marker = ms(text)
+        assert marker.simplify(within=universe, store=store).to_marker_string() == (
+            marker.simplify(within=universe).to_marker_string()
+        )
+        assert marker.equivalent_within(universe, universe, store=store) == (
+            marker.equivalent_within(universe, universe)
+        )
+        assert (marker & ~universe).witness(store=store) == (
+            marker & ~universe
+        ).witness()
+
+
+def test_a_warm_store_does_not_buy_work_budget() -> None:
+    """A stored partition is still charged to the running simplify's meter.
+
+    Skipping the charge on a store hit would leave a lock's later markers
+    decidable only because an earlier one paid for their axes.
+    """
+    within = _narrow_universe()
+    marker = engine.parse(_narrow_linux_span())
+    store = engine.Memo()
+
+    engine.simplify_within(marker, within._tree, _MAX_CELLS, _MAX_WORK, store)
+    with pytest.raises(IntractableMarkerSet, match="max_work"):
+        engine.simplify_within(marker, within._tree, _MAX_CELLS, 1, store)

--- a/nab-python/tests/test_pylock.py
+++ b/nab-python/tests/test_pylock.py
@@ -32,9 +32,14 @@ from nab_python._lockfile.pylock import (
     build_pylock,
     render_lock,
 )
+from nab_python._vendor.packaging import _markersets as engine
 from nab_python._vendor.packaging import markersets
 from nab_python._vendor.packaging.markers import Marker
-from nab_python._vendor.packaging.markersets import IntractableMarkerSet, MarkerSet
+from nab_python._vendor.packaging.markersets import (
+    DecisionStore,
+    IntractableMarkerSet,
+    MarkerSet,
+)
 from nab_python._vendor.packaging.pylock import Package, PackageWheel
 from nab_python._vendor.packaging.utils import canonicalize_name
 from nab_python._vendor.packaging.version import Version
@@ -50,7 +55,9 @@ from nab_python.tags import PlatformSpec
 from nab_python.target import ResolveTarget, environment_declaration
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Callable, Mapping, Sequence
+
+    from nab_python._vendor.packaging._markersets import Atom, Cell
 
 _spec = importlib.util.spec_from_file_location(
     "simplify_corpus_fixtures",
@@ -244,7 +251,9 @@ class TestFailClosed:
     def test_injected_bug_raises_and_emits_nothing(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        def diverge(self: MarkerSet, *, within: MarkerSet) -> MarkerSet:
+        def diverge(
+            self: MarkerSet, *, within: MarkerSet, store: DecisionStore | None = None
+        ) -> MarkerSet:
             return MarkerSet.from_marker('sys_platform == "win32"')
 
         monkeypatch.setattr(MarkerSet, "simplify", diverge)
@@ -254,7 +263,9 @@ class TestFailClosed:
     def test_collapse_to_full_off_universe_raises(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        def collapse(self: MarkerSet, *, within: MarkerSet) -> MarkerSet:
+        def collapse(
+            self: MarkerSet, *, within: MarkerSet, store: DecisionStore | None = None
+        ) -> MarkerSet:
             return MarkerSet.full()
 
         monkeypatch.setattr(MarkerSet, "simplify", collapse)
@@ -274,7 +285,9 @@ class TestFinalizeMarker:
     def test_intractable_emits_raw_byte_identical(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        def intractable(self: MarkerSet, *, within: MarkerSet) -> MarkerSet:
+        def intractable(
+            self: MarkerSet, *, within: MarkerSet, store: DecisionStore | None = None
+        ) -> MarkerSet:
             raise IntractableMarkerSet("over budget")
 
         monkeypatch.setattr(MarkerSet, "simplify", intractable)
@@ -496,7 +509,9 @@ class TestWideMatrixFailClosed:
     def test_injected_bug_on_wide_matrix_raises_without_text(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        def diverge(self: MarkerSet, *, within: MarkerSet) -> MarkerSet:
+        def diverge(
+            self: MarkerSet, *, within: MarkerSet, store: DecisionStore | None = None
+        ) -> MarkerSet:
             return MarkerSet.from_marker('sys_platform == "win32"')
 
         monkeypatch.setattr(MarkerSet, "simplify", diverge)
@@ -582,10 +597,13 @@ class TestFinalizeMemo:
         real = pylock._finalize_marker
 
         def counting(
-            raw: Marker | None, within: MarkerSet, name: str = ""
+            raw: Marker | None,
+            within: MarkerSet,
+            name: str = "",
+            store: DecisionStore | None = None,
         ) -> Marker | None:
             calls.append(name)
-            return real(raw, within, name)
+            return real(raw, within, name, store)
 
         monkeypatch.setattr(pylock, "_finalize_marker", counting)
         targets: dict[str, TargetLock] = {}
@@ -604,7 +622,10 @@ class TestFinalizeMemo:
 
     def test_memo_passes_none_through(self) -> None:
         memo: dict[str, Marker | None] = {}
-        assert _finalize_cached(None, MarkerSet.full(), "foo", memo) is None
+        assert (
+            _finalize_cached(None, MarkerSet.full(), "foo", memo, DecisionStore())
+            is None
+        )
         assert memo == {}
 
 
@@ -755,3 +776,94 @@ class TestRegenLocksIdempotent:
                     continue
                 again = _finalize_marker(Marker(marker), within, pkg["name"])
                 assert str(again) == marker
+
+
+def _partition_counter(monkeypatch: pytest.MonkeyPatch) -> Callable[[], int]:
+    """Start counting axis partitions, and return a reader for the count."""
+    calls = 0
+    real = engine._partition_axis
+
+    def counting(
+        axis: tuple, atoms: Sequence[Atom], max_cells: int, memo: engine.Memo
+    ) -> list[Cell]:
+        nonlocal calls
+        calls += 1
+        return real(axis, atoms, max_cells, memo)
+
+    monkeypatch.setattr(engine, "_partition_axis", counting)
+    return lambda: calls
+
+
+class TestEmissionStore:
+    """One emission's decisions share one store, and answer as if they did not."""
+
+    def test_one_store_across_a_lock_cuts_the_partition_work(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Finalising a lock's markers against one store partitions fewer axes.
+
+        The universe is one per lock and its rows are what each decision
+        complements against, so the axes carry over between packages that share
+        no marker text. A ``store`` the engine ignored would leave the two counts
+        equal.
+        """
+        lock = _LOCK_MARKERS["locks"]["tests"]
+        within = _fixture_universe(lock["environments"])
+        raws = [Marker(pkg["raw"]) for pkg in lock["packages"]]
+
+        partitions = _partition_counter(monkeypatch)
+        alone = [_finalize_marker(raw, within, "pkg") for raw in raws]
+        cold = partitions()
+        store = DecisionStore()
+        shared = [_finalize_marker(raw, within, "pkg", store) for raw in raws]
+        warm = partitions() - cold
+
+        assert [str(m) for m in shared] == [str(m) for m in alone]
+        assert warm < cold
+
+    def test_finalisation_and_coverage_share_one_store(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Every decision of one build_pylock is handed the same store.
+
+        Dropping it at any hop leaves that decision cold, which no emitted byte
+        would show.
+        """
+        seen: list[DecisionStore | None] = []
+        real_simplify = MarkerSet.simplify
+        real_equivalent = MarkerSet.equivalent_within
+        real_coverage = pylock.validate_marker_coverage
+
+        def recording_simplify(
+            self: MarkerSet, *, within: MarkerSet, store: DecisionStore | None = None
+        ) -> MarkerSet:
+            seen.append(store)
+            return real_simplify(self, within=within, store=store)
+
+        def recording_equivalent(
+            self: MarkerSet,
+            other: MarkerSet,
+            within: MarkerSet,
+            *,
+            store: DecisionStore | None = None,
+        ) -> bool:
+            seen.append(store)
+            return real_equivalent(self, other, within, store=store)
+
+        def recording_coverage(
+            targets: Sequence[ResolveTarget],
+            *,
+            environments: Sequence[Marker],
+            store: DecisionStore | None = None,
+        ) -> None:
+            seen.append(store)
+            real_coverage(targets, environments=environments, store=store)
+
+        monkeypatch.setattr(MarkerSet, "simplify", recording_simplify)
+        monkeypatch.setattr(MarkerSet, "equivalent_within", recording_equivalent)
+        monkeypatch.setattr(pylock, "validate_marker_coverage", recording_coverage)
+        build_pylock(_span_lock())
+
+        assert len(seen) >= 3
+        assert {id(store) for store in seen} == {id(seen[0])}
+        assert isinstance(seen[0], DecisionStore)

--- a/tasks/vendoring/packaging.patch
+++ b/tasks/vendoring/packaging.patch
@@ -1,9 +1,9 @@
 diff --git a/nab-python/src/nab_python/_vendor/packaging/_markersets.py b/nab-python/src/nab_python/_vendor/packaging/_markersets.py
 new file mode 100644
-index 0000000..a4847ee
+index 0000000..72eee6b
 --- /dev/null
 +++ b/nab-python/src/nab_python/_vendor/packaging/_markersets.py
-@@ -0,0 +1,1794 @@
+@@ -0,0 +1,1811 @@
 +"""Marker algebra engine: reason about PEP 508 markers as sets of environments.
 +
 +The private engine behind :class:`~packaging.markersets.MarkerSet`. Parses a
@@ -634,11 +634,12 @@ index 0000000..a4847ee
 +
 +
 +class Memo:
-+    """One operation's scratch: the partitions and atom truths it re-reads.
++    """The partitions and atom truths a decision re-reads.
 +
-+    A decision run re-partitions one axis for overlapping atom sets and re-reads one
-+    atom on one point across those partitions. Both are memoised here, and the
-+    operation that creates this drops it, so nothing accumulates between calls.
++    A decision re-partitions one axis for overlapping atom sets and re-reads one
++    atom on one point across those partitions. Both are memoised here. One
++    decision makes its own unless the caller passes one to share; see
++    :class:`~packaging.markersets.DecisionStore` for the sharing contract.
 +    """
 +
 +    __slots__ = ("partitions", "truths")
@@ -1235,7 +1236,9 @@ index 0000000..a4847ee
 +    return next(cells, _MISSING) is _MISSING
 +
 +
-+def witness(node: Formula, max_cells: int) -> dict[str, str | frozenset[str]] | None:
++def witness(
++    node: Formula, max_cells: int, store: Memo | None = None
++) -> dict[str, str | frozenset[str]] | None:
 +    """Return a concrete environment satisfying a tree, or ``None`` if none is found.
 +
 +    The returned environment is verified against the tree before it is returned.
@@ -1246,7 +1249,7 @@ index 0000000..a4847ee
 +    ``python_version`` and ``python_full_version`` share one axis, so those
 +    constraints can sit on different variables.
 +    """
-+    for cell in _satisfying_cells(node, max_cells, Memo()):
++    for cell in _satisfying_cells(node, max_cells, Memo() if store is None else store):
 +        env = _materialize(cell)
 +        if evaluate_tree(node, env):
 +            return env
@@ -1624,7 +1627,9 @@ index 0000000..a4847ee
 +    return True
 +
 +
-+def universe_is_empty(universe: Formula, max_cells: int) -> bool:
++def universe_is_empty(
++    universe: Formula, max_cells: int, store: Memo | None = None
++) -> bool:
 +    """Whether a universe admits no environment, decided per row.
 +
 +    A union is empty iff every top-level disjunct is, so each is tested alone,
@@ -1632,23 +1637,30 @@ index 0000000..a4847ee
 +    """
 +    nnf = universe if isinstance(universe, BoolConst) else to_nnf(universe)
 +    disjuncts = nnf.children if isinstance(nnf, OrNode) else (nnf,)
-+    store: Memo = Memo()
-+    return all(is_empty(disjunct, max_cells, store) for disjunct in disjuncts)
++    shared = Memo() if store is None else store
++    return all(is_empty(disjunct, max_cells, shared) for disjunct in disjuncts)
 +
 +
 +def equivalent_within_rows(
-+    left: Formula, right: Formula, universe: Formula, max_cells: int
++    left: Formula,
++    right: Formula,
++    universe: Formula,
++    max_cells: int,
++    store: Memo | None = None,
 +) -> bool:
 +    """Whether two trees agree on every point of ``universe``, decided per row.
 +
 +    The row-restricted dual of :func:`_equivalent_within`, deciding the same
 +    verdict but staying decidable on wide multi-platform universes. A universe of
 +    ``TRUE`` reduces it to plain global equivalence.
++
++    ``store`` is the caller's scratch when this decision is one of a run.
 +    """
 +    rows = _decompose_rows(universe)
 +    right_by_row = [restrict_tree(right, row.pins) for row in rows]
-+    store: Memo = Memo()
-+    return _rows_equivalent(left, rows, right_by_row, max_cells, store)
++    return _rows_equivalent(
++        left, rows, right_by_row, max_cells, Memo() if store is None else store
++    )
 +
 +
 +def _dedupe(clauses: list[frozenset[Atom]]) -> list[frozenset[Atom]]:
@@ -1753,7 +1765,11 @@ index 0000000..a4847ee
 +
 +
 +def simplify_within(
-+    node: Formula, universe: Formula, max_cells: int, max_work: int
++    node: Formula,
++    universe: Formula,
++    max_cells: int,
++    max_work: int,
++    store: Memo | None = None,
 +) -> Formula:
 +    """Return the smallest tree equivalent to ``node`` on every point of ``universe``.
 +
@@ -1774,7 +1790,8 @@ index 0000000..a4847ee
 +    original = _disjunction(clauses)
 +    rows = _decompose_rows(universe)
 +    original_by_row = [restrict_tree(original, row.pins) for row in rows]
-+    store: Memo = Memo()
++    if store is None:
++        store = Memo()
 +    previous_work = getattr(_work_meter, "remaining", None)
 +    _work_meter.remaining = max_work
 +    try:
@@ -1923,10 +1940,10 @@ index c78fd5d..0d7ee1d 100644
      """
 diff --git a/nab-python/src/nab_python/_vendor/packaging/markersets.py b/nab-python/src/nab_python/_vendor/packaging/markersets.py
 new file mode 100644
-index 0000000..3891398
+index 0000000..c9a2883
 --- /dev/null
 +++ b/nab-python/src/nab_python/_vendor/packaging/markersets.py
-@@ -0,0 +1,362 @@
+@@ -0,0 +1,392 @@
 +"""The public :class:`MarkerSet`: a marker's denotation as a set of environments.
 +
 +A :class:`MarkerSet` is the denotation of a PEP 508 marker as a set of
@@ -1977,6 +1994,7 @@ index 0000000..3891398
 +_MAX_WORK = 100_000_000
 +
 +__all__ = [
++    "DecisionStore",
 +    "IntractableMarkerSet",
 +    "MarkerSet",
 +    "UnserializableMarkerSet",
@@ -2010,6 +2028,21 @@ index 0000000..3891398
 +            raise IntractableMarkerSet(msg) from exc
 +
 +    return wrapper
++
++
++DecisionStore = _markersets.Memo
++"""Scratch that several decisions can share.
++
++Each decision partitions the axes its atoms sit on and reads those atoms on
++the points of the resulting cells. Two decisions over the same universe
++mostly repeat that, so passing one store to both keeps the work; passing
++none is correct and starts each cold.
++
++Answers do not depend on it: the partitions and truths it holds are
++functions of their keys alone. It grows with the atoms it has read, and
++holds them, so give one to the decisions of a single piece of work and drop
++it after. Not safe to share across threads.
++"""
 +
 +
 +class MarkerSet:
@@ -2160,16 +2193,20 @@ index 0000000..3891398
 +        )
 +
 +    @_bounded
-+    def equivalent_within(self, other: MarkerSet, within: MarkerSet) -> bool:
++    def equivalent_within(
++        self, other: MarkerSet, within: MarkerSet, *, store: DecisionStore | None = None
++    ) -> bool:
 +        """Whether the two sets denote the same environments on every point of ``within``.
 +
 +        The row-restricted counterpart of :meth:`equivalent`, deciding each of
 +        ``within``'s rows under its pins so it stays decidable on wide
 +        multi-platform universes. A universe of :meth:`full` reduces it to plain
 +        :meth:`equivalent`.
++
++        ``store`` shares scratch with other decisions (:class:`DecisionStore`).
 +        """
 +        return _markersets.equivalent_within_rows(
-+            self._tree, other._tree, within._tree, _MAX_CELLS
++            self._tree, other._tree, within._tree, _MAX_CELLS, store
 +        )
 +
 +    # ---- restriction and projection
@@ -2226,7 +2263,9 @@ index 0000000..3891398
 +        return _markersets.evaluate_tree(self._tree, env)
 +
 +    @_bounded
-+    def witness(self) -> dict[str, str | frozenset[str]] | None:
++    def witness(
++        self, *, store: DecisionStore | None = None
++    ) -> dict[str, str | frozenset[str]] | None:
 +        """Return a satisfying environment, or ``None`` when none is found.
 +
 +        ``None`` is returned for the empty set. The search over ``contains``
@@ -2235,18 +2274,24 @@ index 0000000..3891398
 +        or more ``contains`` atoms, or a mix) have no jointly realisable cell
 +        representative. ``python_version`` and ``python_full_version`` share one
 +        axis, so those constraints can sit on different variables.
++
++        ``store`` shares scratch with other decisions (:class:`DecisionStore`).
 +        """
-+        return _markersets.witness(self._tree, _MAX_CELLS)
++        return _markersets.witness(self._tree, _MAX_CELLS, store)
 +
 +    # ---- simplification
 +
 +    @_bounded
-+    def simplify(self, *, within: MarkerSet) -> MarkerSet:
++    def simplify(
++        self, *, within: MarkerSet, store: DecisionStore | None = None
++    ) -> MarkerSet:
 +        """Return the smallest set equivalent to this one on every point of ``within``.
 +
 +        ``within`` is the universe the result must agree with this set over: pass
 +        the union of a lock's declared environments for universe-aware
 +        simplification, or :meth:`full` for a context-free factoring.
++
++        ``store`` shares scratch with other decisions (:class:`DecisionStore`).
 +
 +        :raises ValueError: if ``within`` is the empty set, which makes every set
 +            vacuously equivalent.
@@ -2254,11 +2299,13 @@ index 0000000..3891398
 +            cell budget, if the whole run exceeds the internal work budget, or
 +            if the marker nests past the stack.
 +        """
-+        if _markersets.universe_is_empty(within._tree, _MAX_CELLS):
++        if _markersets.universe_is_empty(within._tree, _MAX_CELLS, store):
 +            msg = "within must not be the empty set"
 +            raise ValueError(msg)
 +        return self._wrap(
-+            _markersets.simplify_within(self._tree, within._tree, _MAX_CELLS, _MAX_WORK)
++            _markersets.simplify_within(
++                self._tree, within._tree, _MAX_CELLS, _MAX_WORK, store
++            )
 +        )
 +
 +    # ---- serialisation


### PR DESCRIPTION
A decision partitions the axes its atoms sit on and reads those atoms on the points of the resulting cells, keeping both in a `Memo` it makes and drops. Emitting a lock runs hundreds of decisions over one universe, so each starts cold and repeats what the last one worked out.

That scratch becomes a public `DecisionStore`, the three decision methods a lock emission uses take one, and `build_pylock` makes a single store and hands it to marker finalisation and coverage validation. Passing none is still correct and starts each decision cold, and answers never depend on it: the partitions and truths it holds are functions of their keys alone.

nab's own 30-target locks, min of three: tests 322 to 286ms, types 344 to 249ms, crosshair 558 to 403ms, release 729 to 471ms. Every emitted marker is byte-identical.