### PR TITLE
Lock a project's build requirements

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -65,6 +65,27 @@ a `'X' in extras` or `'X' in dependency_groups` marker, so an
 installer given neither leaves it out; see
 [Lockfiles](lockfile.md).
 
+Build requirements:
+
+* `--build-requirements` locks the project's `[build-system].requires`
+  instead of its dependencies, so the lock describes the environment
+  the project is built in rather than the one it runs in. `--output`
+  defaults to `pylock.build.toml` (or `build-requirements.txt` for the
+  requirements formats), which keeps it clear of the project's runtime
+  lock. Nothing can be selected alongside it: `[build-system].requires`
+  is one flat list, so `--groups`, `--all-groups`, `--extras`,
+  `--all-extras`, `--project-default-group` and `--project-base-group`
+  are all rejected, and `[tool.nab].default-groups`,
+  `[tool.nab].base-group` and `[tool.nab].conflicts` declared in the
+  project's files do not apply.
+* A project that declares no `[build-system]` is an error. nab does not
+  fall back to the PEP 517 default backend, because pinning an implied
+  `setuptools` would put a build requirement in the lock that the project
+  never declared.
+* Only the static list is read. `--build-requirements` never invokes the
+  project's own backend, so whatever that backend would add from
+  `get_requires_for_build_wheel` is not covered.
+
 Workspace flags (see [Lock a workspace](../how-to/workspaces.md)):
 
 * `--workspace-discovery` (default) walks upward from the locked
