### PR TITLE
Name the build requirements as a lock group

### DIFF
--- a/docs/how-to/workspaces.md
+++ b/docs/how-to/workspaces.md
@@ -95,7 +95,7 @@ locked: the workspace `members`, merged into `local-sources`. Everything
 else under `[tool.nab]` is scoped to the pyproject being locked: `conflicts`,
 `default-groups`, `constraints`, `matrix`, `mode`, `requires-python`,
 `uploaded-prior-to`, `build-policy` itself, `dist-policy`, `vcs`,
-`indexes`, `base-group`, and `environment`. Locking a member with `nab lock
+`indexes`, `base-group`, `build-group`, and `environment`. Locking a member with `nab lock
 packages/core/pyproject.toml` reads only that file's keys; the
 root's are ignored.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -72,7 +72,7 @@ Build requirements:
   the project is built in rather than the one it runs in. `--output`
   defaults to `pylock.build.toml` (or `build-requirements.txt` for the
   requirements formats), which keeps it clear of the project's runtime
-  lock. Nothing can be selected alongside it: `[build-system].requires`
+  lock, and `--locked` then checks that file. Nothing can be selected alongside it: `[build-system].requires`
   is one flat list, so `--groups`, `--all-groups`, `--extras`,
   `--all-extras`, `--project-default-group`, `--project-base-group` and
   `--project-build-group` are all rejected, and `[tool.nab].default-groups`,
@@ -83,7 +83,8 @@ Build requirements:
   `setuptools` would put a build requirement in the lock that the project
   never declared. `[tool.nab].build-group`, which carries the build
   requirements in the project's own lock instead of a separate one, is
-  the same.
+  the same, and it requires `[tool.nab].base-group` so the two sets can
+  be asked for separately.
 * Only the static list is read. Neither this flag nor `build-group`
   invokes the project's own backend, so whatever that backend would add
   from `get_requires_for_build_wheel` is not covered.
@@ -184,8 +185,9 @@ change or is missing, so CI can assert the lock is current. It covers
 `pylock` output to a file in single-environment mode.
 
 When a mismatch is provable from the inputs alone, a changed direct
-dependency, a narrowed `requires-python`, a changed extra or group, or a
-tightened constraint, `--locked` fails fast with that reason before
+dependency, a changed `[build-system].requires` under `build-group`, a
+narrowed `requires-python`, a changed extra or group, or a tightened
+constraint, `--locked` fails fast with that reason before
 resolving. Otherwise it runs the full re-resolve, and only that comparison
 reports the lock up to date: nab is non-sticky, so a lock can satisfy every
 input yet be stale once a newer admissible version exists.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -74,17 +74,23 @@ Build requirements:
   requirements formats), which keeps it clear of the project's runtime
   lock. Nothing can be selected alongside it: `[build-system].requires`
   is one flat list, so `--groups`, `--all-groups`, `--extras`,
-  `--all-extras`, `--project-default-group` and `--project-base-group`
-  are all rejected, and `[tool.nab].default-groups`,
-  `[tool.nab].base-group` and `[tool.nab].conflicts` declared in the
-  project's files do not apply.
+  `--all-extras`, `--project-default-group`, `--project-base-group` and
+  `--project-build-group` are all rejected, and `[tool.nab].default-groups`,
+  `[tool.nab].base-group`, `[tool.nab].build-group` and
+  `[tool.nab].conflicts` declared in the project's files do not apply.
 * A project that declares no `[build-system]` is an error. nab does not
   fall back to the PEP 517 default backend, because pinning an implied
   `setuptools` would put a build requirement in the lock that the project
-  never declared.
-* Only the static list is read. `--build-requirements` never invokes the
-  project's own backend, so whatever that backend would add from
-  `get_requires_for_build_wheel` is not covered.
+  never declared. `[tool.nab].build-group`, which carries the build
+  requirements in the project's own lock instead of a separate one, is
+  the same.
+* Only the static list is read. Neither this flag nor `build-group`
+  invokes the project's own backend, so whatever that backend would add
+  from `get_requires_for_build_wheel` is not covered.
+* `[tool.nab].build-group` gates its packages on a marker, and the two
+  requirements formats have nowhere to put one, so they render the build
+  requirements as ordinary pins. Use `pylock` output, or this flag, when
+  the two sets have to stay apart.
 
 Workspace flags (see [Lock a workspace](../how-to/workspaces.md)):
 
@@ -162,7 +168,8 @@ A project option can be overridden for one run with a `--project-<key>`
 flag: `--project-resolution`, `--project-mode`, `--project-requires-python`,
 `--project-uploaded-prior-to`, `--project-dist-policy`,
 `--project-build-policy`, `--project-build-requires-depth`,
-`--project-decision-order`, `--project-base-group`, and the
+`--project-decision-order`, `--project-base-group`,
+`--project-build-group`, and the
 repeatable `--project-constraint` and `--project-default-group`. Every one
 of them replaces the file value outright; repeating `--project-constraint`
 builds up that run's whole constraint list rather than adding to the

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -46,7 +46,9 @@ base-group = "base"
 # no group is installing the project, not building it.  The requirements
 # output formats carry no markers, so there they render as ordinary
 # pins.  The name must not be one [dependency-groups] declares, nor the
-# base-group name.
+# base-group name, and base-group must be set: unnamed, the project's
+# own dependencies carry no marker and come with every group, so nothing
+# could ask for the build requirements alone.
 build-group = "build"
 
 # The Python range this project supports.  A declaration: it is

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -37,6 +37,18 @@ default-groups = ["dev"]
 # declare it there too to keep it in the default selection.
 base-group = "base"
 
+# The group name a lock gives [build-system].requires, so one lock can
+# describe the environment the project is built in as well as the one it
+# runs in.  Unset, a lock says nothing about how the project is built.
+# Set it and those requirements are resolved alongside the project's own,
+# and a pylock gates them behind that name, which it records in
+# dependency-groups but not in default-groups: an install that asks for
+# no group is installing the project, not building it.  The requirements
+# output formats carry no markers, so there they render as ordinary
+# pins.  The name must not be one [dependency-groups] declares, nor the
+# base-group name.
+build-group = "build"
+
 # The Python range this project supports.  A declaration: it is
 # recorded in the lockfile and checked against the resolve target,
 # and it does not choose that target.  Falls back to

--- a/docs/reference/lockfile.md
+++ b/docs/reference/lockfile.md
@@ -192,25 +192,33 @@ built in:
 
 ```toml
 [tool.nab]
+base-group = "default"
 build-group = "build"
 ```
 
 ```toml
-dependency-groups = ["dev", "build"]
+dependency-groups = ["dev", "default", "build"]
+default-groups = ["default"]
 
 [[packages]]
 name = "hatchling"
