### PR TITLE
Fix a resolve crash on a METADATA clause version with too many digits

### DIFF
--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -927,10 +927,9 @@ def target_dep_signature(
     here.  ``Requires-Python`` is left out: it gates admission, not the
     dependency edges a lock records.
 
-    Unlike :func:`cache_deps_from_metadata` this never raises: a direct-URL dep
-    is bucketed instead of routed through :func:`refuse_url_dep`, since the pick
-    already refused its own URL deps, so a sibling's URL dep is a divergence to
-    report.
+    Unlike :func:`cache_deps_from_metadata`, a direct-URL dep is bucketed rather
+    than routed through :func:`refuse_url_dep`: the pick already refused its own
+    URL deps, so a sibling's URL dep is a divergence to report.
     """
     metadata = effective_metadata(provider, cache_key, metadata)
     provided_extras: set[str] = {canonicalize_name(e) for e in metadata.provides_extra}
@@ -1003,16 +1002,13 @@ def check_sibling_metadata_divergence(
     for sibling in wheels:
         if sibling is pick or not _wheels_tie(tags, pick_key, sibling.filename):
             continue
-        sibling_metadata = _tie_sibling_metadata(
-            provider, index, normalized, version, sibling
-        )
-        if sibling_metadata is None:
+        sibling_sig = _tie_sibling_signature(provider, index, sig_key, sibling)
+        if sibling_sig is None:
             continue
         if pick_sig is None:
             pick_sig = target_dep_signature(
                 provider, sig_key, parse_metadata(pick_text)
             )
-        sibling_sig = target_dep_signature(provider, sig_key, sibling_metadata)
         if sibling_sig == pick_sig:
             continue
         labels = _divergent_dep_labels(pick_sig, sibling_sig)
@@ -1023,6 +1019,29 @@ def check_sibling_metadata_divergence(
             f" per-package dependencies override to resolve this version."
         )
         raise SiblingMetadataDivergenceError(msg)
+
+
+def _tie_sibling_signature(
+    provider: Provider,
+    index: InMemoryIndex,
+    sig_key: tuple[str, Version],
+    sibling: WheelFile,
+) -> TargetDepSignature | None:
+    """Project a tie sibling's own metadata, or None to skip the sibling.
+
+    Skipped for the reasons :func:`_tie_sibling_metadata` lists, and when a
+    marker's version will not convert: a marker holds its version as a string
+    until it is evaluated against an environment, so it fails here instead of
+    at the parse.
+    """
+    package, version = sig_key
+    metadata = _tie_sibling_metadata(provider, index, package, version, sibling)
+    if metadata is None:
+        return None
+    try:
+        return target_dep_signature(provider, sig_key, metadata)
+    except ValueError:
+        return None
 
 
 def _tie_sibling_metadata(

--- a/nab-python/src/nab_python/metadata.py
+++ b/nab-python/src/nab_python/metadata.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Any
 import tomli
 
 from ._vendor.packaging.requirements import Requirement
-from ._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
+from ._vendor.packaging.specifiers import SpecifierSet
 from ._vendor.packaging.version import InvalidVersion, Version
 
 if TYPE_CHECKING:
@@ -135,8 +135,12 @@ def _parse_requirement_cached(req_str: str) -> Requirement:
     across many wheels in a dependency graph.  ``Requirement`` exposes
     only read operations (specifier, marker, extras, name) so sharing
     parsed objects is safe.
+
+    Raises ``ValueError`` when the string does not parse or a clause
+    version will not convert.
     """
     req = Requirement(req_str)
+    validate_specifier_versions(req.specifier)
     if req.marker is not None:
         req.marker = _intern_marker(req.marker)
     return req
@@ -192,10 +196,11 @@ def parse_metadata(data: str | bytes) -> WheelMetadata:
     if requires_python_str:
         try:
             requires_python = SpecifierSet(requires_python_str)
-        except InvalidSpecifier as exc:
+            validate_specifier_versions(requires_python)
+        except ValueError as exc:
             # A malformed Requires-Python is invalid metadata; raise rather
             # than silently drop the field, matching the Name/Version checks
-            # above. The resolve boundary turns this into a rejected candidate.
+            # above.
             err = (
                 f"METADATA for {name}=={version_str} has an invalid "
                 f"Requires-Python: {requires_python_str!r}"

--- a/nab-python/tests/test_metadata.py
+++ b/nab-python/tests/test_metadata.py
@@ -244,3 +244,30 @@ class TestValidateSpecifierVersions:
         """``===`` is included: ``to_range`` converts its literal too."""
         with pytest.raises(ValueError, match="Exceeds the limit"):
             validate_specifier_versions(SpecifierSet(spec))
+
+
+class TestOversizedClauseVersions:
+    """A clause version past the int-from-string limit fails at parse time.
+
+    ``SpecifierSet`` and ``Requirement`` both accept one, converting it only
+    when something compares against it, so ``parse_metadata`` forces the
+    conversion and the field fails where it is read.
+    """
+
+    def test_oversized_requires_python_raises(self) -> None:
+        """Requires-Python fails under its own guard, which names the field."""
+        text = (
+            "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\n"
+            f"Requires-Python: >=3.{_OVERSIZED}\n"
+        )
+        with pytest.raises(ValueError, match="invalid Requires-Python"):
+            parse_metadata(text)
+
+    def test_oversized_requires_dist_raises(self) -> None:
+        """A dep clause fails with the raw ``int()`` conversion error."""
+        text = (
+            "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\n"
+            f"Requires-Dist: click>=8.{_OVERSIZED}\n"
+        )
+        with pytest.raises(ValueError, match="Exceeds the limit"):
+            parse_metadata(text)

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -10948,6 +10948,51 @@ class TestSiblingMetadataDivergence:
         deps = provider.get_dependencies("pkg", self._V)
         assert "alpha" in deps
 
+    @pytest.mark.parametrize(
+        "sibling_fields",
+        [
+            pytest.param(
+                "Requires-Python: >=3.{oversized}\nRequires-Dist: beta>=1\n",
+                id="requires-python",
+            ),
+            pytest.param("Requires-Dist: beta>=1.{oversized}\n", id="requires-dist"),
+            pytest.param(
+                'Requires-Dist: beta>=1; python_full_version >= "3.{oversized}"\n',
+                id="marker",
+            ),
+        ],
+    )
+    def test_oversized_sibling_clause_version_skipped(
+        self, sibling_fields: str
+    ) -> None:
+        """A tie sibling whose clause version will not convert is skipped too.
+
+        A digit run past the int-from-string limit gets past the specifier and
+        marker constructors alike and raises only when something compares it,
+        which for a marker is during the sibling's projection.  The sibling is
+        dropped like any other invalid candidate instead of aborting the
+        resolve.
+        """
+        oversized = "9" * (sys.get_int_max_str_digits() + 1)
+        wheel_a = _sib_wheel("py2.py3-none-any")
+        wheel_b = _sib_wheel("py3-none-any")
+        coordinator = make_coordinator([wheel_a, wheel_b], package="pkg")
+
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _sib_meta("alpha>=1"), wheel_a.metadata_url
+        )
+        coordinator.index.store_metadata(
+            "pkg",
+            "1.0",
+            "Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\n"
+            + sibling_fields.format(oversized=oversized)
+            + "\n",
+            wheel_b.metadata_url,
+        )
+
+        provider = Provider(coordinator, target=_LINUX311)
+        assert sorted(provider.get_dependencies("pkg", self._V)) == ["alpha"]
+
     def test_provides_extra_override_folds_divergence(self) -> None:
         """A provides-extra override is applied to both siblings before compare.
 


### PR DESCRIPTION
A resolve aborts with a bare `ValueError` when a wheel's index-served METADATA carries a clause version whose digit run is longer than CPython's int-from-string limit:

    Requires-Dist: beta>=1.<4301 nines>

It takes two tie-ranked wheels for the same release, `py2.py3-none-any` and `py3-none-any`. The sibling holding the bad field is projected and compared against the pick to detect dependency divergence, and that comparison is the first thing to touch the version. `SpecifierSet`, `Requirement` and `Marker` all keep clause versions as strings and convert them only when something compares against one, so the value gets past every constructor and fails well after the point that already treats unparseable metadata as a candidate to drop.

`parse_metadata` now converts Requires-Python and Requires-Dist as it reads them, so a bad value is refused as invalid metadata. A marker holds its version until it is evaluated against an environment, so that case surfaces while the sibling's dependencies are projected, and the sibling is skipped like any other candidate that cannot be used.
