### PR TITLE
Document the resolver's embedding contracts

### DIFF
--- a/docs/how-to/embed-the-resolver.md
+++ b/docs/how-to/embed-the-resolver.md
@@ -1,0 +1,211 @@
+# Embed the resolver in your own tool
+
+`nab-resolver` is the PubGrub core nab drives, published on its own and
+with no dependencies. It knows nothing about Python packaging: package
+identity, version ordering and dependency metadata all come from you,
+through a provider.
+
+This page builds a provider over an in-memory graph, resolves with it,
+and reads the failure report.
+
+Install it with `pip install nab-resolver`.
+
+## What you supply
+
+The resolver calls eleven methods on a provider. `BaseProvider` supplies
+six of them, which leaves five to write:
+
+`choose_version`
+: Pick a version of a package inside a range, or return `None` when none
+  fits.
+
+`has_satisfying_version`
+: Answer whether `choose_version` would pick a version in the range you
+  are handed. Asked only to attribute a failure, so leave no state
+  behind.
+
+`get_dependencies`
+: Report what a version depends on, as a range per dependency.
+
+`prioritize`
+: Return a sort key deciding which undecided package to take next. Lower
+  goes first.
+
+`widen_decision`
+: Return a range that may stand in for a decided version in the clauses
+  the resolver records, or `None` to record the version alone. Its
+  docstring carries the soundness contract, and `Range.full()` breaks it
+  as soon as two versions differ: it claims every version depends on
+  what this one does, turning a solvable graph into a failure report. A
+  widening provider overrides `narrow_for_display` too, or its reports
+  name widened ranges instead of versions it knows.
+
+`ResolverProvider` in `nab_resolver.resolver` documents all eleven, and
+its docstrings are the full contract. Subclassing is optional: the
+resolver accepts any object satisfying that protocol.
+
+## A provider over an in-memory graph
+
+Packages are strings and versions are integers here. A package can be
+any hashable value, a version any type its range type orders.
+
+```python
+from collections.abc import Mapping
+
+from nab_resolver.errors import ResolutionError
+from nab_resolver.ranges import Range
+from nab_resolver.resolver import BaseProvider, Resolver
+from nab_resolver.types import RangeProtocol
+
+Graph = Mapping[str, Mapping[int, Mapping[str, Range[int]]]]
+
+
+class NewestFirstProvider(BaseProvider[str, int]):
+    """Answer from an in-memory graph, preferring the newest version."""
+
+    def __init__(self, graph: Graph) -> None:
+        self._graph = graph
+
+    def _versions(self, package: str) -> list[int]:
+        """Every known version of ``package``, newest first."""
+        return sorted(self._graph.get(package, {}), reverse=True)
+
+    def choose_version(
+        self, package: str, version_range: RangeProtocol[int]
+    ) -> int | None:
+        return next((v for v in self._versions(package) if v in version_range), None)
+
+    def has_satisfying_version(
+        self, package: str, version_range: RangeProtocol[int]
+    ) -> bool:
+        return any(v in version_range for v in self._versions(package))
+
+    def get_dependencies(self, package: str, version: int) -> Mapping[str, Range[int]]:
+        return self._graph.get(package, {}).get(version, {})
+
+    def prioritize(
+        self,
+        package: str,
+        version_range: RangeProtocol[int],
+        conflict_counts: Mapping[str, int],
+        culprit_counts: Mapping[str, int] | None = None,
+    ) -> int:
+        return sum(1 for v in self._versions(package) if v in version_range)
+
+    def widen_decision(self, package: str, version: int) -> RangeProtocol[int] | None:
+        return None
+```
+
+Counting the versions still in range is PubGrub's usual `prioritize`
+heuristic: the most constrained package gets decided first.
+`conflict_counts` tracks a package's own discarded decisions and
+`culprit_counts` the ones it caused elsewhere, for a provider that wants
+to move either kind to the front.
+
+## Resolving
+
+`solve` takes one range per required package and returns the pins, the
+dependency edges it crossed, and the roots you named. Its second
+argument, `constraints`, narrows a package that something else pulls in
+without requiring the package itself.
+
+```python
+graph: Graph = {
+    "app": {1: {"http": Range.at_least(2), "json": Range.full()}},
+    "http": {
+        3: {"json": Range.at_least(2)},
+        2: {"json": Range.less_than(2)},
+    },
+    "json": {2: {}, 1: {}},
+}
+
+solution = Resolver(NewestFirstProvider(graph)).solve({"app": Range.singleton(1)})
+
+print("roots:", solution.roots)
+for package, version in sorted(solution.pins.items()):
+    print("pin:", package, version)
+for parent, child in solution.edges:
+    print("edge:", parent, "->", child)
+```
+
+```text
+roots: ('app',)
+pin: app 1
+pin: http 3
+pin: json 2
+edge: app -> http
+edge: app -> json
+edge: http -> json
+```
+
+`resolve` is the same call, returning `solution.pins` alone.
+
+`pins` holds only the packages reachable from the roots, so one decided
+on a branch the resolver later abandoned is filtered out. Building it
+walks the graph back through your provider, so cache `get_dependencies`
+by package and version.
+
+## Reading a failure
+
+The requirements below pin `http` to 2 and rule out the only `json` it
+can use. `ResolutionError` carries the finished report as its message.
+
+```python
+try:
+    Resolver(NewestFirstProvider(graph)).resolve(
+        {"http": Range.singleton(2), "json": Range.at_least(2)}
+    )
+except ResolutionError as error:
+    print(error)
+```
+
+```text
+because http 2 depends on json (-inf, 2)
+because your project depends on json [2, +inf)
+so http 2
+because your project depends on http 2
+so your project's requirements cannot be satisfied
+```
+
+A `so` line is the clause the lines above it prove, and what it names
+cannot hold: `so http 2` rules that version out rather than choosing it.
+
+That report has already been through the provider's `narrow_for_display`
+and the resolver's `format_range`, so re-rendering from
+`error.incompatibility` means supplying both again. Walk its
+`cause_left` and `cause_right` when you want the proof as a tree rather
+than as text.
+
+Two failures arrive without a report: passing the resolver's
+`max_iterations`, which attaches no `incompatibility`, and a
+conflict-resolution loop that stops making progress, which attaches one
+but reports a resolver bug. Neither means the requirements are
+unsatisfiable.
+
+## Bringing your own range type
+
+`Range` orders whatever it is handed, so integers suit a toy graph and
+`packaging.version.Version` suits a real Python one. A host with its own
+range algebra replaces `Range` outright: pass `Resolver` a `range_type`
+satisfying `RangeProtocol`, a `root_version` to decide the virtual root
+at, which `range_type.singleton()` has to accept, and a `format_range`
+unless
+that type's `str` already reads as a constraint. nab drives the resolver
+this way, with a PEP 440 range type.
+
+## The supported API
+
+These module paths will not move without a major version bump:
+
+```text
+nab_resolver.errors     ResolutionError
+nab_resolver.ranges     Range
+nab_resolver.resolver   BaseProvider, DEFAULT_MAX_ITERATIONS, Resolver,
+                        ResolverObserver, ResolverProvider, Solution
+nab_resolver.root       ROOT
+nab_resolver.types      Incompatibility, IncompatibilityCause,
+                        RangeProtocol, RootRequirement, Term
+```
+
+The package root binds no names, so importing `nab_resolver` pulls in no
+submodules. Anything else is internal and may move in any release.

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,8 @@ installer you trust.
 * New to nab: work through
   [getting started](tutorial/getting-started.md).
 * A task in mind: the how-to guides cover installing nab, local
