### PR TITLE
Apply a base's constraint to an extras proxy a dependency pulled in

### DIFF
--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -493,10 +493,10 @@ class Provider:
     and neither filter runs, since nothing has said which machine the
     resolve targets.
 
-    ``constraints`` are the user's version bounds, keyed as the resolver
-    keys packages, so an extras proxy carries its base's bound under its
-    own ``name[extra]`` key.  The provider reads them when deciding
-    whether a missing root extra is worth reporting.
+    ``constraints`` are the user's version bounds, keyed by package name;
+    a lookup under an extras proxy's ``name[extra]`` key answers with the
+    base's bound.  The provider reads them when deciding whether a missing
+    root extra is worth reporting.
 
     ``preferences`` are versions another resolve already decided, tried
     first when they are usable here.  A multi-target resolve passes the

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -25,6 +25,7 @@ import logging
 import tempfile
 import time
 from collections import defaultdict
+from collections.abc import Mapping
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass, field, replace
 from pathlib import Path
@@ -95,7 +96,7 @@ from .target import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator, Mapping, Sequence
+    from collections.abc import Iterator, Sequence
 
     from nab_index.transport import AsyncHttpTransport
 
@@ -1073,17 +1074,16 @@ def _resolve_one_target(
             environment=environment,
             warned=settings.warned_root_markers,
         )
