### PR TITLE
Fix UnicodeEncodeError on a lone surrogate in a PEP 691 listing

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -455,7 +455,7 @@ def _parse_files(
     PEP 592 ``yanked`` files are dropped unconditionally.
 
     A single malformed *entry* (non-dict, missing string ``filename`` /
-    ``url``, or a ``url`` that does not parse) is skipped so the usable
+    ``url``, or a ``url`` that cannot be used) is skipped so the usable
     entries in the same listing are kept.  A malformed *body* (not a JSON
     object, or a ``files`` value that is not a list) is a broken response,
     not an empty one, so it raises :class:`MalformedSimpleResponseError`
@@ -498,11 +498,13 @@ def _parse_files(
 
 
 def _resolve_file_url(raw_url: str, base_url: str) -> str | None:
-    """Return the entry's absolute URL, or None when it does not parse.
+    """Return the entry's absolute URL, or None when it is not usable.
 
     PEP 691 allows a relative ``url``, which resolves against the package
-    page.  ``urlsplit`` raises on a netloc it cannot parse, such as an
-    unbalanced bracket in an IPv6 host.
+    page.  ``urlsplit`` rejects a netloc it cannot parse, such as an
+    unbalanced bracket in an IPv6 host, and ``encode`` rejects a string
+    with no UTF-8 form, such as one holding an unpaired surrogate; both
+    signal it with a ``ValueError``.
 
     ``urlsplit`` deletes a tab, CR or LF anywhere in a URL, so the split
     round trip stores the URL a later parse of the record would yield.
@@ -515,9 +517,14 @@ def _resolve_file_url(raw_url: str, base_url: str) -> str | None:
             if raw_url.startswith(("https://", "http://"))
             else urljoin(base_url, raw_url)
         )
-        return urlunsplit(urlsplit(absolute))
+        file_url = urlunsplit(urlsplit(absolute))
+
+        # Encode only to reject a string with no UTF-8 form.
+        file_url.encode()
     except ValueError:
         return None