@@ -81,7 +102,9 @@ Workspace flags (see [Lock a workspace](../how-to/workspaces.md)):
   --no-deps -e <member>`.
 
 `--output` defaults to `pylock.toml` for `pylock` and
-`requirements.txt` for the two requirements formats. Pass
+`requirements.txt` for the two requirements formats, or to
+`pylock.build.toml` and `build-requirements.txt` under
+`--build-requirements`. Pass
 `--output -` to write to stdout instead. A matrix has no default
 requirements file: no one file can carry every tuple's pins (see
 below), so the requirements formats print to stdout unless `--output`
@@ -351,7 +374,7 @@ It shows only at normal verbosity on an stderr terminal; `--no-progress`
 | Code | Meaning |
 | ---- | ------- |
 | `0`  | Success. |
-| `1`  | Resolution failed, lockfile cannot be written (missing hash), download failed, missing `[project].dependencies`, invalid `[tool.nab]` configuration, or `--locked` found the lockfile out of date or missing. |
+| `1`  | Resolution failed, lockfile cannot be written (missing hash), download failed, missing `[project].dependencies`, a `--build-requirements` run whose project declares no `[build-system]`, invalid `[tool.nab]` configuration, or `--locked` found the lockfile out of date or missing. |
 | `130` | Interrupted with Ctrl-C. `nab` prints `error: interrupted` and exits. |
 
 [PEP 751]: https://peps.python.org/pep-0751/

--- a/nab-python/src/nab_python/requirements_file.py
+++ b/nab-python/src/nab_python/requirements_file.py
@@ -32,6 +32,7 @@ __all__ = [
     "parse_project_requirement",
     "parse_requirements",
     "raise_for_unsatisfiable",
+    "read_pyproject_build_requires",
     "read_pyproject_dependencies",
     "read_pyproject_groups",
     "read_pyproject_name",
@@ -168,6 +169,44 @@ def read_pyproject_dependencies(path: Path) -> list[Requirement]:
             raise InvalidProjectRequirementError(msg)
     dep_strings = require_string_list(project.get("dependencies", []), source)
     return parse_requirements(dep_strings, source)
+
+
+def read_pyproject_build_requires(path: Path) -> list[Requirement]:
+    """Read [build-system].requires from a pyproject.toml file (PEP 518).
+
+    A project that declares no ``[build-system]`` gets no fallback to the
+    PEP 517 default backend: pinning an implied ``setuptools`` would put a
+    build requirement in the lock that the project never asked for.
+    Absent ``[build-system]`` and a table without the mandatory
+    ``requires`` key both raise
+    :class:`InvalidProjectRequirementError`; a ``[build-system]`` that is
+    not a table raises :class:`InvalidProjectTableError`.
+
+    Only the static list is read.  What a backend adds from
+    ``get_requires_for_build_wheel`` is known only once that backend runs,
+    and nothing runs this project's own backend to find out.
+    """
+    with path.open("rb") as f:
+        data = tomli.load(f)
+
+    if "build-system" not in data:
+        msg = (
+            f"{path} declares no [build-system], so it has no build"
+            " requirements to lock"
+        )
+        raise InvalidProjectRequirementError(msg)
+
+    table = data["build-system"]
+    if not isinstance(table, dict):
+        msg = f"[build-system] must be a table, got {type(table).__name__}"
+        raise InvalidProjectTableError(msg)
+
+    source = "[build-system].requires"
+    if "requires" not in table:
+        msg = f"{source} is required by PEP 518 and {path} does not declare it"
+        raise InvalidProjectRequirementError(msg)
+
+    return parse_requirements(require_string_list(table["requires"], source), source)
 
 
 def read_pyproject_name(path: Path) -> str | None:

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -26,7 +26,7 @@ import tempfile
 import time
 from collections import defaultdict
 from contextlib import contextmanager, suppress
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple, Protocol
 
@@ -75,6 +75,7 @@ from .requirements_file import (
     expand_group_includes,
     expand_self_extras,
     raise_for_unsatisfiable,
+    read_pyproject_build_requires,
     read_pyproject_dependencies,
     read_pyproject_groups,
     read_pyproject_name,
@@ -108,6 +109,7 @@ __all__ = [
     "TargetResult",
     "active_group_names",
     "build_lock_input",
+    "config_for_build_requirements",
     "resolve_for_targets",
     "resolve_with_coordinator",
 ]
@@ -296,6 +298,7 @@ def resolve_for_targets(  # noqa: PLR0913 - the surface mirrors the CLI; bundlin
     python_version: str | None = None,
     groups: Sequence[str] = (),
     extras: Sequence[str] = (),
+    build_requirements: bool = False,
     resolution_strategy: ResolutionStrategy | None = None,
     progress: ProgressSink | None = None,
 ) -> ResolveResult:
@@ -313,6 +316,11 @@ def resolve_for_targets(  # noqa: PLR0913 - the surface mirrors the CLI; bundlin
     ``[project.optional-dependencies]`` keys to fold in;
     ``resolution_strategy`` overrides ``config.resolution`` when set.
 
+    ``build_requirements`` resolves ``[build-system].requires`` instead of
+    the project's dependencies, for a lock of the environment the project
+    is built in rather than the one it runs in.  Neither ``groups`` nor
+    ``extras`` mean anything there, so passing either raises.
+
     A target that cannot be resolved is a failed :class:`TargetResult`,
     not an exception, so a matrix reports every target that failed rather
     than only the first.  Everything else (an unreadable pyproject, a
@@ -320,14 +328,23 @@ def resolve_for_targets(  # noqa: PLR0913 - the surface mirrors the CLI; bundlin
     """
     if config is None:
         config = read_pyproject_config(path)
+    if build_requirements:
+        if groups or extras:
+            msg = "a build-requirements resolve has no groups or extras to select"
+            raise ValueError(msg)
+        config = config_for_build_requirements(config)
     config = with_python_override(config, python_version)
     targets = plan_targets(config)
 
-    tables = _ProjectTables(
-        dependencies=read_pyproject_dependencies(path),
-        groups=read_pyproject_groups(path),
-        optional=read_pyproject_optional_dependencies(path),
-        project_name=read_pyproject_name(path),
+    tables = (
+        _tables_for_build_requires(path)
+        if build_requirements
+        else _ProjectTables(
+            dependencies=read_pyproject_dependencies(path),
+            groups=read_pyproject_groups(path),
+            optional=read_pyproject_optional_dependencies(path),
+            project_name=read_pyproject_name(path),
+        )
     )
 
     # ``default-groups`` is project policy: every default install
@@ -896,6 +913,34 @@ class _ProjectTables:
     groups: Mapping[str, Sequence[str | Mapping[str, str]]]
     optional: Mapping[str, Sequence[str]]
     project_name: str | None
+
+
+def _tables_for_build_requires(path: Path) -> _ProjectTables:
+    """Read ``path`` as a project whose dependencies are its build requirements.
+
+    ``[build-system].requires`` is one flat list, so the group and extra
+    tables are empty, and the project name with them: it is read only to
+    expand self-referencing extras.
+    """
+    return _ProjectTables(
+        dependencies=read_pyproject_build_requires(path),
+        groups={},
+        optional={},
+        project_name=None,
+    )
+
+
+def config_for_build_requirements(config: NabProjectConfig) -> NabProjectConfig:
+    """Return ``config`` with the settings a build-requirements lock cannot use.
+
+    ``default-groups`` and the conflicts declared over groups and extras
+    describe a selection ``[build-system].requires`` does not have, and
+    ``base-group`` names the project's own dependencies, which a build
+    lock holds none of.  Left in they fail the run rather than narrow it:
+    :func:`_tables_for_build_requires` supplies no group or extra table
+    for them to resolve against.
+    """
+    return replace(config, conflicts=(), default_groups=(), base_group=None)
 
 
 def _threaded_preferences(

--- a/nab-python/tests/test_requirements_file.py
+++ b/nab-python/tests/test_requirements_file.py
@@ -13,12 +13,14 @@ from nab_python._vendor.packaging.specifiers import SpecifierSet
 from nab_python._vendor.packaging.utils import InvalidName
 from nab_python.requirements_file import (
     InvalidProjectRequirementError,
+    InvalidProjectTableError,
     _add_extra_marker,
     expand_extra_requirements,
     expand_group_includes,
     expand_self_extras,
     parse_project_requirement,
     raise_for_unsatisfiable,
+    read_pyproject_build_requires,
     read_pyproject_dependencies,
     read_pyproject_groups,
     read_pyproject_name,
@@ -235,6 +237,82 @@ class TestReadPyprojectDependencies:
         p.write_text('project = ["a", "b"]\n')
         with pytest.raises(TypeError, match=r"\[project\] must be a table"):
             read_pyproject_dependencies(p)
+
+
+class TestReadPyprojectBuildRequires:
+    def test_reads_requires(self, tmp_path: object) -> None:
+        """Parse [build-system].requires from a valid pyproject.toml."""
+        p = Path(str(tmp_path)) / "pyproject.toml"
+        p.write_text('[build-system]\nrequires = ["hatchling", "hatch-vcs>=0.4"]\n')
+        requires = read_pyproject_build_requires(p)
+        assert [str(r) for r in requires] == ["hatchling", "hatch-vcs>=0.4"]
+
+    def test_marker_is_kept(self, tmp_path: object) -> None:
+        """A build requirement may carry a PEP 508 marker."""
+        p = Path(str(tmp_path)) / "pyproject.toml"
+        p.write_text(
+            "[build-system]\n"
+            'requires = ["setuptools", "tomli; python_version < \'3.11\'"]\n'
+        )
+        requires = read_pyproject_build_requires(p)
+        assert str(requires[1].marker) == 'python_version < "3.11"'
+
+    def test_empty_requires_is_no_build_requirements(self, tmp_path: object) -> None:
+        """An empty array declares a build system that needs nothing."""
+        p = Path(str(tmp_path)) / "pyproject.toml"
+        p.write_text("[build-system]\nrequires = []\n")
+        assert read_pyproject_build_requires(p) == []
+
+    def test_missing_build_system_raises(self, tmp_path: object) -> None:
+        """No [build-system] is not the PEP 517 default, it is an error."""
+        p = Path(str(tmp_path)) / "pyproject.toml"
+        p.write_text('[project]\nname = "foo"\n')
+        with pytest.raises(
+            InvalidProjectRequirementError, match=r"declares no \[build-system\]"
+        ):
+            read_pyproject_build_requires(p)
+
+    def test_missing_requires_key_raises(self, tmp_path: object) -> None:
+        """PEP 518 makes requires mandatory once [build-system] is present."""
+        p = Path(str(tmp_path)) / "pyproject.toml"
+        p.write_text('[build-system]\nbuild-backend = "flit_core.buildapi"\n')
+        with pytest.raises(
+            InvalidProjectRequirementError, match=r"\[build-system\].requires"
+        ):
+            read_pyproject_build_requires(p)
+
+    def test_non_table_build_system_raises(self, tmp_path: object) -> None:
+        """A [build-system] that is not a table is malformed, not absent."""
+        p = Path(str(tmp_path)) / "pyproject.toml"
+        p.write_text('build-system = "hatchling"\n')
+        with pytest.raises(
+            InvalidProjectTableError, match=r"\[build-system\] must be a table"
+        ):
+            read_pyproject_build_requires(p)
+
+    def test_string_requires_raises(self, tmp_path: object) -> None:
+        """A bare string would iterate character by character."""
+        p = Path(str(tmp_path)) / "pyproject.toml"
+        p.write_text('[build-system]\nrequires = "hatchling"\n')
+        with pytest.raises(
+            InvalidProjectRequirementError, match="must be an array of strings"
+        ):
+            read_pyproject_build_requires(p)
+
+    def test_malformed_requirement_string_raises(self, tmp_path: object) -> None:
+        """A malformed PEP 508 string names the table it came from."""
+        p = Path(str(tmp_path)) / "pyproject.toml"
+        p.write_text('[build-system]\nrequires = ["hatchling >= 1 junk"]\n')
+        with pytest.raises(
+            InvalidProjectRequirementError, match=r"\[build-system\].requires"
+        ):
+            read_pyproject_build_requires(p)
+
+    def test_missing_file_raises(self, tmp_path: object) -> None:
+        """Raise FileNotFoundError for a missing pyproject.toml."""
+        p = Path(str(tmp_path)) / "missing.toml"
+        with pytest.raises(FileNotFoundError):
+            read_pyproject_build_requires(p)
 
 
 class TestReadPyprojectGroups:

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -24,7 +24,10 @@ from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.version import Version
 from nab_python.config import (
     ConfigError,
+    ConflictKind,
+    ConflictMember,
     ConflictSelectionError,
+    ConflictSet,
     MatrixConfig,
     NabProjectConfig,
     ResolveMode,
@@ -58,6 +61,7 @@ from nab_python.resolve import (
     _ResolveObserver,
     _walk_no_versions_packages,
     build_lock_input,
+    config_for_build_requirements,
     resolve_for_targets,
 )
 from nab_python.tags import PlatformSpec
@@ -4842,3 +4846,165 @@ class TestProgressReporting:
         observer = _ResolveObserver(None)
         observer.on_decision("foo", V("1.0"), 3)
         observer.on_backjump(3, 1)
+
+
+class TestBuildRequirementsResolve:
+    """``build_requirements`` swaps the roots for ``[build-system].requires``."""
+
+    @staticmethod
+    def _mocked_resolve(pyproject: Path, **kwargs: object) -> ResolveResult:
+        """Resolve ``pyproject`` against a provider that pins everything at 2.0."""
+        with (
+            patch("nab_python.resolve.FetchCoordinator") as mock_coord_cls,
+            patch("nab_python.resolve.Provider") as mock_provider_cls,
+            patch("nab_python.resolve.build_target_lock"),
+        ):
+            mock_coord_cls.return_value.__enter__ = lambda s: s
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            mock_provider = mock_provider_cls.return_value
+            mock_provider.choose_version.return_value = V("2.0")
+            mock_provider.get_dependencies.return_value = {}
+            mock_provider.prioritize.return_value = 1
+            return _resolved(
+                pyproject, _FAKE_TRANSPORT, python_version="3.12.0", **kwargs
+            )
+
+    def test_build_requires_replace_project_dependencies(self, tmp_path: Path) -> None:
+        """The project's own dependencies are not in a build lock."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "proj"\ndependencies = ["runtime-only"]\n'
+            '[build-system]\nrequires = ["hatchling"]\n'
+        )
+
+        result = self._mocked_resolve(pyproject, build_requirements=True)
+
+        assert _pins(result) == {"hatchling": V("2.0")}
+
+    def test_project_dependencies_are_locked_without_the_flag(
+        self, tmp_path: Path
+    ) -> None:
+        """The same project locks its runtime deps when the flag is off."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "proj"\ndependencies = ["runtime-only"]\n'
+            '[build-system]\nrequires = ["hatchling"]\n'
+        )
+
+        result = self._mocked_resolve(pyproject)
+
+        assert _pins(result) == {"runtime-only": V("2.0")}
+
+    def test_default_groups_do_not_reach_a_build_lock(self, tmp_path: Path) -> None:
+        """A project's default group describes its runtime, not its build."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "proj"\ndependencies = []\n'
+            '[build-system]\nrequires = ["hatchling"]\n'
+            "[dependency-groups]\n"
+            'dev = ["pytest"]\n'
+            "[tool.nab]\n"
+            'default-groups = ["dev"]\n'
+        )
+
+        result = self._mocked_resolve(pyproject, build_requirements=True)
+
+        assert _pins(result) == {"hatchling": V("2.0")}
+
+    def test_conflicts_over_absent_groups_do_not_refuse_the_run(
+        self, tmp_path: Path
+    ) -> None:
+        """Conflicts are declared over a selection a build lock does not have."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "proj"\ndependencies = []\n'
+            '[build-system]\nrequires = ["hatchling"]\n'
+            "[dependency-groups]\n"
+            'cpu = ["torch-cpu"]\n'
+            'gpu = ["torch-gpu"]\n'
+            "[tool.nab]\n"
+            'conflicts = [[{ group = "cpu" }, { group = "gpu" }]]\n'
+        )
+
+        result = self._mocked_resolve(pyproject, build_requirements=True)
+
+        assert _pins(result) == {"hatchling": V("2.0")}
+
+    @patch("nab_python.resolve.resolve_with_coordinator")
+    def test_the_matrix_still_expands(
+        self, mock_engine: MagicMock, tmp_path: Path
+    ) -> None:
+        """A static requires list needs no interpreter to read, so it goes wide."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "proj"\ndependencies = ["runtime-only"]\n'
+            '[build-system]\nrequires = ["hatchling"]\n'
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            "[tool.nab.matrix]\n"
+            'python = ">=3.11,<3.13"\n'
+            'platforms = ["linux_x86_64"]\n'
+        )
+
+        resolve_for_targets(pyproject, _FAKE_TRANSPORT, build_requirements=True)
+
+        targets = mock_engine.call_args.args[1]
+        assert [t.label for t in targets] == [
+            "py311-linux_x86_64",
+            "py312-linux_x86_64",
+        ]
+        (fork,) = mock_engine.call_args.kwargs["forks"]
+        assert [str(r) for r in fork.requirements] == ["hatchling"]
+
+    def test_no_build_system_is_an_error(self, tmp_path: Path) -> None:
+        """The PEP 517 default backend is a fallback, not a thing to pin."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text('[project]\nname = "proj"\ndependencies = ["foo"]\n')
+
+        with pytest.raises(
+            InvalidProjectRequirementError, match=r"declares no \[build-system\]"
+        ):
+            self._mocked_resolve(pyproject, build_requirements=True)
+
+    @pytest.mark.parametrize("selection", [{"groups": ("dev",)}, {"extras": ("gpu",)}])
+    def test_a_selection_is_refused(
+        self, tmp_path: Path, selection: dict[str, tuple[str, ...]]
+    ) -> None:
+        """Neither groups nor extras mean anything to a build lock."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text('[build-system]\nrequires = ["hatchling"]\n')
+
+        with pytest.raises(ValueError, match="no groups or extras"):
+            self._mocked_resolve(pyproject, build_requirements=True, **selection)
+
+
+class TestBuildRequirementsConfig:
+    def test_drops_every_selection_setting(self) -> None:
+        """Nothing describing a group or extra survives into a build lock."""
+        config = NabProjectConfig(
+            default_groups=("dev",),
+            base_group="default",
+            conflicts=(
+                ConflictSet(
+                    members=(
+                        ConflictMember(kind=ConflictKind.GROUP, name="cpu"),
+                        ConflictMember(kind=ConflictKind.GROUP, name="gpu"),
+                    )
+                ),
+            ),
+        )
+
+        pruned = config_for_build_requirements(config)
+
+        assert pruned.default_groups == ()
+        assert pruned.base_group is None
+        assert pruned.conflicts == ()
+
+    def test_keeps_the_settings_a_resolve_still_needs(self) -> None:
+        """Constraints and the resolve window are not part of the selection."""
+        config = NabProjectConfig(constraints=("urllib3<2",), requires_python=">=3.10")
+
+        pruned = config_for_build_requirements(config)
+
+        assert pruned.constraints == ("urllib3<2",)
+        assert pruned.requires_python == ">=3.10"

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -62,13 +62,18 @@ from nab_python.requirements_file import (
     InvalidProjectRequirementError,
     InvalidProjectTableError,
     expand_extra_requirements,
+    read_pyproject_build_requires,
     read_pyproject_dependencies,
     read_pyproject_groups,
     read_pyproject_name,
     read_pyproject_optional_dependencies,
     resolve_groups_to_requirements,
 )
-from nab_python.resolve import active_group_names, build_lock_input
+from nab_python.resolve import (
+    active_group_names,
+    build_lock_input,
+    config_for_build_requirements,
+)
 from nab_python.target import UnevaluableMarkerError
 
 from . import cli as _cli
@@ -116,6 +121,7 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
     all_groups: bool = False,
     extras: tuple[str, ...] = (),
     all_extras: bool = False,
+    build_requirements: bool = False,
     workspace_discovery: bool = True,
     no_emit_workspace: bool = False,
     project_resolution: ResolutionFlag | None = None,
@@ -143,6 +149,16 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
     ``--extras`` / ``--all-extras`` select entries from
     ``[project.optional-dependencies]``.  Selected names are folded into
     the resolve and recorded in the lockfile.
+
+    ``--build-requirements`` locks ``[build-system].requires`` instead of
+    the project's dependencies, for the environment the project is built
+    in rather than the one it runs in.  A project that declares no
+    ``[build-system]`` is an error: the PEP 517 default backend is what
+    an installer falls back to, not something the project asked to pin.
+    Only the static list is read, so what a backend adds from
+    ``get_requires_for_build_wheel`` is not covered.  ``--output``
+    defaults to ``pylock.build.toml`` or ``build-requirements.txt``, and
+    no group or extra can be selected alongside it.
 
     Universal mode (``[tool.nab].mode = "universal"``) supports all
     three formats.  For requirements formats, an ``--output`` template
@@ -177,6 +193,17 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
     if locked and (format != "pylock" or _cli.is_stdout(output)):
         _cli.printer().error("--locked is only supported for pylock output to a file.")
         sys.exit(1)
+    if format == "pylock" and output is None:
+        output = _default_output_path(format, build_requirements=build_requirements)
+    if build_requirements:
+        _refuse_group_selection_with_build_requirements(
+            groups=groups,
+            all_groups=all_groups,
+            extras=extras,
+            all_extras=all_extras,
+            default_group=project_default_group,
+            base_group=project_base_group,
+        )
     overrides = _cli._cli_overrides(  # noqa: SLF001
         cli_resolution=project_resolution,
         cli_offline=offline,
@@ -208,6 +235,8 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
         anchor=anchor,
         cli_overrides=project_overrides,
     )
+    if build_requirements:
+        config = config_for_build_requirements(config)
     if locked and config.mode is ResolveMode.UNIVERSAL:
         _cli.printer().error("--locked is not supported in universal mode.")
         sys.exit(1)
@@ -247,6 +276,7 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
             python=python,
             extras=selected_extras,
             groups=selected_groups,
+            build_requirements=build_requirements,
             workspace_to_drop=workspace_to_drop,
         )
 
@@ -261,6 +291,7 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
         python=python,
         groups=selected_groups,
         extras=selected_extras,
+        build_requirements=build_requirements,
         resolution_strategy=settings.resolution,
         progress=ProgressReporter(_cli.printer()),
     )
@@ -279,7 +310,14 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
     if locked:
         _check_locked(lock_input, output=output)
         return
-    _emit_or_exit(lambda: _emit(lock_input, format=format, output=output))
+    _emit_or_exit(
+        lambda: _emit(
+            lock_input,
+            format=format,
+            output=output,
+            build_requirements=build_requirements,
+        )
+    )
 
 
 def _emit(
@@ -287,12 +325,16 @@ def _emit(
     *,
     format: str,  # noqa: A002 - shadows builtin by convention
     output: Path | None,
+    build_requirements: bool = False,
 ) -> None:
     """Write the resolved lock in the requested format."""
+    default_output = _default_output_path(format, build_requirements=build_requirements)
     if format == "pylock":
-        _emit_pylock(lock_input, output=output)
+        _emit_pylock(lock_input, output=output, default_output=default_output)
     else:
-        _emit_requirements(lock_input, format=format, output=output)
+        _emit_requirements(
+            lock_input, format=format, output=output, default_output=default_output
+        )
 
 
 def _packages_only(text: str) -> str:
@@ -307,9 +349,75 @@ def _packages_only(text: str) -> str:
     return tomli_w.dumps(data)
 
 
+_BUILD_DEFAULT_OUTPUT: dict[str, str] = {
+    "pylock": "pylock.build.toml",
+    "requirements": "build-requirements.txt",
+    "requirements-without-hashes": "build-requirements.txt",
+}
+
+
+def _default_output_path(
+    format: str,  # noqa: A002 - shadows builtin by convention
+    *,
+    build_requirements: bool = False,
+) -> Path:
+    """Return the file this run writes when ``--output`` is not given.
+
+    A build-requirements lock gets a name of its own so it cannot
+    overwrite the project's runtime lock.  ``pylock.build.toml`` is the
+    PEP 751 ``pylock.<name>.toml`` spelling.
+    """
+    names = _BUILD_DEFAULT_OUTPUT if build_requirements else _cli._DEFAULT_OUTPUT  # noqa: SLF001
+    return Path(names[format])
+
+
+def _refuse_group_selection_with_build_requirements(
+    *,
+    groups: tuple[str, ...],
+    all_groups: bool,
+    extras: tuple[str, ...],
+    all_extras: bool,
+    default_group: tuple[str, ...],
+    base_group: str | None,
+) -> None:
+    """Exit 1 when a run names a selection a build-requirements lock has none of.
+
+    Refusing is what keeps the flags honest.  ``--project-default-group``
+    and ``--project-base-group`` would otherwise be dropped by
+    :func:`~nab_python.resolve.config_for_build_requirements` after the run had
+    already printed a reproducibility notice and recorded them in the lock,
+    claiming an override that changed nothing.
+    """
+    named = (
+        bool(groups),
+        all_groups,
+        bool(extras),
+        all_extras,
+        bool(default_group),
+        base_group is not None,
+    )
+    if not any(named):
+        return
+    _cli.printer().error(
+        "--build-requirements locks [build-system].requires, which has no"
+        " groups or extras to select."
+    )
+    sys.exit(1)
+
+
+def _refresh_command(*, build_requirements: bool) -> str:
+    """Return the command that would rewrite the lock ``--locked`` just read.
+
+    A build lock is written by a different run than the project's own, so
+    telling the user to run bare ``nab lock`` would send them to overwrite
+    the wrong file and leave the failure in place.
+    """
+    return "nab lock --build-requirements" if build_requirements else "nab lock"
+
+
 def _locked_target_path(output: Path | None) -> Path:
     """Return the file ``--locked`` reads and re-renders against."""
-    return output if output is not None else Path(_cli._DEFAULT_OUTPUT["pylock"])  # noqa: SLF001
+    return output if output is not None else _default_output_path("pylock")
 
 
 def _fast_fail_locked(
@@ -320,6 +428,7 @@ def _fast_fail_locked(
     python: str | None,
     extras: tuple[str, ...],
     groups: tuple[str, ...],
+    build_requirements: bool,
     workspace_to_drop: frozenset[str],
 ) -> None:
     """Fast-fail ``nab lock --locked`` before any resolve when a mismatch is proven.
@@ -329,11 +438,12 @@ def _fast_fail_locked(
     non-zero; otherwise it returns and the full resolve runs.
     """
     target = _locked_target_path(output)
+    refresh = _refresh_command(build_requirements=build_requirements)
 
     # A stat that failed is not an absent lock.
     if path_state(target) is PathState.ABSENT:
         _cli.printer().error(
-            f"--locked: no lockfile at {target} to check; run `nab lock` first."
+            f"--locked: no lockfile at {target} to check; run `{refresh}` first."
         )
         sys.exit(1)
 
@@ -347,6 +457,7 @@ def _fast_fail_locked(
             groups=groups,
             default_groups=config.default_groups,
             base_group=config.base_group,
+            build_requirements=build_requirements,
         )
     except (
         InvalidProjectTableError,
@@ -377,20 +488,20 @@ def _fast_fail_locked(
     except LockfileSyntaxError as e:
         _cli.printer().error(
             f"--locked: lockfile {target} is not valid TOML: {e};"
-            " re-run `nab lock` to regenerate it."
+            f" re-run `{refresh}` to regenerate it."
         )
         sys.exit(1)
     except InvalidLockfileError as e:
         _cli.printer().error(
             f"--locked: lockfile {target} is not a valid PEP 751 lockfile: {e};"
-            " re-run `nab lock` to regenerate it."
+            f" re-run `{refresh}` to regenerate it."
         )
         sys.exit(1)
     if disqualification is None:
         return
     _cli.printer().error(
         f"--locked: lockfile {target} is out of date: {disqualification.reason};"
-        " re-run `nab lock` to update it."
+        f" re-run `{refresh}` to update it."
     )
     sys.exit(1)
 
@@ -418,6 +529,7 @@ def _active_root_requirements(
     groups: tuple[str, ...],
     default_groups: tuple[str, ...],
     base_group: str | None = None,
+    build_requirements: bool = False,
 ) -> list[RootRequirement]:
     """Collect this run's active direct requirements with their source clause.
 
@@ -425,7 +537,16 @@ def _active_root_requirements(
     and group contributes, each carrying the clause it came from so a
     disqualification can name it.  A default group is expanded only so an
     undeclared name raises here too; its requirements are left to the resolve.
+
+    A build-requirements run has one source and no selection, so
+    ``[build-system].requires`` stands alone.
     """
+    if build_requirements:
+        return [
+            RootRequirement(requirement=req, source="[build-system].requires")
+            for req in read_pyproject_build_requires(path)
+        ]
+
     roots = [
         RootRequirement(requirement=req, source="[project].dependencies")
         for req in read_pyproject_dependencies(path)
@@ -479,13 +600,15 @@ def _check_locked(lock_input: LockInput, *, output: Path | None) -> None:
     sys.exit(1)
 
 
-def _emit_pylock(lock_input: LockInput, *, output: Path | None) -> None:
+def _emit_pylock(
+    lock_input: LockInput, *, output: Path | None, default_output: Path
+) -> None:
     """Write the PEP 751 lock to a file, or print it."""
     if _cli.is_stdout(output):
         sys.stdout.write(_write_lock_or_exit(lock_input, target=None))
         return
 
-    target = output if output is not None else Path(_cli._DEFAULT_OUTPUT["pylock"])  # noqa: SLF001
+    target = output if output is not None else default_output
     # Read the prior pins before the write overwrites the file.
     prior = read_lockfile_packages(target)
     # Pass the target so wheel/sdist/directory paths are written relative
@@ -598,6 +721,7 @@ def _emit_requirements(
     *,
     format: str,  # noqa: A002 - shadows builtin by convention
     output: Path | None,
+    default_output: Path,
 ) -> None:
     """Emit the pins as requirements, one file per target where needed.
 
@@ -609,7 +733,7 @@ def _emit_requirements(
       multi-block file), and it is why a multi-target lock has no default
       file to fall back to: there is no one file to write.
     * ``output`` is unset and the lock covers one target: write
-      ``requirements.txt``.
+      ``default_output``.
     * ``output`` names a :data:`~nab.cli.TUPLE_TEMPLATE_VARS` variable:
       write one file per target, substituting the target's values into
       the template.  This is the constraints-per-Python-version shape
@@ -631,7 +755,7 @@ def _emit_requirements(
         sys.stdout.write(text)
         return
 
-    target = output if output is not None else Path(_cli._DEFAULT_OUTPUT[format])  # noqa: SLF001
+    target = output if output is not None else default_output
     template = str(target)
     if not any(var in template for var in _cli.TUPLE_TEMPLATE_VARS):
         if multi_target:
@@ -979,7 +1103,7 @@ def _reused_lock_anchor(
         return absolute, None
     if _cli.is_stdout(output) or format != "pylock":
         return None, None
-    target = output if output is not None else Path(_cli._DEFAULT_OUTPUT[format])  # noqa: SLF001
+    target = output if output is not None else _default_output_path(format)
     return None, read_lockfile_anchor(target)
 
 
@@ -1002,7 +1126,10 @@ def _determine_lock_anchor(
     resolve either way), so the notice fires only in that case.
     """
     absolute, prior = _reused_lock_anchor(
-        path, output=output, format=format, cli_overrides=cli_overrides
+        path,
+        output=output,
+        format=format,
+        cli_overrides=cli_overrides,
     )
     if upgrade:
         fresh = datetime.now(timezone.utc)

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -560,6 +560,7 @@ def _resolve(  # noqa: PLR0913, PLR0912, C901 - one wrapper per resolve_for_targ
     python: str | None = None,
     groups: tuple[str, ...] = (),
     extras: tuple[str, ...] = (),
+    build_requirements: bool = False,
     resolution_strategy: ResolutionStrategy | None = None,
     progress: ProgressReporter | None = None,
 ) -> ResolveResult:
@@ -584,6 +585,7 @@ def _resolve(  # noqa: PLR0913, PLR0912, C901 - one wrapper per resolve_for_targ
                 offline=offline,
                 groups=groups,
                 extras=extras,
+                build_requirements=build_requirements,
                 resolution_strategy=resolution_strategy,
                 progress=progress,
             )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,6 +32,7 @@ from nab import _version as nab_version
 from nab import cli
 from nab._download import download
 from nab._lock import (
+    _BUILD_DEFAULT_OUTPUT,
     _determine_lock_anchor,
     _emit,
     _emit_pylock,
@@ -40,6 +41,7 @@ from nab._lock import (
     resolve_group_selection,
 )
 from nab.cli import (
+    _DEFAULT_OUTPUT,
     _default_cache_dir,
     _make_transport,
     _normalize_layered_bool_flags,
@@ -52,6 +54,7 @@ from nab_index.httpx_async_transport import HttpxAsyncTransport
 from nab_index.local_index import LocalIndexClient, UnreadableLocalIndexError
 from nab_index.transport import HttpError
 from nab_index.urllib3_async_transport import Urllib3AsyncTransport
+from nab_python._testing.coordinator_fake import make_coordinator
 from nab_python._vendor.packaging.pylock import Pylock
 from nab_python._vendor.packaging.version import Version
 from nab_python.config import ConfigError, read_pyproject_config
@@ -276,6 +279,13 @@ def _make_pyproject(tmp_path: Path, body: str = "") -> Path:
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text(body or '[project]\ndependencies = ["foo"]\n')
     return pyproject
+
+
+# A well-formed project for tests that stub the resolve; neither list is read.
+_BUILD_SYSTEM_PROJECT = (
+    '[project]\nname = "proj"\ndependencies = ["runtime-only"]\n'
+    '[build-system]\nrequires = ["foo"]\n'
+)
 
 
 def _make_pylock_with_groups(tmp_path: Path) -> Path:
@@ -604,6 +614,119 @@ class TestLockCommandSpecific:
         text = (tmp_path / "requirements.txt").read_text()
         assert "foo==1.0" in text
         assert "--hash" not in text
+
+    def test_build_requirements_pylock_default_filename(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A build lock defaults clear of the runtime lock's name."""
+        monkeypatch.chdir(tmp_path)
+        pyproject = _make_pyproject(tmp_path, _BUILD_SYSTEM_PROJECT)
+        with patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()):
+            lock(pyproject, build_requirements=True)
+        assert (tmp_path / "pylock.build.toml").exists()
+        assert not (tmp_path / "pylock.toml").exists()
+
+    @pytest.mark.parametrize(
+        "lock_format", ["requirements", "requirements-without-hashes"]
+    )
+    def test_build_requirements_requirements_default_filename(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, lock_format: str
+    ) -> None:
+        """Both requirements formats get their own default name."""
+        monkeypatch.chdir(tmp_path)
+        pyproject = _make_pyproject(tmp_path, _BUILD_SYSTEM_PROJECT)
+        with patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()):
+            lock(pyproject, format=lock_format, build_requirements=True)
+        assert (tmp_path / "build-requirements.txt").exists()
+        assert not (tmp_path / "requirements.txt").exists()
+
+    def test_every_format_has_a_build_default(self) -> None:
+        """A format added to one map alone would be a KeyError, not an error."""
+        assert _BUILD_DEFAULT_OUTPUT.keys() == _DEFAULT_OUTPUT.keys()
+
+    def test_build_lock_reuses_its_own_prior_anchor(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The build lock's cutoff comes from the build lock, not pylock.toml."""
+        monkeypatch.chdir(tmp_path)
+        recorded = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        (tmp_path / "pylock.build.toml").write_text(
+            f"[tool.nab]\ncreated-at = {recorded.isoformat()}\n"
+        )
+        (tmp_path / "pylock.toml").write_text(
+            "[tool.nab]\ncreated-at = 2020-01-01T00:00:00+00:00\n"
+        )
+        pyproject = _make_pyproject(tmp_path, _BUILD_SYSTEM_PROJECT)
+        with patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()):
+            lock(pyproject, build_requirements=True)
+        written = tomli.loads((tmp_path / "pylock.build.toml").read_text())
+        assert written["tool"]["nab"]["created-at"] == recorded
+
+    def test_build_lock_records_no_group_selection(self, tmp_path: Path) -> None:
+        """The project's group settings describe a selection it does not have."""
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\nname = "proj"\ndependencies = ["runtime-only"]\n'
+            '[build-system]\nrequires = ["foo"]\n'
+            '[dependency-groups]\ndev = ["foo"]\n'
+            '[tool.nab]\ndefault-groups = ["dev"]\nbase-group = "default"\n',
+        )
+        out = tmp_path / "pylock.build.toml"
+        with patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()):
+            lock(pyproject, output=out, build_requirements=True)
+        written = tomli.loads(out.read_text())
+        assert "default-groups" not in written
+        assert "dependency-groups" not in written
+
+    def test_build_requirements_locks_the_build_requires(self, tmp_path: Path) -> None:
+        """End to end: the emitted lock holds the build requirement alone."""
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\nname = "proj"\ndependencies = ["runtime-only"]\n'
+            '[build-system]\nrequires = ["builder"]\n'
+            + "".join(
+                f'[[tool.nab.local-sources]]\nname = "{name}"\npath = "{name}"\n'
+                for name in ("runtime-only", "builder")
+            ),
+        )
+        for name in ("runtime-only", "builder"):
+            member = tmp_path / name
+            member.mkdir()
+            (member / "pyproject.toml").write_text(
+                f'[project]\nname = "{name}"\nversion = "1.0"\n'
+            )
+        out = tmp_path / "pylock.build.toml"
+        with patch("nab_python.resolve.FetchCoordinator") as mock_coord_cls:
+            mock_coord_cls.return_value.__enter__ = lambda _self: make_coordinator([])
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            lock(pyproject, output=out, build_requirements=True, cache=False)
+        written = tomli.loads(out.read_text())
+        assert [pkg["name"] for pkg in written["packages"]] == ["builder"]
+
+    @pytest.mark.parametrize(
+        "selection",
+        [
+            {"groups": ("dev",)},
+            {"all_groups": True},
+            {"extras": ("gpu",)},
+            {"all_extras": True},
+            {"project_default_group": ("dev",)},
+            {"project_base_group": "default"},
+        ],
+    )
+    def test_build_requirements_refuses_a_selection(
+        self, tmp_path: Path, selection: dict[str, object]
+    ) -> None:
+        """[build-system].requires is one flat list with nothing to select."""
+        pyproject = _make_pyproject(tmp_path, _BUILD_SYSTEM_PROJECT)
+        err = io.StringIO()
+        with (
+            contextlib.redirect_stderr(err),
+            pytest.raises(SystemExit) as exc,
+        ):
+            lock(pyproject, build_requirements=True, **selection)
+        assert exc.value.code == 1
+        assert "no groups or extras to select" in err.getvalue()
 
     def test_requirements_writes_to_file(self, tmp_path: Path) -> None:
         """`requirements` format renders --hash lines."""
@@ -4457,7 +4580,7 @@ class TestEmitHelpers:
             targets={tup.label: _target_lock(tup, {"foo": V("1.0")})}
         )
         out = tmp_path / "pylock.toml"
-        _emit_pylock(lock_input, output=out)
+        _emit_pylock(lock_input, output=out, default_output=Path("pylock.toml"))
         text = out.read_text()
         assert 'lock-version = "1.0"' in text
 
@@ -4472,7 +4595,11 @@ class TestEmitHelpers:
                 second.label: _target_lock(second, {"foo": V("2.0")}),
             }
         )
-        _emit_pylock(lock_input, output=tmp_path / "pylock.toml")
+        _emit_pylock(
+            lock_input,
+            output=tmp_path / "pylock.toml",
+            default_output=Path("pylock.toml"),
+        )
         assert "(2 tuples)" in capsys.readouterr().err
 
 

--- a/tests/test_lock_locked.py
+++ b/tests/test_lock_locked.py
@@ -142,6 +142,83 @@ def test_tightened_direct_specifier_fires_without_resolving(
     assert out.read_bytes() == before
 
 
+def test_tightened_build_requirement_fires_without_resolving(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """--locked proves a build lock stale from [build-system].requires."""
+    body = '[project]\nname = "proj"\ndependencies = []\n'
+    pyproject = _write_pyproject(
+        tmp_path, body + '[build-system]\nrequires = ["foo"]\n'
+    )
+    out = tmp_path / "pylock.build.toml"
+    _write_lock(pyproject, out, _result({"foo": "1.5"}), "--build-requirements")
+    capsys.readouterr()
+    pyproject.write_text(
+        body + '[build-system]\nrequires = ["foo>=2.0"]\n', encoding="utf-8"
+    )
+
+    mock = _locked_mock()
+    with pytest.raises(SystemExit) as exc:
+        _run_locked(pyproject, out, mock, "--build-requirements")
+
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "[build-system].requires requires foo>=2.0 but the lock pins foo 1.5" in err
+    assert "re-run `nab lock --build-requirements` to update it" in err
+    mock.assert_not_called()
+
+
+def test_locked_build_lock_defaults_to_the_build_lock_path(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without --output, --build-requirements checks pylock.build.toml."""
+    monkeypatch.chdir(tmp_path)
+    pyproject = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "proj"\ndependencies = []\n'
+        '[build-system]\nrequires = ["foo"]\n',
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        app.cli(
+            args=["lock", str(pyproject), "--locked", "--build-requirements"],
+            prog="nab",
+        )
+
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "no lockfile at pylock.build.toml" in err
+    assert "run `nab lock --build-requirements` first" in err
+
+
+def test_locked_build_lock_checks_its_own_default_file(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stale pylock.toml alongside must not decide the build lock's verdict."""
+    monkeypatch.chdir(tmp_path)
+    pyproject = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "proj"\ndependencies = ["bar"]\n'
+        '[build-system]\nrequires = ["foo"]\n',
+    )
+    _write_lock(pyproject, tmp_path / "pylock.toml", _result({"bar": "9.9"}))
+    _write_lock(
+        pyproject,
+        tmp_path / "pylock.build.toml",
+        _result({"foo": "1.0"}),
+        "--build-requirements",
+    )
+    capsys.readouterr()
+
+    with patch("nab.cli.resolve_for_targets", _locked_mock(_result({"foo": "1.0"}))):
+        app.cli(
+            args=["lock", str(pyproject), "--locked", "--build-requirements"],
+            prog="nab",
+        )
+
+    assert "Lockfile pylock.build.toml is up to date." in capsys.readouterr().err
+
+
 def test_tightened_constraint_fires_without_resolving(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
`nab lock --build-requirements` locks a project's `[build-system].requires` instead of its dependencies, so the lock describes the environment the project is built in rather than the one it runs in. Output defaults to `pylock.build.toml`, PEP 751's `pylock.<name>.toml` spelling, so it cannot overwrite the runtime lock.

A build environment is separate by construction: PEP 517 isolates it, and `NabBuildEnv` already resolves `[build-system].requires` on its own when it populates one. Locking it separately keeps that separation, so a backend needing a version the project's own dependencies exclude still resolves. A project that declares no `[build-system]` is an error rather than a lock of the PEP 517 default backend, and only the static list is read, so whatever a backend would add from `get_requires_for_build_wheel` is not covered.

Stacked on #804.
