### PR TITLE
Skip contradicted clauses in unit propagation, ~40% off a backtracking resolve

### DIFF
--- a/nab-resolver/src/nab_resolver/conflict.py
+++ b/nab-resolver/src/nab_resolver/conflict.py
@@ -476,7 +476,10 @@ def maybe_restart(
         return restart_threshold, restarts_remaining, False
 
     resolver.stats.restarts += 1
-    resolver.solution = PartialSolution(range_type=resolver.range_type)
+    resolver.solution = PartialSolution(
+        range_type=resolver.range_type,
+        contradiction_epoch=resolver.solution.contradiction_epoch + 1,
+    )
     resolver.solution.decide(ROOT, resolver.root_version)
     resolver.pending_targeted_backtrack.clear()
     resolver.stats.targeted_backtracks = 0

--- a/nab-resolver/src/nab_resolver/incompat_index.py
+++ b/nab-resolver/src/nab_resolver/incompat_index.py
@@ -1,10 +1,12 @@
 """Incompatibility index and dependency-clause merging.
 
-The resolver keeps two derived indexes alongside ``incompatibilities``:
+The resolver keeps three structures alongside ``incompatibilities``:
 ``package_to_incompatibilities`` (package -> list of clause indices) for
-unit-propagation lookup, and ``dependency_index`` (merge key -> index)
-for collapsing many singleton dependency clauses into one
-``pkg in {v1, v2, ...}`` clause (pubgrub-rs's ``merge_dependents``).
+unit-propagation lookup, ``dependency_index`` (merge key -> index) for
+collapsing many singleton dependency clauses into one
+``pkg in {v1, v2, ...}`` clause (pubgrub-rs's ``merge_dependents``), and
+``clause_contradicted_at`` (clause index -> epoch), unit propagation's
+per-clause skip stamp.
 """
 
 from __future__ import annotations
@@ -28,6 +30,10 @@ __all__ = [
 # A dependency-style clause is exactly two terms (parent + dep).
 _DEPENDENCY_CLAUSE_TERMS = 2
 
+# Stamp for a clause with no term known to be contradicted.  Epochs start at
+# zero, so this can never read as current.
+_NOT_CONTRADICTED = -1
+
 
 def add_incompatibility(
     resolver: Resolver[Any, Any], incompatibility: Incompatibility[Any, Any]
@@ -38,6 +44,7 @@ def add_incompatibility(
 
     index = len(resolver.incompatibilities)
     resolver.incompatibilities.append(incompatibility)
+    resolver.clause_contradicted_at.append(_NOT_CONTRADICTED)
     for term in incompatibility.terms:
         resolver.package_to_incompatibilities[term.package].append(index)
     index_dependency(resolver, incompatibility, index)
@@ -116,4 +123,6 @@ def maybe_merge_dependency(
     # Safe to replace in place: DEPENDENCY clauses have no cause_left/right
     # references that would break.
     resolver.incompatibilities[existing_index] = merged
+    # The union widens the package term, which can lift a contradiction.
+    resolver.clause_contradicted_at[existing_index] = _NOT_CONTRADICTED
     return True

--- a/nab-resolver/src/nab_resolver/partial_solution.py
+++ b/nab-resolver/src/nab_resolver/partial_solution.py
@@ -82,8 +82,19 @@ class PartialSolution(Generic[PackageType, VersionType]):
     See: https://en.wikipedia.org/wiki/Conflict-driven_clause_learning#Organization
     """
 
-    def __init__(self, range_type: type[RangeProtocol[Any]] = Range) -> None:
-        """Initialize an empty partial solution."""
+    def __init__(
+        self,
+        range_type: type[RangeProtocol[Any]] = Range,
+        *,
+        contradiction_epoch: int = 0,
+    ) -> None:
+        """Initialize an empty partial solution.
+
+        ``contradiction_epoch`` carries on from a solution this one replaces,
+        so a stamp taken against the old trail cannot look current against the
+        new one.
+        """
+        self._contradiction_epoch = contradiction_epoch
         self._range_type = range_type
         self._assignments: list[Assignment[PackageType, VersionType]] = []
         self._decision_level = 0
@@ -108,6 +119,17 @@ class PartialSolution(Generic[PackageType, VersionType]):
     def decision_level(self) -> int:
         """Return the current decision depth."""
         return self._decision_level
+
+    @property
+    def contradiction_epoch(self) -> int:
+        """Return the epoch a contradicted term stays contradicted for.
+
+        It advances on a rollback, and on any assignment that empties a
+        package's range: an empty range is both a subset of and disjoint from
+        every constraint, so terms on that package stop reading as
+        contradicted.
+        """
+        return self._contradiction_epoch
 
     @property
     def trail_length(self) -> int:
@@ -153,6 +175,14 @@ class PartialSolution(Generic[PackageType, VersionType]):
         self._effective_range_cache[package] = result
         return result
 
+    def _refresh_effective_range(self, package: PackageType) -> None:
+        """Recompute the package's range, advancing the epoch if it emptied."""
+        self._effective_range_cache.pop(package, None)
+        effective = self.get(package)
+        assert effective is not None
+        if effective.is_empty:
+            self._contradiction_epoch += 1
+
     def decide(self, package: PackageType, version: VersionType) -> None:
         """Record a decision: pick a specific version for a package."""
         self._decision_level += 1
@@ -160,7 +190,7 @@ class PartialSolution(Generic[PackageType, VersionType]):
 
         self._positive_ranges[package] = exact_range
         self._decided_versions[package] = version
-        self._effective_range_cache.pop(package, None)
+        self._refresh_effective_range(package)
         self._undecided.discard(package)
 
         package_entries = self._assignments_by_package[package]
@@ -208,7 +238,7 @@ class PartialSolution(Generic[PackageType, VersionType]):
                 new_range = self._range_type.empty() | constraint
             self._negative_ranges[package] = new_range
 
-        self._effective_range_cache.pop(package, None)
+        self._refresh_effective_range(package)
 
         package_entries = self._assignments_by_package[package]
         assignment = Assignment(
@@ -235,6 +265,8 @@ class PartialSolution(Generic[PackageType, VersionType]):
         package's surviving state can be rebuilt without re-intersecting.
         See: https://github.com/dart-lang/pub/blob/master/doc/solver.md#conflict-resolution
         """
+        self._contradiction_epoch += 1
+
         while self._assignments and self._assignments[-1].decision_level > target_level:
             self._assignments.pop()
 

--- a/nab-resolver/src/nab_resolver/propagate.py
+++ b/nab-resolver/src/nab_resolver/propagate.py
@@ -40,10 +40,17 @@ def unit_propagation(
     conflicting incompatibility if all terms are satisfied, or
     None if propagation completes without conflict.
 
+    One contradicted term settles a clause for the rest of the solution's
+    contradiction epoch.  Each clause records the epoch it was last settled in,
+    and is skipped while that stamp is current.
+
     Reference: https://github.com/dart-lang/pub/blob/master/doc/solver.md#unit-propagation
     """
     propagation_queue: deque[Any] = deque([changed_package])
     in_queue: set[Any] = {changed_package}
+
+    contradicted_at = resolver.clause_contradicted_at
+    epoch = resolver.solution.contradiction_epoch
 
     while propagation_queue:
         package = propagation_queue.popleft()
@@ -51,8 +58,15 @@ def unit_propagation(
         related_indices = resolver.package_to_incompatibilities.get(package, [])
 
         for incompatibility_index in related_indices:
+            if contradicted_at[incompatibility_index] == epoch:
+                continue
+
             incompatibility = resolver.incompatibilities[incompatibility_index]
             evaluation = evaluate_incompatibility(resolver, incompatibility)
+
+            if evaluation is IncompatibilityState.CONTRADICTED:
+                contradicted_at[incompatibility_index] = epoch
+                continue
 
             if evaluation is IncompatibilityState.CONFLICT:
                 return incompatibility
@@ -67,6 +81,10 @@ def unit_propagation(
                     cause=incompatibility,
                 )
                 range_after = resolver.solution.get(negated_term.package)
+
+                # A derive that empties a range advances the epoch, which
+                # retires the stamps taken before it.
+                epoch = resolver.solution.contradiction_epoch
 
                 if range_before != range_after:
                     resolver.stats.derivations += 1
@@ -89,8 +107,9 @@ def evaluate_incompatibility(
 
     Returns:
       ``IncompatibilityState.CONFLICT``: all terms satisfied
+      ``IncompatibilityState.CONTRADICTED``: some term is contradicted
       ``Term``: exactly one undetermined term (unit propagation candidate)
-      ``None``: 0 or 2+ undetermined terms (nothing to do yet)
+      ``None``: two or more undetermined terms (nothing to do yet)
     """
     undetermined_term: Term[Any, Any] | None = None
 
@@ -99,7 +118,7 @@ def evaluate_incompatibility(
         if relation is SetRelation.SATISFIED:
             continue
         if relation is SetRelation.CONTRADICTED:
-            return None
+            return IncompatibilityState.CONTRADICTED
         if undetermined_term is not None:
             return None
         undetermined_term = term

--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -452,6 +452,11 @@ class Resolver(Generic[PackageType, VersionType]):
             list
         )
 
+        # Per clause, the contradiction epoch in which one of its terms was
+        # last seen contradicted; unit propagation skips a clause whose stamp
+        # is still current.
+        self.clause_contradicted_at: list[int] = []
+
         # Keyed by (package, dep_package, dep_constraint, dep_positive); used
         # to merge mergeable dependency clauses (pubgrub-rs's merge_dependents).
         self.dependency_index: dict[Any, int] = {}
@@ -648,6 +653,7 @@ class Resolver(Generic[PackageType, VersionType]):
         """Reset solver state for a new resolution."""
         self.incompatibilities.clear()
         self.package_to_incompatibilities.clear()
+        self.clause_contradicted_at.clear()
         self.dependency_index.clear()
         self.solution = PartialSolution(range_type=self.range_type)
         self.stats = ResolverStats()

--- a/nab-resolver/src/nab_resolver/types.py
+++ b/nab-resolver/src/nab_resolver/types.py
@@ -279,6 +279,10 @@ class IncompatibilityState(enum.Enum):
     """Result of evaluating an incompatibility against the partial solution."""
 
     CONFLICT = enum.auto()
+    """Every term is satisfied."""
+
+    CONTRADICTED = enum.auto()
+    """At least one term is contradicted, so the clause already holds."""
 
 
 class IncompatibilityCause(enum.Enum):

--- a/nab-resolver/tests/property/test_incompat_index.py
+++ b/nab-resolver/tests/property/test_incompat_index.py
@@ -139,7 +139,10 @@ def test_merged_store_semantically_equivalent(
 @given(specs=st.lists(clause_specs(), min_size=1, max_size=8))
 @PROPERTY_SETTINGS
 def test_package_index_matches_full_scan(specs: list[tuple[object, ...]]) -> None:
-    """The per-package index reaches exactly the clauses a full scan finds."""
+    """The per-package index reaches exactly the clauses a full scan finds.
+
+    The skip stamps stay at one entry per clause too.
+    """
     resolver = _fresh_resolver()
     for spec in specs:
         add_incompatibility(resolver, _build_clause(spec))
@@ -156,6 +159,8 @@ def test_package_index_matches_full_scan(specs: list[tuple[object, ...]]) -> Non
         )
     for indices in resolver.package_to_incompatibilities.values():
         assert all(0 <= i < len(resolver.incompatibilities) for i in indices)
+
+    assert len(resolver.clause_contradicted_at) == len(resolver.incompatibilities)
 
 
 @given(specs=st.lists(clause_specs(), min_size=1, max_size=8))

--- a/nab-resolver/tests/test_partial_solution.py
+++ b/nab-resolver/tests/test_partial_solution.py
@@ -332,3 +332,40 @@ class TestDecisionMap:
         ps.decide("bar", 1)
         assert "foo" in ps.undecided_packages()
         assert "bar" not in ps.undecided_packages()
+
+
+class TestContradictionEpoch:
+    def test_a_narrowing_that_leaves_versions_holds_the_epoch(self) -> None:
+        """Only a rollback un-contradicts a term while ranges keep versions."""
+        ps = PartialSolution()
+        inc = Incompatibility(
+            [Term("bar", Range.at_least(5))],
+            cause=IncompatibilityCause.NO_VERSIONS,
+        )
+
+        assert ps.contradiction_epoch == 0
+
+        ps.decide("foo", 5)
+        ps.derive("bar", Range.at_least(5), positive=False, cause=inc)
+        assert ps.contradiction_epoch == 0
+
+        ps.backtrack(0)
+        assert ps.contradiction_epoch == 1
+
+    def test_an_emptied_range_advances_the_epoch(self) -> None:
+        """An empty range reads as satisfied on either polarity."""
+        ps = PartialSolution()
+        inc = Incompatibility(
+            [Term("bar", Range.singleton(1))],
+            cause=IncompatibilityCause.NO_VERSIONS,
+        )
+        ps.derive("bar", Range.singleton(1), positive=True, cause=inc)
+
+        assert ps.contradiction_epoch == 0
+
+        ps.derive("bar", Range.singleton(1), positive=False, cause=inc)
+
+        effective = ps.get("bar")
+        assert effective is not None
+        assert effective.is_empty
+        assert ps.contradiction_epoch == 1

--- a/nab-resolver/tests/test_resolver.py
+++ b/nab-resolver/tests/test_resolver.py
@@ -15,6 +15,7 @@ from nab_resolver.conflict import (
     conflict_resolution,
     find_most_recent_satisfier,
     is_terminal_incompatibility,
+    maybe_restart,
     recompute_previous_level,
     try_force_resolution_step,
     update_culprit_counts,
@@ -45,6 +46,7 @@ from nab_resolver.root import ROOT
 from nab_resolver.types import (
     Incompatibility,
     IncompatibilityCause,
+    IncompatibilityState,
     RangeProtocol,
     RootRequirement,
     SetRelation,
@@ -3007,3 +3009,179 @@ class TestRelationCache:
 
         key = (True, resolver.solution.get("foo"), term.constraint)
         assert resolver.relation_cache == {key: result}
+
+
+class LowestVersionProvider(DictProvider):
+    """Provider that picks the lowest matching version rather than the highest."""
+
+    def choose_version(
+        self, package: str, version_range: RangeProtocol[int]
+    ) -> int | None:
+        for version in reversed(self._get_versions(package)):
+            if version in version_range:
+                return version
+        return None
+
+
+def climbing_packages(count: int) -> dict[str, dict[int, dict[str, Range]]]:
+    """Package data whose lowest-first resolve tries every version of ``a``.
+
+    Version ``i`` of ``a`` needs ``b`` at exactly ``i`` and only the last ``b``
+    exists, so each attempt adds a dependency clause and both packages' clause
+    lists grow with the search.
+    """
+    return {
+        "a": {
+            version: {"b": Range.singleton(version)} for version in range(1, count + 1)
+        },
+        "b": {count: {}},
+    }
+
+
+class StampAuditor(ResolverObserver[str, int]):
+    """Collects clauses a live stamp claims are contradicted but are not.
+
+    A stale stamp is invisible from outside the solver, because propagation
+    skips the clause instead of evaluating it.  An assignment is what leaves
+    one behind, so the audit runs on each derivation.
+    """
+
+    def __init__(self, resolver: Resolver[str, int]) -> None:
+        self._resolver = resolver
+        self.stale: list[Incompatibility[str, int]] = []
+
+    def on_derivation(
+        self,
+        package: str,
+        *,
+        positive: bool,
+        cause: Incompatibility[str, int],
+    ) -> None:
+        del package, positive, cause
+        resolver = self._resolver
+        epoch = resolver.solution.contradiction_epoch
+
+        for index, stamp in enumerate(resolver.clause_contradicted_at):
+            if stamp != epoch:
+                continue
+            clause = resolver.incompatibilities[index]
+            if (
+                propagate.evaluate_incompatibility(resolver, clause)
+                is not IncompatibilityState.CONTRADICTED
+            ):
+                self.stale.append(clause)
+
+
+class TestSettledClauseSkip:
+    """Cover the skip stamp unit propagation keeps for each clause."""
+
+    def test_a_settled_clause_is_not_re_evaluated_before_a_rollback(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """One contradicted term settles a clause for the rest of the epoch."""
+        evaluate = propagate.evaluate_incompatibility
+        settled: set[tuple[int, Incompatibility[str, int]]] = set()
+        repeats: list[Incompatibility[str, int]] = []
+
+        def record(
+            resolver: Resolver[str, int], incompatibility: Incompatibility[str, int]
+        ) -> IncompatibilityState | Term[str, int] | None:
+            """Note any clause evaluated twice in the epoch that settled it."""
+            key = (resolver.solution.contradiction_epoch, incompatibility)
+            if key in settled:
+                repeats.append(incompatibility)
+
+            result = evaluate(resolver, incompatibility)
+            if result is IncompatibilityState.CONTRADICTED:
+                settled.add(key)
+            return result
+
+        monkeypatch.setattr(propagate, "evaluate_incompatibility", record)
+        resolver = Resolver(LowestVersionProvider(climbing_packages(20)))
+
+        assert resolver.resolve({"a": Range.full()}) == {"a": 20, "b": 20}
+        assert repeats == [], f"{len(repeats)} settled clauses were re-evaluated"
+
+    def test_a_skipped_clause_is_still_contradicted(self) -> None:
+        """Emptying a package's range must retire the stamps on its clauses.
+
+        ``b`` has no versions at all, so propagation excludes every version of
+        it while clauses naming ``b`` already carry a stamp.
+        """
+        provider = DictProvider(
+            {"a": {1: {"b": Range.full()}, 2: {"b": Range.at_least(1)}}, "b": {}}
+        )
+        resolver = Resolver(provider)
+        auditor = StampAuditor(resolver)
+        resolver.observer = auditor
+
+        with pytest.raises(ResolutionError):
+            resolver.resolve({"a": Range.full()})
+
+        assert auditor.stale == []
+
+    def test_an_emptied_range_retires_stamps_within_one_propagation(self) -> None:
+        """A range emptied mid-propagation retires the stamps taken before it.
+
+        ``p`` carries only exclusions, so one more exclusion empties it and the
+        clause stamped earlier in the same pass stops being contradicted.  No
+        rollback happens in between, so propagation has to notice within the
+        call and derive from that clause after all.
+        """
+        setup_cause = Incompatibility(
+            [Term("p", Range.at_least(5))], cause=IncompatibilityCause.NO_VERSIONS
+        )
+        stamped = Incompatibility(
+            [Term("x", Range.singleton(1)), Term("p", Range.at_least(10))],
+            cause=IncompatibilityCause.DERIVED,
+        )
+        empties_p = Incompatibility(
+            [Term("x", Range.singleton(1)), Term("p", Range.less_than(5))],
+            cause=IncompatibilityCause.DERIVED,
+        )
+
+        resolver: Resolver[str, int] = Resolver(DictProvider({}))
+        solution = resolver.solution
+        solution.derive("p", Range.at_least(5), positive=False, cause=setup_cause)
+        solution.decide("x", 1)
+
+        add_incompatibility(resolver, stamped)
+        add_incompatibility(resolver, empties_p)
+
+        assert propagate.unit_propagation(resolver, "x") is None
+
+        causes = [entry.cause for entry in solution.assignments_for("p")]
+        assert any(cause is stamped for cause in causes)
+
+    def test_a_second_resolve_starts_from_clean_stamps(self) -> None:
+        """A finished resolve's stamps must not survive into the next one.
+
+        The epoch restarts at zero, so a leftover stamp would read as current
+        against a clause list it no longer lines up with.
+        """
+        provider = DictProvider(
+            {
+                "a": {1: {"b": Range.singleton(1)}, 2: {"b": Range.singleton(2)}},
+                "b": {1: {}, 2: {}},
+                "c": {1: {"b": Range.singleton(9)}},
+            }
+        )
+        resolver = Resolver(provider)
+        assert resolver.resolve({"a": Range.full()}) == {"a": 2, "b": 2}
+
+        with pytest.raises(ResolutionError):
+            resolver.resolve({"c": Range.full()})
+
+        assert len(resolver.clause_contradicted_at) == len(resolver.incompatibilities)
+
+    def test_a_restart_continues_the_contradiction_epoch(self) -> None:
+        """A restart drops the whole trail, so stamps taken before it go stale."""
+        resolver: Resolver[str, int] = Resolver(DictProvider({"a": {1: {}}}))
+        resolver.solution.backtrack(0)
+        before = resolver.solution.contradiction_epoch
+        resolver.stats.package_conflict_counts["a"] = 5
+
+        _, _, restarted = maybe_restart(resolver, 5, 3)
+
+        assert restarted
+        assert resolver.solution.contradiction_epoch > before


### PR DESCRIPTION
Locally, about 40% off the wall of `ecosystem:pandas-with-aws-s3 --resolution lowest`, at an identical resolution.

| | main | this branch |
|---|---|---|
| wall, median of 3 warm pairs | ~8.2 s | ~4.9 s |
| clause evaluations | 1,765,024 | 669,281 |
| decisions / conflicts / rounds | 1321 / 1077 / 2404 | 1321 / 1077 / 2404 |

The wall figures come off one machine and will land differently on other hardware. The evaluation counts are deterministic.

Unit propagation walks every clause that mentions the changed package and re-reads all of its terms, including the clauses that already hold because one term is contradicted. Those cannot go unit or conflict until something lifts the contradiction, so the walk gets more expensive as the search learns clauses it will never find anything in.

A contradicted term stays contradicted until the trail moves under it. The solution now carries a contradiction epoch, each clause records the epoch it was last seen contradicted in, and propagation skips a clause whose stamp is current. Four things retire a stamp:

- a rollback, which widens ranges
- a restart, which replaces the trail
- an assignment that empties a package's range, since an empty range is both a subset of and disjoint from every constraint, so its terms stop reading as contradicted
- merging a dependency clause, which widens the parent term

The win is shape-dependent. A decision-heavy resolve has almost nothing to skip, so `pip:apache-airflow-311-full --resolution highest` is flat, and the 19-scenario canary shows no movement worth quoting either way.
