### PR TITLE
Lock nab's own build backend from build-system.requires

### DIFF
--- a/.github/requirements/pylock.build.toml
+++ b/.github/requirements/pylock.build.toml
@@ -1,0 +1,203 @@
+lock-version = "1.0"
+environments = [
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
+    "python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
+    "python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
+    "python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
+    "python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
+    "python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
+    "python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
+    "python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
+    "python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
+    "python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
+    "python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
+    "python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
+    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
+    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
+    "python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
+    "python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
+    "python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
+    "python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
+    "python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
+    "python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
+    "python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
+    "python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
+]
+requires-python = ">=3.10"
+created-by = "nab"
+
+[[packages]]
+name = "hatchling"
+version = "1.31.0"
+requires-python = ">=3.10"
+dependencies = [
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pluggy" },
+    { name = "tomli" },
+    { name = "trove-classifiers" },
+]
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "hatchling-1.31.0.tar.gz"
+upload-time = 2026-07-08 01:48:32.237659+00:00
+url = "https://files.pythonhosted.org/packages/25/e2/dfa73fe78f773018dcaebc6d09b819bc10d328ff5a6b4a66efa1e3d71f52/hatchling-1.31.0.tar.gz"
+size = 57208
+
+[packages.sdist.hashes]
+sha256 = "6b48ad4068a482ed7239b3a8215bc55b47aad3345d58dfc94e553c5d2d46211b"
+
+[[packages.wheels]]
+name = "hatchling-1.31.0-py3-none-any.whl"
+upload-time = 2026-07-08 01:48:31.024633+00:00
+url = "https://files.pythonhosted.org/packages/64/e2/2c0af0a52d16be74a4f194564fcdc417521ed863e9b65e4bc9052dacba6f/hatchling-1.31.0-py3-none-any.whl"
+size = 77747
+
+[packages.wheels.hashes]
+sha256 = "aac80bec8b6fe35e8480f1c335be8910fa210a0e6f735a139be205dadcacb544"
+
+[[packages]]
+name = "packaging"
+version = "26.2"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "packaging-26.2.tar.gz"
+upload-time = 2026-04-24 20:15:23.917886+00:00
+url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz"
+size = 228134
+
+[packages.sdist.hashes]
+sha256 = "ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"
+
+[[packages.wheels]]
+name = "packaging-26.2-py3-none-any.whl"
+upload-time = 2026-04-24 20:15:22.081511+00:00
+url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl"
+size = 100195
+
+[packages.wheels.hashes]
+sha256 = "5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e"
+
+[[packages]]
+name = "pathspec"
+version = "1.1.1"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "pathspec-1.1.1.tar.gz"
+upload-time = 2026-04-27 01:46:08.907631+00:00
+url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz"
+size = 135180
+
+[packages.sdist.hashes]
+sha256 = "17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a"
+
+[[packages.wheels]]
+name = "pathspec-1.1.1-py3-none-any.whl"
+upload-time = 2026-04-27 01:46:07.060850+00:00
+url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl"
+size = 57328
+
+[packages.wheels.hashes]
+sha256 = "a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189"
+
+[[packages]]
+name = "pluggy"
+version = "1.6.0"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "pluggy-1.6.0.tar.gz"
+upload-time = 2025-05-15 12:30:07.975376+00:00
+url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz"
+size = 69412
+
+[packages.sdist.hashes]
+sha256 = "7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"
+
+[[packages.wheels]]
+name = "pluggy-1.6.0-py3-none-any.whl"
+upload-time = 2025-05-15 12:30:06.134003+00:00
+url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl"
+size = 20538
+
+[packages.wheels.hashes]
+sha256 = "e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"
+
+[[packages]]
+name = "tomli"
+version = "2.4.1"
+marker = "python_version == \"3.10\""
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "tomli-2.4.1.tar.gz"
+upload-time = 2026-03-25 20:22:03.828102+00:00
+url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz"
+size = 17543
+
+[packages.sdist.hashes]
+sha256 = "7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-py3-none-any.whl"
+upload-time = 2026-03-25 20:22:03.012768+00:00
+url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl"
+size = 14583
+
+[packages.wheels.hashes]
+sha256 = "0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe"
+
+[[packages]]
+name = "trove-classifiers"
+version = "2026.6.1.19"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "trove_classifiers-2026.6.1.19.tar.gz"
+upload-time = 2026-06-01 19:41:34.649417+00:00
+url = "https://files.pythonhosted.org/packages/c2/e3/7ca82ee24c82d344584abd5b8637b3bd056f2900226e8d82fc22f1184b92/trove_classifiers-2026.6.1.19.tar.gz"
+size = 17059
+
+[packages.sdist.hashes]
+sha256 = "c5132b4b61a829d11cfbd2d72e97f20a45ed6edb95e45c5efdeb5e00836b2745"
+
+[[packages.wheels]]
+name = "trove_classifiers-2026.6.1.19-py3-none-any.whl"
+upload-time = 2026-06-01 19:41:33.434069+00:00
+url = "https://files.pythonhosted.org/packages/7c/a4/81502f486f01db95bc8320646a8a12511f5e556cb63d5e224d91816605c4/trove_classifiers-2026.6.1.19-py3-none-any.whl"
+size = 14211
+
+[packages.wheels.hashes]
+sha256 = "ab4c4ec93cc4a4e7815fa759906e05e6bb3f2fbd92ea0f897288c6a43efd15b3"
+
+[tool.nab]
+nab-version = "0.0.13.dev0"
+created-at = 2026-08-10 17:33:30.130437+00:00
+command-line = [
+    "nab",
+    "lock",
+    "--build-requirements",
+    "--no-emit-workspace",
+    "--output",
+    ".github/requirements/pylock.build.toml",
+]
+input-path = "pyproject.toml"
+mode = "universal"
+python-specifier = ">=3.10,<3.15"
+platforms = [
+    "linux_x86_64",
+    "linux_aarch64",
+    "macos_arm64",
+    "macos_x86_64",
+    "windows_amd64",
+]