-  checkouts, VCS sources, multiple indexes, and workspaces.
+  checkouts, VCS sources, multiple indexes, workspaces, and
+  [embedding the resolver](how-to/embed-the-resolver.md).
 * Looking something up: the reference covers the
   [`[tool.nab]` keys](reference/configuration.md), the
   [CLI](reference/cli.md), the
@@ -38,6 +39,7 @@ how-to/local-sources
 how-to/vcs
 how-to/multi-index
 how-to/workspaces
+how-to/embed-the-resolver
 ```
 
 ```{toctree}

--- a/nab-resolver/README.md
+++ b/nab-resolver/README.md
@@ -11,7 +11,8 @@ It has no runtime dependencies: the standard library is all it needs.
 ## When to use it
 
 Use `nab-resolver` when you are building some kind of package
-resolver, Python or otherwise.
+resolver, Python or otherwise.  There is a worked example in the docs:
+<https://nab.readthedocs.io/en/stable/how-to/embed-the-resolver.html>
 
 ## The public API
 

--- a/nab-resolver/src/nab_resolver/errors.py
+++ b/nab-resolver/src/nab_resolver/errors.py
@@ -1,7 +1,7 @@
 """Resolution error types.
 
-Defines the exception raised when the resolver proves that no valid
-solution exists, along with the derivation tree for error reporting.
+Defines the exception the resolver raises when it stops without a
+solution, along with the derivation tree for error reporting.
 """
 
 from __future__ import annotations