-version = "1.27.0"
+version = "1.31.0"
 marker = "\"build\" in dependency_groups"
 ```
 
-The name lands in `dependency-groups` and not in `default-groups`: an
-install that asks for no group is installing the project, not building
+The build name lands in `dependency-groups` and not in `default-groups`:
+an install that asks for no group is installing the project, not building
 it. Only the static list is read, so whatever a backend would add from
-`get_requires_for_build_wheel` is not covered. The name must be free of
-`[dependency-groups]` and of `base-group`. The requirements output
-formats carry no markers, so there the build requirements render as
-ordinary pins.
+`get_requires_for_build_wheel` is not covered.
+
+`base-group` must be set alongside it, as above. Without a name of their own the
+project's own dependencies carry no marker, so they install under every
+selection and asking for the build group returns them too, which leaves
+no way to install the build requirements alone. With both named, an
+install that wants them together selects both groups. The name must also
+be free of `[dependency-groups]` and of `base-group` itself. The
+requirements output formats carry no markers, so there the build
+requirements render as ordinary pins.
 
 The build requirements resolve in the same version space as the
 project's own, which is what a single lock can express: an installer

--- a/docs/reference/lockfile.md
+++ b/docs/reference/lockfile.md
@@ -184,6 +184,42 @@ consumers rather than a group of the project's own, so `--groups` does
 not accept it; `[tool.nab].default-groups` does, which is how it stays
 in the default selection.
 
+### Naming the build requirements
+
+The same mechanism carries a project's `[build-system].requires`, so one
+lock pins both the environment the project runs in and the one it is
+built in:
+
+```toml
+[tool.nab]
+build-group = "build"
+```
+
+```toml
+dependency-groups = ["dev", "build"]
+
+[[packages]]
+name = "hatchling"
+version = "1.27.0"
+marker = "\"build\" in dependency_groups"
+```
+
+The name lands in `dependency-groups` and not in `default-groups`: an
+install that asks for no group is installing the project, not building
+it. Only the static list is read, so whatever a backend would add from
+`get_requires_for_build_wheel` is not covered. The name must be free of
+`[dependency-groups]` and of `base-group`. The requirements output
+formats carry no markers, so there the build requirements render as
+ordinary pins.
+
+The build requirements resolve in the same version space as the
+project's own, which is what a single lock can express: an installer
+reading it installs into one environment. A project whose backend needs
+a version its own dependencies exclude has no lock that can say so, and
+the resolve fails. `nab lock --build-requirements` is the way out, since
+a separate lock is a separate version space, which is also what PEP 517
+build isolation gives the build at install time.
+
 ### Portable paths
 
 A lockfile can reference content on disk: a `LocalPin`'s

--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -275,7 +275,9 @@ def build_pylock(lock_input: LockInput, *, lock_dir: Path | None = None) -> Pylo
             else None
         ),
         dependency_groups=_group_array(
-            lock_input.dependency_groups, lock_input.base_group
+            lock_input.dependency_groups,
+            lock_input.base_group,
+            lock_input.build_group,
         ),
         default_groups=_group_array(
             lock_input.default_groups,
@@ -315,21 +317,23 @@ def _name_base_group(lock_input: LockInput) -> LockInput:
 
 
 def _group_array(
-    groups: Sequence[str], base_group: str | None
+    groups: Sequence[str], *configured: str | None
 ) -> tuple[str, ...] | None:
     """Render one of the lock's group arrays, or ``None`` when it is empty.
 
-    ``base_group`` is appended when given.  It always joins
-    ``dependency-groups``, since an installer that offers only those
-    names would otherwise never reach it.  It joins ``default-groups``
-    only when the project declares none of its own: a declared
+    Every name is canonicalized here and deduplicated in order.  Which
+    arrays a ``configured`` name belongs in is the caller's decision:
+    ``build-group`` joins ``dependency-groups`` alone, and ``base-group``
+    joins it too, since an installer that offers only those names would
+    otherwise never reach it.  ``base-group`` joins ``default-groups``
+    only when the project declares none of its own, because a declared
     ``default-groups`` replaces the default selection rather than
-    extending it, so a project that wants its own dependencies installed
-    by default alongside a group names them there itself.
+    extending it.
     """
     names = dict.fromkeys(str(canonicalize_name(group)) for group in groups)
-    if base_group is not None:
-        names[str(canonicalize_name(base_group))] = None
+    for name in configured:
+        if name is not None:
+            names[str(canonicalize_name(name))] = None
     return tuple(names) or None
 
 

--- a/nab-python/src/nab_python/_lockfile/validate.py
+++ b/nab-python/src/nab_python/_lockfile/validate.py
@@ -93,6 +93,7 @@ def check_envelope(
     dependency_groups: tuple[str, ...],
     default_groups: tuple[str, ...],
     base_group: str | None = None,
+    build_group: str | None = None,
 ) -> LockDisqualification | None:
     """Compare the current envelope against the committed lock.
 
@@ -101,10 +102,10 @@ def check_envelope(
     does not fire and an empty selection matches the ``None`` the writer
     commits. Returns the first difference, or ``None`` when every field agrees.
 
-    ``base_group`` is the name this run would give the project's own
-    dependencies. No run selects it, so it is checked before the arrays are
-    compared and then dropped from them, and a run that sets it gets a
-    reason naming only groups the caller asked for.
+    ``base_group`` and ``build_group`` are the names this run would give
+    the project's own dependencies and its build requirements. No run
+    selects either, so both are checked before the arrays are compared and
+    then dropped from them: a reason names only groups the caller asked for.
     """
     requires_python_result = _check_requires_python(
         committed.requires_python, requires_python
@@ -112,15 +113,19 @@ def check_envelope(
     if requires_python_result is not None:
         return requires_python_result
 
-    base_group_result = _check_base_group(committed, base_group)
-    if base_group_result is not None:
-        return base_group_result
+    for name, subject in (
+        (base_group, "the project's own dependencies"),
+        (build_group, "the build requirements"),
+    ):
+        named_result = _check_configured_group(committed, name, subject)
+        if named_result is not None:
+            return named_result
 
     for kind, committed_names, current_names in (
         ("extras", committed.extras, extras),
         (
             "dependency-groups",
-            _without(committed.dependency_groups, base_group),
+            _without(committed.dependency_groups, base_group, build_group),
             dependency_groups,
         ),
         (
@@ -136,37 +141,31 @@ def check_envelope(
     return None
 
 
-def _without(names: Sequence[str] | None, dropped: str | None) -> list[str]:
-    """Return ``names`` without ``dropped``, comparing canonical names."""
-    if dropped is None:
-        return list(names or ())
-    return [
-        name
-        for name in names or ()
-        if canonicalize_name(name) != canonicalize_name(dropped)
-    ]
+def _without(names: Sequence[str] | None, *dropped: str | None) -> list[str]:
+    """Return ``names`` without any of ``dropped``, comparing canonical names."""
+    drop = {canonicalize_name(name) for name in dropped if name is not None}
+    return [name for name in names or () if canonicalize_name(name) not in drop]
 
 
-def _check_base_group(
-    committed: Pylock, base_group: str | None
+def _check_configured_group(
+    committed: Pylock, name: str | None, subject: str
 ) -> LockDisqualification | None:
-    """Whether the lock names the project's own dependencies as this run does.
+    """Whether the lock offers ``name`` for ``subject`` as this run would.
 
     A committed name looks like any other group, so which one an earlier
-    run gave them cannot be read back.  The reason says only what this
+    run gave to what cannot be read back.  The reason says only what this
     run would write and the lock does not have.
     """
-    if base_group is None:
+    if name is None:
         return None
     if any(
-        canonicalize_name(name) == canonicalize_name(base_group)
-        for name in committed.dependency_groups or ()
+        canonicalize_name(committed_name) == canonicalize_name(name)
+        for committed_name in committed.dependency_groups or ()
     ):
         return None
     return LockDisqualification(
         reason=(
-            f"the lockfile does not name {base_group!r} for the project's"
-            f" own dependencies, which this run does"
+            f"the lockfile does not name {name!r} for {subject}, which this run does"
         )
     )
 
@@ -397,6 +396,7 @@ def check_locked(  # noqa: PLR0913 - the envelope fields and the validity inputs
     dependency_groups: tuple[str, ...],
     default_groups: tuple[str, ...],
     base_group: str | None = None,
+    build_group: str | None = None,
     roots: Iterable[RootRequirement] | None = None,
     constraints: Iterable[str] = (),
     resolve_target: ResolveTarget | None = None,
@@ -421,6 +421,7 @@ def check_locked(  # noqa: PLR0913 - the envelope fields and the validity inputs
         dependency_groups=dependency_groups,
         default_groups=default_groups,
         base_group=base_group,
+        build_group=build_group,
     )
     if disqualification is not None or roots is None or resolve_target is None:
         return disqualification

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -436,6 +436,7 @@ class NabProjectConfig:
     constraints: tuple[str, ...] = ()
     default_groups: tuple[str, ...] = ()
     base_group: str | None = None
+    build_group: str | None = None
     # The project's declared Python support range: recorded as the lock's
     # top-level ``requires-python`` and checked against the resolve target.
     # It does not choose the target; ``environment`` does.
@@ -658,6 +659,9 @@ def read_pyproject_config(
         project_requires_python=project_requires_python,
     )
     _validate_base_group_is_free(effective["base-group"], path)
+    _validate_build_group_is_free(
+        effective["build-group"], effective["base-group"], path
+    )
     if discover_workspace:
         config = _apply_workspace_discovery(
             path, config, declared_in=effective["workspace"].origin.label
@@ -777,6 +781,7 @@ def _config_from_effective(
         constraints=effective["constraints"].value,
         default_groups=default_groups,
         base_group=effective["base-group"].value,
+        build_group=effective["build-group"].value,
         requires_python=requires_python,
         requires_python_source=requires_python_source,
         uploaded_prior_to=effective["uploaded-prior-to"].value,
@@ -1325,6 +1330,22 @@ def _parse_base_group(value: object) -> str | None:
     return str(canonical)
 
 
+def _parse_build_group(value: object) -> str | None:
+    """Parse ``[tool.nab].build-group`` as a PEP 735 group name.
+
+    Names the group a lock gives ``[build-system].requires``, so one lock
+    can describe the environment the project is built in as well as the
+    one it runs in.  Unset, a lock says nothing about how it is built.
+    """
+    raw = _parse_string_value("build-group", value)
+    try:
+        canonical = canonicalize_name(raw, validate=True)
+    except InvalidName as e:
+        msg = f"build-group {raw!r} is not a valid group name: {e}"
+        raise ConfigError(msg) from e
+    return str(canonical)
+
+
 def _parse_requires_python(value: object) -> str | None:
     """Parse ``[tool.nab].requires-python`` as a PEP 440 specifier.
 
@@ -1376,6 +1397,52 @@ def _validate_base_group_is_free(base_group: EffectiveValue, path: Path) -> None
         if base_group.origin.kind is SourceKind.CLI
         else "base-group"
     )
+    msg = (
+        f"{key} {name!r} and [dependency-groups] {names} are the same name;"
+        " one marker cannot mean both"
+    )
+    raise ConfigError(msg)
+
+
+def _validate_build_group_is_free(
+    build_group: EffectiveValue, base_group: EffectiveValue, path: Path
+) -> None:
+    """Reject a ``build-group`` some other group already answers to.
+
+    A declared ``[dependency-groups]`` name and ``base-group`` are both
+    already spoken for, and all three emit ``'name' in dependency_groups``.
+    Checked as the file is read, like :func:`_validate_base_group_is_free`.
+    """
+    name: str | None = build_group.value
+    if name is None:
+        return
+    key = (
+        "--project-build-group"
+        if build_group.origin.kind is SourceKind.CLI
+        else "build-group"
+    )
+    if name == base_group.value:
+        other = (
+            "--project-base-group"
+            if base_group.origin.kind is SourceKind.CLI
+            else "base-group"
+        )
+        msg = f"{key} and {other} are both {name!r}; one marker cannot mean both"
+        raise ConfigError(msg)
+
+    with path.open("rb") as f:
+        data = tomli.load(f)
+    groups = data.get("dependency-groups")
+    if not isinstance(groups, dict):
+        return
+    taken = sorted(
+        declared
+        for declared in groups
+        if isinstance(declared, str) and canonicalize_name(declared) == name
+    )
+    if not taken:
+        return
+    names = ", ".join(repr(declared) for declared in taken)
     msg = (
         f"{key} {name!r} and [dependency-groups] {names} are the same name;"
         " one marker cannot mean both"

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -659,6 +659,9 @@ def read_pyproject_config(
         project_requires_python=project_requires_python,
     )
     _validate_base_group_is_free(effective["base-group"], path)
+    _validate_build_group_has_a_base_group(
+        effective["build-group"], effective["base-group"]
+    )
     _validate_build_group_is_free(
         effective["build-group"], effective["base-group"], path
     )
@@ -1400,6 +1403,33 @@ def _validate_base_group_is_free(base_group: EffectiveValue, path: Path) -> None
     msg = (
         f"{key} {name!r} and [dependency-groups] {names} are the same name;"
         " one marker cannot mean both"
+    )
+    raise ConfigError(msg)
+
+
+def _validate_build_group_has_a_base_group(
+    build_group: EffectiveValue, base_group: EffectiveValue
+) -> None:
+    """Reject a ``build-group`` without a ``base-group`` to answer for the rest.
+
+    Unnamed, the project's own dependencies carry no marker and install
+    under every selection, so asking for the build group returns them too
+    and nothing can install the build requirements alone, which is the
+    reason to name them.  Naming both costs nothing: an install that wants
+    them together selects both groups.
+    """
+    if build_group.value is None or base_group.value is not None:
+        return
+    key = (
+        "--project-build-group"
+        if build_group.origin.kind is SourceKind.CLI
+        else "build-group"
+    )
+    msg = (
+        f"{key} is {build_group.value!r}, but base-group is unset, so the"
+        " project's own dependencies carry no marker and install alongside"
+        " every group; set base-group to name them, or drop build-group and"
+        " use nab lock --build-requirements for a separate lock"
     )
     raise ConfigError(msg)
 

--- a/nab-python/src/nab_python/config_sources.py
+++ b/nab-python/src/nab_python/config_sources.py
@@ -558,6 +558,15 @@ def _parse_base_group(value: Any, where: str) -> str | None:
     return _delegate(lambda: _impl(value))
 
 
+def _parse_build_group(value: Any, where: str) -> str | None:
+    del where
+    from .config import (  # noqa: PLC0415 (config import cycle)
+        _parse_build_group as _impl,
+    )
+
+    return _delegate(lambda: _impl(value))
+
+
 def _parse_indexes(value: Any, where: str) -> tuple[IndexConfig, ...]:
     # One file's array-of-tables: config._parse_indexes validates shape,
     # keys, and the same-name check into IndexConfig entries.
@@ -891,6 +900,17 @@ OPTIONS: tuple[OptionSpec, ...] = (
         cli_flag="--project-base-group",
         cli_param="project_base_group",
         parse=_parse_base_group,
+        render=lambda v: "<none>" if v is None else v,
+    ),
+    OptionSpec(
+        key="build-group",
+        scope=Scope.PROJECT,
+        type_label="group",
+        default=None,
+        env_var=None,
+        cli_flag="--project-build-group",
+        cli_param="project_build_group",
+        parse=_parse_build_group,
         render=lambda v: "<none>" if v is None else v,
     ),
     OptionSpec(

--- a/nab-python/src/nab_python/lockfile.py
+++ b/nab-python/src/nab_python/lockfile.py
@@ -449,6 +449,9 @@ class LockInput:
     base_group: str | None = None
     """``[tool.nab].base-group``: the group name the lock gives
     the project's own dependencies, or ``None`` to leave them unconditional."""
+    build_group: str | None = None
+    """``[tool.nab].build-group``: the group name the lock gives
+    ``[build-system].requires``, or ``None`` to leave them out of the lock."""
 
     @property
     def active_groups(self) -> tuple[str, ...]:
@@ -461,8 +464,9 @@ class LockInput:
         gives the project's own dependencies.
         """
         names = dict.fromkeys((*self.dependency_groups, *self.default_groups))
-        if self.base_group is not None:
-            names[self.base_group] = None
+        for named in (self.base_group, self.build_group):
+            if named is not None:
+                names[named] = None
         return tuple(names)
 
     @property

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -344,6 +344,11 @@ def resolve_for_targets(  # noqa: PLR0913 - the surface mirrors the CLI; bundlin
             groups=read_pyproject_groups(path),
             optional=read_pyproject_optional_dependencies(path),
             project_name=read_pyproject_name(path),
+            build_requires=(
+                read_pyproject_build_requires(path)
+                if config.build_group is not None
+                else []
+            ),
         )
     )
 
@@ -819,6 +824,7 @@ def build_lock_input(
         default_groups=effective.default_groups,
         conflicts=effective.conflicts,
         base_group=effective.base_group,
+        build_group=effective.build_group,
     )
 
 
@@ -913,6 +919,10 @@ class _ProjectTables:
     groups: Mapping[str, Sequence[str | Mapping[str, str]]]
     optional: Mapping[str, Sequence[str]]
     project_name: str | None
+    build_requires: list[Requirement] = field(default_factory=list)
+    """``[build-system].requires``, read only when ``[tool.nab].build-group``
+    names a group for them.  A ``--build-requirements`` resolve carries them
+    in ``dependencies`` instead and leaves this empty."""
 
 
 def _tables_for_build_requires(path: Path) -> _ProjectTables:
@@ -938,9 +948,17 @@ def config_for_build_requirements(config: NabProjectConfig) -> NabProjectConfig:
     ``base-group`` names the project's own dependencies, which a build
     lock holds none of.  Left in they fail the run rather than narrow it:
     :func:`_tables_for_build_requires` supplies no group or extra table
-    for them to resolve against.
+    for them to resolve against.  ``build-group`` goes too: a lock whose
+    roots already are the build requirements has no second context to
+    gate them behind.
     """
-    return replace(config, conflicts=(), default_groups=(), base_group=None)
+    return replace(
+        config,
+        conflicts=(),
+        default_groups=(),
+        base_group=None,
+        build_group=None,
+    )
 
 
 def _threaded_preferences(
@@ -1239,7 +1257,9 @@ def _plan_forks(
                 requirements=tuple(_fork_requirements(path, tables, fork)),
                 contexts=InstallContexts(
                     project=tuple(tables.dependencies),
-                    selectors=_selector_requirements(path, tables, fork),
+                    selectors=_selector_requirements(
+                        path, tables, fork, build_group=config.build_group
+                    ),
                     name_project=config.base_group is not None,
                 ),
             )
@@ -1255,7 +1275,11 @@ def _plan_forks(
 
 
 def _selector_requirements(
-    path: Path, tables: _ProjectTables, fork: ConflictFork
+    path: Path,
+    tables: _ProjectTables,
+    fork: ConflictFork,
+    *,
+    build_group: str | None,
 ) -> dict[tuple[str, str], tuple[Requirement, ...]]:
     """Split a fork's active extras and groups into one requirement list each.
 
@@ -1272,6 +1296,9 @@ def _selector_requirements(
     install.
     """
     selectors: dict[tuple[str, str], tuple[Requirement, ...]] = {}
+    if build_group is not None:
+        member = (ConflictKind.GROUP.value, build_group)
+        selectors[member] = tuple(tables.build_requires)
     for extra in fork.active_extras:
         member = (ConflictKind.EXTRA.value, str(canonicalize_name(extra)))
         selectors[member] = tuple(_extra_requirements(tables, [extra], path))
@@ -1291,6 +1318,7 @@ def _fork_requirements(
     rather than shared.
     """
     requirements = list(tables.dependencies)
+    requirements.extend(tables.build_requires)
     requirements.extend(_group_requirements(tables.groups, fork.active_groups, path))
     requirements.extend(_extra_requirements(tables, fork.active_extras, path))
     return requirements

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -912,6 +912,32 @@ class TestMainGroup:
         with pytest.raises(ConfigError, match="not a valid group name"):
             read_pyproject_config(path)
 
+    def test_build_group_is_normalised(self, tmp_path: Path) -> None:
+        path = write(tmp_path, '[tool.nab]\nbuild-group = "Build_Deps"\n')
+        assert read_pyproject_config(path).build_group == "build-deps"
+
+    def test_build_group_rejects_a_non_name(self, tmp_path: Path) -> None:
+        path = write(tmp_path, '[tool.nab]\nbuild-group = "-nope-"\n')
+        with pytest.raises(ConfigError, match="build-group '-nope-'"):
+            read_pyproject_config(path)
+
+    def test_build_group_rejects_a_declared_group_name(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[dependency-groups]\nbuild = ["pytest"]\n'
+            '[tool.nab]\nbuild-group = "build"\n',
+        )
+        with pytest.raises(ConfigError, match="build-group 'build' and"):
+            read_pyproject_config(path)
+
+    def test_build_group_rejects_the_base_group_name(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab]\nbase-group = "shared"\nbuild-group = "Shared"\n',
+        )
+        with pytest.raises(ConfigError, match="build-group and base-group"):
+            read_pyproject_config(path)
+
 
 class TestRequiresPython:
     """``requires-python`` declares the supported range; it is not a target.

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -913,19 +913,34 @@ class TestMainGroup:
             read_pyproject_config(path)
 
     def test_build_group_is_normalised(self, tmp_path: Path) -> None:
-        path = write(tmp_path, '[tool.nab]\nbuild-group = "Build_Deps"\n')
+        path = write(
+            tmp_path, '[tool.nab]\nbase-group = "main"\nbuild-group = "Build_Deps"\n'
+        )
         assert read_pyproject_config(path).build_group == "build-deps"
 
     def test_build_group_rejects_a_non_name(self, tmp_path: Path) -> None:
-        path = write(tmp_path, '[tool.nab]\nbuild-group = "-nope-"\n')
+        path = write(
+            tmp_path, '[tool.nab]\nbase-group = "main"\nbuild-group = "-nope-"\n'
+        )
         with pytest.raises(ConfigError, match="build-group '-nope-'"):
             read_pyproject_config(path)
+
+    def test_build_group_without_a_base_group_is_refused(self, tmp_path: Path) -> None:
+        """Unnamed, the project's own dependencies come with every group."""
+        path = write(tmp_path, '[tool.nab]\nbuild-group = "build"\n')
+        with pytest.raises(ConfigError, match="but base-group is unset"):
+            read_pyproject_config(path)
+
+    def test_a_base_group_alone_is_fine(self, tmp_path: Path) -> None:
+        """The dependency runs one way: naming the rest needs no build group."""
+        path = write(tmp_path, '[tool.nab]\nbase-group = "main"\n')
+        assert read_pyproject_config(path).base_group == "main"
 
     def test_build_group_rejects_a_declared_group_name(self, tmp_path: Path) -> None:
         path = write(
             tmp_path,
             '[dependency-groups]\nbuild = ["pytest"]\n'
-            '[tool.nab]\nbuild-group = "build"\n',
+            '[tool.nab]\nbase-group = "main"\nbuild-group = "build"\n',
         )
         with pytest.raises(ConfigError, match="build-group 'build' and"):
             read_pyproject_config(path)

--- a/nab-python/tests/test_config_sources.py
+++ b/nab-python/tests/test_config_sources.py
@@ -918,6 +918,7 @@ class TestReproducibilityNotice:
                 "project_build_requires_depth": None,
                 "project_decision_order": None,
                 "project_base_group": None,
+                "project_build_group": None,
                 "project_constraint": (),
                 "project_default_group": ("dev",),
             }
@@ -940,6 +941,7 @@ class TestParserFoldHelpers:
                 "resolution",
                 "decision-order",
                 "base-group",
+                "build-group",
                 "mode",
                 "constraints",
                 "default-groups",

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -2032,6 +2032,15 @@ class TestDependencyGroups:
         )
         assert lock_input.active_groups == ("docs", "default")
 
+    def test_active_groups_includes_the_build_group(self) -> None:
+        lock_input = LockInput(
+            targets=_one({"foo": _index_pin()}),
+            dependency_groups=("docs",),
+            base_group="default",
+            build_group="build",
+        )
+        assert lock_input.active_groups == ("docs", "default", "build")
+
     def test_group_names_normalized(self) -> None:
         text = write_lock(
             LockInput(

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -4319,6 +4319,19 @@ class TestLockDeclaresItsEnvironment:
 _BASE_GROUP = '[tool.nab]\nbase-group = "default"\n'
 
 
+def _pylock_markers(pylock: Pylock) -> dict[str, str | None]:
+    """Each emitted package's marker text, or ``None`` where it carries none."""
+    return {
+        str(pkg.name): str(pkg.marker) if pkg.marker else None
+        for pkg in pylock.packages
+    }
+
+
+def _pylock_selected(pylock: Pylock, **kwargs: list[str]) -> set[str]:
+    """The package names an install with ``kwargs`` selected would receive."""
+    return {str(pkg.name) for pkg, _ in pylock.select(**kwargs)}
+
+
 class TestExtraAndGroupMembershipMarkers:
     """A selected extra or group gates the packages only it reaches.
 
@@ -4392,21 +4405,10 @@ class TestExtraAndGroupMembershipMarkers:
         pylock.validate()
         return pylock
 
-    @staticmethod
-    def _markers(pylock: Pylock) -> dict[str, str | None]:
-        return {
-            str(pkg.name): str(pkg.marker) if pkg.marker else None
-            for pkg in pylock.packages
-        }
-
-    @staticmethod
-    def _selected(pylock: Pylock, **kwargs: list[str]) -> set[str]:
-        return {str(pkg.name) for pkg, _ in pylock.select(**kwargs)}
-
     def test_extra_only_package_carries_extras_membership(self, tmp_path: Path) -> None:
         pylock = self._lock(tmp_path, extras=("cli",), groups=("dev",))
 
-        assert self._markers(pylock) == {
+        assert _pylock_markers(pylock) == {
             "core": None,
             "mydev": '"dev" in dependency_groups',
             "mytool": '"cli" in extras',
@@ -4419,10 +4421,10 @@ class TestExtraAndGroupMembershipMarkers:
         """The spec's default install context: no extras, no groups."""
         pylock = self._lock(tmp_path, extras=("cli",), groups=("dev",))
 
-        assert self._selected(pylock) == {"core"}
-        assert self._selected(pylock, extras=["cli"]) == {"core", "mytool", "subtool"}
-        assert self._selected(pylock, dependency_groups=["dev"]) == {"core", "mydev"}
-        assert self._selected(pylock, extras=["cli"], dependency_groups=["dev"]) == {
+        assert _pylock_selected(pylock) == {"core"}
+        assert _pylock_selected(pylock, extras=["cli"]) == {"core", "mytool", "subtool"}
+        assert _pylock_selected(pylock, dependency_groups=["dev"]) == {"core", "mydev"}
+        assert _pylock_selected(pylock, extras=["cli"], dependency_groups=["dev"]) == {
             "core",
             "mydev",
             "mytool",
@@ -4443,15 +4445,15 @@ class TestExtraAndGroupMembershipMarkers:
             tmp_path, extras=("cli",), groups=("dev",), root=self._ROOT + _BASE_GROUP
         )
 
-        assert self._markers(pylock) == {
+        assert _pylock_markers(pylock) == {
             "core": '"default" in dependency_groups',
             "mydev": '"dev" in dependency_groups',
             "mytool": '"cli" in extras',
             "subtool": '"cli" in extras',
         }
 
-        assert self._selected(pylock, dependency_groups=["dev"]) == {"mydev"}
-        assert self._selected(pylock, dependency_groups=["default", "dev"]) == {
+        assert _pylock_selected(pylock, dependency_groups=["dev"]) == {"mydev"}
+        assert _pylock_selected(pylock, dependency_groups=["default", "dev"]) == {
             "core",
             "mydev",
         }
@@ -4467,10 +4469,10 @@ class TestExtraAndGroupMembershipMarkers:
         root = self._ROOT.replace('dev = ["mydev"]', 'dev = ["mydev", "core"]')
         pylock = self._lock(tmp_path, groups=("dev",), root=root + _BASE_GROUP)
 
-        assert self._markers(pylock)["core"] == (
+        assert _pylock_markers(pylock)["core"] == (
             '"default" in dependency_groups or "dev" in dependency_groups'
         )
-        assert self._selected(pylock, dependency_groups=["dev"]) == {"core", "mydev"}
+        assert _pylock_selected(pylock, dependency_groups=["dev"]) == {"core", "mydev"}
 
     def test_package_reached_by_base_and_extra_is_unconditional(
         self, tmp_path: Path
@@ -4479,7 +4481,7 @@ class TestExtraAndGroupMembershipMarkers:
         root = self._ROOT.replace('cli = ["mytool"]', 'cli = ["mytool", "core"]')
         pylock = self._lock(tmp_path, extras=("cli",), root=root)
 
-        assert self._selected(pylock) == {"core"}
+        assert _pylock_selected(pylock) == {"core"}
 
     def test_default_group_still_installs_by_default(self, tmp_path: Path) -> None:
         """A ``default-groups`` member gates on the group but installs by default.
@@ -4493,8 +4495,8 @@ class TestExtraAndGroupMembershipMarkers:
         pylock = self._lock(tmp_path, root=root)
 
         assert pylock.default_groups == ("dev",)
-        assert self._selected(pylock) == {"core", "mydev"}
-        assert self._selected(pylock, dependency_groups=[]) == {"core"}
+        assert _pylock_selected(pylock) == {"core", "mydev"}
+        assert _pylock_selected(pylock, dependency_groups=[]) == {"core"}
 
     def test_declared_default_groups_replace_rather_than_extend(
         self, tmp_path: Path
@@ -4547,7 +4549,7 @@ class TestExtraAndGroupMembershipMarkers:
         pylock = self._lock(tmp_path, groups=("de_fault",), root=root + _BASE_GROUP)
 
         assert pylock.dependency_groups == ("de-fault", "default")
-        assert self._selected(pylock, dependency_groups=["de-fault"]) == {"mydev"}
+        assert _pylock_selected(pylock, dependency_groups=["de-fault"]) == {"mydev"}
 
     def test_no_group_offered_names_nothing(self, tmp_path: Path) -> None:
         """With no group to select, nothing needs a name for the project's own."""
@@ -4558,7 +4560,7 @@ class TestExtraAndGroupMembershipMarkers:
         pylock = self._lock(tmp_path, root=root)
 
         assert pylock.default_groups is None
-        assert self._markers(pylock) == {"core": None}
+        assert _pylock_markers(pylock) == {"core": None}
 
     def test_naming_them_gates_them_with_nothing_selected(self, tmp_path: Path) -> None:
         """The name means one thing whether or not the run selects a group.
@@ -4569,9 +4571,9 @@ class TestExtraAndGroupMembershipMarkers:
         """
         pylock = self._lock(tmp_path, root=self._ROOT + _BASE_GROUP)
 
-        assert self._markers(pylock) == {"core": '"default" in dependency_groups'}
-        assert self._selected(pylock) == {"core"}
-        assert self._selected(pylock, dependency_groups=[]) == set()
+        assert _pylock_markers(pylock) == {"core": '"default" in dependency_groups'}
+        assert _pylock_selected(pylock) == {"core"}
+        assert _pylock_selected(pylock, dependency_groups=[]) == set()
 
     def test_dynamic_project_dependencies_still_refuse(self, tmp_path: Path) -> None:
         """Setting the option does not open a path around the refusal.
@@ -4589,7 +4591,7 @@ class TestExtraAndGroupMembershipMarkers:
         pylock = self._lock(tmp_path)
 
         assert [pkg.marker for pkg in pylock.packages] == [None]
-        assert self._selected(pylock) == {"core"}
+        assert _pylock_selected(pylock) == {"core"}
 
     def test_marker_excluded_extra_requirement_is_not_locked(
         self, tmp_path: Path
@@ -4601,7 +4603,7 @@ class TestExtraAndGroupMembershipMarkers:
         )
         pylock = self._lock(tmp_path, extras=("cli",), root=root)
 
-        assert set(self._markers(pylock)) == {"core", "mytool", "subtool"}
+        assert set(_pylock_markers(pylock)) == {"core", "mytool", "subtool"}
 
     def test_extra_requiring_an_extra_of_a_base_package(self, tmp_path: Path) -> None:
         """``cli = ["core[fancy]"]``: core stays unconditional, fancy's dep is gated."""
@@ -4619,7 +4621,7 @@ class TestExtraAndGroupMembershipMarkers:
             },
         )
 
-        assert self._markers(pylock) == {"core": None, "subtool": '"cli" in extras'}
+        assert _pylock_markers(pylock) == {"core": None, "subtool": '"cli" in extras'}
 
     def test_matrix_gates_the_extra_on_every_target(self, tmp_path: Path) -> None:
         """A matrix folds the extra into every target, and gates it there too.
@@ -4635,7 +4637,7 @@ class TestExtraAndGroupMembershipMarkers:
         )
         pylock = self._lock(tmp_path, extras=("cli",), root=root)
 
-        assert self._markers(pylock) == {
+        assert _pylock_markers(pylock) == {
             "core": None,
             "mytool": '"cli" in extras',
             "subtool": '"cli" in extras',
@@ -4689,7 +4691,7 @@ class TestConflictMemberMembershipMarkers:
     def test_shared_package_names_both_selections_that_reach_it(
         self, tmp_path: Path
     ) -> None:
-        markers = TestExtraAndGroupMembershipMarkers._markers(self._lock(tmp_path))
+        markers = _pylock_markers(self._lock(tmp_path))
 
         assert markers["shared-lib"] == '"cpu" in extras or "docs" in extras'
         assert markers["sphinx"] == '"docs" in extras'
@@ -4700,7 +4702,7 @@ class TestConflictMemberMembershipMarkers:
     ) -> None:
         """``shared-lib`` is a direct requirement of the ``cpu`` extra."""
         pylock = self._lock(tmp_path)
-        selected = TestExtraAndGroupMembershipMarkers._selected
+        selected = _pylock_selected
 
         assert selected(pylock, extras=["cpu"]) == {"core", "cpu-only", "shared-lib"}
         assert selected(pylock, extras=["gpu"]) == {"core", "gpu-only"}
@@ -5008,3 +5010,215 @@ class TestBuildRequirementsConfig:
 
         assert pruned.constraints == ("urllib3<2",)
         assert pruned.requires_python == ">=3.10"
+
+
+class TestBuildGroup:
+    """``[tool.nab].build-group`` carries the build requirements in the lock."""
+
+    _PYPROJECT = (
+        '[project]\nname = "proj"\ndependencies = ["runtime-only"]\n'
+        '[build-system]\nrequires = ["hatchling"]\n'
+    )
+
+    @staticmethod
+    def _mocked_resolve(pyproject: Path, **kwargs: object) -> ResolveResult:
+        """Resolve ``pyproject`` against a provider that pins everything at 2.0."""
+        with (
+            patch("nab_python.resolve.FetchCoordinator") as mock_coord_cls,
+            patch("nab_python.resolve.Provider") as mock_provider_cls,
+            patch("nab_python.resolve.build_target_lock"),
+        ):
+            mock_coord_cls.return_value.__enter__ = lambda s: s
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            mock_provider = mock_provider_cls.return_value
+            mock_provider.choose_version.return_value = V("2.0")
+            mock_provider.get_dependencies.return_value = {}
+            mock_provider.prioritize.return_value = 1
+            return _resolved(
+                pyproject, _FAKE_TRANSPORT, python_version="3.12.0", **kwargs
+            )
+
+    def test_build_requires_join_the_resolve(self, tmp_path: Path) -> None:
+        """Naming a group puts the build requirements in the lock."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(self._PYPROJECT + '[tool.nab]\nbuild-group = "build"\n')
+
+        result = self._mocked_resolve(pyproject)
+
+        assert _pins(result) == {"runtime-only": V("2.0"), "hatchling": V("2.0")}
+
+    def test_unset_leaves_them_out(self, tmp_path: Path) -> None:
+        """A lock says nothing about how the project is built by default."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(self._PYPROJECT)
+
+        result = self._mocked_resolve(pyproject)
+
+        assert _pins(result) == {"runtime-only": V("2.0")}
+
+    def test_no_build_system_is_an_error(self, tmp_path: Path) -> None:
+        """Naming a group for requirements the project does not declare."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "proj"\ndependencies = []\n'
+            "[tool.nab]\n"
+            'build-group = "build"\n'
+        )
+
+        with pytest.raises(
+            InvalidProjectRequirementError, match=r"declares no \[build-system\]"
+        ):
+            self._mocked_resolve(pyproject)
+
+    def test_a_build_requirements_lock_drops_the_group(self, tmp_path: Path) -> None:
+        """Its roots already are the build requirements, so nothing gates them.
+
+        The pins are the same either way, so what the group would change is
+        the lock offering a name that gates nothing.
+        """
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(self._PYPROJECT + '[tool.nab]\nbuild-group = "build"\n')
+        config = config_for_build_requirements(read_pyproject_config(pyproject))
+
+        result = self._mocked_resolve(pyproject, build_requirements=True)
+        lock_input = build_lock_input(result, config=config)
+
+        assert _pins(result) == {"hatchling": V("2.0")}
+        assert lock_input.build_group is None
+        assert lock_input.active_groups == ()
+
+    @patch("nab_python.resolve.resolve_with_coordinator")
+    def test_build_requires_join_every_conflict_fork(
+        self, mock_engine: MagicMock, tmp_path: Path
+    ) -> None:
+        """A project is built the same way whichever member is selected."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            self._PYPROJECT + "[dependency-groups]\n"
+            'cpu = ["torch-cpu"]\n'
+            'gpu = ["torch-gpu"]\n'
+            "[tool.nab]\n"
+            'build-group = "build"\n'
+            'conflicts = [[{ group = "cpu" }, { group = "gpu" }]]\n'
+        )
+
+        with patch("nab_python.resolve.FetchCoordinator") as mock_coord_cls:
+            mock_coord_cls.return_value.__enter__ = lambda coordinator: coordinator
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            _resolved(
+                pyproject,
+                _FAKE_TRANSPORT,
+                groups=("cpu", "gpu"),
+                python_version="3.12.0",
+            )
+
+        forks = mock_engine.call_args.kwargs["forks"]
+        assert len(forks) == 2
+        for fork in forks:
+            assert "hatchling" in {r.name for r in fork.requirements}
+            assert ("group", "build") in fork.contexts.selectors
+
+    @patch("nab_python.resolve.resolve_with_coordinator")
+    def test_the_matrix_still_expands(
+        self, mock_engine: MagicMock, tmp_path: Path
+    ) -> None:
+        """A static requires list needs no interpreter to read, so it goes wide."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            self._PYPROJECT + "[tool.nab]\n"
+            'build-group = "build"\n'
+            'mode = "universal"\n'
+            "[tool.nab.matrix]\n"
+            'python = ">=3.11,<3.13"\n'
+            'platforms = ["linux_x86_64"]\n'
+        )
+
+        with patch("nab_python.resolve.FetchCoordinator") as mock_coord_cls:
+            mock_coord_cls.return_value.__enter__ = lambda coordinator: coordinator
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            _resolved(pyproject, _FAKE_TRANSPORT)
+
+        targets = mock_engine.call_args.args[1]
+        assert [t.label for t in targets] == [
+            "py311-linux_x86_64",
+            "py312-linux_x86_64",
+        ]
+        (fork,) = mock_engine.call_args.kwargs["forks"]
+        assert [str(r) for r in fork.requirements] == ["runtime-only", "hatchling"]
+
+
+class TestBuildGroupMarkers:
+    """``build-group`` gates ``[build-system].requires`` end to end."""
+
+    _MEMBERS: ClassVar[dict[str, str]] = {
+        "core": '[project]\nname = "core"\nversion = "1.0"\n',
+        "mydev": '[project]\nname = "mydev"\nversion = "3.0"\n',
+        "builder": '[project]\nname = "builder"\nversion = "5.0"\n',
+    }
+
+    _ROOT = (
+        '[project]\nname = "app"\nversion = "1.0"\ndependencies = ["core"]\n'
+        '[dependency-groups]\ndev = ["mydev"]\n'
+        '[build-system]\nrequires = ["builder"]\n'
+        + "".join(
+            f'[[tool.nab.local-sources]]\nname = "{name}"\npath = "{name}"\n'
+            for name in ("core", "mydev", "builder")
+        )
+    )
+
+    def _lock(
+        self, tmp_path: Path, *, tool: str, groups: tuple[str, ...] = ()
+    ) -> Pylock:
+        """Resolve and emit the root project, with ``tool`` appended to it."""
+        return TestExtraAndGroupMembershipMarkers._lock(
+            tmp_path,
+            groups=groups,
+            root=self._ROOT + tool,
+            members=self._MEMBERS,
+        )
+
+    def test_build_requirement_carries_the_group_membership(
+        self, tmp_path: Path
+    ) -> None:
+        """Only the build group reaches it, so only its name gates it."""
+        pylock = self._lock(tmp_path, tool='[tool.nab]\nbuild-group = "build"\n')
+
+        assert _pylock_markers(pylock) == {
+            "core": None,
+            "builder": '"build" in dependency_groups',
+        }
+
+    def test_the_name_is_selectable_but_not_a_default(self, tmp_path: Path) -> None:
+        """An install that asks for no group is installing, not building."""
+        pylock = self._lock(tmp_path, tool='[tool.nab]\nbuild-group = "build"\n')
+
+        assert pylock.dependency_groups == ("build",)
+        assert pylock.default_groups is None
+
+        assert _pylock_selected(pylock) == {"core"}
+        assert _pylock_selected(pylock, dependency_groups=["build"]) == {
+            "core",
+            "builder",
+        }
+
+    def test_it_composes_with_a_named_base_group(self, tmp_path: Path) -> None:
+        """Both names are selectable, and neither drags in the other."""
+        pylock = self._lock(
+            tmp_path,
+            tool='[tool.nab]\nbase-group = "default"\nbuild-group = "build"\n',
+        )
+
+        assert pylock.dependency_groups == ("default", "build")
+        assert pylock.default_groups == ("default",)
+
+        assert _pylock_selected(pylock, dependency_groups=["build"]) == {"builder"}
+        assert _pylock_selected(pylock, dependency_groups=["default"]) == {"core"}
+
+    def test_a_selected_group_keeps_its_own_gate(self, tmp_path: Path) -> None:
+        """The build group is one selector among the run's own selection."""
+        pylock = self._lock(
+            tmp_path, tool='[tool.nab]\nbuild-group = "build"\n', groups=("dev",)
+        )
+
+        assert _pylock_markers(pylock)["mydev"] == '"dev" in dependency_groups'
+        assert _pylock_selected(pylock, dependency_groups=["dev"]) == {"core", "mydev"}

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -4510,7 +4510,7 @@ class TestExtraAndGroupMembershipMarkers:
         replaced = self._lock(tmp_path, root=root + 'base-group = "base"\n')
 
         assert replaced.default_groups == ("dev",)
-        assert self._selected(replaced) == {"mydev"}
+        assert _pylock_selected(replaced) == {"mydev"}
 
     def test_naming_the_base_group_in_default_groups_keeps_it(
         self, tmp_path: Path
@@ -4520,7 +4520,7 @@ class TestExtraAndGroupMembershipMarkers:
         pylock = self._lock(tmp_path, root=root + 'base-group = "base"\n')
 
         assert pylock.default_groups == ("dev", "base")
-        assert self._selected(pylock) == {"core", "mydev"}
+        assert _pylock_selected(pylock) == {"core", "mydev"}
 
     def test_selecting_the_base_group_by_name_refuses(self, tmp_path: Path) -> None:
         """It is project policy, not a per-run selection.
@@ -5012,6 +5012,11 @@ class TestBuildRequirementsConfig:
         assert pruned.requires_python == ">=3.10"
 
 
+_BOTH_GROUPS = '[tool.nab]\nbase-group = "main"\nbuild-group = "build"\n'
+"""Naming the build requirements needs a name for the rest, or they would
+install alongside every group."""
+
+
 class TestBuildGroup:
     """``[tool.nab].build-group`` carries the build requirements in the lock."""
 
@@ -5041,7 +5046,7 @@ class TestBuildGroup:
     def test_build_requires_join_the_resolve(self, tmp_path: Path) -> None:
         """Naming a group puts the build requirements in the lock."""
         pyproject = tmp_path / "pyproject.toml"
-        pyproject.write_text(self._PYPROJECT + '[tool.nab]\nbuild-group = "build"\n')
+        pyproject.write_text(self._PYPROJECT + _BOTH_GROUPS)
 
         result = self._mocked_resolve(pyproject)
 
@@ -5062,6 +5067,7 @@ class TestBuildGroup:
         pyproject.write_text(
             '[project]\nname = "proj"\ndependencies = []\n'
             "[tool.nab]\n"
+            'base-group = "main"\n'
             'build-group = "build"\n'
         )
 
@@ -5077,7 +5083,7 @@ class TestBuildGroup:
         the lock offering a name that gates nothing.
         """
         pyproject = tmp_path / "pyproject.toml"
-        pyproject.write_text(self._PYPROJECT + '[tool.nab]\nbuild-group = "build"\n')
+        pyproject.write_text(self._PYPROJECT + _BOTH_GROUPS)
         config = config_for_build_requirements(read_pyproject_config(pyproject))
 
         result = self._mocked_resolve(pyproject, build_requirements=True)
@@ -5098,6 +5104,7 @@ class TestBuildGroup:
             'cpu = ["torch-cpu"]\n'
             'gpu = ["torch-gpu"]\n'
             "[tool.nab]\n"
+            'base-group = "main"\n'
             'build-group = "build"\n'
             'conflicts = [[{ group = "cpu" }, { group = "gpu" }]]\n'
         )
@@ -5126,6 +5133,7 @@ class TestBuildGroup:
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text(
             self._PYPROJECT + "[tool.nab]\n"
+            'base-group = "main"\n'
             'build-group = "build"\n'
             'mode = "universal"\n'
             "[tool.nab.matrix]\n"
@@ -5177,48 +5185,42 @@ class TestBuildGroupMarkers:
             members=self._MEMBERS,
         )
 
-    def test_build_requirement_carries_the_group_membership(
-        self, tmp_path: Path
-    ) -> None:
-        """Only the build group reaches it, so only its name gates it."""
-        pylock = self._lock(tmp_path, tool='[tool.nab]\nbuild-group = "build"\n')
+    def test_each_side_gates_on_its_own_name(self, tmp_path: Path) -> None:
+        """Only the build group reaches the build requirement."""
+        pylock = self._lock(tmp_path, tool=_BOTH_GROUPS)
 
         assert _pylock_markers(pylock) == {
-            "core": None,
+            "core": '"main" in dependency_groups',
             "builder": '"build" in dependency_groups',
         }
 
-    def test_the_name_is_selectable_but_not_a_default(self, tmp_path: Path) -> None:
+    def test_the_build_name_is_selectable_but_not_a_default(
+        self, tmp_path: Path
+    ) -> None:
         """An install that asks for no group is installing, not building."""
-        pylock = self._lock(tmp_path, tool='[tool.nab]\nbuild-group = "build"\n')
+        pylock = self._lock(tmp_path, tool=_BOTH_GROUPS)
 
-        assert pylock.dependency_groups == ("build",)
-        assert pylock.default_groups is None
+        assert pylock.dependency_groups == ("main", "build")
+        assert pylock.default_groups == ("main",)
 
         assert _pylock_selected(pylock) == {"core"}
-        assert _pylock_selected(pylock, dependency_groups=["build"]) == {
+
+    def test_the_build_requirements_can_be_asked_for_alone(
+        self, tmp_path: Path
+    ) -> None:
+        """Naming the rest is what makes the build side selectable on its own."""
+        pylock = self._lock(tmp_path, tool=_BOTH_GROUPS)
+
+        assert _pylock_selected(pylock, dependency_groups=["build"]) == {"builder"}
+        assert _pylock_selected(pylock, dependency_groups=["main"]) == {"core"}
+        assert _pylock_selected(pylock, dependency_groups=["main", "build"]) == {
             "core",
             "builder",
         }
 
-    def test_it_composes_with_a_named_base_group(self, tmp_path: Path) -> None:
-        """Both names are selectable, and neither drags in the other."""
-        pylock = self._lock(
-            tmp_path,
-            tool='[tool.nab]\nbase-group = "default"\nbuild-group = "build"\n',
-        )
-
-        assert pylock.dependency_groups == ("default", "build")
-        assert pylock.default_groups == ("default",)
-
-        assert _pylock_selected(pylock, dependency_groups=["build"]) == {"builder"}
-        assert _pylock_selected(pylock, dependency_groups=["default"]) == {"core"}
-
     def test_a_selected_group_keeps_its_own_gate(self, tmp_path: Path) -> None:
         """The build group is one selector among the run's own selection."""
-        pylock = self._lock(
-            tmp_path, tool='[tool.nab]\nbuild-group = "build"\n', groups=("dev",)
-        )
+        pylock = self._lock(tmp_path, tool=_BOTH_GROUPS, groups=("dev",))
 
         assert _pylock_markers(pylock)["mydev"] == '"dev" in dependency_groups'
-        assert _pylock_selected(pylock, dependency_groups=["dev"]) == {"core", "mydev"}
+        assert _pylock_selected(pylock, dependency_groups=["dev"]) == {"mydev"}

--- a/src/nab/_config_cmd.py
+++ b/src/nab/_config_cmd.py
@@ -67,6 +67,7 @@ def config_command(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag
     project_constraint: Annotated[tuple[str, ...], tyro.conf.UseAppendAction] = (),
     project_default_group: Annotated[tuple[str, ...], tyro.conf.UseAppendAction] = (),
     project_base_group: str | None = None,
+    project_build_group: str | None = None,
     include_rejected: bool = False,
 ) -> None:
     """Inspect the effective layered configuration.
@@ -112,6 +113,7 @@ def config_command(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag
         cli_constraint=project_constraint,
         cli_default_group=project_default_group,
         cli_base_group=project_base_group,
+        cli_build_group=project_build_group,
     )
 
     rejected: list[RejectedLayer] = []

--- a/src/nab/_download.py
+++ b/src/nab/_download.py
@@ -64,6 +64,7 @@ def download(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config 
     project_constraint: Annotated[tuple[str, ...], tyro.conf.UseAppendAction] = (),
     project_default_group: Annotated[tuple[str, ...], tyro.conf.UseAppendAction] = (),
     project_base_group: str | None = None,
+    project_build_group: str | None = None,
 ) -> None:
     """Resolve and download every wheel, sdist, and direct-URL archive.
 
@@ -108,6 +109,7 @@ def download(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config 
         cli_constraint=project_constraint,
         cli_default_group=project_default_group,
         cli_base_group=project_base_group,
+        cli_build_group=project_build_group,
     )
     project_overrides = _cli.project_config_overrides(overrides)
     _cli._project_cli_overrides_or_exit(project_overrides)  # noqa: SLF001

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -135,6 +135,7 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
     project_constraint: Annotated[tuple[str, ...], tyro.conf.UseAppendAction] = (),
     project_default_group: Annotated[tuple[str, ...], tyro.conf.UseAppendAction] = (),
     project_base_group: str | None = None,
+    project_build_group: str | None = None,
     upgrade: bool = False,
     locked: bool = False,
 ) -> None:
@@ -203,6 +204,7 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
             all_extras=all_extras,
             default_group=project_default_group,
             base_group=project_base_group,
+            build_group=project_build_group,
         )
     overrides = _cli._cli_overrides(  # noqa: SLF001
         cli_resolution=project_resolution,
@@ -219,6 +221,7 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
         cli_constraint=project_constraint,
         cli_default_group=project_default_group,
         cli_base_group=project_base_group,
+        cli_build_group=project_build_group,
     )
     project_overrides = _cli.project_config_overrides(overrides)
     _cli._project_cli_overrides_or_exit(project_overrides)  # noqa: SLF001
@@ -379,11 +382,13 @@ def _refuse_group_selection_with_build_requirements(
     all_extras: bool,
     default_group: tuple[str, ...],
     base_group: str | None,
+    build_group: str | None,
 ) -> None:
     """Exit 1 when a run names a selection a build-requirements lock has none of.
 
-    Refusing is what keeps the flags honest.  ``--project-default-group``
-    and ``--project-base-group`` would otherwise be dropped by
+    Refusing is what keeps the flags honest.  ``--project-default-group``,
+    ``--project-base-group`` and ``--project-build-group`` would otherwise
+    be dropped by
     :func:`~nab_python.resolve.config_for_build_requirements` after the run had
     already printed a reproducibility notice and recorded them in the lock,
     claiming an override that changed nothing.
@@ -395,6 +400,7 @@ def _refuse_group_selection_with_build_requirements(
         all_extras,
         bool(default_group),
         base_group is not None,
+        build_group is not None,
     )
     if not any(named):
         return
@@ -477,6 +483,7 @@ def _fast_fail_locked(
             dependency_groups=groups,
             default_groups=config.default_groups,
             base_group=config.base_group,
+            build_group=config.build_group,
             roots=roots,
             constraints=config.constraints,
             resolve_target=resolve_target,

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -194,8 +194,6 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
     if locked and (format != "pylock" or _cli.is_stdout(output)):
         _cli.printer().error("--locked is only supported for pylock output to a file.")
         sys.exit(1)
-    if format == "pylock" and output is None:
-        output = _default_output_path(format, build_requirements=build_requirements)
     if build_requirements:
         _refuse_group_selection_with_build_requirements(
             groups=groups,
@@ -229,6 +227,7 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
         path,
         output=output,
         format=format,
+        build_requirements=build_requirements,
         upgrade=upgrade,
         cli_overrides=project_overrides,
     )
@@ -311,7 +310,7 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
     lock_input.provenance = provenance
 
     if locked:
-        _check_locked(lock_input, output=output)
+        _check_locked(lock_input, output=output, build_requirements=build_requirements)
         return
     _emit_or_exit(
         lambda: _emit(
@@ -411,6 +410,13 @@ def _refuse_group_selection_with_build_requirements(
     sys.exit(1)
 
 
+def _locked_target_path(output: Path | None, *, build_requirements: bool) -> Path:
+    """Return the file ``--locked`` reads and re-renders against."""
+    if output is not None:
+        return output
+    return _default_output_path("pylock", build_requirements=build_requirements)
+
+
 def _refresh_command(*, build_requirements: bool) -> str:
     """Return the command that would rewrite the lock ``--locked`` just read.
 
@@ -419,11 +425,6 @@ def _refresh_command(*, build_requirements: bool) -> str:
     the wrong file and leave the failure in place.
     """
     return "nab lock --build-requirements" if build_requirements else "nab lock"
-
-
-def _locked_target_path(output: Path | None) -> Path:
-    """Return the file ``--locked`` reads and re-renders against."""
-    return output if output is not None else _default_output_path("pylock")
 
 
 def _fast_fail_locked(
@@ -443,7 +444,7 @@ def _fast_fail_locked(
     checks.  On the first disqualification it prints the reason and exits
     non-zero; otherwise it returns and the full resolve runs.
     """
-    target = _locked_target_path(output)
+    target = _locked_target_path(output, build_requirements=build_requirements)
     refresh = _refresh_command(build_requirements=build_requirements)
 
     # A stat that failed is not an absent lock.
@@ -464,6 +465,7 @@ def _fast_fail_locked(
             default_groups=config.default_groups,
             base_group=config.base_group,
             build_requirements=build_requirements,
+            build_group=config.build_group,
         )
     except (
         InvalidProjectTableError,
@@ -537,6 +539,7 @@ def _active_root_requirements(
     default_groups: tuple[str, ...],
     base_group: str | None = None,
     build_requirements: bool = False,
+    build_group: str | None = None,
 ) -> list[RootRequirement]:
     """Collect this run's active direct requirements with their source clause.
 
@@ -546,7 +549,10 @@ def _active_root_requirements(
     undeclared name raises here too; its requirements are left to the resolve.
 
     A build-requirements run has one source and no selection, so
-    ``[build-system].requires`` stands alone.
+    ``[build-system].requires`` stands alone.  ``build_group`` names them
+    on a run that carries them alongside the project's own, and they are
+    appended as their own source rather than routed through the group
+    table, which does not hold the configured name.
     """
     if build_requirements:
         return [
@@ -584,10 +590,18 @@ def _active_root_requirements(
                 for req in requirements
             )
 
+    if build_group is not None:
+        roots.extend(
+            RootRequirement(requirement=req, source="[build-system].requires")
+            for req in read_pyproject_build_requires(path)
+        )
+
     return roots
 
 
-def _check_locked(lock_input: LockInput, *, output: Path | None) -> None:
+def _check_locked(
+    lock_input: LockInput, *, output: Path | None, build_requirements: bool
+) -> None:
     """Verify the committed pylock matches a fresh resolve, writing nothing.
 
     The resolve has already run; this renders the lock it would produce and
@@ -595,14 +609,15 @@ def _check_locked(lock_input: LockInput, *, output: Path | None) -> None:
     both, so only a real change to the locked packages fails.  The committed
     lock is never read back into the resolve.
     """
-    target = _locked_target_path(output)
+    target = _locked_target_path(output, build_requirements=build_requirements)
     new_text = _render_or_exit(lambda: render_lock(lock_input, lock_dir=target.parent))
     committed = _packages_only(target.read_text(encoding="utf-8"))
     if _packages_only(new_text) == committed:
         _cli.printer().done(f"Lockfile {target} is up to date.")
         return
+    refresh = _refresh_command(build_requirements=build_requirements)
     _cli.printer().error(
-        f"--locked: lockfile {target} is out of date; re-run `nab lock` to update it."
+        f"--locked: lockfile {target} is out of date; re-run `{refresh}` to update it."
     )
     sys.exit(1)
 
@@ -1091,6 +1106,7 @@ def _reused_lock_anchor(
     *,
     output: Path | None,
     format: str,  # noqa: A002 - shadows builtin by convention
+    build_requirements: bool = False,
     cli_overrides: Mapping[str, object] | None = None,
 ) -> tuple[datetime | None, datetime | None]:
     """Return ``(absolute_cutoff, prior_lock_anchor)`` for the re-lock anchor.
@@ -1110,8 +1126,8 @@ def _reused_lock_anchor(
         return absolute, None
     if _cli.is_stdout(output) or format != "pylock":
         return None, None
-    target = output if output is not None else _default_output_path(format)
-    return None, read_lockfile_anchor(target)
+    target = _default_output_path(format, build_requirements=build_requirements)
+    return None, read_lockfile_anchor(output if output is not None else target)
 
 
 def _determine_lock_anchor(
@@ -1119,6 +1135,7 @@ def _determine_lock_anchor(
     *,
     output: Path | None,
     format: str,  # noqa: A002 - shadows builtin by convention
+    build_requirements: bool = False,
     upgrade: bool,
     cli_overrides: Mapping[str, object] | None = None,
 ) -> datetime:
@@ -1136,6 +1153,7 @@ def _determine_lock_anchor(
         path,
         output=output,
         format=format,
+        build_requirements=build_requirements,
         cli_overrides=cli_overrides,
     )
     if upgrade:

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -322,6 +322,7 @@ def _cli_overrides(  # noqa: PLR0913 - one keyword per CLI flag it maps to a reg
     cli_constraint: tuple[str, ...] = (),
     cli_default_group: tuple[str, ...] = (),
     cli_base_group: str | None = None,
+    cli_build_group: str | None = None,
 ) -> dict[str, object]:
     """Build the registry-keyed CLI override dict from the named flags.
 
@@ -349,6 +350,7 @@ def _cli_overrides(  # noqa: PLR0913 - one keyword per CLI flag it maps to a reg
             "project_constraint": cli_constraint,
             "project_default_group": cli_default_group,
             "project_base_group": cli_base_group,
+            "project_build_group": cli_build_group,
         }
     )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -678,6 +678,41 @@ class TestLockCommandSpecific:
         assert "default-groups" not in written
         assert "dependency-groups" not in written
 
+    def test_build_group_reaches_the_lock(self, tmp_path: Path) -> None:
+        """The configured name is what the writer offers and gates on."""
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\nname = "proj"\ndependencies = ["foo"]\n'
+            '[build-system]\nrequires = ["foo"]\n'
+            '[tool.nab]\nbuild-group = "build"\n',
+        )
+        out = tmp_path / "pylock.toml"
+        with patch(
+            "nab.cli.resolve_for_targets",
+            return_value=_stub_resolve_result(pins={"foo": V("1.0")}),
+        ):
+            lock(pyproject, output=out)
+        written = tomli.loads(out.read_text())
+        assert written["dependency-groups"] == ["build"]
+        assert "default-groups" not in written
+
+    def test_build_group_naming_a_declared_group_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The name for the build requirements is already a group's own."""
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\nname = "proj"\ndependencies = ["foo"]\n'
+            '[build-system]\nrequires = ["foo"]\n'
+            '[dependency-groups]\nbuild = ["foo"]\n'
+            '[tool.nab]\nbuild-group = "build"\n',
+        )
+        with pytest.raises(SystemExit, match="1"):
+            lock(pyproject, output=tmp_path / "pylock.toml")
+        err = capsys.readouterr().err
+        assert "build-group 'build' and [dependency-groups] 'build'" in err
+        assert "Traceback" not in err
+
     def test_build_requirements_locks_the_build_requires(self, tmp_path: Path) -> None:
         """End to end: the emitted lock holds the build requirement alone."""
         pyproject = _make_pyproject(
@@ -712,6 +747,7 @@ class TestLockCommandSpecific:
             {"all_extras": True},
             {"project_default_group": ("dev",)},
             {"project_base_group": "default"},
+            {"project_build_group": "build"},
         ],
     )
     def test_build_requirements_refuses_a_selection(
@@ -1824,6 +1860,16 @@ class TestProjectFlagErrors:
         assert "error: --project-requires-python: requires-python must be a" in err
         assert "[tool.nab]" not in err
 
+    def test_download_build_group_bad_value_names_the_flag(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """``--project-build-group`` reaches the registry from this command too."""
+        pyproject = _make_pyproject(tmp_path)
+        with pytest.raises(SystemExit) as exc:
+            download(pyproject, output=tmp_path / "wheels", project_build_group="-no-")
+        assert exc.value.code == 1
+        assert "error: --project-build-group:" in capsys.readouterr().err
+
     def test_valid_override_threads_through(self, tmp_path: Path) -> None:
         pyproject = _make_pyproject(tmp_path)
         out = tmp_path / "pylock.toml"
@@ -2206,6 +2252,25 @@ class TestLockCommandUniversal:
             )
 
         assert "--project-base-group 'dev' and" in capsys.readouterr().err
+
+    def test_the_build_group_flag_names_the_flag(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The project file may not hold the value the run is refusing."""
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\ndependencies = ["foo"]\n'
+            '[build-system]\nrequires = ["foo"]\n'
+            '[dependency-groups]\ndev = ["foo"]\n',
+        )
+        with pytest.raises(SystemExit, match="1"):
+            lock(
+                pyproject,
+                output=tmp_path / "pylock.toml",
+                project_build_group="dev",
+            )
+
+        assert "--project-build-group 'dev' and" in capsys.readouterr().err
 
     def test_pylock_divergent_base_dep_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -684,7 +684,7 @@ class TestLockCommandSpecific:
             tmp_path,
             '[project]\nname = "proj"\ndependencies = ["foo"]\n'
             '[build-system]\nrequires = ["foo"]\n'
-            '[tool.nab]\nbuild-group = "build"\n',
+            '[tool.nab]\nbase-group = "main"\nbuild-group = "build"\n',
         )
         out = tmp_path / "pylock.toml"
         with patch(
@@ -693,8 +693,8 @@ class TestLockCommandSpecific:
         ):
             lock(pyproject, output=out)
         written = tomli.loads(out.read_text())
-        assert written["dependency-groups"] == ["build"]
-        assert "default-groups" not in written
+        assert written["dependency-groups"] == ["main", "build"]
+        assert written["default-groups"] == ["main"]
 
     def test_build_group_naming_a_declared_group_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -705,7 +705,7 @@ class TestLockCommandSpecific:
             '[project]\nname = "proj"\ndependencies = ["foo"]\n'
             '[build-system]\nrequires = ["foo"]\n'
             '[dependency-groups]\nbuild = ["foo"]\n'
-            '[tool.nab]\nbuild-group = "build"\n',
+            '[tool.nab]\nbase-group = "main"\nbuild-group = "build"\n',
         )
         with pytest.raises(SystemExit, match="1"):
             lock(pyproject, output=tmp_path / "pylock.toml")
@@ -2261,7 +2261,8 @@ class TestLockCommandUniversal:
             tmp_path,
             '[project]\ndependencies = ["foo"]\n'
             '[build-system]\nrequires = ["foo"]\n'
-            '[dependency-groups]\ndev = ["foo"]\n',
+            '[dependency-groups]\ndev = ["foo"]\n'
+            '[tool.nab]\nbase-group = "main"\n',
         )
         with pytest.raises(SystemExit, match="1"):
             lock(

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -219,6 +219,15 @@ class TestConfigGet:
         assert _run_config(["get", "http-backend", *base]) == "urllib3\n"
         assert _run_config(["get", "max-concurrency", *base]) == "8\n"
 
+    def test_get_build_group_reads_the_cli_override(self, hermetic_roots: Path) -> None:
+        """``--project-build-group`` reaches the registry from this command too."""
+        _project(hermetic_roots)
+        base = ["get", "build-group", "--path", str(hermetic_roots / "pyproject.toml")]
+        assert _run_config(base) == "<none>\n"
+        assert _run_config([*base, "--project-build-group", "Build_Reqs"]) == (
+            "build-reqs\n"
+        )
+
     def test_get_reads_new_user_env_vars(
         self, hermetic_roots: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_lock_locked.py
+++ b/tests/test_lock_locked.py
@@ -240,6 +240,33 @@ def test_a_lock_offering_a_build_group_is_up_to_date(
     assert "is up to date" in capsys.readouterr().err
 
 
+def test_a_tightened_build_requirement_fires_with_a_build_group(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The fast-fail tier sees the build side when build-group carries it."""
+    body = '[project]\nname = "proj"\ndependencies = ["bar"]\n[build-system]\n'
+    pyproject = _write_pyproject(
+        tmp_path,
+        body + 'requires = ["foo"]\n[tool.nab]\nbuild-group = "build"\n',
+    )
+    out = tmp_path / "pylock.toml"
+    _write_lock(pyproject, out, _result({"bar": "1.0", "foo": "1.5"}))
+    capsys.readouterr()
+    pyproject.write_text(
+        body + 'requires = ["foo>=2.0"]\n[tool.nab]\nbuild-group = "build"\n',
+        encoding="utf-8",
+    )
+
+    mock = _locked_mock()
+    with pytest.raises(SystemExit) as exc:
+        _run_locked(pyproject, out, mock)
+
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "[build-system].requires requires foo>=2.0 but the lock pins foo 1.5" in err
+    mock.assert_not_called()
+
+
 def test_a_renamed_build_group_is_out_of_date(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -482,6 +509,29 @@ def test_non_sticky_stale_falls_through_out_of_date(
 
     assert exc.value.code == 1
     assert "out of date" in capsys.readouterr().err
+    mock.assert_called_once()
+
+
+def test_a_stale_build_lock_names_the_build_command(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The post-resolve verdict must send the user to the file it just read."""
+    pyproject = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "proj"\ndependencies = []\n'
+        '[build-system]\nrequires = ["foo>=1.0"]\n',
+    )
+    out = tmp_path / "pylock.build.toml"
+    _write_lock(pyproject, out, _result({"foo": "1.0"}), "--build-requirements")
+    capsys.readouterr()
+
+    mock = _locked_mock(_result({"foo": "2.0"}))
+    with pytest.raises(SystemExit) as exc:
+        _run_locked(pyproject, out, mock, "--build-requirements")
+
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "is out of date; re-run `nab lock --build-requirements` to update it" in err
     mock.assert_called_once()
 
 

--- a/tests/test_lock_locked.py
+++ b/tests/test_lock_locked.py
@@ -228,12 +228,12 @@ def test_a_lock_offering_a_build_group_is_up_to_date(
         tmp_path,
         '[project]\nname = "proj"\ndependencies = ["foo"]\n'
         '[build-system]\nrequires = ["foo"]\n'
-        '[tool.nab]\nbuild-group = "build"\n',
+        '[tool.nab]\nbase-group = "main"\nbuild-group = "build"\n',
     )
     out = tmp_path / "pylock.toml"
     _write_lock(pyproject, out, _result({"foo": "1.0"}))
     capsys.readouterr()
-    assert tomli.loads(out.read_text())["dependency-groups"] == ["build"]
+    assert tomli.loads(out.read_text())["dependency-groups"] == ["main", "build"]
 
     _run_locked(pyproject, out, _locked_mock(_result({"foo": "1.0"})))
 
@@ -247,13 +247,16 @@ def test_a_tightened_build_requirement_fires_with_a_build_group(
     body = '[project]\nname = "proj"\ndependencies = ["bar"]\n[build-system]\n'
     pyproject = _write_pyproject(
         tmp_path,
-        body + 'requires = ["foo"]\n[tool.nab]\nbuild-group = "build"\n',
+        body
+        + 'requires = ["foo"]\n[tool.nab]\nbase-group = "main"\nbuild-group = "build"\n',
     )
     out = tmp_path / "pylock.toml"
     _write_lock(pyproject, out, _result({"bar": "1.0", "foo": "1.5"}))
     capsys.readouterr()
     pyproject.write_text(
-        body + 'requires = ["foo>=2.0"]\n[tool.nab]\nbuild-group = "build"\n',
+        body
+        + 'requires = ["foo>=2.0"]\n'
+        + '[tool.nab]\nbase-group = "main"\nbuild-group = "build"\n',
         encoding="utf-8",
     )
 
@@ -276,11 +279,15 @@ def test_a_renamed_build_group_is_out_of_date(
         '[build-system]\nrequires = ["foo"]\n'
         "[tool.nab]\n"
     )
-    pyproject = _write_pyproject(tmp_path, body + 'build-group = "build"\n')
+    pyproject = _write_pyproject(
+        tmp_path, body + 'base-group = "main"\nbuild-group = "build"\n'
+    )
     out = tmp_path / "pylock.toml"
     _write_lock(pyproject, out, _result({"foo": "1.0"}))
     capsys.readouterr()
-    pyproject.write_text(body + 'build-group = "builder"\n', encoding="utf-8")
+    pyproject.write_text(
+        body + 'base-group = "main"\nbuild-group = "builder"\n', encoding="utf-8"
+    )
 
     mock = _locked_mock()
     with pytest.raises(SystemExit) as exc:

--- a/tests/test_lock_locked.py
+++ b/tests/test_lock_locked.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import tomli
 
 from nab.cli import app
 from nab_python._vendor.packaging.version import Version
@@ -217,6 +218,52 @@ def test_locked_build_lock_checks_its_own_default_file(
         )
 
     assert "Lockfile pylock.build.toml is up to date." in capsys.readouterr().err
+
+
+def test_a_lock_offering_a_build_group_is_up_to_date(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """No run selects the build group, so its name must not read as drift."""
+    pyproject = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "proj"\ndependencies = ["foo"]\n'
+        '[build-system]\nrequires = ["foo"]\n'
+        '[tool.nab]\nbuild-group = "build"\n',
+    )
+    out = tmp_path / "pylock.toml"
+    _write_lock(pyproject, out, _result({"foo": "1.0"}))
+    capsys.readouterr()
+    assert tomli.loads(out.read_text())["dependency-groups"] == ["build"]
+
+    _run_locked(pyproject, out, _locked_mock(_result({"foo": "1.0"})))
+
+    assert "is up to date" in capsys.readouterr().err
+
+
+def test_a_renamed_build_group_is_out_of_date(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Renaming it renames a marker on every package it gates."""
+    body = (
+        '[project]\nname = "proj"\ndependencies = ["foo"]\n'
+        '[build-system]\nrequires = ["foo"]\n'
+        "[tool.nab]\n"
+    )
+    pyproject = _write_pyproject(tmp_path, body + 'build-group = "build"\n')
+    out = tmp_path / "pylock.toml"
+    _write_lock(pyproject, out, _result({"foo": "1.0"}))
+    capsys.readouterr()
+    pyproject.write_text(body + 'build-group = "builder"\n', encoding="utf-8")
+
+    mock = _locked_mock()
+    with pytest.raises(SystemExit) as exc:
+        _run_locked(pyproject, out, mock)
+
+    assert exc.value.code == 1
+    assert "does not name 'builder' for the build requirements" in (
+        capsys.readouterr().err
+    )
+    mock.assert_not_called()
 
 
 def test_tightened_constraint_fires_without_resolving(


### PR DESCRIPTION
`[tool.nab].build-group = "build"` names a dependency group for the project's `[build-system].requires`, so one lock describes both the environment the project runs in and the one it is built in. The name lands in the lock's `dependency-groups` array and not in `default-groups`: an install that asks for no group is installing the project, not building it.

sbidoul's case on #790 was `pylock.select(dependency_groups=["build"])` returning the build tools alone, which needed a hand-written group standing in for the real build requirements. Paired with `main-group` that now works from the project's own file. The build requirements co-resolve with the project's own, which is what a single lock can express, since an installer reading it installs into one environment; a project whose backend needs a version its dependencies exclude wants the separate `nab lock --build-requirements` lock instead.

Stacked on #814.