--- a/.github/requirements/pylock.crosshair.toml
+++ b/.github/requirements/pylock.crosshair.toml
@@ -2276,7 +2276,7 @@ size = 10238
 sha256 = "25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f"
 
 [tool.nab]
-nab-version = "0.0.12.dev0"
+nab-version = "0.0.13.dev0"
 created-at = 2026-07-31 17:59:06.261054+00:00
 command-line = [
     "nab",

--- a/.github/requirements/pylock.dists.toml
+++ b/.github/requirements/pylock.dists.toml
@@ -121,38 +121,6 @@ size = 22484
 sha256 = "b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b"
 
 [[packages]]
-name = "hatchling"
-version = "1.31.0"
-marker = "\"dists\" in dependency_groups"
-requires-python = ">=3.10"
-dependencies = [
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "pluggy" },
-    { name = "tomli" },
-    { name = "trove-classifiers" },
-]
-index = "https://pypi.org/simple/"
-
-[packages.sdist]
-name = "hatchling-1.31.0.tar.gz"
-upload-time = 2026-07-08 01:48:32.237659+00:00
-url = "https://files.pythonhosted.org/packages/25/e2/dfa73fe78f773018dcaebc6d09b819bc10d328ff5a6b4a66efa1e3d71f52/hatchling-1.31.0.tar.gz"
-size = 57208
-
-[packages.sdist.hashes]
-sha256 = "6b48ad4068a482ed7239b3a8215bc55b47aad3345d58dfc94e553c5d2d46211b"
-
-[[packages.wheels]]
-name = "hatchling-1.31.0-py3-none-any.whl"
-upload-time = 2026-07-08 01:48:31.024633+00:00
-url = "https://files.pythonhosted.org/packages/64/e2/2c0af0a52d16be74a4f194564fcdc417521ed863e9b65e4bc9052dacba6f/hatchling-1.31.0-py3-none-any.whl"
-size = 77747
-
-[packages.wheels.hashes]
-sha256 = "aac80bec8b6fe35e8480f1c335be8910fa210a0e6f735a139be205dadcacb544"
-
-[[packages]]
 name = "importlib-metadata"
 version = "9.0.0"
 marker = "python_full_version < \"3.10.2\""
