### PR TITLE
note where a conflict set forks the extras/groups resolve

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -59,8 +59,14 @@ Extras selection:
   array.
 * `--all-extras` selects every declared extra.
 
-Both `--groups` and `--extras` produce a single union resolve. A
-package that only a selected extra or group reaches is emitted with
+Both `--groups` and `--extras` produce a single union resolve, unless
+two or more members of a mutually exclusive `[tool.nab].conflicts` set
+are active, either because the selection names them or because they are
+the groups `base-group` and `build-group` name, which are active on
+every run. The run then forks into one resolve per choice of member;
+see [Conflicting extras and groups](../explanation/conflicts.md).
+
+A package that only a selected extra or group reaches is emitted with
 a `'X' in extras` or `'X' in dependency_groups` marker, so an
 installer given neither leaves it out; see
 [Lockfiles](lockfile.md).

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -25,7 +25,9 @@ constraints = ["urllib3<2"]
 # and pinned into the lock.  The names are also recorded in the
 # lockfile's default-groups array.  Two members of the same
 # at-most-one or exactly-one set in [tool.nab].conflicts cannot
-# both be defaults.
+# both be defaults.  A --groups selection that adds a second
+# member of such a set to a default forks the run into one
+# resolve per member.
 default-groups = ["dev"]
 
 # The group name a lock gives the project's own [project.dependencies],

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -887,6 +887,12 @@ class TestDefaultGroups:
         comment = default_groups_doc_comment().lower()
         assert any(word in comment for word in ("resolve", "activat")), comment
 
+    def test_doc_notes_the_conflict_fork(self) -> None:
+        # A default that --groups joins to another member of its conflict
+        # set forks rather than unions, so "every resolve" needs the caveat.
+        comment = default_groups_doc_comment()
+        assert "forks" in comment, comment
+
 
 class TestMainGroup:
     """``base-group`` names the project's own dependencies in a lock."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3569,12 +3569,86 @@ def _doc_section(text: str, heading: str) -> str:
     return text.partition(f"\n{heading}\n")[2].partition("\n## ")[0]
 
 
+def _doc_paragraph(text: str, needle: str) -> str:
+    """The blank-line-delimited paragraph of ``text`` that contains ``needle``."""
+    for paragraph in text.split("\n\n"):
+        if needle in paragraph:
+            return paragraph
+
+    msg = f"no paragraph containing {needle!r}"
+    raise AssertionError(msg)
+
+
 def _names_flag(text: str, flag: str) -> bool:
     """Whether ``text`` names ``flag``, its ``--no-`` form, or a covering wildcard."""
     forms = [flag, f"--no-{flag.removeprefix('--')}"]
     if flag.startswith("--project-"):
         forms.append("--project-*")
     return any(re.search(rf"`{re.escape(form)}(?![\w-])", text) for form in forms)
+
+
+class TestCliReferenceSelectionShape:
+    """The reference's selection paragraph matches how many resolves a selection runs.
+
+    ``--extras`` and ``--groups`` union into one resolve until they select
+    two members of a declared conflict set, which forks the run.
+    """
+
+    _EXTRAS = (
+        '[project]\nname = "proj"\nversion = "0.1.0"\ndependencies = []\n'
+        "[project.optional-dependencies]\n"
+        "cpu = []\n"
+        "gpu = []\n"
+    )
+
+    _CONFLICT = '[tool.nab]\nconflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]\n'
+
+    def _emitted_labels(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str], body: str
+    ) -> list[str]:
+        """The ``# label`` headers ``nab lock --extras cpu gpu`` prints for ``body``.
+
+        The requirements formats label one block per emitted target and omit
+        the header when there is only one, so for these single-target
+        specific-mode locks the headers count the forks.
+        """
+        pyproject = _make_pyproject(tmp_path, body)
+        lock(
+            pyproject,
+            cache_dir=tmp_path / "cache",
+            offline=True,
+            extras=("cpu", "gpu"),
+            format="requirements-without-hashes",
+            output=Path("-"),
+        )
+        printed = capsys.readouterr().out
+        return [line for line in printed.splitlines() if line.startswith("# ")]
+
+    def _selection_paragraph(self) -> str:
+        """The ``nab lock`` paragraph that states what a selection resolves to."""
+        text = _doc_section(
+            _CLI_REFERENCE_DOC.read_text(encoding="utf-8"), "## `nab lock`"
+        )
+        return _doc_paragraph(text, "union resolve")
+
+    def test_selection_alone_is_one_union_resolve(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Two extras with no conflict declared resolve once, as the page says."""
+        assert self._emitted_labels(tmp_path, capsys, self._EXTRAS) == []
+
+        assert "single union resolve" in self._selection_paragraph()
+
+    def test_co_selected_conflict_members_fork_the_resolve(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Declaring the same two extras exclusive resolves each separately."""
+        labels = self._emitted_labels(tmp_path, capsys, self._EXTRAS + self._CONFLICT)
+        assert labels == ["# host-extra-cpu", "# host-extra-gpu"]
+
+        paragraph = self._selection_paragraph()
+        assert "`[tool.nab].conflicts`" in paragraph
+        assert "../explanation/conflicts.md" in paragraph
 
 
 class TestCliReferenceFlagCoverage:


### PR DESCRIPTION
The `nab lock` reference said `--groups` and `--extras` produce a single union resolve, with no caveat. That holds only until the selection names two or more members of a mutually exclusive `[tool.nab].conflicts` set, when the run forks into one resolve per member. The same page already shows the forked case a few paragraphs down: the `--output` template example runs `--extras cpu gpu` and writes `req-3.12-extra-cpu.txt` alongside `req-3.12-extra-gpu.txt`.

The paragraph now names that case and links to the conflicts explanation. The `default-groups` comment in the configuration reference had the same gap, so it now says that a `--groups` selection that adds a second member of a default's conflict set forks the run rather than widening it.
