### PR TITLE
Stop the failure report printing a VersionRange debug repr

### DIFF
--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -40,6 +40,7 @@ from ._vcs_admission import (
     VcsPolicy,
 )
 from ._vendor.packaging.ranges import VersionRange
+from ._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
 from ._vendor.packaging.utils import canonicalize_name
 from .metadata import WheelMetadata
 from .target import host_environment
@@ -475,6 +476,51 @@ def _unset_if_none(value: object) -> object:
     if value is None:
         return _UNSET
     return value
+
+
+# Past this many exclusions the requirement reads worse than the range it states.
+_MAX_EXCLUSIONS = 3
+
+
+def _requirement_over_listing(
+    constraint: VersionRange,
+    universe: Sequence[Version],
+    selected: Sequence[Version],
+) -> VersionRange | None:
+    """Return the requirement admitting exactly ``selected`` out of ``universe``.
+
+    Bounds ``selected`` on each side ``constraint`` is bounded, then excludes
+    by name every other listed version those bounds admit.  Built out of
+    specifiers, so it has a spelling to render.
+
+    ``None`` when a bound carries a local segment, which an ordering specifier
+    does not accept, or when the span holds more than ``_MAX_EXCLUSIONS``
+    versions to exclude.
+    """
+    clauses: list[str] = []
+    if not VersionRange.from_bounds(None, selected[0]).is_subset(constraint):
+        clauses.append(f">={selected[0]}")
+    if not VersionRange.from_bounds(selected[-1], None).is_subset(constraint):
+        clauses.append(f"<={selected[-1]}")
+
+    try:
+        bounded = SpecifierSet(",".join(clauses)).to_range()
+    except InvalidSpecifier:
+        return None
+
+    chosen = set(selected)
+    holes: list[Version] = []
+    for version in universe:
+        if version in bounded and version not in chosen:
+            holes.append(version)
+            if len(holes) > _MAX_EXCLUSIONS:
+                return None
+
+    if not holes:
+        return bounded
+
+    clauses.extend(f"!={hole}" for hole in holes)
+    return SpecifierSet(",".join(clauses)).to_range()
 
 
 class Provider:
@@ -2018,10 +2064,16 @@ class Provider:
     ) -> RangeProtocol[Version]:
         """Map a possibly-widened ``constraint`` back onto listed versions.
 
-        A constraint containing every listed version is promoted to the full
-        range rather than snapped, so it reads as "any version".  An empty
-        universe never promotes: that would widen a constraint no version
-        satisfies.
+        Returns a requirement admitting the same listed versions as
+        ``constraint``, built out of specifiers so :meth:`format_range` has a
+        spelling to print.  Where no short requirement states those versions,
+        ``constraint`` stands if it spells, and is snapped onto the listing if
+        it does not.
+
+        A constraint containing every listed version becomes the full range,
+        so it reads as "any version".  One containing none is returned
+        unchanged, as is any constraint under an empty listing: promoting
+        there would widen a constraint no version satisfies.
 
         Render-time only and cache-only: the ROOT sentinel (a non-str
         package) and packages whose listing is not cached return
@@ -2034,14 +2086,19 @@ class Provider:
         if version_list is None:
             return constraint
         assert isinstance(constraint, VersionRange)
+
         universe = self._ascending_versions(normalized, version_list)
-        if (
-            universe
-            and universe[-1] in constraint
-            and all(version in constraint for version in universe)
-        ):
+        selected = [version for version in universe if version in constraint]
+        if not selected:
+            return constraint
+        if len(selected) == len(universe):
             return VersionRange.full(admit_arbitrary=False)
-        return constraint.snap_bounds(universe)
+
+        spelled = _requirement_over_listing(constraint, universe, selected)
+        if spelled is not None:
+            return spelled
+        has_spelling = constraint.to_specifier_set() is not None
+        return constraint if has_spelling else constraint.snap_bounds(universe)
 
     def format_range(self, constraint: RangeProtocol[Version]) -> str:
         """Render ``constraint`` for a failure report.

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -3460,6 +3460,50 @@ class TestAugmentResolutionError:
             " requires b in ==1.0 but root has it in >=2"
         ) in diagnostics
 
+    def test_derivation_renders_readable_ranges(self, tmp_path: Path) -> None:
+        """The derivation states ranges as requirements, like the diagnostics do.
+
+        ``a`` and ``b`` pin ``c`` at different versions, so the term the report
+        carries for ``b`` is the widened complement of ``b``'s pin.
+        """
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "proj"\ndependencies = ["a", "b"]\n',
+            encoding="utf-8",
+        )
+
+        coordinator = make_coordinator(
+            listings={
+                "a": _index_wheels("a", "7.0"),
+                "b": _index_wheels("b", "8.0"),
+                "c": _index_wheels("c", "1.0", "2.0"),
+            },
+            metadata_by_version={
+                "7.0": _metadata("a", "7.0", "c==1.0"),
+                "8.0": _metadata("b", "8.0", "c==2.0"),
+                "1.0": _metadata("c", "1.0"),
+                "2.0": _metadata("c", "2.0"),
+            },
+        )
+
+        with patch("nab_python.resolve.FetchCoordinator") as mock_coord_cls:
+            mock_coord_cls.return_value.__enter__ = lambda _self: coordinator
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            with pytest.raises(ResolutionError) as info:
+                _resolved(pyproject, _FAKE_TRANSPORT, python_version="3.12.0")
+
+        derivation = str(info.value).split("Diagnostics:")[0]
+        assert derivation.splitlines() == [
+            "because all versions of a depend on c ==1.0",
+            "because all versions of b are incompatible with c <=1.0",
+            "so all versions of a and all versions of b",
+            "because your project depends on b",
+            "so all versions of a",
+            "because your project depends on a",
+            "so your project's requirements cannot be satisfied",
+            "",
+        ]
+
 
 class TestConflictingRootRequirements:
     def test_both_requirements_are_named(self, tmp_path: Path) -> None:

--- a/nab-python/tests/test_widen_decision.py
+++ b/nab-python/tests/test_widen_decision.py
@@ -93,6 +93,11 @@ def _listing_provider(package: str, versions: list[str]) -> Provider:
     return provider
 
 
+def _descending_listing(count: int) -> list[str]:
+    """``count`` versions, ``1.0`` up to ``1.<count - 1>``, newest first."""
+    return [f"1.{index}" for index in reversed(range(count))]
+
+
 def _deps_provider(
     graph: dict[str, dict[str, list[str]]],
     package: str,
@@ -570,6 +575,63 @@ class TestNarrowForDisplay:
         provider.versions_cache["empty"] = []
         constraint = SpecifierSet(">=1,<2").to_range()
         assert provider.narrow_for_display("empty", constraint) == constraint
+
+    def test_range_no_listed_version_satisfies_is_unchanged(self) -> None:
+        """With nothing listed to state it over, the constraint stands."""
+        provider = _listing_provider("p", ["1.0"])
+        constraint = SpecifierSet(">=5").to_range()
+        assert provider.narrow_for_display("p", constraint) is constraint
+
+    def test_narrowed_pin_complement_reads_as_a_requirement(self) -> None:
+        """The complement of a pin reads as a requirement.
+
+        Snapping it onto the listing lands on bounds no specifier set spells.
+        """
+        provider = _listing_provider("p", ["2.0", "1.0"])
+        constraint = SpecifierSet("==2.0").to_range().complement()
+        snapped = constraint.snap_bounds([V("1.0"), V("2.0")])
+        assert snapped.to_specifier_set() is None
+
+        narrowed = provider.narrow_for_display("p", constraint)
+        assert provider.format_range(narrowed) == "<=1.0"
+
+    def test_narrowing_keeps_an_unbounded_side_unbounded(self) -> None:
+        """Neither side is stated when the constraint reaches past the listing."""
+        provider = _listing_provider("p", ["3.0", "2.0", "1.0"])
+        narrowed = provider.narrow_for_display("p", SpecifierSet("!=2.0").to_range())
+        assert provider.format_range(narrowed) == "!=2.0"
+
+    def test_narrowing_states_the_versions_the_span_would_admit(self) -> None:
+        """A listed version inside the stated span is excluded by name."""
+        provider = _listing_provider("p", ["4.0", "3.0", "2.0", "1.0"])
+        constraint = SpecifierSet(">=1.0,<=3.0,!=2.0").to_range()
+        narrowed = provider.narrow_for_display("p", constraint)
+        assert provider.format_range(narrowed) == "!=2.0,<=3.0,>=1.0"
+
+    def test_local_version_bound_keeps_the_constraint(self) -> None:
+        """An ordering specifier takes no local segment, so the term stands."""
+        provider = _listing_provider("p", ["2.0", "1.0+cuda"])
+        narrowed = provider.narrow_for_display("p", SpecifierSet("<2.0").to_range())
+        assert provider.format_range(narrowed) == "<2.0"
+
+    def test_narrowing_states_a_few_holes_by_name(self) -> None:
+        """Several listed versions inside the span are each excluded by name."""
+        provider = _listing_provider("p", _descending_listing(30))
+        window = SpecifierSet(">=1.5,<=1.20").to_range()
+        constraint = window - SpecifierSet(">=1.10,<=1.12").to_range()
+        narrowed = provider.narrow_for_display("p", constraint)
+        assert provider.format_range(narrowed) == "!=1.10,!=1.11,!=1.12,<=1.20,>=1.5"
+
+    def test_narrowing_a_span_full_of_holes_falls_back_to_snapping(self) -> None:
+        """Past a handful of holes the exclusions run longer than the range."""
+        provider = _listing_provider("p", _descending_listing(30))
+        window = SpecifierSet(">=1.5,<=1.20").to_range()
+        constraint = window - SpecifierSet(">=1.10,<=1.13").to_range()
+        narrowed = provider.narrow_for_display("p", constraint)
+        assert (
+            provider.format_range(narrowed)
+            == "<VersionRange '[1.5, 1.9] | [1.14, 1.20]'>"
+        )
 
     def test_availability_line_keeps_its_range(self) -> None:
         """``a`` is rejected only against pinned ``c``, so the line keeps its range.


### PR DESCRIPTION
A failed resolve printed a range object where a requirement belongs:

    because all versions of b are incompatible with c <VersionRange '(-inf, 1.0] | (2.0[AFTER_LOCALS], +inf)'>

with `a` depending on `c==1.0` and `b` on `c==2.0`. That line should read `c <=1.0`.

Before rendering a term the report maps it back onto the versions the index lists, and snapping the bounds onto that listing can land on boundaries no specifier set spells. The renderer then falls back to the range's own repr, and the internal boundary kinds leak into the output.

The narrowing now builds the display range out of specifiers: bound the versions the term admits on each side the term is bounded, then exclude by name any other listed version those bounds would let back in. Past three exclusions that reads worse than the range itself, so the narrowing stops there and the term keeps the spelling it already had.
