### PR TITLE
Strip tab, CR and LF from index file URLs at ingest

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -503,15 +503,19 @@ def _resolve_file_url(raw_url: str, base_url: str) -> str | None:
     PEP 691 allows a relative ``url``, which resolves against the package
     page.  ``urlsplit`` raises on a netloc it cannot parse, such as an
     unbalanced bracket in an IPv6 host.
+
+    ``urlsplit`` deletes a tab, CR or LF anywhere in a URL, so the split
+    round trip stores the URL a later parse of the record would yield.
     """
     try:
-        if raw_url.startswith(("https://", "http://")):
-            # Split only to reject a host urllib cannot parse; urljoin
-            # would hand back this same string.
-            urlsplit(raw_url)
-            return raw_url
-
-        return urljoin(base_url, raw_url)
+        # urljoin resolves a same-scheme URL against the base, which would
+        # hand ``https:///pkg.whl`` the base's authority.
+        absolute = (
+            raw_url
+            if raw_url.startswith(("https://", "http://"))
+            else urljoin(base_url, raw_url)
+        )
+        return urlunsplit(urlsplit(absolute))
     except ValueError:
         return None
 

--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -30,7 +30,7 @@ import zlib
 from email.parser import BytesParser, Parser
 from pathlib import Path
 from typing import TYPE_CHECKING
-from urllib.parse import unquote, urljoin, urlparse, urlsplit
+from urllib.parse import unquote, urljoin, urlparse, urlsplit, urlunsplit
 from urllib.request import url2pathname
 
 from packaging.utils import canonicalize_name as _canonical
@@ -306,11 +306,12 @@ def _resolve_local_link(
     href_no_frag, _, fragment = href.partition("#")
     hashes = hash_fragment(fragment)
 
-    # A malformed authority (an unterminated IPv6 bracket) makes both of
-    # these raise, so the drop guard has to start here rather than at the
-    # path resolution below.
+    # A malformed authority (an unterminated IPv6 bracket) makes these raise,
+    # so the drop guard has to start here rather than at the path resolution
+    # below.  urljoin leaves an href alone when its scheme differs from the
+    # page's, so the split round trip is what drops a tab, CR or LF.
     try:
-        url = urljoin(base_url, href_no_frag)
+        url = urlunsplit(urlsplit(urljoin(base_url, href_no_frag)))
         parsed = urlparse(url)
     except ValueError:
         return (None, href_no_frag, None, hashes)

--- a/nab-index/src/nab_index/parsed_listing.py
+++ b/nab-index/src/nab_index/parsed_listing.py
@@ -41,9 +41,11 @@ if TYPE_CHECKING:
 
 __all__ = ["corruption_reason", "decode", "encode"]
 
-# Record-shape version, redundant with the bucket suffix but guards against a
-# stale-shape blob surfacing under the current bucket.
-FORMAT_VERSION = 0
+# Record version, redundant with the bucket suffix but guards against a stale
+# blob surfacing under the current bucket. Bump it when the row shape changes
+# or when the same body parses to different records: ``body_digest`` pins only
+# the input.
+FORMAT_VERSION = 1
 # Serialization variant that wrote the rows, so a future codec switch
 # self-heals rather than misdecodes.
 CODEC = 1

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -25,6 +25,7 @@ from packaging.utils import canonicalize_name
 
 import nab_index.cache as cache_mod
 import nab_index.cached_client as cached_client_mod
+from nab_index._pep503 import json_listing
 from nab_index.cache import CachePolicy, NullCache, OfflineError, OnDiskCache
 from nab_index.cached_client import (
     CachedAsyncSimpleClient,
@@ -577,6 +578,58 @@ class TestRelativeUrlResolution:
         data = {"files": [{"filename": "foo-1.0-py3-none-any.whl", "url": raw}]}
         files = _parse_files(data, "https://example.com/simple/", "foo")
         assert files[0].url == urljoin(base, raw) != raw
+
+
+class TestControlCharacterUrl:
+    """A file URL is stored without the tab, CR and LF bytes urlsplit removes."""
+
+    _PAGE = "https://example.com/simple/foo/"
+    _STRIPPED = "https://files.example.com/ab/foo-1.0-py3-none-any.whl"
+
+    def _entry(self, url: str) -> dict[str, object]:
+        """A PEP 691 wheel entry for ``url`` that advertises a metadata sidecar."""
+        return {
+            "filename": "foo-1.0-py3-none-any.whl",
+            "url": url,
+            "core-metadata": True,
+        }
+
+    @pytest.mark.parametrize("control", ["\t", "\r", "\n"], ids=["tab", "cr", "lf"])
+    def test_artifact_and_sidecar_name_the_same_file(self, control: str) -> None:
+        raw = f"https://files.example.com/a{control}b/foo-1.0-py3-none-any.whl"
+        data = {"files": [self._entry(raw)]}
+
+        (wheel,) = _parse_files(data, "https://example.com/simple/", "foo")
+
+        assert isinstance(wheel, WheelFile)
+        assert wheel.url == self._STRIPPED
+        assert wheel.metadata_url == f"{self._STRIPPED}.metadata"
+
+    def test_different_scheme_url_is_stripped(self) -> None:
+        """urljoin returns an href verbatim when its scheme differs from the page's."""
+        raw = "ftp://files.example.com/a\tb/foo-1.0.tar.gz"
+        data = {"files": [{"filename": "foo-1.0.tar.gz", "url": raw}]}
+
+        (sdist,) = _parse_files(data, "https://example.com/simple/", "foo")
+
+        assert sdist.url == "ftp://files.example.com/ab/foo-1.0.tar.gz"
+
+    def test_html_and_json_serializations_agree(self) -> None:
+        """The HTML and JSON forms of one page yield the same file URL."""
+        raw = "https://files.example.com/a\nb/foo-1.0-py3-none-any.whl"
+        html_listing = json.loads(json_listing(f'<a href="{raw}">foo</a>', self._PAGE))
+
+        (from_json,) = _parse_files(
+            {"files": [self._entry(raw)]},
+            "https://example.com/simple/",
+            "foo",
+            page_url=self._PAGE,
+        )
+        (from_html,) = _parse_files(
+            html_listing, "https://example.com/simple/", "foo", page_url=self._PAGE
+        )
+
+        assert from_json.url == from_html.url == self._STRIPPED
 
 
 class TestMetadataUrl:

