### PR TITLE
Drop the unread package_index field from Assignment

### DIFF
--- a/nab-resolver/src/nab_resolver/partial_solution.py
+++ b/nab-resolver/src/nab_resolver/partial_solution.py
@@ -71,9 +71,6 @@ class Assignment(Generic[PackageType, VersionType]):
     cum_negative: RangeProtocol[VersionType] | None = None
     """Latest negative accumulated range for the package as of this entry."""
 
-    package_index: int = 0
-    """Position in the package's own assignment trail."""
-
 
 class PartialSolution(Generic[PackageType, VersionType]):
     """Tracks the resolver's current partial solution as a decision trail.
@@ -163,7 +160,6 @@ class PartialSolution(Generic[PackageType, VersionType]):
         self._effective_range_cache.pop(package, None)
         self._undecided.discard(package)
 
-        package_entries = self._assignments_by_package[package]
         assignment = Assignment(
             package=package,
             accumulated_range=exact_range,
@@ -174,10 +170,9 @@ class PartialSolution(Generic[PackageType, VersionType]):
             positive=True,
             cum_positive=exact_range,
             cum_negative=self._negative_ranges.get(package),
-            package_index=len(package_entries),
         )
         self._assignments.append(assignment)
-        package_entries.append(assignment)
+        self._assignments_by_package[package].append(assignment)
 
     def derive(
         self,
@@ -210,7 +205,6 @@ class PartialSolution(Generic[PackageType, VersionType]):
 
         self._effective_range_cache.pop(package, None)
 
-        package_entries = self._assignments_by_package[package]
         assignment = Assignment(
             package=package,
             accumulated_range=new_range,
@@ -221,10 +215,9 @@ class PartialSolution(Generic[PackageType, VersionType]):
             positive=positive,
             cum_positive=self._positive_ranges.get(package),
             cum_negative=self._negative_ranges.get(package),
-            package_index=len(package_entries),
         )
         self._assignments.append(assignment)
-        package_entries.append(assignment)
+        self._assignments_by_package[package].append(assignment)
 
     def backtrack(self, target_level: int) -> None:
         """Remove all assignments above target_level.

--- a/nab-resolver/tests/property/test_partial_solution_model.py
+++ b/nab-resolver/tests/property/test_partial_solution_model.py
@@ -7,7 +7,7 @@ constraint shapes, are applied in lockstep to the real class and to
 :class:`ModelPS`, then every public query is compared:
 
 - trail bookkeeping (levels monotone non-decreasing, decision count
-  equals ``decision_level``, ``trail_index``/``package_index`` match);
+  equals ``decision_level``, ``trail_index`` matches trail position);
 - state queries (``get`` membership, ``decisions``,
   ``undecided_packages``, ``has_positive_constraint``);
 - the binary-search ``satisfier``;
@@ -53,11 +53,10 @@ def _check_trail_invariants(ps: PartialSolution[str, int], model: ModelPS) -> No
     )
     for i, a in enumerate(trail):
         assert a.trail_index == i
+
     for pkg in PROBE_PACKAGES:
         entries = list(ps.assignments_for(pkg))
         assert entries == [a for a in trail if a.package == pkg]
-        for j, a in enumerate(entries):
-            assert a.package_index == j
 
 
 def _check_state(ps: PartialSolution[str, int], model: ModelPS) -> None:
@@ -118,8 +117,8 @@ def test_satisfier_matches_model(
                     f"satisfier missing for {term!r}, model index {idx}"
                 )
                 assert impl is entries[idx], (
-                    f"satisfier mismatch for {term!r}: impl index "
-                    f"{impl.package_index}, model index {idx}"
+                    f"satisfier mismatch for {term!r}: impl trail index "
+                    f"{impl.trail_index}, expected {entries[idx].trail_index}"
                 )
 
 


### PR DESCRIPTION
`Assignment.package_index` is written by every `decide()` and `derive()` and read by nothing. Dropping it:

- takes the slots dataclass from 11 fields to 10
- takes a live trail entry from 120 bytes to 112 on 64-bit CPython
- leaves decisions identical, and shows no wall change locally

Its only reader was `satisfier_is_sole`, through `_effective_range_before`, which stepped back one entry in the package's own trail to ask what earlier assignments implied. Both went in June with the partial-satisfier backjump fix, and the writes stayed. `trail_index` still has a live reader in `conflict.py`, so it stays.

Nothing flagged this because the field kept a reader: a property test asserting it equals the position it was assigned from, which cannot fail. That assertion goes with the field. The check that `assignments_for(pkg)` equals the trail filtered to that package stays.
