### PR TITLE
Drop the look-ahead blocks a constraint probe leaves on a hard error

### DIFF
--- a/nab-python/src/nab_python/_provider/lookahead.py
+++ b/nab-python/src/nab_python/_provider/lookahead.py
@@ -176,6 +176,16 @@ def _membership_widened(
     return accumulated.union.complement()
 
 
+def reset_pending_blocks(provider: Provider) -> None:
+    """Drop the rejections queued so far without flushing them into clauses."""
+    provider.pending_blocks = defaultdict(list)
+    provider.pending_decision_dep_ranges = defaultdict(DepRangeUnion.zero)
+    provider.pending_range_blocks = defaultdict(list)
+    provider.pending_range_dep_ranges = defaultdict(DepRangeUnion.zero)
+    provider.pending_root_blocks = defaultdict(list)
+    provider.pending_metadata_blocks = defaultdict(dict)
+
+
 def flush_pending_blocks(provider: Provider) -> None:
     """Convert queued rejections into incompatibilities.
 
@@ -230,8 +240,6 @@ def flush_pending_blocks(provider: Provider) -> None:
                 cause=IncompatibilityCause.DEPENDENCY,
             )
         )
-    provider.pending_blocks = defaultdict(list)
-    provider.pending_decision_dep_ranges = defaultdict(DepRangeUnion.zero)
 
     # Range-keyed rejections: the blocker term starts from the positive range.
     for (
@@ -263,8 +271,6 @@ def flush_pending_blocks(provider: Provider) -> None:
                 cause=IncompatibilityCause.DEPENDENCY,
             )
         )
-    provider.pending_range_blocks = defaultdict(list)
-    provider.pending_range_dep_ranges = defaultdict(DepRangeUnion.zero)
 
     # Permanent rejections: a root requirement is fixed for the whole resolve,
     # and a version whose metadata will not read is unusable in every state.
@@ -284,5 +290,4 @@ def flush_pending_blocks(provider: Provider) -> None:
             )
         )
 
-    provider.pending_root_blocks = defaultdict(list)
-    provider.pending_metadata_blocks = defaultdict(dict)
+    reset_pending_blocks(provider)

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -1362,10 +1362,10 @@ class Provider:
 
         Runs the real ``choose_version`` over ``version_range`` so look-ahead
         rejections are honored, then rolls back the state it records: the queued
-        clauses and force-backtrack signal are drained, and the force-backtrack
-        budget and no-versions reasons are restored to their pre-probe values.
-        A failed-resolve attribution probe therefore cannot alter a later
-        decision.
+        clauses, the force-backtrack signal, and the pending look-ahead blocks
+        are dropped, and the force-backtrack budget and no-versions reasons are
+        restored to their pre-probe values.  A failed-resolve attribution probe
+        therefore cannot alter a later decision.
 
         The one exception is ``package``'s own no-versions reason.  When the
         un-narrowed range yields no version because a transitive conflict
@@ -1420,6 +1420,7 @@ class Provider:
             self._probing_satisfiable = False
             self.consume_pending_clauses()
             self.consume_force_backtrack_targets()
+            _lookahead.reset_pending_blocks(self)
             self._force_backtrack_counts = saved_counts
 
             # Restore the snapshot but keep the probe's own blocker reason.

--- a/nab-python/tests/test_constraint_probe_hard_error.py
+++ b/nab-python/tests/test_constraint_probe_hard_error.py
@@ -11,6 +11,10 @@ resolve.
 What the probe contains is bounded by what the error says.  A fault of the one
 version is contained; a transient transport failure, which names the moment and
 not the version, still escapes and aborts.
+
+An aborted scan never reaches its flush, so the probe also has to drop the
+rejections it queued before the error, or the next package's scan turns them
+into incompatibilities.
 """
 
 from __future__ import annotations
@@ -31,6 +35,7 @@ from nab_python._vendor.packaging.version import Version
 from nab_python.provider import Provider
 from nab_python.target import ResolveTarget
 from nab_resolver.resolver import Resolver
+from nab_resolver.types import Incompatibility
 
 V = Version
 _PY312 = ResolveTarget.for_host_python("3.12.0")
@@ -61,6 +66,12 @@ def _tie_wheel(tag: str) -> WheelFile:
 
 def _tie_meta(requires_dist: str) -> str:
     return f"Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\nRequires-Dist: {requires_dist}\n\n"
+
+
+def _leftover_clauses(provider: Provider) -> list[Incompatibility[str, Version]]:
+    """Return the clauses a later ``choose_version`` flush would hand the resolver."""
+    provider._flush_pending_blocks()
+    return provider.consume_pending_clauses()
 
 
 class TestConstraintProbeContainsHardError:
@@ -208,3 +219,75 @@ class TestConstraintProbeContainsHardError:
         found = provider.has_satisfying_version("pkg", VersionRange.full())
 
         assert found is False
+
+
+class TestConstraintProbeDropsItsRejections:
+    def test_decision_rejection_before_a_hard_error_is_dropped(self) -> None:
+        """A candidate rejected before the error leaves no clause behind.
+
+        ``foo==3.0`` needs ``bar<2`` against a decided ``bar==2.0``, so the
+        scan queues a decision block and moves on to ``foo==2.0``, whose
+        sidecar fails its hash.  The error skips the flush that would have
+        emptied the queue, so the probe has to drop it.
+        """
+        listings = {
+            "foo": [_wheel("foo", "3.0"), _wheel("foo", "2.0")],
+            "bar": [_wheel("bar", "2.0")],
+        }
+        metadata = {
+            "3.0": (
+                "Metadata-Version: 2.1\nName: foo\nVersion: 3.0\n"
+                "Requires-Dist: bar<2\n\n"
+            )
+        }
+
+        coordinator = make_coordinator(listings=listings, metadata_by_version=metadata)
+        coordinator.index.store_metadata_error(
+            "foo", "2.0", MetadataHashMismatchError("metadata sha256 mismatch")
+        )
+
+        root_reqs = {"foo": VersionRange.full(admit_arbitrary=False)}
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
+        provider.receive_partial_solution_hint({}, {"bar": V("2.0")})
+
+        assert provider.has_satisfying_version("foo", VersionRange.full()) is False
+
+        assert _leftover_clauses(provider) == []
+
+    def test_root_and_metadata_rejections_before_a_hard_error_are_dropped(self) -> None:
+        """The permanent-rejection tables are dropped as well.
+
+        ``foo==3.0`` needs ``bar<2`` against the root requirement ``bar>=2``
+        and ``foo==2.5`` has no readable metadata, so the scan queues a root
+        block and a metadata block before ``foo==2.0`` raises.  Flushed, those
+        two would ban every ``foo`` above ``2.0`` for the rest of the resolve.
+        """
+        listings = {
+            "foo": [
+                _wheel("foo", "3.0"),
+                _wheel("foo", "2.5", has_metadata=False),
+                _wheel("foo", "2.0"),
+            ],
+            "bar": [_wheel("bar", "2.0")],
+        }
+        metadata = {
+            "3.0": (
+                "Metadata-Version: 2.1\nName: foo\nVersion: 3.0\n"
+                "Requires-Dist: bar<2\n\n"
+            )
+        }
+
+        coordinator = make_coordinator(listings=listings, metadata_by_version=metadata)
+        coordinator.index.store_metadata_error(
+            "foo", "2.0", MetadataHashMismatchError("metadata sha256 mismatch")
+        )
+
+        root_reqs = {
+            "foo": VersionRange.full(admit_arbitrary=False),
+            "bar": SpecifierSet(">=2").to_range(),
+        }
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
+
+        assert provider.has_satisfying_version("foo", VersionRange.full()) is False
+
+        assert _leftover_clauses(provider) == []


### PR DESCRIPTION
A hard metadata error during `has_satisfying_version` leaves look-ahead rejections in the provider's block tables, and the next package's `choose_version` turns them into real incompatibilities. Two things go wrong from there:

- clauses about the probed package land on an unrelated turn, and a turn that hands the resolver clauses skips its own no-versions clause, so the package that actually ran out of versions loses the clause that explains it
- root and metadata rejections leak the same way, as a standing ban on the probed package's versions

The probe reruns the real `choose_version` over the un-narrowed range and is meant to leave nothing behind. That holds while the scan finishes, since the flush at the end of a scan empties the queued rejections into clauses and the probe drops them. An abort skips the flush.

The probe now clears the pending block tables in the same `finally` that drops the queued clauses.