+
+    return file_url
 
 
 def _parse_file_entry(
@@ -532,7 +539,7 @@ def _parse_file_entry(
     ``filename`` and ``raw_url`` are the entry's already-validated string
     fields.  ``expected`` is the queried package's canonical name; files
     whose parsed name differs, whose filename packaging does not
-    recognise, or whose URL does not parse are dropped (see
+    recognise, or whose URL cannot be used are dropped (see
     :func:`_parse_files`).
     """
     file_url = _resolve_file_url(raw_url, base_url)

--- a/nab-index/src/nab_index/parsed_listing.py
+++ b/nab-index/src/nab_index/parsed_listing.py
@@ -104,9 +104,10 @@ def encode(files: list[WheelFile | SdistFile], body_digest: str) -> bytes:
                 ]
             )
     header = [FORMAT_VERSION, CODEC, KEY_SCHEME, body_digest]
-    return json.dumps(
-        [header, rows], ensure_ascii=False, separators=(",", ":")
-    ).encode()
+
+    # Escape non-ASCII: a field kept verbatim from the listing, such as
+    # ``requires_python``, can hold a lone surrogate with no UTF-8 form.
+    return json.dumps([header, rows], separators=(",", ":")).encode()
 
 
 def decode(blob: bytes, policy: CachePolicy) -> list[WheelFile | SdistFile] | None:

--- a/nab-index/tests/test_index_parsed_cache.py
+++ b/nab-index/tests/test_index_parsed_cache.py
@@ -487,6 +487,51 @@ class TestWritePathParsedBlob:
         assert decode(old_blob, policy) is None
 
 
+_SURROGATE_REQUIRES_PYTHON = ">=3.8\ud800"
+
+# The escape is plain ASCII on the wire; json.loads is what makes it a surrogate.
+_SURROGATE_LISTING_BYTES = json.dumps(
+    {
+        "meta": {"api-version": "1.0"},
+        "name": "pkg",
+        "files": [
+            {
+                "filename": "pkg-1.0-py3-none-any.whl",
+                "url": "https://files.example.com/pkg-1.0-py3-none-any.whl",
+                "requires-python": _SURROGATE_REQUIRES_PYTHON,
+                "hashes": {"sha256": "cafef00d"},
+            }
+        ],
+    }
+).encode()
+
+
+class TestSurrogateInListingString:
+    def test_field_with_no_utf8_form_is_served_and_cached(self, tmp_path: Path) -> None:
+        """A field with no UTF-8 form must not abort the fetch or the blob write.
+
+        ``requires-python`` is kept verbatim, so a surrogate in it reaches the
+        blob; the warm read proves the blob was written rather than rebuilt.
+        """
+        cache = _cache(tmp_path)
+        transport = _FakeTransport([_FakeResponse(_SURROGATE_LISTING_BYTES)])
+        client = CachedAsyncSimpleClient(transport, cache, _INDEX)
+
+        files = _run(client.get_files("pkg"))
+
+        assert [record.requires_python for record in files] == [
+            _SURROGATE_REQUIRES_PYTHON
+        ]
+
+        stats = ParsedCacheStats()
+        warm = CachedAsyncSimpleClient(
+            _FakeTransport([]), cache, _INDEX, parsed_stats=stats
+        )
+
+        assert _run(warm.get_files("pkg")) == files
+        assert (stats.hit, stats.miss, stats.rebuild) == (1, 0, 0)
+
+
 _PARSED = _parse_files(json.loads(_LISTING_BYTES), _INDEX_NORM, "pkg")
 
 _JSON_PATH_PARTS = (_SIMPLE_BUCKET, "pypi", "pkg.json")

--- a/nab-index/tests/test_parsed_listing_codec.py
+++ b/nab-index/tests/test_parsed_listing_codec.py
@@ -12,6 +12,7 @@ reaching a record.
 
 from __future__ import annotations
 
+import dataclasses
 import json
 import sys
 
@@ -141,6 +142,17 @@ def test_metadata_hash_present_and_absent() -> None:
     assert isinstance(bare, WheelFile)
     assert full.metadata_hash == ("sha256", "dead")
     assert bare.metadata_hash is None
+
+
+def test_lone_surrogate_in_field_round_trips() -> None:
+    """A field with no UTF-8 form still round-trips, escaped in the blob.
+
+    ``json.loads`` accepts an unpaired ``\\udXXX`` escape, so a listing can put
+    one in ``requires-python``, which ``_parse_files`` keeps verbatim.
+    """
+    record = dataclasses.replace(SDIST_FULL, requires_python=f"{RP}\ud800")
+
+    assert decode(encode([record], DIGEST), _policy()) == [record]
 
 
 def test_blob_is_portable_json() -> None:

--- a/nab-python/tests/property_python/test_parsed_listing_equiv.py
+++ b/nab-python/tests/property_python/test_parsed_listing_equiv.py
@@ -12,8 +12,9 @@ This harness discharges that contract two ways:
 
 * a Hypothesis strategy generating PEP 691 bodies across the parse surface
   (wheels, sdists, name-mismatch phantoms, yanked bool/string, non-string
-  ``requires-python``, negative/bool/string ``size``, PEP 714 key
-  precedence, empty and multi hash, relative and absolute URLs), and
+  and unpaired-surrogate ``requires-python``, negative/bool/string
+  ``size``, PEP 714 key precedence, empty and multi hash, relative and
+  absolute URLs), and
 * a checked-in trimmed real corpus (boto3, botocore, cryptography, and one
   large AI-stack body, torch).
 
@@ -145,7 +146,7 @@ def _file_entry(draw: st.DrawFn, package: str) -> Any:
         entry["hashes"] = draw(_hash_table())
     if draw(st.booleans()):
         entry["requires-python"] = draw(
-            st.sampled_from([">=3.9", ">=3.7,<4", "", 3.9, 3, None])
+            st.sampled_from([">=3.9", ">=3.7,<4", ">=3.9\ud800", "", 3.9, 3, None])
         )
     if draw(st.booleans()):
         entry["upload-time"] = draw(

--- a/nab-python/tests/test_simple_client_malformed.py
+++ b/nab-python/tests/test_simple_client_malformed.py
@@ -142,3 +142,24 @@ def test_sdist_entry_with_unsplittable_url_is_skipped() -> None:
     }
     files = _parse_files({"files": [entry, _good_file()]}, _INDEX, "foo")
     assert [f.filename for f in files] == ["foo-1.0-py3-none-any.whl"]
+
+
+@pytest.mark.parametrize(
+    "bad_url",
+    [
+        pytest.param(
+            "https://example.com/foo/foo-2.0-py3-none-any.whl?sig=\ud800",
+            id="absolute",
+        ),
+        pytest.param("../pool/foo-2.0-py3-none-any.whl?sig=\ud800", id="relative"),
+    ],
+)
+def test_entry_with_no_utf8_url_is_skipped(bad_url: str) -> None:
+    """Only the entry whose URL holds an unpaired surrogate is dropped.
+
+    ``json.loads`` accepts a lone ``\\udXXX`` escape, so a listing can serve
+    one, but there is no byte form to request it with.
+    """
+    entry = {"filename": "foo-2.0-py3-none-any.whl", "url": bad_url}
+    files = _parse_files({"files": [entry, _good_file()]}, _INDEX, "foo")
+    assert [f.filename for f in files] == ["foo-1.0-py3-none-any.whl"]


### PR DESCRIPTION
`json.loads` accepts an unpaired surrogate escape, so an index can serve a listing whose `requires-python`, or any other string nab keeps verbatim, holds a lone surrogate. The parsed-listing blob is serialized with `ensure_ascii=False`, which puts that character straight into the UTF-8 encode, and the encode raises.

The write sits on the fetch path, so the `UnicodeEncodeError` comes back out of `get_files` and fails every resolve that touches the package:

- on the cold fetch
- again on the warm read, which rebuilds the blob from the cached body

Dropping `ensure_ascii=False` escapes the character instead, so the blob is ASCII and decodes back to the same string.

A `url` is the one field where a surrogate is more than an encoding problem, since there is no byte form to request it with. Entries whose `url` holds one are now dropped at parse time along with the other unusable URLs.