@@ -227,56 +195,6 @@ size = 100195
 
 [packages.wheels.hashes]
 sha256 = "5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e"
-
-[[packages]]
-name = "pathspec"
-version = "1.1.1"
-marker = "\"dists\" in dependency_groups"
-requires-python = ">=3.9"
-index = "https://pypi.org/simple/"
-
-[packages.sdist]
-name = "pathspec-1.1.1.tar.gz"
-upload-time = 2026-04-27 01:46:08.907631+00:00
-url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz"
-size = 135180
-
-[packages.sdist.hashes]
-sha256 = "17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a"
-
-[[packages.wheels]]
-name = "pathspec-1.1.1-py3-none-any.whl"
-upload-time = 2026-04-27 01:46:07.060850+00:00
-url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl"
-size = 57328
-
-[packages.wheels.hashes]
-sha256 = "a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189"
-
-[[packages]]
-name = "pluggy"
-version = "1.6.0"
-marker = "\"dists\" in dependency_groups"
-requires-python = ">=3.9"
-index = "https://pypi.org/simple/"
-
-[packages.sdist]
-name = "pluggy-1.6.0.tar.gz"
-upload-time = 2025-05-15 12:30:07.975376+00:00
-url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz"
-size = 69412
-
-[packages.sdist.hashes]
-sha256 = "7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"
-
-[[packages.wheels]]
-name = "pluggy-1.6.0-py3-none-any.whl"
-upload-time = 2025-05-15 12:30:06.134003+00:00
-url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl"
-size = 20538
-
-[packages.wheels.hashes]
-sha256 = "e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"
 
 [[packages]]
 name = "pyproject-hooks"
@@ -531,30 +449,6 @@ size = 6675
 sha256 = "188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90"
 
 [[packages]]
-name = "trove-classifiers"
-version = "2026.6.1.19"
-marker = "\"dists\" in dependency_groups"
-index = "https://pypi.org/simple/"
-
-[packages.sdist]
-name = "trove_classifiers-2026.6.1.19.tar.gz"
-upload-time = 2026-06-01 19:41:34.649417+00:00
-url = "https://files.pythonhosted.org/packages/c2/e3/7ca82ee24c82d344584abd5b8637b3bd056f2900226e8d82fc22f1184b92/trove_classifiers-2026.6.1.19.tar.gz"
-size = 17059
-
-[packages.sdist.hashes]
-sha256 = "c5132b4b61a829d11cfbd2d72e97f20a45ed6edb95e45c5efdeb5e00836b2745"
-
-[[packages.wheels]]
-name = "trove_classifiers-2026.6.1.19-py3-none-any.whl"
-upload-time = 2026-06-01 19:41:33.434069+00:00
-url = "https://files.pythonhosted.org/packages/7c/a4/81502f486f01db95bc8320646a8a12511f5e556cb63d5e224d91816605c4/trove_classifiers-2026.6.1.19-py3-none-any.whl"
-size = 14211
-
-[packages.wheels.hashes]
-sha256 = "ab4c4ec93cc4a4e7815fa759906e05e6bb3f2fbd92ea0f897288c6a43efd15b3"
-
-[[packages]]
 name = "truststore"
 version = "0.10.4"
 requires-python = ">=3.10"
@@ -708,7 +602,7 @@ size = 10238
 sha256 = "25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f"
 
 [tool.nab]
