### PR TITLE
Resolve local index links against the page path, not its realpath

### DIFF
--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import errno
 import lzma
+import os
 import re
 import stat
 import sys
@@ -227,6 +228,9 @@ def _scan_pep503_directory(
 ) -> tuple[list[WheelFile | SdistFile], bool]:
     """Parse ``<package>/index.html`` and return file records.
 
+    ``package_dir`` has to be absolute, because the page's URI is the base
+    for its relative links.
+
     The second element says the page linked a file in a format nab does
     not read, which tells a page of ``.zip`` sdists from an empty one.
     """
@@ -241,7 +245,10 @@ def _scan_pep503_directory(
         raise MalformedLocalListingError(msg) from exc
 
     anchors, base_href = read_page(text)
-    base_url = (package_dir.resolve() / "index.html").as_uri()
+
+    # RFC 3986 section 5.1.3: the base is the URI the page was read from, not
+    # its realpath.
+    base_url = index_html.as_uri()
     if base_href is not None:
         # A base href every relative anchor resolves against, so one that
         # cannot be parsed leaves the whole page's targets unknown. Fail
@@ -566,11 +573,14 @@ class LocalIndexClient:
     """
 
     def __init__(self, index_url: str) -> None:
-        """Hold the resolved root path for ``index_url``.
+        """Hold the absolute root path for ``index_url``.
 
         A ``file:`` URL may be cwd-relative; artefact URLs have to be absolute.
+        Dropping the dot segments must not follow symlinks, so a page keeps the
+        path it was reached by.
         """
-        self._root = parse_file_url(index_url).resolve()
+        root = parse_file_url(index_url)
+        self._root = Path(os.path.abspath(root))  # noqa: PTH100
         self._unreadable_only: set[str] = set()
 
     async def aclose(self) -> None:

--- a/nab-python/tests/test_local_index.py
+++ b/nab-python/tests/test_local_index.py
@@ -501,6 +501,20 @@ class TestFlatWheelhouse:
         assert [f.url for f in wheelhouse] == [flat.as_uri()]
         assert [f.local_path for f in wheelhouse] == [flat]
 
+    def test_dot_segment_in_root_is_dropped_from_artefact_urls(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A root spelled ``idx/../idx`` still names artefacts under ``idx``."""
+        root = tmp_path.resolve() / "idx"
+        root.mkdir()
+        wheel = root / "foo-1.0-py3-none-any.whl"
+        wheel.write_bytes(b"")
+
+        monkeypatch.chdir(root.parent)
+        client = LocalIndexClient("file:idx/../idx")
+
+        assert [f.url for f in run(client.get_files("foo"))] == [wheel.as_uri()]
+
     def test_unreadable_root_raises_index_error(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -830,6 +844,66 @@ class TestPep503Directory:
         result = run(client.get_files("foo"))
         assert len(result) == 1
         assert result[0].local_path == wheel_path.resolve()
+
+    def test_symlinked_package_dir_resolves_hrefs_against_the_page_path(
+        self, tmp_path: Path
+    ) -> None:
+        """A mirror may link ``<root>/<package>`` at a directory held elsewhere.
+
+        Its shared ``../../packages/`` tree still sits beside the root, not
+        beside the link target.
+        """
+        base = tmp_path.resolve()
+        name = "foo-1.0-py3-none-any.whl"
+
+        stored = base / "store" / "foo"
+        stored.mkdir(parents=True)
+        body = f'<a href="../../packages/ab/cd/{name}">foo</a>'
+        (stored / "index.html").write_text(body, encoding="utf-8")
+
+        simple = base / "mirror" / "simple"
+        simple.mkdir(parents=True)
+        (simple / "foo").symlink_to(stored, target_is_directory=True)
+
+        wheel = base / "mirror" / "packages" / "ab" / "cd" / name
+        wheel.parent.mkdir(parents=True)
+        wheel.write_bytes(b"")
+
+        client = LocalIndexClient(simple.as_uri())
+        result = run(client.get_files("foo"))
+
+        assert [f.url for f in result] == [wheel.as_uri()]
+        assert [f.local_path for f in result] == [wheel]
+
+    def test_symlinked_root_resolves_hrefs_against_the_page_path(
+        self, tmp_path: Path
+    ) -> None:
+        """The symlink may be the index root itself, not only ``<root>/<package>``.
+
+        A mirror can serve ``simple/`` out of another tree while the
+        ``../../packages/`` its pages link to sits beside the served root.
+        """
+        base = tmp_path.resolve()
+        name = "foo-1.0-py3-none-any.whl"
+
+        stored = base / "srv" / "mirror" / "simple"
+        (stored / "foo").mkdir(parents=True)
+        body = f'<a href="../../packages/ab/cd/{name}">foo</a>'
+        (stored / "foo" / "index.html").write_text(body, encoding="utf-8")
+
+        served = base / "home"
+        served.mkdir()
+        (served / "simple").symlink_to(stored, target_is_directory=True)
+
+        wheel = served / "packages" / "ab" / "cd" / name
+        wheel.parent.mkdir(parents=True)
+        wheel.write_bytes(b"")
+
+        client = LocalIndexClient((served / "simple").as_uri())
+        result = run(client.get_files("foo"))
+
+        assert [f.url for f in result] == [wheel.as_uri()]
+        assert [f.local_path for f in result] == [wheel]
 
     def test_relative_href_with_query_names_the_artifact(self, tmp_path: Path) -> None:
         # RFC 3986 puts the query outside the path, so a cache-busting query


### PR DESCRIPTION
A local `file:` index reached through a symlink points at files that are not there. When `simple/foo`, or the `simple/` root itself, is a symlink to a directory elsewhere, a page linking `../../packages/ab/cd/foo-1.0-py3-none-any.whl` resolves under the symlink target rather than under the index root, so the shared `packages/` tree beside the root is never found.

The links were joined against the realpath of the page's directory. Two changes:

- a page's relative anchors now join against the path the page was read from
- the index root drops dot segments without resolving symlinks