-        resolver_constraints = _build_resolver_inputs(
+        constraint_ranges = _build_resolver_inputs(
             constraints,
             config,
             environment=environment,
             kind="constraint",
             warned=settings.warned_root_markers,
         ).ranges
+        resolver_constraints = _ProxyConstraints(constraint_ranges)
     except ResolutionError as exc:
         return TargetResult(target=target, success=False, error=exc)
-
-    _extend_constraints_to_proxies(resolver_constraints, root_extras)
 
     source_root = settings.source_root
     provider = Provider(
@@ -1914,22 +1914,31 @@ def _build_resolver_inputs(
     return _ResolverInputs(roots, resolver_requirements, root_extras)
 
 
-def _extend_constraints_to_proxies(
-    constraints: dict[str, VersionRange],
-    root_extras: set[tuple[str, str]],
-) -> None:
-    """Copy each base package's constraint onto its extras proxies.
+class _ProxyConstraints(Mapping[str, VersionRange]):
+    """The user's constraints, where an extras proxy's key reads its base's bound.
 
-    The resolver keys constraints by the package it is deciding, and an
+    The resolver keys a constraint by the package it is deciding, and an
     extras proxy decides under its own ``name[extra]`` key, so the base's
-    constraint does not otherwise reach it.  Sharing the key also keeps
-    the proxy on the constraint-attribution path, so a constraint that
-    leaves it nothing is named in the failure.
+    bound would not otherwise reach it.  Answering under both keys also
+    lets a failure blame the constraint that left the proxy nothing,
+    rather than the proxy's listing.
+
+    Iteration lists only the keys the user wrote, so a proxy key answers a
+    lookup but is never enumerated.
     """
-    for name, extra in root_extras:
-        constraint = constraints.get(name)
-        if constraint is not None:
-            constraints[join_extra(name, extra)] = constraint
+
+    def __init__(self, ranges: Mapping[str, VersionRange]) -> None:
+        self._ranges = ranges
+
+    def __getitem__(self, package: str) -> VersionRange:
+        # Constraints may not carry extras, so a proxy has no bound of its own.
+        return self._ranges[split_extra(package)[0]]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._ranges)
+
+    def __len__(self) -> int:
+        return len(self._ranges)
 
 
 def _raise_for_source_python(

--- a/nab-python/tests/test_resolve_targets.py
+++ b/nab-python/tests/test_resolve_targets.py
@@ -76,6 +76,7 @@ from nab_python.resolve import (
     TargetResult,
     _build_resolver_inputs,
     _EngineSettings,
+    _ProxyConstraints,
     _resolve_one_target,
     _run_pass,
     build_lock_input,
@@ -1253,6 +1254,21 @@ class TestBuildResolverInputs:
             )
 
 
+class TestProxyConstraints:
+    """``_ProxyConstraints`` answers an extras proxy with its base's bound."""
+
+    def test_a_proxy_key_reads_the_base_bound(self) -> None:
+        """``aaa[x]`` reads ``aaa``'s bound; an unconstrained base has none."""
+        bound = Requirement("aaa<3.0").specifier.to_range()
+        constraints = _ProxyConstraints({"aaa": bound})
+
+        assert constraints["aaa[x]"] == bound
+        assert constraints.get("bbb[x]") is None
+
+        # Iteration stays over the keys the user wrote.
+        assert dict(constraints) == {"aaa": bound}
+
+
 class TestSelfRefMarker:
     """The extras flatten must keep a self-ref's marker so the per-target
     parse drops its dep on the targets the marker excludes."""
@@ -2108,6 +2124,115 @@ class TestResolveWithCoordinator:
                 _reqs("aaa[x]"),
                 config=NabProjectConfig(constraints=("aaa==3.0",)),
             )
+
+    @staticmethod
+    def _transitive_proxy_coordinator(*, newest_dep: str = "") -> MagicMock:
+        """An index where ``ccc`` reaches ``aaa`` only through ``aaa[x]``.
+
+        ``aaa`` 1.0 and 2.0 declare ``x`` and pull ``bbb`` through it; 3.0
+        declares no extras and appends ``newest_dep`` to its METADATA.
+        """
+        aaa_wheels = [_make_wheel(v, package="aaa") for v in ("1.0", "2.0", "3.0")]
+        ccc_wheel = _make_wheel("1.0", package="ccc")
+        coordinator = make_coordinator(
+            listings={
+                "aaa": aaa_wheels,
+                "bbb": [_make_wheel("1.0", package="bbb")],
+                "ccc": [ccc_wheel],
+            },
+            auto_metadata=True,
+        )
+
+        for wheel in aaa_wheels[:-1]:
+            coordinator.index.store_metadata(
+                "aaa",
+                wheel.version,
+                f"Metadata-Version: 2.1\nName: aaa\nVersion: {wheel.version}\n"
+                "Provides-Extra: x\n"
+                'Requires-Dist: bbb; extra == "x"\n\n',
+                wheel.metadata_url,
+            )
+
+        coordinator.index.store_metadata(
+            "aaa",
+            "3.0",
+            f"Metadata-Version: 2.1\nName: aaa\nVersion: 3.0\n{newest_dep}\n",
+            aaa_wheels[-1].metadata_url,
+        )
+
+        coordinator.index.store_metadata(
+            "ccc",
+            "1.0",
+            "Metadata-Version: 2.1\nName: ccc\nVersion: 1.0\nRequires-Dist: aaa[x]\n\n",
+            ccc_wheel.metadata_url,
+        )
+        return coordinator
+
+    def test_constraint_bounds_a_transitive_extras_proxy(self) -> None:
+        """A constraint bounds a proxy that arrived through a dependency.
+
+        3.0 is out of bounds, so the resolve must not read its metadata:
+        the direct-URL dependency it declares would be refused and abort
+        the resolve.
+        """
+        result = resolve_with_coordinator(
+            self._transitive_proxy_coordinator(
+                newest_dep="Requires-Dist: zzz @ https://example.com/zzz-1.0.zip\n"
+            ),
+            _one_target(),
+            _reqs("ccc"),
+            config=NabProjectConfig(constraints=("aaa<3.0",)),
+        )
+        assert result.success
+        assert result.target_results[0].pins == {
+            "aaa": Version("2.0"),
+            "bbb": Version("1.0"),
+            "ccc": Version("1.0"),
+        }
+
+    def test_constraint_keeps_a_transitive_proxy_off_the_missing_extra(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The bound is applied before the proxy checks ``Provides-Extra``.
+
+        3.0 drops the extra, and warning about it would name a version
+        the lock cannot contain.
+        """
+        with caplog.at_level(logging.WARNING):
+            result = resolve_with_coordinator(
+                self._transitive_proxy_coordinator(),
+                _one_target(),
+                _reqs("ccc"),
+                config=NabProjectConfig(constraints=("aaa<3.0",)),
+            )
+
+        assert result.success
+        assert result.target_results[0].pins == {
+            "aaa": Version("2.0"),
+            "bbb": Version("1.0"),
+            "ccc": Version("1.0"),
+        }
+
+        assert [r.getMessage() for r in caplog.records if "aaa" in r.getMessage()] == []
+
+    def test_constraint_that_empties_a_transitive_proxy_is_blamed(self) -> None:
+        """The failure names the constraint, not the proxy's listing.
+
+        Three versions of ``aaa`` exist, so blaming ``aaa[x]``'s own
+        listing would be wrong.
+        """
+        result = resolve_with_coordinator(
+            self._transitive_proxy_coordinator(),
+            _one_target(),
+            _reqs("ccc"),
+            config=NabProjectConfig(constraints=("aaa<0.5",)),
+        )
+        assert not result.success
+
+        message = str(result.target_results[0].error)
+        assert "the user constrained aaa[x]" in message
+        assert "0.5" in message
+        assert "no versions of aaa[x]" not in message
 
     def test_resolution_strategy_overrides_the_config(self) -> None:
         """An explicit strategy wins over the config's ``resolution``."""


### PR DESCRIPTION
A `[tool.nab]` constraint reached an extras proxy only when a root requirement named the extra. An `aaa[x]` that arrives through another package's `Requires-Dist` was still offered every version of `aaa`, so the resolve picked one the constraint excludes and read its metadata:

- if that version declares a direct-URL dependency, the resolve stops with "refusing direct-URL requirement" over a package the lock cannot contain
- if it does not declare the extra, nab warns about a version the constraint already ruled out

The constraint map now answers a lookup under `name[extra]` with the base package's bound, so every proxy is narrowed rather than only the ones a root requirement named. A constraint that leaves a proxy nothing is named in the failure, instead of the resolve reporting that `aaa[x]` has no versions.
