### PR TITLE
Fix the documented sdist pyproject fallback rule

### DIFF
--- a/docs/reference/build-policy.md
+++ b/docs/reference/build-policy.md
@@ -23,14 +23,18 @@ rather than enabling builds for the whole graph.
 Static metadata only, from any source:
 
 * Wheels: always fine; their `METADATA` is static by definition.
-* PEP 643 (Metadata 2.2+) sdists: fine; the resolver reads the
-  static `Requires-Dist` lines from `PKG-INFO`.
-* Sdists whose `PKG-INFO` declares `Dynamic: Requires-Dist`: nab
-  falls back to reading `[project].dependencies` from the
-  bundled `pyproject.toml` when the field is not listed under
-  `[project].dynamic`.  Anything beyond that is skipped at
-  look-ahead and surfaces as a no-version diagnostic if no
-  candidate ultimately works.
+* PEP 643 (Metadata 2.2+) sdists: fine when `Dynamic:` lists
+  neither `Requires-Dist` nor `Provides-Extra`; the resolver reads
+  the static `Requires-Dist` lines from `PKG-INFO`.
+* Every other sdist, whether it lists one of those fields under
+  `Dynamic:` or predates Metadata 2.2: nab falls back to the
+  bundled `pyproject.toml`, reading `[project].dependencies` and
+  `[project].optional-dependencies` when `[project].dynamic`
+  lists neither.  Anything beyond that is skipped at look-ahead
+  and surfaces as a no-version diagnostic if no candidate works.
+  Setting `trust-unverified-deps` in the `dist-policy` table
+  trusts a pre-2.2 `PKG-INFO` instead; see the
+  [configuration reference](configuration.md).
 * Local checkouts declared via `[[tool.nab.local-sources]]`:
   the directory's `pyproject.toml` is read statically.  A missing
   or malformed `[project]`, or a `dynamic` list covering
@@ -69,9 +73,9 @@ sdists.  On top of `build-local`:
 * Archive sources declared via `[[tool.nab.archive-sources]]` with
   dynamic deps have the backend invoked on the extracted tree; the
   bytes are network-fetched, so they count as remote.
-* PyPI sdists whose `PKG-INFO` is dynamic and which have no
-  static `pyproject.toml` fallback are downloaded, extracted to a
-  temp directory, and built.
+* PyPI sdists are downloaded, extracted to a temp directory, and
+  built when their `PKG-INFO` deps are not PEP 643 static and the
+  bundled `pyproject.toml` offers no static fallback.
 
 A backend failure on any of these surfaces as
 `UnsupportedSdistError`; for a PyPI sdist the resolver skips that

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -9196,11 +9196,12 @@ class TestStaticSdistMetadata:
             provider.get_dependencies("pkg", V("1.0"))
 
     def test_pyproject_marks_optional_dependencies_dynamic(self) -> None:
-        """Pyproject with optional-dependencies in dynamic also falls through."""
+        """Optional-dependencies in dynamic blocks even a static dependencies list."""
         pyproject = (
             "[project]\n"
             'name = "pkg"\n'
             'version = "1.0"\n'
+            "dependencies = ['dep-a>=1.0']\n"
             "dynamic = ['optional-dependencies']\n"
         )
         coordinator = make_coordinator(


### PR DESCRIPTION
Under `never`, `build-policy.md` described the sdist `pyproject.toml` fallback in two ways that do not match the code:

| | documented | actual |
|---|---|---|
| when the fallback runs | `PKG-INFO` declares `Dynamic: Requires-Dist` | the `PKG-INFO` deps are not PEP 643 static, which a pre-2.2 `PKG-INFO` also satisfies |
| what the static read covers | `[project].dependencies`, unless it appears in `[project].dynamic` | `dependencies` and `optional-dependencies`, and naming either one in `[project].dynamic` refuses the whole table |

So a project that declares its dependencies statically and leaves `optional-dependencies` dynamic gets no fallback, the reverse of the documented rule. The `build-remote` section carried the same narrow condition and gets the same correction, and the `never` list now points at `trust-unverified-deps` for trusting a pre-2.2 `PKG-INFO`.

The test for that refusal declared no static `dependencies`, so it could not tell the real rule from the documented one. It now declares one.
