### PR TITLE
Drop build_remote's private copy of find_sdist

### DIFF
--- a/nab-python/src/nab_python/_provider/build_remote.py
+++ b/nab-python/src/nab_python/_provider/build_remote.py
@@ -20,14 +20,13 @@ import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from nab_index.client import SdistFile, WheelFile, extract_sdist_archive
+from nab_index.client import extract_sdist_archive
 
 from .._vendor.packaging.specifiers import SpecifierSet
 from .._vendor.packaging.utils import canonicalize_name
+from .metadata_resolver import find_sdist
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-
     from .._vendor.packaging.version import Version
     from ..metadata import WheelMetadata
     from ..provider import Provider
@@ -57,7 +56,7 @@ def build_remote_sdist(
 
     canonical = canonicalize_name(package)
     versions = provider.versions_cache.get(canonical, [])
-    sdist = _find_sdist(versions, version)
+    sdist = find_sdist(versions, version)
     if sdist is None:
         msg = (
             f"{package}=={version} build-remote requested but no sdist"
@@ -122,13 +121,3 @@ def build_remote_sdist(
         )
         raise UnsupportedSdistError(msg)
     return built
-
-
-def _find_sdist(
-    versions: Sequence[tuple[Version, WheelFile | SdistFile]],
-    version: Version,
-) -> SdistFile | None:
-    for v, d in versions:
-        if v == version and isinstance(d, SdistFile):
-            return d
-    return None

--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -414,7 +414,7 @@ def resolve_dynamic_sdist(
     :func:`nab_python._provider.lookahead.look_ahead_ok` and surfaces the
     accumulated reasons if no candidate ultimately works.
     """
-    # Late import: ``provider`` imports this module at module load.
+    # Late imports: both modules import this one at module load.
     from ..provider import BuildPolicy, UnsupportedSdistError
     from .build_remote import build_remote_sdist
 


### PR DESCRIPTION
`build_remote.py` carried its own `_find_sdist` with the same body as `find_sdist` in `metadata_resolver.py`, the module beside it in `_provider`. Nothing forced the duplication: `metadata_resolver` only reaches `build_remote` through the late import inside `resolve_dynamic_sdist`, so `build_remote` can import `find_sdist` at module level without making a cycle.

- the copy goes, and the build-remote path calls the shared helper, which is already typed against the `list[tuple[Version, DistFile]]` that `versions_cache` holds
- the late-import note in `resolve_dynamic_sdist` now names both modules that import it at load time
