### PR TITLE
Stop an unwritable cache root from crashing a warm resolve

### DIFF
--- a/nab-index/src/nab_index/cache.py
+++ b/nab-index/src/nab_index/cache.py
@@ -191,6 +191,7 @@ class OnDiskCache:
 
     Stores are best-effort: a write the filesystem refuses is dropped,
     just as an entry that cannot be read is a miss.
+    :meth:`put_simple_parsed` raises instead.
     """
 
     def __init__(
@@ -355,7 +356,10 @@ class OnDiskCache:
             return None
 
     def put_simple_parsed(self, package: str, blob: bytes) -> None:
-        """Write the opaque parsed-listing blob for ``package`` atomically."""
+        """Write the opaque parsed-listing blob for ``package`` atomically.
+
+        A refused write raises ``OSError``.
+        """
         _atomic_write(self._parsed_path(package), blob)
 
     def get_metadata(self, package: str, metadata_url: str) -> str | None:

--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -303,6 +303,7 @@ class CachedAsyncSimpleClient:
         self._parsed_stats = (
             parsed_stats if parsed_stats is not None else ParsedCacheStats()
         )
+        self._parsed_store_failed = False
 
     async def aclose(self) -> None:
         """Close the underlying transport."""
@@ -461,10 +462,22 @@ class CachedAsyncSimpleClient:
         records is skipped too: :meth:`_parsed_hit` declines a blob holding
         none, so writing one would rebuild and rewrite it on every later read
         without ever serving it.
+
+        A refused write is dropped: the blob only accelerates a read the raw
+        body already answers. Only the first refusal warns.
         """
         if digest is None or not files:
             return
-        self._cache.put_simple_parsed(package, _encode_parsed(files, digest))
+
+        blob = _encode_parsed(files, digest)
+        try:
+            self._cache.put_simple_parsed(package, blob)
+        except OSError as exc:
+            if not self._parsed_store_failed:
+                self._parsed_store_failed = True
+                logger.warning(
+                    "cannot store parsed listings for %s: %s", self._index_url, exc
+                )
 
     def _rebuild_parsed(
         self,

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -1349,6 +1349,35 @@ class TestGetFiles:
         files = asyncio.run(go())
         assert len(files) == 1
 
+    def test_unwritable_parsed_bucket_still_serves_a_warm_listing(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A refused blob write still serves the listing from the cached body.
+
+        A fresh body with no blob beside it rebuilds one on every read, so the
+        refusal repeats and the run warns about it once.
+        """
+        cache = _make_cache(tmp_path)
+        cache.put_simple("pkg", LISTING_BYTES, _fresh_policy())
+
+        bucket = tmp_path / f"simple-parsed-{cache_mod.CACHE_VERSION_SIMPLE_PARSED}"
+        bucket.write_bytes(b"not a directory")
+
+        async def go() -> tuple[list, list]:
+            client = CachedAsyncSimpleClient(_FakeTransport(), cache)
+            try:
+                return (await client.get_files("pkg"), await client.get_files("pkg"))
+            finally:
+                await client.aclose()
+
+        with caplog.at_level(logging.WARNING, logger="nab_index.cached_client"):
+            first, second = asyncio.run(go())
+
+        assert [f.filename for f in first] == ["pkg-1.0-py3-none-any.whl"]
+        assert [f.filename for f in second] == [f.filename for f in first]
+
+        assert len(_cached_warnings(caplog)) == 1
+
 
 class TestResponseAge:
     """An Age header counts toward the entry's age (RFC 9111 4.2.3).


### PR DESCRIPTION
`nab lock` against a warm cache whose root is read-only or out of space ends in a `PermissionError` traceback instead of a resolve.

Every other store in `OnDiskCache` is best effort and drops a write the filesystem refuses. `put_simple_parsed` wrote straight through, so the first cached listing body with no parsed blob beside it took the rebuild path and raised.

A refused blob write is now dropped the same way, with one warning per index. The listing still comes from the cached body, and the cost is reparsing it on each read.