@@ -17,11 +17,20 @@ __all__ = [
 
 
 class ResolutionError(Exception):
-    """Resolution failed: no valid solution exists.
+    """Resolution stopped without a solution.
 
-    The ``incompatibility`` attribute holds the root incompatibility
-    whose derivation tree explains why resolution failed. Walk
-    ``cause_left`` and ``cause_right`` to trace the full proof.
+    As raised by this package, ``str(error)`` is the finished report: the
+    derivation rendered through the provider's ``narrow_for_display`` and the
+    resolver's ``format_range``, so re-rendering it means supplying both again.
+
+    The ``incompatibility`` attribute holds the root of that derivation, and is
+    None where the resolver stopped before proving one. Walk ``cause_left`` and
+    ``cause_right`` to trace the full proof.
+
+    Two paths raise without a report: exceeding ``max_iterations``, which
+    leaves ``incompatibility`` None, and a stalled conflict-resolution loop,
+    which attaches one but reports a resolver bug. Neither proves the
+    requirements unsatisfiable.
 
     Reference: https://github.com/dart-lang/pub/blob/master/doc/solver.md#error-reporting
     """

--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -111,7 +111,16 @@ class ResolverProvider(Protocol[PackageType, VersionType]):
     def get_dependencies(
         self, package: PackageType, version: VersionType
     ) -> Mapping[PackageType, RangeProtocol[VersionType]]:
-        """Return ``{dependency_package: required_range}`` for this version."""
+        """Return ``{dependency_package: required_range}`` for this version.
+
+        Asked only about a version ``choose_version`` returned, immediately
+        after that decision is recorded.  The virtual root sentinel is never
+        passed.
+
+        The same pair is asked more than once: a backjump that re-decides a
+        version asks again, and building the final :class:`Solution` asks once
+        per pin.  Cache by package and version.
+        """
         ...
 
     def begin_decision_scan(self) -> None:

--- a/nab-resolver/tests/test_resolver.py
+++ b/nab-resolver/tests/test_resolver.py
@@ -39,6 +39,7 @@ from nab_resolver.resolver import (
     ResolutionError,
     Resolver,
     ResolverObserver,
+    Solution,
 )
 from nab_resolver.root import ROOT
 from nab_resolver.types import (
@@ -576,6 +577,118 @@ class TestNoExtraPackages:
         result = Resolver(provider).resolve({"root": Range.singleton(1)})
         assert "pkg2" not in result
         assert result["pkg1"] == 1
+
+
+LogEntry = tuple[str, Any, Any]
+
+
+class CallLogProvider(DictProvider):
+    """DictProvider that appends the questions it is asked to a shared log."""
+
+    def __init__(
+        self,
+        packages: dict[str, dict[int, dict[str, Range]]],
+        log: list[LogEntry],
+    ) -> None:
+        super().__init__(packages)
+        self._log = log
+
+    def choose_version(
+        self, package: str, version_range: RangeProtocol[int]
+    ) -> int | None:
+        chosen = super().choose_version(package, version_range)
+        self._log.append(("choose_version", package, chosen))
+        return chosen
+
+    def get_dependencies(self, package: str, version: int) -> dict[str, Range]:
+        self._log.append(("get_dependencies", package, version))
+        return super().get_dependencies(package, version)
+
+
+class DecisionLogObserver(ResolverObserver[str, int]):
+    """Writes decisions into the provider's log so the two interleave."""
+
+    def __init__(self, log: list[LogEntry]) -> None:
+        self._log = log
+
+    def on_decision(self, package: str, version: int, level: int) -> None:
+        self._log.append(("decide", package, version))
+
+
+def record_resolve(
+    packages: dict[str, dict[int, dict[str, Range]]],
+    requirements: dict[str, Range],
+) -> tuple[list[LogEntry], Solution[str, int]]:
+    """Resolve, logging every version choice, decision and dependency question."""
+    log: list[LogEntry] = []
+    provider = CallLogProvider(packages, log)
+    solution = Resolver(provider, observer=DecisionLogObserver(log)).solve(requirements)
+    return log, solution
+
+
+class TestGetDependenciesCallingContract:
+    """``get_dependencies`` is asked right after each decision, then once per pin."""
+
+    def test_a_conflict_free_resolve_asks_once_per_decision_then_once_per_pin(
+        self,
+    ) -> None:
+        log, solution = record_resolve(
+            {
+                "root": {1: {"foo": Range.at_least(1)}},
+                "foo": {2: {"bar": Range.at_least(1)}, 1: {}},
+                "bar": {2: {}, 1: {}},
+            },
+            {"root": Range.singleton(1)},
+        )
+
+        assert log == [
+            ("choose_version", "root", 1),
+            ("decide", "root", 1),
+            ("get_dependencies", "root", 1),
+            ("choose_version", "foo", 2),
+            ("decide", "foo", 2),
+            ("get_dependencies", "foo", 2),
+            ("choose_version", "bar", 2),
+            ("decide", "bar", 2),
+            ("get_dependencies", "bar", 2),
+            ("get_dependencies", "root", 1),
+            ("get_dependencies", "foo", 2),
+            ("get_dependencies", "bar", 2),
+        ]
+        assert solution.pins == {"root": 1, "foo": 2, "bar": 2}
+
+    def test_a_backjump_asks_again_for_a_pair_already_answered(self) -> None:
+        """foo 2 is decided, undone, and foo 1 decided in its place.
+
+        ``bar`` offers no version, so it is never asked for dependencies.
+        """
+        log, solution = record_resolve(
+            {
+                "root": {1: {"foo": Range.full()}},
+                "foo": {2: {"bar": Range.at_least(5)}, 1: {}},
+                "bar": {1: {}},
+            },
+            {"root": Range.singleton(1)},
+        )
+
+        assert log == [
+            ("choose_version", "root", 1),
+            ("decide", "root", 1),
+            ("get_dependencies", "root", 1),
+            ("choose_version", "foo", 2),
+            ("decide", "foo", 2),
+            ("get_dependencies", "foo", 2),
+            ("choose_version", "bar", None),
+            ("choose_version", "root", 1),
+            ("decide", "root", 1),
+            ("get_dependencies", "root", 1),
+            ("choose_version", "foo", 1),
+            ("decide", "foo", 1),
+            ("get_dependencies", "foo", 1),
+            ("get_dependencies", "root", 1),
+            ("get_dependencies", "foo", 1),
+        ]
+        assert solution.pins == {"root": 1, "foo": 1}
 
 
 class TestPreference:

--- a/nab-resolver/tests/test_resolver.py
+++ b/nab-resolver/tests/test_resolver.py
@@ -2162,6 +2162,83 @@ class TestErrorMessages:
         assert negative == "not a [1, +inf)"
 
 
+class WideningProvider(DictProvider):
+    """Widens every decision to the full range, narrowing it back at display time.
+
+    The narrowing has to change the report, or a render that skipped the hook
+    would look the same.
+    """
+
+    def widen_decision(self, package: str, version: int) -> RangeProtocol[int] | None:
+        return Range.full()
+
+    def narrow_for_display(
+        self, package: str, constraint: RangeProtocol[int]
+    ) -> RangeProtocol[int]:
+        return Range.singleton(1) if package == "foo" else constraint
+
+
+def bracketed(constraint: object) -> str:
+    """Render a constraint unlike ``str`` does, to tell the two renders apart."""
+    return f"<{constraint}>"
+
+
+# foo and bar each depend on a half of baz the other rules out.
+CONFLICTING: dict[str, dict[int, dict[str, Range]]] = {
+    "root": {1: {"foo": Range.full(), "bar": Range.full()}},
+    "foo": {1: {"baz": Range.at_least(2)}},
+    "bar": {1: {"baz": Range.less_than(2)}},
+    "baz": {2: {}, 1: {}},
+}
+
+
+class TestResolutionErrorMessageContract:
+    """What ``str(error)`` is, and the two raise sites where it is something else."""
+
+    def test_message_is_the_report_the_display_hooks_produce(self) -> None:
+        provider = WideningProvider(CONFLICTING)
+        resolver = Resolver(provider, format_range=bracketed)
+
+        with pytest.raises(ResolutionError) as excinfo:
+            resolver.resolve({"root": Range.singleton(1)})
+
+        error = excinfo.value
+        assert error.incompatibility is not None
+        assert str(error) == format_error(
+            error.incompatibility,
+            narrow=provider.narrow_for_display,
+            format_range=bracketed,
+        )
+
+        # Neither hook is optional: leaving either out gives a different report.
+        assert str(error) != format_error(
+            error.incompatibility, narrow=provider.narrow_for_display
+        )
+        assert str(error) != format_error(error.incompatibility, format_range=bracketed)
+
+    def test_the_iteration_limit_carries_no_derivation(self) -> None:
+        resolver = Resolver(DictProvider(CONFLICTING), max_iterations=1)
+
+        with pytest.raises(ResolutionError) as excinfo:
+            resolver.resolve({"root": Range.singleton(1)})
+
+        assert excinfo.value.incompatibility is None
+        assert str(excinfo.value) == "Resolution exceeded 1 iterations"
+
+    @pytest.mark.timeout(STALL_TIMEOUT_SECONDS)
+    def test_a_stalled_conflict_loop_reports_the_bug_not_the_derivation(self) -> None:
+        solution, stalled = stalled_solution(padding=0)
+        resolver: Resolver[str, int] = Resolver(DictProvider({}))
+        resolver.solution = solution
+
+        with pytest.raises(ResolutionError) as excinfo:
+            conflict_resolution(resolver, stalled)
+
+        error = excinfo.value
+        assert error.incompatibility is not None
+        assert str(error) != format_error(error.incompatibility)
+
+
 class TestFormatRangeHook:
     """``format_range`` renders every constraint a report line shows.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ exclude = [
     "tests/test_build_dists.py",
     "tests/test_classifiers.py",
     "tests/test_contributing_docs.py",
+    "tests/test_embedding_docs.py",
     "tests/test_release.py",
     "tests/test_type_check_scope.py",
 ]

--- a/tests/test_embedding_docs.py
+++ b/tests/test_embedding_docs.py
@@ -1,0 +1,104 @@
+"""Run the embedding guide's example and hold it to the output it prints.
+
+The nab-resolver wheel ships no tests, so this page is the only worked provider
+an installed consumer can read.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+import textwrap
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import nab_resolver
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GUIDE = REPO_ROOT / "docs" / "how-to" / "embed-the-resolver.md"
+
+_FENCE = re.compile(
+    r"^```(?P<language>\w*)\n(?P<body>.*?)^```", re.DOTALL | re.MULTILINE
+)
+
+
+def _fences() -> list[tuple[str, str]]:
+    """Every fenced block on the page as ``(language, body)``, in page order."""
+    text = GUIDE.read_text(encoding="utf-8")
+    return [(match["language"], match["body"]) for match in _FENCE.finditer(text)]
+
+
+def _output_after(fences: list[tuple[str, str]], index: int) -> str | None:
+    """The output a Python block documents, or None when the page shows none.
+
+    A fence right after a Python block is that block's output unless it opens
+    the next one.  Any other language fails here rather than being skipped: a
+    fence this cannot read is a block that goes unchecked.
+    """
+    following = fences[index + 1 : index + 2]
+    if not following or following[0][0] == "python":
+        return None
+
+    language, body = following[0]
+    assert language == "text", (
+        f"{GUIDE.name} follows a python block with a ```{language} fence; want ```text"
+    )
+    return body
+
+
+def _example() -> list[tuple[str, str | None]]:
+    """Each Python block paired with the output it documents, in page order."""
+    fences = _fences()
+    return [
+        (body, _output_after(fences, index))
+        for index, (language, body) in enumerate(fences)
+        if language == "python"
+    ]
+
+
+def _promised_api_table() -> str:
+    """The API table lifted out of ``nab_resolver.__doc__``, left-aligned.
+
+    The rows and their wrapped continuations are the docstring's only indented
+    block, so the slice runs from the first indented line to the last.
+    """
+    lines = (nab_resolver.__doc__ or "").splitlines()
+    indented = [index for index, line in enumerate(lines) if line.startswith(" ")]
+    return textwrap.dedent("\n".join(lines[indented[0] : indented[-1] + 1]))
+
+
+def test_the_guide_prints_what_it_documents() -> None:
+    """Every block runs, and each documented output is the one it produced.
+
+    The blocks are one program split across the page, so they run in order
+    against a single namespace.
+    """
+    example = _example()
+    assert example, f"{GUIDE.name} carries no python block"
+    assert any(expected is not None for _, expected in example), (
+        f"{GUIDE.name} documents no output to compare against"
+    )
+
+    namespace: dict[str, object] = {"__name__": "embedding_guide"}
+    for position, (body, expected) in enumerate(example, start=1):
+        printed = io.StringIO()
+        with redirect_stdout(printed):
+            exec(compile(body, str(GUIDE), "exec"), namespace)  # noqa: S102
+        if expected is not None:
+            assert printed.getvalue() == expected, (
+                f"{GUIDE.name} python block {position} no longer prints this output"
+            )
+
+
+def test_the_guide_copies_the_promised_api_table() -> None:
+    """The page's supported-API table is the package docstring's, verbatim."""
+    tables = [
+        body
+        for language, body in _fences()
+        if language == "text" and body.startswith("nab_resolver.")
+    ]
+
+    assert len(tables) == 1, f"{GUIDE.name} carries {len(tables)} API tables, want 1"
+    assert tables[0].rstrip("\n") == _promised_api_table(), (
+        f"{GUIDE.name}'s API table is not the one nab_resolver.__doc__ promises"
+    )


### PR DESCRIPTION
core-pip vendored nab-resolver and hit two contracts nothing stated. It worked out by experiment that `get_dependencies` is only ever asked about a version `choose_version` returned, and encoded that as a runtime guard of its own. It also re-rendered a failure report out of `error.incompatibility` that `ResolutionError` was already carrying as its message. Both docstrings now say so, and the `ResolutionError` one names the two raise sites where the message is not a derivation.

A how-to page builds a provider over an in-memory graph, resolves with it, and reads the report a failing resolve raises. The suite runs every block on the page and holds each documented output to what the code printed. nab-resolver's README points at it.