--- a/nab-python/tests/test_local_index.py
+++ b/nab-python/tests/test_local_index.py
@@ -1142,6 +1142,25 @@ class TestPep503Directory:
         assert result[0].hashes == (("sha256", digest),)
         assert "#" not in result[0].url
 
+    @pytest.mark.parametrize("control", ["\t", "\r", "\n"], ids=["tab", "cr", "lf"])
+    def test_pep503_control_character_on_https_href(
+        self, tmp_path: Path, control: str
+    ) -> None:
+        """The wheel and its metadata sidecar name one file."""
+        body = (
+            f'<a href="https://example.com/a{control}b/foo-1.0-py3-none-any.whl"'
+            ' data-core-metadata="true">foo</a>'
+        )
+        stripped = "https://example.com/ab/foo-1.0-py3-none-any.whl"
+
+        self._make_index(tmp_path, body)
+        client = LocalIndexClient(tmp_path.as_uri())
+        (wheel,) = run(client.get_files("foo"))
+
+        assert isinstance(wheel, WheelFile)
+        assert wheel.url == stripped
+        assert wheel.metadata_url == f"{stripped}.metadata"
+
     def test_pep503_hash_fragment_on_file_href(self, tmp_path: Path) -> None:
         wheel_path = tmp_path / "foo" / "foo-1.0-py3-none-any.whl"
         wheel_path.parent.mkdir()


### PR DESCRIPTION
A tab, CR or LF inside a file URL from an index survives ingest untouched, and no two readers of that URL then agree on what it points at:

- `WheelFile.metadata_url` rebuilds it through `urlsplit`, which deletes the byte, so the PEP 658 sidecar is fetched from a path the file entry never named
- urllib3 percent-encodes the byte instead, so the download goes to a third path
- the same page resolves two ways depending on its serialization, because the HTML reader goes through `urljoin`, which strips the byte, while the JSON reader hands back an absolute URL as it stood

Neither ingest path normalized the URL. The remote reader skipped `urljoin` for an absolute URL, and `urljoin` returns an href unchanged when its scheme differs from the page's, which is every http href on a local `file://` index.

Both readers now re-serialize the URL from its split parts, so the stored record is what a later parse of it yields. The parsed-listing format version goes up with it, so a listing cached before this is rebuilt instead of replaying the old URL.
