### PR TITLE
Let a conflict name a configured group

### DIFF
--- a/docs/explanation/conflicts.md
+++ b/docs/explanation/conflicts.md
@@ -13,7 +13,9 @@ Declaring the conflict tells nab to keep them apart.
 
 Conflicts live in `[tool.nab].conflicts`. Each entry is a set of
 members that are mutually exclusive with each other. A member is an
-extra or a dependency group:
+extra, a dependency group, or one of the groups `[tool.nab]` names
+itself: `base-group` for the project's own dependencies and
+`build-group` for its `[build-system].requires`.
 
 ```toml
 [tool.nab]
@@ -63,6 +65,64 @@ Declaring conflicts in the workspace root does not propagate to a
 `nab lock packages/<member>/pyproject.toml`; each member declares
 its own. See [Lock a workspace](../how-to/workspaces.md) for the full
 list of keys that flow vs stay local.
+
+## Conflicting the build requirements
+
+`[tool.nab].build-group` puts a project's `[build-system].requires` in
+the same lock as its dependencies, resolved in one version space. A
+backend that needs a version the project's own dependencies exclude
+therefore fails to resolve. Declaring the two mutually exclusive splits
+them:
+
+```toml
+[project]
+dependencies = ["packaging<24"]
+
+[build-system]
+requires = ["hatchling", "packaging>=24"]
+
+[tool.nab]
+base-group = "base"
+build-group = "build"
+conflicts = [[{ group = "base" }, { group = "build" }]]
+```
+
+Each side now resolves on its own and gets its own pins, disjoint on the
+group clause, which is what PEP 517 build isolation gives the build at
+install time. `base-group` must be set: it is what makes the project's
+own dependencies a named context that can be one side of a conflict.
+
+Conflicting `build-group` against an ordinary group instead, say
+`[[{ group = "build" }, { group = "dev" }]]`, separates the build
+requirements from that group but not from the project's dependencies,
+which stay in every fork.
+
+A configured name is active on every run rather than selected, so a set
+holding only configured names engages always: every `nab lock` for that
+project forks, and `at-most-one` and `exactly-one` say the same thing
+there. An `at-least-one` set that names either of them is refused, since
+a group that is always active means the set can never fail.
+
+A member belongs to at most one set, so putting the build requirements
+in a set with both the project's dependencies and `dev` is one
+three-member declaration, and it makes all three mutually exclusive:
+
+```toml
+conflicts = [[{ group = "base" }, { group = "build" }, { group = "dev" }]]
+```
+
+That forks three ways when the run selects `dev`, and two otherwise,
+since a set forks only over the members the selection activates. With
+`dev` selected, an install choosing it gets that group without the
+project's own dependencies. Declare two sets instead if
+`dev` should install alongside them, remembering that `build` can be in
+only one of them.
+
+> [!NOTE]
+> `base-group` is in the lock's `default-groups`, so an install that
+> selects no group gets the project's own dependencies, and one that
+> selects `build` gets the build side in their place. An installer that
+> cannot select a group from a lock gets the defaults.
 
 ## Forking co-selected members
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -48,7 +48,9 @@ base-group = "base"
 # pins.  The name must not be one [dependency-groups] declares, nor the
 # base-group name, and base-group must be set: unnamed, the project's
 # own dependencies carry no marker and come with every group, so nothing
-# could ask for the build requirements alone.
+# could ask for the build requirements alone.  Either name may be a
+# [tool.nab].conflicts member, which forks the resolve so each side gets
+# its own pins.
 build-group = "build"
 
 # The Python range this project supports.  A declaration: it is

--- a/docs/reference/lockfile.md
+++ b/docs/reference/lockfile.md
@@ -221,12 +221,16 @@ requirements output formats carry no markers, so there the build
 requirements render as ordinary pins.
 
 The build requirements resolve in the same version space as the
-project's own, which is what a single lock can express: an installer
-reading it installs into one environment. A project whose backend needs
-a version its own dependencies exclude has no lock that can say so, and
-the resolve fails. `nab lock --build-requirements` is the way out, since
-a separate lock is a separate version space, which is also what PEP 517
-build isolation gives the build at install time.
+project's own, since one install context is all a shared marker can
+describe. A project whose backend needs a version its own dependencies
+exclude declares the two mutually exclusive; the resolve then forks and
+each side gets its own pins under disjoint markers. See
+[Conflicting extras and groups](../explanation/conflicts.md).
+
+`nab lock --build-requirements` writes the build side to a file of its
+own instead. That is what a consumer needs when it cannot select groups
+at all, which covers the requirements output formats and today's pylock
+installers.
 
 ### Portable paths
 

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -101,6 +101,7 @@ __all__ = [
     "OverrideConflictError",
     "PackageOverride",
     "ResolveMode",
+    "configured_group_names",
     "conflict_exclusion_groups",
     "conflict_forks",
     "conflict_member_groups",
@@ -279,15 +280,20 @@ class ConflictFork:
     """One fork of a conflict-driven universal resolve.
 
     ``selection`` is the active conflicting members as ``(kind, name)``
-    pairs.  ``active_extras`` and ``active_groups`` are the full extra
-    and group selections this fork resolves with: the non-conflicting
-    selections plus this fork's chosen members.  An unforked resolve is
-    a single fork with an empty ``selection``.
+    pairs.  ``active_extras`` and ``active_groups`` are the selections
+    this fork resolves with, the non-conflicting ones plus its own chosen
+    members, and hold only names the project declares.  A name
+    ``[tool.nab]`` configures is on ``active_configured`` instead.  An
+    unforked resolve is a single fork with an empty ``selection``.
     """
 
     selection: tuple[tuple[str, str], ...]
     active_extras: tuple[str, ...]
     active_groups: tuple[str, ...]
+    active_configured: tuple[str, ...] = ()
+    """The configured group names (``base-group``, ``build-group``) this
+    fork carries.  Their requirements come from a pyproject table rather
+    than from ``[dependency-groups]``."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -369,6 +375,7 @@ def conflict_forks(
     selected_extras: Sequence[str],
     selected_groups: Sequence[str],
     conflicts: Sequence[ConflictSet],
+    configured_groups: Sequence[str] = (),
 ) -> list[ConflictFork]:
     """Split a selection into one fork per mutually-exclusive combination.
 
@@ -381,14 +388,24 @@ def conflict_forks(
     in every fork.  With no engaged set the result is a single unforked
     fork carrying the whole selection.
 
+    A declared group is active when the selection names it.  A
+    ``configured_groups`` name is active whenever it is set, since the
+    context it names is part of every resolve rather than something a run
+    asks for, so a set naming one engages on every run.  Those names come
+    back on :attr:`ConflictFork.active_configured` rather than
+    ``active_groups``, which stays what the ``[dependency-groups]`` loader
+    can resolve.
+
     Names compare and emit canonicalised; the extra and group loaders
     normalise on lookup, so a canonical active set resolves the same
     requirements the user's spelling would.
     """
     base_extras = [canonicalize_name(e) for e in selected_extras]
     base_groups = [canonicalize_name(g) for g in selected_groups]
+    configured = list(dict.fromkeys(canonicalize_name(g) for g in configured_groups))
+    configured_set = set(configured)
     extra_set = set(base_extras)
-    group_set = set(base_groups)
+    group_set = set(base_groups) | configured_set
 
     # Collect the engaged sets (2+ selected members) and the members to
     # drop from the shared base; each engaged set becomes a fork axis.
@@ -409,20 +426,31 @@ def conflict_forks(
             target.add(member.name)
 
     if not engaged:
-        return [ConflictFork((), tuple(base_extras), tuple(base_groups))]
+        return [
+            ConflictFork(
+                selection=(),
+                active_extras=tuple(base_extras),
+                active_groups=tuple(base_groups),
+                active_configured=tuple(configured),
+            )
+        ]
 
     # One fork per choice of a single member from each engaged set.
     rest_extras = [e for e in base_extras if e not in drop_extras]
     rest_groups = [g for g in base_groups if g not in drop_groups]
+    rest_configured = [g for g in configured if g not in drop_groups]
     forks: list[ConflictFork] = []
     for combo in itertools.product(*engaged):
         chosen_extras = [m.name for m in combo if m.kind is ConflictKind.EXTRA]
-        chosen_groups = [m.name for m in combo if m.kind is ConflictKind.GROUP]
+        chosen = [m.name for m in combo if m.kind is ConflictKind.GROUP]
+        chosen_groups = [g for g in chosen if g not in configured_set]
+        chosen_configured = [g for g in chosen if g in configured_set]
         forks.append(
             ConflictFork(
                 selection=tuple(sorted((m.kind.value, m.name) for m in combo)),
                 active_extras=tuple(rest_extras + chosen_extras),
                 active_groups=tuple(rest_groups + chosen_groups),
+                active_configured=tuple(rest_configured + chosen_configured),
             )
         )
     return forks
@@ -482,6 +510,19 @@ class NabProjectConfig:
     # ``local_sources``, which also carries explicit
     # ``[[tool.nab.local-sources]]`` entries.
     workspace_member_names: frozenset[str] = field(default_factory=frozenset)
+
+
+def configured_group_names(config: NabProjectConfig) -> tuple[str, ...]:
+    """Return the group names active by configuration rather than by selection.
+
+    ``base-group`` names the project's own dependencies and ``build-group``
+    its build requirements; neither is ever in a run's selection, so every
+    caller that has to treat them as active asks here rather than naming
+    the two fields itself.
+    """
+    return tuple(
+        name for name in (config.base_group, config.build_group) if name is not None
+    )
 
 
 class ConflictSelectionError(ConfigError):
@@ -769,7 +810,12 @@ def _config_from_effective(
 
     default_groups = effective["default-groups"].value
     conflicts = effective["conflicts"].value
-    _validate_default_groups_against_conflicts(default_groups, conflicts)
+    _validate_default_groups_against_conflicts(
+        default_groups, conflicts, effective["base-group"].value
+    )
+    _validate_configured_conflict_sets(
+        conflicts, effective["base-group"].value, effective["build-group"].value
+    )
 
     local_sources = effective["local-sources"].value
     vcs_sources = effective["vcs-sources"].value
@@ -2979,28 +3025,112 @@ def _check_conflict_member_uniqueness(sets: Sequence[ConflictSet]) -> None:
 def _validate_default_groups_against_conflicts(
     default_groups: Sequence[str],
     conflicts: Sequence[ConflictSet],
+    base_group: str | None = None,
 ) -> None:
-    """Reject default-groups that co-activate an exclusive conflict set.
+    """Reject a default install that co-activates an exclusive conflict set.
 
     A default install activates every default group with no user
     selection, but the emit-time disjointness validator prunes any
     context that activates two members of an exclusive set, so it never
-    enumerates that install.  Two default groups in the same at-most-one
-    or exactly-one set would silently violate the declared conflict;
-    catch it at parse time.
+    enumerates that install.  Two members co-active by default would
+    silently violate the declared conflict; catch it at parse time.
+
+    ``base_group`` counts as a default: PEP 751 seeds ``dependency_groups``
+    from ``default-groups``, and the lock puts that name there so an
+    install asking for nothing still gets the project's own dependencies.
     """
+    configured = None if base_group is None else canonicalize_name(base_group)
     active = {canonicalize_name(g) for g in default_groups}
+    if configured is not None:
+        active.add(configured)
+
     for group in conflict_exclusion_groups(conflicts):
         co_active = sorted(
             name
             for kind, name in group
             if kind == ConflictKind.GROUP.value and name in active
         )
-        if len(co_active) >= _MIN_ENGAGED_MEMBERS:
+        if len(co_active) < _MIN_ENGAGED_MEMBERS:
+            continue
+
+        if configured in co_active:
+            others = ", ".join(repr(name) for name in co_active if name != configured)
+            msg = (
+                f"default-groups activates {others}, and base-group"
+                f" {base_group!r} names the project's own dependencies, which"
+                " every default install activates too; they are declared"
+                " mutually exclusive in [tool.nab].conflicts, so an installer"
+                " given no selection would install neither"
+            )
+        else:
             joined = ", ".join(repr(name) for name in co_active)
             msg = (
                 f"default-groups activates {joined}, which are declared"
                 " mutually exclusive in [tool.nab].conflicts"
+            )
+        raise ConfigError(msg)
+
+
+def _validate_configured_conflict_sets(
+    conflicts: Sequence[ConflictSet],
+    base_group: str | None,
+    build_group: str | None,
+) -> None:
+    """Reject the conflict sets a configured group name cannot mean.
+
+    A configured member is active on every run, so an at-least-one set
+    holding one can never fail and decides nothing.  A declaration that
+    decides nothing reads as one that took effect, so it is refused
+    rather than left to sit.
+
+    An exclusive set pairing ``base-group`` with an extra is worse than
+    inert.  A PEP 621 extra installs on top of the project's own
+    dependencies, and the extras axis never deselects a default group, so
+    the fork that chooses the extra describes an install context no
+    installer can produce.  ``build-group`` pairs with an extra fine: the
+    project's dependencies stay in every fork of that set.
+    """
+    names = {
+        canonicalize_name(name)
+        for name in (base_group, build_group)
+        if name is not None
+    }
+    for conflict_set in conflicts:
+        members = conflict_set.members
+        if conflict_set.policy is ConflictPolicy.AT_LEAST_ONE:
+            inert = sorted(
+                member.name
+                for member in members
+                if member.kind is ConflictKind.GROUP and member.name in names
+            )
+            if inert:
+                joined = ", ".join(repr(name) for name in inert)
+                msg = (
+                    f"[tool.nab].conflicts declares {joined} in an at-least-one"
+                    " set, but a group named by base-group or build-group is"
+                    " active on every run, so the set can never fail and"
+                    " decides nothing"
+                )
+                raise ConfigError(msg)
+            continue
+
+        if base_group is None:
+            continue
+        canonical_base = canonicalize_name(base_group)
+        holds_main = any(
+            member.kind is ConflictKind.GROUP and member.name == canonical_base
+            for member in members
+        )
+        extras = sorted(
+            member.name for member in members if member.kind is ConflictKind.EXTRA
+        )
+        if holds_main and extras:
+            joined = ", ".join(repr(name) for name in extras)
+            msg = (
+                f"[tool.nab].conflicts declares base-group {base_group!r}"
+                f" mutually exclusive with the extra {joined}, but an extra"
+                " installs on top of the project's own dependencies and never"
+                " deselects them, so nothing could install that extra"
             )
             raise ConfigError(msg)
 

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -52,6 +52,7 @@ from .config import (
     ConflictSelectionError,
     ConflictSet,
     NabProjectConfig,
+    configured_group_names,
     conflict_forks,
     index_cache_floors_from_config,
     index_routes_from_config,
@@ -176,10 +177,13 @@ class InstallContexts:
     it shares with another active selection names both members and
     installs for either.
 
+    ``project`` is the project's own dependencies *as this fork resolved
+    them*, empty in a fork a declared conflict excluded them from.
+
     ``name_project`` is set when ``[tool.nab].base-group`` names the
-    project's own dependencies.  They are then walked even with nothing
-    selected, since the name has to mean the same thing in every lock it
-    appears in.
+    project's own dependencies.  It is a lock-wide fact rather than a
+    per-fork one: the name has to mean the same thing in every lock it
+    appears in, so the roots are walked even with nothing selected.
     """
 
     project: tuple[Requirement, ...] = ()
@@ -190,13 +194,26 @@ class InstallContexts:
 
 
 @dataclass(frozen=True, slots=True)
+class _ConfiguredContext:
+    """An install context ``[tool.nab]`` configures rather than a run selects.
+
+    ``name`` is ``None`` for the project's own dependencies when no
+    ``base-group`` names them.  Unnamed they cannot be a conflict member,
+    so every fork carries them.
+    """
+
+    name: str | None
+    requirements: tuple[Requirement, ...]
+
+
+@dataclass(frozen=True, slots=True)
 class ResolveFork:
     """A conflict fork's resolver input: a selection and its requirements.
 
     ``selection`` is the conflicting members active in this fork, empty
     for an unforked resolve; ``requirements`` are the requirements folded
-    for it (the project's dependencies plus the groups and extras the
-    selection activates).  Each fork runs against every target, with its
+    for it: the configured contexts this fork carries plus the groups and
+    extras the selection activates.  Each fork runs against every target, with its
     ``selection`` stamped onto each so the pins land under a distinct
     label and a membership-gated marker.
 
@@ -925,6 +942,40 @@ class _ProjectTables:
     in ``dependencies`` instead and leaves this empty."""
 
 
+def _configured_contexts(
+    config: NabProjectConfig, tables: _ProjectTables
+) -> tuple[_ConfiguredContext, tuple[_ConfiguredContext, ...]]:
+    """Split the configured install contexts into the project's and the rest.
+
+    The project's own dependencies are always a context, named or not.  The
+    build requirements are one only when ``build-group`` names them, which
+    is also the only time they were read.
+    """
+    project = _ConfiguredContext(config.base_group, tuple(tables.dependencies))
+    selectors = (
+        (_ConfiguredContext(config.build_group, tuple(tables.build_requires)),)
+        if config.build_group is not None
+        else ()
+    )
+    return project, selectors
+
+
+def _carried_by(
+    fork: ConflictFork,
+    project: _ConfiguredContext,
+    selectors: Sequence[_ConfiguredContext],
+) -> tuple[tuple[Requirement, ...], tuple[_ConfiguredContext, ...]]:
+    """Return the configured contexts ``fork`` resolves, project first.
+
+    An unnamed context cannot be a conflict member, so every fork carries
+    it; a named one is carried only by the fork that chose it.
+    """
+    carried = tuple(c for c in selectors if c.name in fork.active_configured)
+    if project.name is None or project.name in fork.active_configured:
+        return project.requirements, carried
+    return (), carried
+
+
 def _tables_for_build_requires(path: Path) -> _ProjectTables:
     """Read ``path`` as a project whose dependencies are its build requirements.
 
@@ -1214,19 +1265,21 @@ def _plan_forks(
     The second element is the no-member requirement list, needed only
     when the plan actually forked; see :func:`resolve_with_coordinator`.
     """
+    configured = configured_group_names(config)
+    project_context, selector_contexts = _configured_contexts(config, tables)
     if config.conflicts:
         _validate_conflict_members_exist(
-            config.conflicts, tables.optional, tables.groups
+            config.conflicts, tables.optional, tables.groups, configured
         )
         _check_conflict_minimums(
             config.conflicts,
             tables,
             extras,
-            expand_group_includes(tables.groups, groups),
+            [*expand_group_includes(tables.groups, groups), *configured],
             targets,
         )
 
-    plan = conflict_forks(extras, groups, config.conflicts)
+    plan = conflict_forks(extras, groups, config.conflicts, configured)
     forks: list[ResolveFork] = []
     # Forks of an extra-based conflict share a group selection, so the
     # (group, group) -> target scan runs once per distinct one.
@@ -1237,7 +1290,7 @@ def _plan_forks(
                 config.conflicts,
                 tables,
                 fork.active_extras,
-                fork.active_groups,
+                (*fork.active_groups, *fork.active_configured),
                 targets,
             )
 
@@ -1251,14 +1304,19 @@ def _plan_forks(
                 targets,
             )
 
+        project, carried = _carried_by(fork, project_context, selector_contexts)
         forks.append(
             ResolveFork(
                 selection=fork.selection,
-                requirements=tuple(_fork_requirements(path, tables, fork)),
+                requirements=tuple(
+                    _fork_requirements(
+                        path, tables, fork, project=project, selectors=carried
+                    )
+                ),
                 contexts=InstallContexts(
-                    project=tuple(tables.dependencies),
+                    project=project,
                     selectors=_selector_requirements(
-                        path, tables, fork, build_group=config.build_group
+                        path, tables, fork, contexts=carried
                     ),
                     name_project=config.base_group is not None,
                 ),
@@ -1270,7 +1328,13 @@ def _plan_forks(
     # requirements are resolved too.
     base_requirements = None
     if len(plan) > 1:
-        base_requirements = _fork_requirements(path, tables, _base_fork(plan[0]))
+        base_fork = _base_fork(plan[0])
+        base_project, base_carried = _carried_by(
+            base_fork, project_context, selector_contexts
+        )
+        base_requirements = _fork_requirements(
+            path, tables, base_fork, project=base_project, selectors=base_carried
+        )
     return forks, base_requirements
 
 
@@ -1279,7 +1343,7 @@ def _selector_requirements(
     tables: _ProjectTables,
     fork: ConflictFork,
     *,
-    build_group: str | None,
+    contexts: Sequence[_ConfiguredContext],
 ) -> dict[tuple[str, str], tuple[Requirement, ...]]:
     """Split a fork's active extras and groups into one requirement list each.
 
@@ -1294,11 +1358,14 @@ def _selector_requirements(
     seeds ``dependency_groups`` from ``default-groups`` when the
     installer selects none, so the gate still holds for a default
     install.
+
+    A configured context is a selector no run selects, and only a fork
+    that carries it gets one: a fork that did not resolve the build
+    requirements must not claim an install context it never walked.
     """
     selectors: dict[tuple[str, str], tuple[Requirement, ...]] = {}
-    if build_group is not None:
-        member = (ConflictKind.GROUP.value, build_group)
-        selectors[member] = tuple(tables.build_requires)
+    for context in contexts:
+        selectors[(ConflictKind.GROUP.value, context.name)] = context.requirements
     for extra in fork.active_extras:
         member = (ConflictKind.EXTRA.value, str(canonicalize_name(extra)))
         selectors[member] = tuple(_extra_requirements(tables, [extra], path))
@@ -1309,16 +1376,24 @@ def _selector_requirements(
 
 
 def _fork_requirements(
-    path: Path, tables: _ProjectTables, fork: ConflictFork
+    path: Path,
+    tables: _ProjectTables,
+    fork: ConflictFork,
+    *,
+    project: Sequence[Requirement],
+    selectors: Sequence[_ConfiguredContext],
 ) -> list[Requirement]:
-    """Fold one fork's active groups and extras onto the project deps.
+    """Fold one fork's contexts, groups and extras into one requirement list.
 
     Each fork resolves a different slice of the selection (one member per
     engaged conflict set), so its requirement list is built separately
-    rather than shared.
+    rather than shared.  ``project`` and ``selectors`` are the configured
+    contexts this fork carries, empty where a declared conflict put one in
+    another fork.
     """
-    requirements = list(tables.dependencies)
-    requirements.extend(tables.build_requires)
+    requirements = list(project)
+    for context in selectors:
+        requirements.extend(context.requirements)
     requirements.extend(_group_requirements(tables.groups, fork.active_groups, path))
     requirements.extend(_extra_requirements(tables, fork.active_extras, path))
     return requirements
@@ -1343,8 +1418,16 @@ def _base_fork(reference: ConflictFork) -> ConflictFork:
         for g in reference.active_groups
         if (ConflictKind.GROUP.value, g) not in chosen
     )
+    rest_configured = tuple(
+        g
+        for g in reference.active_configured
+        if (ConflictKind.GROUP.value, g) not in chosen
+    )
     return ConflictFork(
-        selection=(), active_extras=rest_extras, active_groups=rest_groups
+        selection=(),
+        active_extras=rest_extras,
+        active_groups=rest_groups,
+        active_configured=rest_configured,
     )
 
 
@@ -1403,6 +1486,7 @@ def _validate_conflict_members_exist(
     conflicts: Sequence[ConflictSet],
     optional: Mapping[str, Sequence[str]],
     groups: Mapping[str, Sequence[str | Mapping[str, str]]],
+    configured_groups: Sequence[str] = (),
 ) -> None:
     """Raise when a declared conflict names an extra/group the project lacks.
 
@@ -1411,7 +1495,9 @@ def _validate_conflict_members_exist(
     canonicalisation, matching the loaders.
     """
     known_extras = {canonicalize_name(name) for name in optional}
-    known_groups = {canonicalize_name(name) for name in groups}
+    known_groups = {canonicalize_name(name) for name in groups} | {
+        canonicalize_name(name) for name in configured_groups
+    }
     unknown: list[str] = []
     for conflict_set in conflicts:
         for member in conflict_set.members:
@@ -1422,7 +1508,8 @@ def _validate_conflict_members_exist(
         joined = ", ".join(unknown)
         msg = (
             f"[tool.nab].conflicts names {joined}, which the project does not"
-            " declare in [project.optional-dependencies] or [dependency-groups]"
+            " declare in [project.optional-dependencies] or [dependency-groups],"
+            " and which is not [tool.nab].base-group or [tool.nab].build-group"
         )
         raise ConfigError(msg)
 

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -945,6 +945,106 @@ class TestMainGroup:
         with pytest.raises(ConfigError, match="build-group 'build' and"):
             read_pyproject_config(path)
 
+    def test_a_base_group_conflicting_with_a_default_group_is_refused(
+        self, tmp_path: Path
+    ) -> None:
+        """An install given no selection would otherwise get neither side."""
+        path = write(
+            tmp_path,
+            "[dependency-groups]\ndev = []\n"
+            "[tool.nab]\n"
+            'base-group = "main"\n'
+            'default-groups = ["dev"]\n'
+            'conflicts = [[{ group = "main" }, { group = "dev" }]]\n',
+        )
+        with pytest.raises(ConfigError, match="would install neither"):
+            read_pyproject_config(path)
+
+    def test_two_default_groups_still_report_themselves(self, tmp_path: Path) -> None:
+        """base-group being set does not make every clash its fault."""
+        path = write(
+            tmp_path,
+            "[dependency-groups]\na = []\nb = []\n"
+            "[tool.nab]\n"
+            'base-group = "main"\n'
+            'default-groups = ["a", "b"]\n'
+            'conflicts = [[{ group = "a" }, { group = "b" }]]\n',
+        )
+        with pytest.raises(ConfigError, match="which are declared") as info:
+            read_pyproject_config(path)
+        assert "base-group" not in str(info.value)
+
+    def test_an_exclusive_set_of_configured_names_is_allowed(
+        self, tmp_path: Path
+    ) -> None:
+        """Only at-least-one is refused; the exclusive policies are the point."""
+        for policy in ("at-most-one", "exactly-one"):
+            path = write(
+                tmp_path,
+                "[build-system]\nrequires = []\n"
+                "[tool.nab]\n"
+                'base-group = "main"\n'
+                'build-group = "build"\n'
+                "conflicts = [{ members = ["
+                '{ group = "main" }, { group = "build" }],'
+                f' policy = "{policy}" }}]\n',
+            )
+            assert read_pyproject_config(path).build_group == "build"
+
+    def test_a_main_build_conflict_is_not_a_default_clash(self, tmp_path: Path) -> None:
+        """build-group is never a default, so the pair can be declared."""
+        path = write(
+            tmp_path,
+            "[build-system]\nrequires = []\n"
+            "[tool.nab]\n"
+            'base-group = "main"\n'
+            'build-group = "build"\n'
+            'conflicts = [[{ group = "main" }, { group = "build" }]]\n',
+        )
+        assert read_pyproject_config(path).base_group == "main"
+
+    def test_an_at_least_one_set_naming_a_configured_group_is_refused(
+        self, tmp_path: Path
+    ) -> None:
+        """A configured member cannot be deselected, so the minimum is free."""
+        path = write(
+            tmp_path,
+            "[dependency-groups]\ndev = []\n"
+            "[tool.nab]\n"
+            'base-group = "main"\n'
+            'conflicts = [{ members = [{ group = "main" }, { group = "dev" }],'
+            ' policy = "at-least-one" }]\n',
+        )
+        with pytest.raises(ConfigError, match="decides nothing"):
+            read_pyproject_config(path)
+
+    def test_a_base_group_conflicting_with_an_extra_is_refused(
+        self, tmp_path: Path
+    ) -> None:
+        """An extra installs on top of the project's own dependencies."""
+        path = write(
+            tmp_path,
+            '[project.optional-dependencies]\ncli = ["clitool"]\n'
+            "[tool.nab]\n"
+            'base-group = "main"\n'
+            'conflicts = [[{ group = "main" }, { extra = "cli" }]]\n',
+        )
+        with pytest.raises(ConfigError, match="nothing could install that extra"):
+            read_pyproject_config(path)
+
+    def test_a_build_group_may_conflict_with_an_extra(self, tmp_path: Path) -> None:
+        """The project's dependencies stay in every fork of that set."""
+        path = write(
+            tmp_path,
+            '[project.optional-dependencies]\ncli = ["clitool"]\n'
+            "[build-system]\nrequires = []\n"
+            "[tool.nab]\n"
+            'base-group = "main"\n'
+            'build-group = "build"\n'
+            'conflicts = [[{ group = "build" }, { extra = "cli" }]]\n',
+        )
+        assert read_pyproject_config(path).build_group == "build"
+
     def test_build_group_rejects_the_base_group_name(self, tmp_path: Path) -> None:
         path = write(
             tmp_path,

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -48,6 +48,7 @@ from nab_python.requirements_file import (
     read_pyproject_optional_dependencies,
 )
 from nab_python.resolve import (
+    ResolveFork,
     ResolveResult,
     _augment_resolution_error,
     _build_resolver_inputs,
@@ -5224,3 +5225,363 @@ class TestBuildGroupMarkers:
 
         assert _pylock_markers(pylock)["mydev"] == '"dev" in dependency_groups'
         assert _pylock_selected(pylock, dependency_groups=["dev"]) == {"mydev"}
+
+
+class TestConfiguredGroupConflicts:
+    """A conflict may name ``base-group`` or ``build-group``, which forks."""
+
+    _ROOT = (
+        '[project]\nname = "proj"\nversion = "1.0"\n'
+        'dependencies = ["packaging<24", "requests"]\n'
+        '[build-system]\nrequires = ["setuptools>=70", "packaging>=24"]\n'
+        "[dependency-groups]\n"
+        'dev = ["pytest"]\n'
+        "[tool.nab]\n"
+        'base-group = "main"\n'
+        'build-group = "build"\n'
+    )
+
+    _CONFLICT = 'conflicts = [[{ group = "main" }, { group = "build" }]]\n'
+
+    @staticmethod
+    def _planned(pyproject: Path, **kwargs: object) -> MagicMock:
+        """Resolve far enough to capture the fork plan, without an index."""
+        with (
+            patch("nab_python.resolve.resolve_with_coordinator") as mock_engine,
+            patch("nab_python.resolve.FetchCoordinator") as mock_coord_cls,
+        ):
+            mock_coord_cls.return_value.__enter__ = lambda coordinator: coordinator
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            resolve_for_targets(
+                pyproject, _FAKE_TRANSPORT, python_version="3.12.0", **kwargs
+            )
+        return mock_engine
+
+    def _forks(self, tmp_path: Path, tool: str, **kwargs: object) -> list[ResolveFork]:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(self._ROOT + tool)
+        return self._planned(pyproject, **kwargs).call_args.kwargs["forks"]
+
+    def test_the_two_sides_resolve_separately(self, tmp_path: Path) -> None:
+        """Each fork carries one context, so neither constrains the other."""
+        forks = self._forks(tmp_path, self._CONFLICT)
+
+        assert [f.selection for f in forks] == [
+            (("group", "main"),),
+            (("group", "build"),),
+        ]
+        assert [str(r) for r in forks[0].requirements] == ["packaging<24", "requests"]
+        assert [str(r) for r in forks[1].requirements] == [
+            "setuptools>=70",
+            "packaging>=24",
+        ]
+
+    def test_each_fork_claims_only_the_context_it_walked(self, tmp_path: Path) -> None:
+        """A fork that never resolved the build requirements has no gate for them."""
+        main_fork, build_fork = self._forks(tmp_path, self._CONFLICT)
+
+        assert [str(r) for r in main_fork.contexts.project] == [
+            "packaging<24",
+            "requests",
+        ]
+        assert ("group", "build") not in main_fork.contexts.selectors
+
+        assert build_fork.contexts.project == ()
+        assert ("group", "build") in build_fork.contexts.selectors
+
+    def test_the_base_pass_carries_neither_side(self, tmp_path: Path) -> None:
+        """With both contexts conflicted, no dependency is a base dependency.
+
+        That is what lets the two forks pin one package differently: a
+        divergence is only refused for a package the base pass named.
+        """
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(self._ROOT + self._CONFLICT)
+
+        engine = self._planned(pyproject)
+
+        assert engine.call_args.kwargs["base_requirements"] == []
+
+    def test_without_the_conflict_both_sides_share_one_resolve(
+        self, tmp_path: Path
+    ) -> None:
+        """The default is co-resolution, which is what one version space means."""
+        (fork,) = self._forks(tmp_path, "")
+
+        assert fork.selection == ()
+        assert [str(r) for r in fork.requirements] == [
+            "packaging<24",
+            "requests",
+            "setuptools>=70",
+            "packaging>=24",
+        ]
+
+    def test_a_build_group_may_conflict_with_a_declared_group(
+        self, tmp_path: Path
+    ) -> None:
+        """The request's other half: build against any other dependency group."""
+        forks = self._forks(
+            tmp_path,
+            'conflicts = [[{ group = "build" }, { group = "dev" }]]\n',
+            groups=("dev",),
+        )
+
+        assert [f.selection for f in forks] == [
+            (("group", "build"),),
+            (("group", "dev"),),
+        ]
+        build_fork, dev_fork = forks
+        assert "setuptools>=70" in {str(r) for r in build_fork.requirements}
+        assert "pytest" not in {str(r) for r in build_fork.requirements}
+        assert "pytest" in {str(r) for r in dev_fork.requirements}
+        assert "setuptools>=70" not in {str(r) for r in dev_fork.requirements}
+
+    def test_the_project_dependencies_stay_in_every_fork_of_that_set(
+        self, tmp_path: Path
+    ) -> None:
+        """Only conflicting base-group moves the project's own dependencies."""
+        forks = self._forks(
+            tmp_path,
+            'conflicts = [[{ group = "build" }, { group = "dev" }]]\n',
+            groups=("dev",),
+        )
+
+        for fork in forks:
+            assert "packaging<24" in {str(r) for r in fork.requirements}
+
+    def test_a_three_member_set_forks_three_ways(self, tmp_path: Path) -> None:
+        """The spelling the docs give for conflicting all three at once."""
+        forks = self._forks(
+            tmp_path,
+            'conflicts = [[{ group = "main" }, { group = "build" },'
+            ' { group = "dev" }]]\n',
+            groups=("dev",),
+        )
+
+        assert [f.selection for f in forks] == [
+            (("group", "main"),),
+            (("group", "build"),),
+            (("group", "dev"),),
+        ]
+        assert forks[2].contexts.project == ()
+
+    def test_an_exactly_one_set_is_satisfied_by_a_configured_member(
+        self, tmp_path: Path
+    ) -> None:
+        """A configured member counts towards the minimum without being selected."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            self._ROOT + "conflicts = [{ members = ["
+            '{ group = "main" }, { group = "build" }],'
+            ' policy = "exactly-one" }]\n'
+        )
+
+        forks = self._planned(pyproject).call_args.kwargs["forks"]
+
+        assert [f.selection for f in forks] == [
+            (("group", "main"),),
+            (("group", "build"),),
+        ]
+
+    def test_an_umbrella_group_reaching_a_conflicted_member_is_refused(
+        self, tmp_path: Path
+    ) -> None:
+        """A fork can only carry a member the run selected directly.
+
+        The umbrella reaches ``dev`` without naming it, so this fork would
+        carry the project's own dependencies and ``dev`` together, which
+        the declaration says cannot happen.
+        """
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "proj"\nversion = "1.0"\ndependencies = ["core"]\n'
+            "[dependency-groups]\n"
+            'dev = ["mydev"]\n'
+            'all = [{ include-group = "dev" }]\n'
+            "[tool.nab]\n"
+            'base-group = "main"\n'
+            'conflicts = [[{ group = "main" }, { group = "dev" }]]\n'
+        )
+
+        with pytest.raises(ConflictSelectionError, match="cannot be selected together"):
+            self._planned(pyproject, groups=("all",))
+
+    def test_a_near_miss_for_a_configured_name_still_raises(
+        self, tmp_path: Path
+    ) -> None:
+        """Widening the known names must not let an inert member through."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            self._ROOT
+            + 'conflicts = [[{ group = "build-tools" }, { group = "dev" }]]\n'
+        )
+
+        with pytest.raises(ConfigError, match="build-tools"):
+            self._planned(pyproject, groups=("dev",))
+
+    def test_an_unset_configured_name_is_not_known(self, tmp_path: Path) -> None:
+        """``build`` names nothing when build-group is unset."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "proj"\nversion = "1.0"\ndependencies = []\n'
+            "[dependency-groups]\n"
+            'dev = ["pytest"]\n'
+            "[tool.nab]\n"
+            'conflicts = [[{ group = "build" }, { group = "dev" }]]\n'
+        )
+
+        with pytest.raises(ConfigError, match="group 'build'"):
+            self._planned(pyproject, groups=("dev",))
+
+
+class TestConfiguredGroupConflictMarkers:
+    """A declared main/build conflict emits one lock with two version spaces."""
+
+    _MEMBERS: ClassVar[dict[str, str]] = {
+        "core": '[project]\nname = "core"\nversion = "1.0"\n',
+        "builder": '[project]\nname = "builder"\nversion = "5.0"\n',
+    }
+
+    _ROOT = (
+        '[project]\nname = "app"\nversion = "1.0"\ndependencies = ["core"]\n'
+        '[build-system]\nrequires = ["builder"]\n'
+        "[tool.nab]\n"
+        'base-group = "main"\n'
+        'build-group = "build"\n'
+        'conflicts = [[{ group = "main" }, { group = "build" }]]\n'
+        + "".join(
+            f'[[tool.nab.local-sources]]\nname = "{name}"\npath = "{name}"\n'
+            for name in ("core", "builder")
+        )
+    )
+
+    def _lock(self, tmp_path: Path) -> Pylock:
+        return TestExtraAndGroupMembershipMarkers._lock(
+            tmp_path, root=self._ROOT, members=self._MEMBERS
+        )
+
+    def test_each_side_gates_on_its_own_name_and_negates_the_other(
+        self, tmp_path: Path
+    ) -> None:
+        """Naming both is what keeps a co-selecting installer to the overlap."""
+        markers = _pylock_markers(self._lock(tmp_path))
+
+        assert markers["core"] is not None
+        assert '"main" in dependency_groups' in markers["core"]
+        assert '"build" not in dependency_groups' in markers["core"]
+
+        assert markers["builder"] is not None
+        assert '"build" in dependency_groups' in markers["builder"]
+        assert '"main" not in dependency_groups' in markers["builder"]
+
+    def test_an_installer_gets_one_side_or_the_other(self, tmp_path: Path) -> None:
+        """The point of the declaration: the two never install together."""
+        pylock = self._lock(tmp_path)
+
+        assert _pylock_selected(pylock) == {"core"}
+        assert _pylock_selected(pylock, dependency_groups=["main"]) == {"core"}
+        assert _pylock_selected(pylock, dependency_groups=["build"]) == {"builder"}
+
+        # Asking for both is the context the declaration says cannot exist,
+        # and each side's negation is what leaves it holding neither.
+        assert _pylock_selected(pylock, dependency_groups=["main", "build"]) == set()
+
+    def test_the_lock_offers_both_names(self, tmp_path: Path) -> None:
+        """Only the project's own dependencies are a default install."""
+        pylock = self._lock(tmp_path)
+
+        assert pylock.dependency_groups == ("main", "build")
+        assert pylock.default_groups == ("main",)
+
+
+class TestConfiguredGroupConflictDivergentPins:
+    """The case the declaration exists for: one package, two pins, one lock."""
+
+    _ROOT = (
+        '[project]\nname = "app"\nversion = "1.0"\n'
+        'dependencies = ["packaging<24"]\n'
+        '[build-system]\nrequires = ["packaging>=24"]\n'
+        "[tool.nab]\n"
+        'base-group = "main"\n'
+        'build-group = "build"\n'
+    )
+
+    _CONFLICT = 'conflicts = [[{ group = "main" }, { group = "build" }]]\n'
+
+    @staticmethod
+    def _wheel(version: str) -> WheelFile:
+        return WheelFile(
+            filename=f"packaging-{version}-py3-none-any.whl",
+            url=f"https://example.com/packaging-{version}.whl",
+            version=version,
+            requires_python=None,
+            has_metadata=True,
+            upload_time=None,
+            hashes=(("sha256", "a" * 64),),
+        )
+
+    def _resolved_lock(self, tmp_path: Path, tool: str) -> Pylock:
+        """Resolve against an index carrying both versions, and emit the lock."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(self._ROOT + tool)
+        coordinator = make_coordinator(
+            [self._wheel("23.2"), self._wheel("24.2")],
+            package="packaging",
+            auto_metadata=True,
+        )
+        with patch("nab_python.resolve.FetchCoordinator") as mock_coord_cls:
+            mock_coord_cls.return_value.__enter__ = lambda _self: coordinator
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            config = read_pyproject_config(pyproject)
+            result = _resolved(pyproject, _FAKE_TRANSPORT, config=config)
+        pylock = build_pylock(
+            build_lock_input(result, config=config), lock_dir=tmp_path
+        )
+        pylock.validate()
+        return pylock
+
+    def test_without_the_conflict_one_version_space_cannot_hold_both(
+        self, tmp_path: Path
+    ) -> None:
+        """Co-resolution is the default, and this project has no solution."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(self._ROOT)
+        coordinator = make_coordinator(
+            [self._wheel("23.2"), self._wheel("24.2")],
+            package="packaging",
+            auto_metadata=True,
+        )
+
+        with patch("nab_python.resolve.FetchCoordinator") as mock_coord_cls:
+            mock_coord_cls.return_value.__enter__ = lambda _self: coordinator
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            with pytest.raises(ResolutionError):
+                _resolved(pyproject, _FAKE_TRANSPORT)
+
+    def test_the_conflict_gives_each_side_its_own_pin(self, tmp_path: Path) -> None:
+        """Two entries for one name, disjoint on the group clause."""
+        pylock = self._resolved_lock(tmp_path, self._CONFLICT)
+
+        entries = sorted(
+            (str(pkg.version), str(pkg.marker))
+            for pkg in pylock.packages
+            if str(pkg.name) == "packaging"
+        )
+        assert len(entries) == 2
+
+        runtime, build = entries
+        assert runtime[0] == "23.2"
+        assert '"main" in dependency_groups' in runtime[1]
+        assert build[0] == "24.2"
+        assert '"build" in dependency_groups' in build[1]
+
+    def test_an_installer_gets_the_right_one(self, tmp_path: Path) -> None:
+        """The two sides never install together, which is what was declared."""
+        pylock = self._resolved_lock(tmp_path, self._CONFLICT)
+
+        def versions(**kwargs: list[str]) -> set[str]:
+            return {str(pkg.version) for pkg, _ in pylock.select(**kwargs)}
+
+        assert versions() == {"23.2"}
+        assert versions(dependency_groups=["main"]) == {"23.2"}
+        assert versions(dependency_groups=["build"]) == {"24.2"}

--- a/nab-python/tests/test_resolve_targets.py
+++ b/nab-python/tests/test_resolve_targets.py
@@ -195,6 +195,46 @@ class TestConflictForks:
         assert forks[0].active_extras == ("docs",)
         assert forks[0].active_groups == ("dev",)
 
+    def test_a_configured_name_is_active_without_being_selected(self) -> None:
+        """A configured group is active whenever it is set, so its set engages."""
+        forks = conflict_forks(
+            (), (), (_group_set("main", "build"),), ("main", "build")
+        )
+
+        assert [f.selection for f in forks] == [
+            (("group", "main"),),
+            (("group", "build"),),
+        ]
+        assert [f.active_configured for f in forks] == [("main",), ("build",)]
+        assert [f.active_groups for f in forks] == [(), ()]
+
+    def test_configured_names_stay_out_of_the_unforked_group_list(self) -> None:
+        """``active_groups`` stays what the [dependency-groups] loader can read."""
+        forks = conflict_forks((), ("dev",), (), ("main", "build"))
+
+        assert len(forks) == 1
+        assert forks[0].active_groups == ("dev",)
+        assert forks[0].active_configured == ("main", "build")
+
+    def test_a_configured_name_in_a_dormant_set_is_still_carried(self) -> None:
+        """The set does not engage, so every fork keeps both configured names."""
+        forks = conflict_forks((), (), (_group_set("main", "dev"),), ("main", "build"))
+
+        assert len(forks) == 1
+        assert forks[0].selection == ()
+        assert forks[0].active_configured == ("main", "build")
+
+    def test_a_configured_and_a_declared_name_fork_together(self) -> None:
+        """Selecting the declared member engages the set the configured one is in."""
+        forks = conflict_forks((), ("dev",), (_group_set("build", "dev"),), ("build",))
+
+        assert [f.selection for f in forks] == [
+            (("group", "build"),),
+            (("group", "dev"),),
+        ]
+        assert [f.active_configured for f in forks] == [("build",), ()]
+        assert [f.active_groups for f in forks] == [(), ("dev",)]
+
     def test_single_selected_member_does_not_engage(self) -> None:
         # Only cpu selected, gpu absent: no conflict, no fork.
         forks = conflict_forks(("cpu",), (), (_extra_set("cpu", "gpu"),))


### PR DESCRIPTION
A `[tool.nab].conflicts` member may now name a group `[tool.nab]` configures rather than one `[dependency-groups]` declares, so `main-group` and `build-group` can be declared mutually exclusive with each other or with any dependency group.

That is what a project needs when its backend requires a version its own dependencies exclude. `packaging<24` in `[project]` against `packaging>=24` in `[build-system]` has no single resolution, and until now `build-group` had to co-resolve them and fail. Declaring the two exclusive forks the resolve instead, and each side gets its own pin under a marker that negates the other, which is the separation PEP 517 build isolation gives the build at install time.

The names are active by configuration rather than by selection, so a set holding one engages on every run. They come back on their own fork field and never reach the `[dependency-groups]` loader. The no-member base pass carries neither side, which is what makes the divergence a member-only dependency the writer already knows how to emit, so `_lockfile/` is untouched.

Two config-time refusals come with it: an `at-least-one` set naming a configured group can never fail, and `main-group` paired with an extra describes an install context no installer can produce, since an extra installs on top of the project's dependencies and never deselects them.

Stacked on #815.
