### PR TITLE
Drop a non-ASCII ETag instead of failing every later resolve

### DIFF
--- a/nab-index/src/nab_index/cache.py
+++ b/nab-index/src/nab_index/cache.py
@@ -103,6 +103,9 @@ class CachePolicy:
     ``fetched_at`` is the start of the freshness window: when nab received the
     response, less any Age a relaying shared cache reported.
 
+    ``etag`` is the entity tag to revalidate with. A non-ASCII tag is dropped,
+    since nab cannot send it back.
+
     ``page_url`` is the URL the stored body was retrieved from, the base its
     relative entries resolve against. It is ``None`` for the negative
     sentinel, which has no body, and for an entry cached without it.
@@ -577,7 +580,7 @@ def _encode_policy(policy: CachePolicy) -> bytes:
     doc: dict[str, object] = {
         "fetched_at": policy.fetched_at,
         "max_age": policy.max_age,
-        "etag": policy.etag,
+        "etag": _policy_etag(policy.etag),
         "page_url": policy.page_url,
     }
     # Emit only when set so an older policy or a bodyless negative entry keeps
@@ -592,13 +595,22 @@ def _policy_page_url(value: object) -> str | None:
     return value if isinstance(value, str) and value else None
 
 
+def _policy_etag(value: object) -> str | None:
+    """Entity tag from a policy, or None when it cannot be sent back.
+
+    RFC 9110 8.8.3 admits obs-text in an entity-tag, and httpx raises on a
+    non-ASCII request header value.
+    """
+    return value if isinstance(value, str) and value.isascii() else None
+
+
 def _decode_policy(policy_bytes: bytes) -> CachePolicy | None:
     try:
         doc = json.loads(policy_bytes)
         return CachePolicy(
             fetched_at=int(doc["fetched_at"]),
             max_age=int(doc["max_age"]),
-            etag=doc.get("etag"),
+            etag=_policy_etag(doc.get("etag")),
             page_url=_policy_page_url(doc.get("page_url")),
             body_digest=doc.get("body_digest"),
         )

--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -561,7 +561,8 @@ class CachedAsyncSimpleClient:
     ) -> list[WheelFile | SdistFile]:
         url = f"{self._index_url}{package}/"
         headers = {"Accept": simple_accept_header(self._serialization)}
-        if policy.etag is not None:
+        # httpx raises on a non-ASCII header value.
+        if policy.etag is not None and policy.etag.isascii():
             headers["If-None-Match"] = policy.etag
         response = await self._transport.get(url, headers=headers)
         if response.status_code == _HTTP_NOT_MODIFIED:

--- a/nab-python/tests/test_cache.py
+++ b/nab-python/tests/test_cache.py
@@ -714,6 +714,24 @@ class TestEncodePolicy:
         assert entry is not None
         assert entry[1].page_url is None
 
+    def test_non_ascii_etag_is_not_stored(self) -> None:
+        policy = CachePolicy(fetched_at=10, max_age=20, etag='"é"')
+        assert json.loads(_encode_policy(policy))["etag"] is None
+
+    @pytest.mark.parametrize("etag", ['"é"', 123, []])
+    def test_unusable_etag_is_dropped(self, tmp_path: Path, etag: object) -> None:
+        cache = OnDiskCache(tmp_path, "https://pypi.org/simple")
+        cache.put_simple("foo", b"{}", _FRESH)
+        path = tmp_path / SIMPLE_BUCKET / "pypi" / "foo.policy"
+        path.write_bytes(
+            json.dumps({"fetched_at": 1, "max_age": 600, "etag": etag}).encode()
+        )
+
+        entry = cache.get_simple("foo")
+
+        assert entry is not None
+        assert entry[1].etag is None
+
 
 class TestReadCacheEntry:
     def _cache(self, tmp_path: Path) -> OnDiskCache:

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -150,6 +150,25 @@ def _make_cache(tmp_path: Path) -> OnDiskCache:
     return OnDiskCache(tmp_path, "https://pypi.org/simple/")
 
 
+class _MemoryPolicyCache(OnDiskCache):
+    """Cache that returns policies from memory, skipping the sidecar codec."""
+
+    def __init__(self, root: Path) -> None:
+        super().__init__(root, "https://pypi.org/simple/")
+        self._policies: dict[str, CachePolicy] = {}
+
+    def put_simple(self, package: str, body: bytes, policy: CachePolicy) -> str | None:
+        digest = super().put_simple(package, body, policy)
+        self._policies[package] = replace(policy, body_digest=digest)
+        return digest
+
+    def get_simple(self, package: str) -> tuple[bytes, CachePolicy] | None:
+        entry = super().get_simple(package)
+        if entry is None:
+            return None
+        return entry[0], self._policies.get(package, entry[1])
+
+
 def _build_tarball(members: list[tuple[str, bytes]]) -> bytes:
     buf = io.BytesIO()
     with tarfile.open(fileobj=buf, mode="w:gz") as tar:
@@ -1126,6 +1145,48 @@ class TestGetFiles:
                 await client.aclose()
 
         asyncio.run(go())
+        sent = transport.calls[0][1]
+        assert sent is not None
+        assert "If-None-Match" not in sent
+
+    def test_stale_revalidates_non_ascii_etag_unconditionally(
+        self, tmp_path: Path
+    ) -> None:
+        """An entity tag holding obs-text cannot go back in a request header."""
+        cache = _make_cache(tmp_path)
+        cache.put_simple(
+            "pkg",
+            LISTING_BYTES,
+            CachePolicy(fetched_at=0, max_age=1, etag='"é"'),
+        )
+        transport = _FakeTransport(
+            [_FakeResponse(LISTING_BYTES, headers={"etag": '"é"'})]
+        )
+
+        assert len(_run_get_files(transport, cache, "pkg")) == 1
+
+        sent = transport.calls[0][1]
+        assert sent is not None
+        assert "If-None-Match" not in sent
+
+        cached = cache.get_simple("pkg")
+        assert cached is not None
+        assert cached[1].etag is None
+
+    def test_stale_skips_non_ascii_etag_kept_by_backend(self, tmp_path: Path) -> None:
+        """A backend that keeps the tag on read still must not send it."""
+        cache = _MemoryPolicyCache(tmp_path)
+        cache.put_simple(
+            "pkg",
+            LISTING_BYTES,
+            CachePolicy(fetched_at=0, max_age=1, etag='"é"'),
+        )
+        transport = _FakeTransport(
+            [_FakeResponse(LISTING_BYTES, headers={"etag": '"ok"'})]
+        )
+
+        assert len(_run_get_files(transport, cache, "pkg")) == 1
+
         sent = transport.calls[0][1]
         assert sent is not None
         assert "If-None-Match" not in sent


### PR DESCRIPTION
An index is allowed to put obs-text in an ETag (RFC 9110 8.8.3), and one that does poisons every later resolve of that package:

- nab writes the tag into the Simple API policy sidecar
- once the entry goes stale, it sends the tag back as `If-None-Match`
- httpx cannot encode it into a request header, so the resolve raises `UnicodeEncodeError` before the request reaches the index
- nothing clears the entry, because the request that would replace it is the one that fails

The policy codec now drops a tag it cannot send, both when writing the sidecar and when reading it back. A cache already holding one recovers on its next read, and revalidation falls back to an unconditional GET.