-nab-version = "0.0.12.dev0"
+nab-version = "0.0.13.dev0"
 created-at = 2026-07-31 17:59:17.904067+00:00
 command-line = [
     "nab",

--- a/.github/requirements/pylock.docs.toml
+++ b/.github/requirements/pylock.docs.toml
@@ -1247,7 +1247,7 @@ size = 131087
 sha256 = "9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
 
 [tool.nab]
-nab-version = "0.0.12.dev0"
+nab-version = "0.0.13.dev0"
 created-at = 2026-07-31 17:59:15.510783+00:00
 command-line = [
     "nab",

--- a/.github/requirements/pylock.nox.toml
+++ b/.github/requirements/pylock.nox.toml
@@ -904,7 +904,7 @@ size = 10238
 sha256 = "25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f"
 
 [tool.nab]
-nab-version = "0.0.12.dev0"
+nab-version = "0.0.13.dev0"
 created-at = 2026-07-31 17:59:16.285265+00:00
 command-line = [
     "nab",

--- a/.github/requirements/pylock.pre-commit.toml
+++ b/.github/requirements/pylock.pre-commit.toml
@@ -1085,7 +1085,7 @@ size = 10238
 sha256 = "25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f"
 
 [tool.nab]
-nab-version = "0.0.12.dev0"
+nab-version = "0.0.13.dev0"
 created-at = 2026-07-31 17:59:04.850557+00:00
 command-line = [
     "nab",

--- a/.github/requirements/pylock.release.toml
+++ b/.github/requirements/pylock.release.toml
@@ -888,38 +888,6 @@ size = 35604
 sha256 = "80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4"
 
 [[packages]]
-name = "hatchling"
-version = "1.31.0"
-marker = "\"release\" in dependency_groups"
-requires-python = ">=3.10"
-dependencies = [
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "pluggy" },
-    { name = "tomli" },
-    { name = "trove-classifiers" },
-]
-index = "https://pypi.org/simple/"
-
-[packages.sdist]
-name = "hatchling-1.31.0.tar.gz"
-upload-time = 2026-07-08 01:48:32.237659+00:00
-url = "https://files.pythonhosted.org/packages/25/e2/dfa73fe78f773018dcaebc6d09b819bc10d328ff5a6b4a66efa1e3d71f52/hatchling-1.31.0.tar.gz"
-size = 57208
-
-[packages.sdist.hashes]
-sha256 = "6b48ad4068a482ed7239b3a8215bc55b47aad3345d58dfc94e553c5d2d46211b"
-
-[[packages.wheels]]
-name = "hatchling-1.31.0-py3-none-any.whl"
-upload-time = 2026-07-08 01:48:31.024633+00:00
-url = "https://files.pythonhosted.org/packages/64/e2/2c0af0a52d16be74a4f194564fcdc417521ed863e9b65e4bc9052dacba6f/hatchling-1.31.0-py3-none-any.whl"
-size = 77747
-
-[packages.wheels.hashes]
-sha256 = "aac80bec8b6fe35e8480f1c335be8910fa210a0e6f735a139be205dadcacb544"
-
-[[packages]]
 name = "id"
 version = "1.6.1"
 marker = "\"release\" in dependency_groups"
@@ -1347,31 +1315,6 @@ size = 100195
 sha256 = "5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e"
 
 [[packages]]
-name = "pathspec"
-version = "1.1.1"
-marker = "\"release\" in dependency_groups"
-requires-python = ">=3.9"
-index = "https://pypi.org/simple/"
-
-[packages.sdist]
-name = "pathspec-1.1.1.tar.gz"
-upload-time = 2026-04-27 01:46:08.907631+00:00
-url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz"
-size = 135180
-
-[packages.sdist.hashes]
-sha256 = "17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a"
-
-[[packages.wheels]]
-name = "pathspec-1.1.1-py3-none-any.whl"
-upload-time = 2026-04-27 01:46:07.060850+00:00
-url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl"
-size = 57328
-
-[packages.wheels.hashes]
-sha256 = "a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189"
-
-[[packages]]
 name = "platformdirs"
 version = "4.11.0"
 marker = "\"release\" in dependency_groups"
@@ -1395,31 +1338,6 @@ size = 23247
 
 [packages.wheels.hashes]
 sha256 = "360ccded2b7fce0af0ff80cc8f5942a1c5d99b0e856033acb030bfc634709e74"
-
-[[packages]]
-name = "pluggy"
-version = "1.6.0"
-marker = "\"release\" in dependency_groups"
-requires-python = ">=3.9"
-index = "https://pypi.org/simple/"
-
-[packages.sdist]
-name = "pluggy-1.6.0.tar.gz"
-upload-time = 2025-05-15 12:30:07.975376+00:00
-url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz"
-size = 69412
-
-[packages.sdist.hashes]
-sha256 = "7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"
-
-[[packages.wheels]]
-name = "pluggy-1.6.0-py3-none-any.whl"
-upload-time = 2025-05-15 12:30:06.134003+00:00
-url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl"
-size = 20538
-
-[packages.wheels.hashes]
-sha256 = "e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"
 
 [[packages]]
 name = "pyasn1"
@@ -2552,30 +2470,6 @@ size = 49449
 sha256 = "177a05aece5a8ca5266fd3c448abb47b8d352f09d477d3ca8332db4d89b24304"
 
 [[packages]]
-name = "trove-classifiers"
-version = "2026.6.1.19"
-marker = "\"release\" in dependency_groups"
-index = "https://pypi.org/simple/"
-
-[packages.sdist]
-name = "trove_classifiers-2026.6.1.19.tar.gz"
-upload-time = 2026-06-01 19:41:34.649417+00:00
-url = "https://files.pythonhosted.org/packages/c2/e3/7ca82ee24c82d344584abd5b8637b3bd056f2900226e8d82fc22f1184b92/trove_classifiers-2026.6.1.19.tar.gz"
-size = 17059
-
-[packages.sdist.hashes]
-sha256 = "c5132b4b61a829d11cfbd2d72e97f20a45ed6edb95e45c5efdeb5e00836b2745"
-
-[[packages.wheels]]
-name = "trove_classifiers-2026.6.1.19-py3-none-any.whl"
-upload-time = 2026-06-01 19:41:33.434069+00:00
-url = "https://files.pythonhosted.org/packages/7c/a4/81502f486f01db95bc8320646a8a12511f5e556cb63d5e224d91816605c4/trove_classifiers-2026.6.1.19-py3-none-any.whl"
-size = 14211
-
-[packages.wheels.hashes]
-sha256 = "ab4c4ec93cc4a4e7815fa759906e05e6bb3f2fbd92ea0f897288c6a43efd15b3"
-
-[[packages]]
 name = "truststore"
 version = "0.10.4"
 requires-python = ">=3.10"
@@ -2822,7 +2716,7 @@ size = 10238
 sha256 = "25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f"
 
 [tool.nab]
-nab-version = "0.0.12.dev0"
+nab-version = "0.0.13.dev0"
 created-at = 2026-07-31 17:59:10.332748+00:00
 command-line = [
     "nab",

--- a/.github/requirements/pylock.tests.toml
+++ b/.github/requirements/pylock.tests.toml
@@ -1716,7 +1716,7 @@ size = 10238
 sha256 = "25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f"
 
 [tool.nab]
-nab-version = "0.0.12.dev0"
+nab-version = "0.0.13.dev0"
 created-at = 2026-07-31 17:58:58.797148+00:00
 command-line = [
     "nab",

--- a/.github/requirements/pylock.types.toml
+++ b/.github/requirements/pylock.types.toml
@@ -2554,7 +2554,7 @@ size = 10806625
 sha256 = "4889a911b72269258c54c94a250450ee721e6c7c6ad058c416286e83fa3f3685"
 
 [tool.nab]
-nab-version = "0.0.12.dev0"
+nab-version = "0.0.13.dev0"
 created-at = 2026-07-31 17:59:01.653678+00:00
 command-line = [
     "nab",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Install release toolchain
         run: pip install -r .github/requirements/pylock.release.toml
 
+      - name: Install the build backend
+        run: pip install -r .github/requirements/pylock.build.toml
+
       - name: Verify the tag matches the package versions
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -180,6 +180,7 @@ jobs:
           cache-dependency-path: |
             .github/requirements/pylock.nox.toml
             .github/requirements/pylock.dists.toml
+            .github/requirements/pylock.build.toml
           allow-prereleases: true
 
       - name: Upgrade pip to PEP 751 install support

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -28,8 +28,10 @@ All four packages release together at one version (lockstep).
 
 - Prereleases work: `hatch run release:make 0.0.3rc1`.
 - The changelog is the generated GitHub release notes (a list of merged PRs).
-- The workflow runs `tasks/release.py check` and `tasks/build_dists.py`; both
-  install only from `.github/requirements/pylock.release.toml`.
+- The workflow runs `tasks/release.py check` and `tasks/build_dists.py`, and
+  installs only from hash-pinned locks: `pylock.release.toml` for the
+  toolchain, plus `pylock.build.toml` for the backend, which the build needs
+  because it runs with `--no-isolation`.
 - After changing a dependency group, regenerate the locks with
   `tasks/refresh-locks.sh`.
 - To abort before publishing, delete the branch and the tag.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -68,6 +68,20 @@ pyright accepts can still fail the matrix. Reproduce a single cell with
 `nox -s "types(checker='mypy')"`; the trees are `TYPED_TREES` in
 `noxfile.py`.
 
+## The build backend
+
+nab builds its distributions with `--no-isolation`, so the backend has to be
+installed rather than fetched during the build. It is locked from
+`[build-system].requires`: `tasks/refresh-locks.sh` writes
+`.github/requirements/pylock.build.toml` with `nab lock --build-requirements`,
+and every path that builds installs it, the `dists` nox session, the release
+workflow and `hatch run release:build`.
+
+One lock serves all four packages, which holds only while they declare the
+same `[build-system]`. The refresh script checks that before it writes
+anything, and checks afterwards that the locks sharing an environment agree on
+the packages they share.
+
 ## Building the docs
 
 ```bash

--- a/hatch.toml
+++ b/hatch.toml
@@ -77,6 +77,7 @@ detached = true
 _sync = [
     'python -m pip install --upgrade "pip>=26.1"',
     "python -m pip install -r .github/requirements/pylock.release.toml",
+    "python -m pip install -r .github/requirements/pylock.build.toml",
 ]
 make = ["_sync", "python tasks/release.py make {args}"]
 build = ["_sync", "python tasks/build_dists.py {args}"]

--- a/noxfile.py
+++ b/noxfile.py
@@ -30,6 +30,7 @@ nox.options.default_venv_backend = "venv"
 TESTS_LOCK = ".github/requirements/pylock.tests.toml"
 TYPES_LOCK = ".github/requirements/pylock.types.toml"
 DISTS_LOCK = ".github/requirements/pylock.dists.toml"
+BUILD_LOCK = ".github/requirements/pylock.build.toml"
 
 # workspace -> (editable packages, pytest paths, coverage-gated packages).
 # nab-index rides with the python workspace: nab-python is its only consumer
@@ -134,4 +135,7 @@ def dists(session: nox.Session) -> None:
     # subprocess and installs it into its own throwaway venv.
     session.install("--upgrade", "pip>=26.1")
     session.install("-r", DISTS_LOCK)
+    # The build runs with --no-isolation, so the backend comes from the lock
+    # of [build-system].requires rather than from a hand-listed group.
+    session.install("-r", BUILD_LOCK)
     session.run("python", "tasks/check_dists.py")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,15 +115,14 @@ release = [
     "tomlkit>=0.13",
     "tyro>=1.0",
     "build>=1.2",
-    "hatchling>=1.27",
     "twine>=6.1",
     "pypi-attestations>=0.0.21",
 ]
-# The dists nox session builds every distribution and installs it. It needs
-# build plus the hatchling backend, since it builds without isolation.
+# The dists nox session builds every distribution and installs it. It needs the
+# build frontend; the backend comes from pylock.build.toml, locked from
+# [build-system].requires, since the build runs without isolation.
 dists = [
     "build>=1.2",
-    "hatchling>=1.27",
 ]
 
 # `nab lock` config: universal mode resolves the full matrix in one

--- a/tasks/refresh-locks.sh
+++ b/tasks/refresh-locks.sh
@@ -18,6 +18,11 @@ if [[ -n "${REFRESH_NAB_BIN:-}" ]]; then
     read -ra NAB <<<"${REFRESH_NAB_BIN}"
 fi
 
+# The consistency checks below parse pyproject files rather than run nab, so
+# they need an interpreter of their own. tomli comes from nab-python, which the
+# project venv always has, and unlike tomllib it is there on the 3.10 floor.
+PYTHON="${REFRESH_PYTHON:-.venv/bin/python}"
+
 EXTRA_ARGS=("$@")
 
 # Only one interpreter ever builds the docs: Read the Docs and the CI docs job
@@ -31,6 +36,29 @@ DOCS_PYTHON="3.13"
 # uv seed the PEP 751 dependency_groups marker from default-groups and cannot
 # select a non-default group at install time, so without this the group's
 # packages carry a marker no install-time flag ever satisfies and are skipped.
+# One build lock serves every package here, which holds only while they agree.
+# Checked before any lock is rewritten, so a mismatch leaves the tree untouched.
+echo "==> Checking every package declares the same build system"
+"${PYTHON}" - <<'PY'
+import sys
+import tomli
+from pathlib import Path
+
+KEYS = ("requires", "build-backend", "backend-path")
+declared = {}
+for path in [Path("pyproject.toml"), *sorted(Path().glob("nab-*/pyproject.toml"))]:
+    table = tomli.loads(path.read_text())["build-system"]
+    declared[path] = tuple(str(table.get(key)) for key in KEYS)
+
+if len(set(declared.values())) > 1:
+    for path, values in declared.items():
+        print(f"  {path}: {dict(zip(KEYS, values))}", file=sys.stderr)
+    sys.exit(
+        "packages disagree on [build-system], so one build lock cannot serve"
+        " them all; align them or lock each package separately"
+    )
+PY
+
 for group in tests types pre-commit crosshair release docs nox dists; do
     echo "==> Locking group: ${group}"
     group_args=()
@@ -45,6 +73,45 @@ for group in tests types pre-commit crosshair release docs nox dists; do
         "${group_args[@]}" \
         "${EXTRA_ARGS[@]}"
 done
+
+echo "==> Locking [build-system].requires"
+"${NAB[@]}" lock \
+    --build-requirements \
+    --no-emit-workspace \
+    --output ".github/requirements/pylock.build.toml" \
+    "${EXTRA_ARGS[@]}"
+
+# The build lock is installed alongside the dists and release locks, so a
+# package they share has to resolve the same in both or the second install
+# silently moves the first.
+echo "==> Checking the locks that share an environment agree"
+"${PYTHON}" - <<'PY'
+import sys
+import tomli
+from pathlib import Path
+
+
+def pins(name):
+    lock = tomli.loads(Path(f".github/requirements/pylock.{name}.toml").read_text())
+    versions = {}
+    for package in lock["packages"]:
+        versions.setdefault(package["name"], set()).add(package.get("version"))
+    return versions
+
+
+build = pins("build")
+disagreed = [
+    f"  {name}: {package} is {sorted(build[package])} in the build lock"
+    f" and {sorted(other[package])} there"
+    for name in ("dists", "release")
+    for other in [pins(name)]
+    for package in sorted(build.keys() & other.keys())
+    if build[package] != other[package]
+]
+if disagreed:
+    print("\n".join(disagreed), file=sys.stderr)
+    sys.exit("locks installed into one environment disagree on a shared package")
+PY
 
 echo "==> Done"
 ls -1 .github/requirements/pylock.*.toml


### PR DESCRIPTION
nab pinned its own build backend by writing `hatchling>=1.27` into the `dists` and `release` dependency groups, duplicating `[build-system].requires`. Since `tasks/build_dists.py` builds with `--no-isolation`, the backend came from whichever group the session had installed, and changing the build system would have left both groups quietly stale.

`tasks/refresh-locks.sh` now writes `.github/requirements/pylock.build.toml` with `nab lock --build-requirements`, and the groups keep only the tools that are tools. Every path that builds installs it: the `dists` nox session, the release workflow, and `hatch run release:build`.

One lock serves all four packages, which holds only while they declare the same `[build-system]`, so the script checks that before writing anything and checks afterwards that the locks sharing an environment agree on the packages they share.

Stacked on #819, though it only needs #814.
