### PR TITLE
Report a missing build system before a missing build lock

### DIFF
--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -447,13 +447,6 @@ def _fast_fail_locked(
     target = _locked_target_path(output, build_requirements=build_requirements)
     refresh = _refresh_command(build_requirements=build_requirements)
 
-    # A stat that failed is not an absent lock.
-    if path_state(target) is PathState.ABSENT:
-        _cli.printer().error(
-            f"--locked: no lockfile at {target} to check; run `{refresh}` first."
-        )
-        sys.exit(1)
-
     # A run whose own requirements cannot be read or evaluated is not the
     # lock's fault, so leave the error to the resolve rather than reporting a
     # stale lock.
@@ -474,6 +467,13 @@ def _fast_fail_locked(
         UnevaluableMarkerError,
     ):
         return
+
+    # A stat that failed is not an absent lock.
+    if path_state(target) is PathState.ABSENT:
+        _cli.printer().error(
+            f"--locked: no lockfile at {target} to check; run `{refresh}` first."
+        )
+        sys.exit(1)
 
     resolve_target = _locked_resolve_target(config, python=python)
 

--- a/tests/test_lock_locked.py
+++ b/tests/test_lock_locked.py
@@ -834,6 +834,24 @@ def test_undeclared_extra_reports_the_extra_error(
     assert "re-run `nab lock`" not in err
 
 
+def test_missing_build_system_reports_the_project_error(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    pyproject = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "proj"\nversion = "0"\ndependencies = []\n',
+    )
+    out = tmp_path / "pylock.build.toml"
+
+    with pytest.raises(SystemExit) as exc:
+        _run_locked_unmocked(pyproject, out, "--build-requirements")
+
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "declares no [build-system]" in err
+    assert "run `nab lock --build-requirements` first" not in err
+
+
 def test_unreadable_requirement_with_changed_envelope_reports_the_parse_error(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
For a project with neither `[build-system]` nor a build lock, `nab lock --locked --build-requirements` tells the user to run `nab lock --build-requirements`. That command then fails, because there are no build requirements to lock.

The check now reads the build requirements first, so the CLI reports the missing `[build-system]` instead of prescribing a command that cannot succeed.
