### PR TITLE
Use best-effort cleanup for temporary build directories

### DIFF
--- a/nab-python/src/nab_python/_build/env.py
+++ b/nab-python/src/nab_python/_build/env.py
@@ -223,7 +223,9 @@ class NabBuildEnv:
 
     def __enter__(self) -> Self:
         """Build the venv, run the inner resolve, install build requirements."""
-        self._tmpdir = tempfile.TemporaryDirectory(prefix="nab-build-env-")
+        self._tmpdir = tempfile.TemporaryDirectory(
+            prefix="nab-build-env-", ignore_cleanup_errors=True
+        )
         try:
             self._provision(Path(self._tmpdir.name))
         except BaseException:
@@ -301,7 +303,7 @@ class NabBuildEnv:
                 raise BuildEnvError(msg) from exc
 
     def __exit__(self, *args: object) -> None:
-        """Remove the temp tree that holds the venv and downloaded wheels."""
+        """Clean up the temp tree that holds the venv and downloaded wheels."""
         if self._tmpdir is not None:
             self._tmpdir.cleanup()
             self._tmpdir = None
@@ -565,7 +567,9 @@ class NabBuildEnv:
             msg = f"build requirement {label} could not be read at {archive}: {exc}"
             raise BuildEnvError(msg) from exc
 
-        with tempfile.TemporaryDirectory(prefix="nab-build-req-") as td:
+        with tempfile.TemporaryDirectory(
+            prefix="nab-build-req-", ignore_cleanup_errors=True
+        ) as td:
             try:
                 source_dir = extract_sdist_archive(data, Path(td))
             except ValueError as exc:

--- a/nab-python/src/nab_python/_build/runner.py
+++ b/nab-python/src/nab_python/_build/runner.py
@@ -99,7 +99,9 @@ def run_build_backend(
         _prepared_project(
             source_dir, data, config=config, offline=offline, chain=chain
         ) as (project, backend),
-        tempfile.TemporaryDirectory(prefix="nab-build-meta-") as out_str,
+        tempfile.TemporaryDirectory(
+            prefix="nab-build-meta-", ignore_cleanup_errors=True
+        ) as out_str,
     ):
         metadata_dir = _extract_metadata_dir(
             project,

--- a/nab-python/src/nab_python/_provider/build_remote.py
+++ b/nab-python/src/nab_python/_provider/build_remote.py
@@ -83,7 +83,9 @@ def build_remote_sdist(
         )
         raise UnsupportedSdistError(msg)
 
-    with tempfile.TemporaryDirectory(prefix="nab-build-remote-") as td:
+    with tempfile.TemporaryDirectory(
+        prefix="nab-build-remote-", ignore_cleanup_errors=True
+    ) as td:
         try:
             source_dir = extract_sdist_archive(data, Path(td))
         except ValueError as exc:

--- a/nab-python/tests/test_build_runner.py
+++ b/nab-python/tests/test_build_runner.py
@@ -37,6 +37,7 @@ from installer.utils import SCHEME_NAMES, Scheme
 
 from nab_index.client import SdistFile, WheelFile
 from nab_index.multi_index import IndexConfig
+from nab_python._build import env as env_mod
 from nab_python._build import runner as runner_mod
 from nab_python._build.env import (
     BuildEnvError,
@@ -2705,6 +2706,38 @@ class TestBuildRequirementBuildFailures:
         with pytest.raises(BuildEnvError, match="could not be built"):
             self._env()._build_requirement(self.PENDING, tmp_path)
 
+    @pytest.mark.parametrize("cancel", [False, True], ids=["success", "cancel"])
+    def test_cleanup_error_does_not_replace_result_or_cancellation(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        cancel: bool,
+    ) -> None:
+        (tmp_path / self.PENDING.sdist.filename).write_bytes(b"sdist")
+        wheel = tmp_path / "demo-1.0-py3-none-any.whl"
+
+        monkeypatch.setattr(
+            env_mod.tempfile,
+            "TemporaryDirectory",
+            _CleanupErrorTemporaryDirectory,
+        )
+        monkeypatch.setattr(
+            env_mod, "extract_sdist_archive", lambda _data, target: target
+        )
+
+        build = MagicMock(
+            return_value=wheel,
+            side_effect=KeyboardInterrupt if cancel else None,
+        )
+        monkeypatch.setattr(runner_mod, "build_wheel_for_install", build)
+
+        if cancel:
+            with pytest.raises(KeyboardInterrupt):
+                self._env()._build_requirement(self.PENDING, tmp_path)
+        else:
+            assert self._env()._build_requirement(self.PENDING, tmp_path) == wheel
+
     def test_non_string_wheel_path(self, tmp_path: Path) -> None:
         """A backend returning something other than a wheel's basename.
 
@@ -2733,6 +2766,37 @@ class TestBuildRequirementBuildFailures:
             )
 
 
+class _CleanupErrorTemporaryDirectory:
+    """Raise ``PermissionError`` unless cleanup errors are ignored."""
+
+    def __init__(self, *, prefix: str, ignore_cleanup_errors: bool = False) -> None:
+        self.name = f"/tmp/{prefix}in-use"
+        self._ignore_cleanup_errors = ignore_cleanup_errors
+
+    def cleanup(self) -> None:
+        if not self._ignore_cleanup_errors:
+            raise PermissionError("build env is still in use")
+
+    def __enter__(self) -> str:
+        return self.name
+
+    def __exit__(self, *_args: object) -> None:
+        self.cleanup()
+
+
+def _build_env_with_cleanup_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> NabBuildEnv:
+    """Return an unprovisioned build env whose temp tree cannot be removed."""
+    monkeypatch.setattr(
+        env_mod.tempfile,
+        "TemporaryDirectory",
+        _CleanupErrorTemporaryDirectory,
+    )
+    monkeypatch.setattr(NabBuildEnv, "_provision", lambda self, _root: None)
+    return NabBuildEnv(requires=[], config=NabProjectConfig())
+
+
 class TestNabBuildEnvLifecycle:
     """Edge cases of the context-manager lifecycle that fall outside
     the happy-path runner tests.
@@ -2746,6 +2810,57 @@ class TestNabBuildEnvLifecycle:
         env = NabBuildEnv(requires=[], config=NabProjectConfig())
         env.__exit__(None, None, None)
         assert env._tmpdir is None  # type: ignore[attr-defined]
+
+    def test_exit_ignores_cleanup_error_after_success(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        with _build_env_with_cleanup_error(monkeypatch):
+            pass
+
+    def test_exit_preserves_cancellation_when_cleanup_fails(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        with (
+            pytest.raises(KeyboardInterrupt),
+            _build_env_with_cleanup_error(monkeypatch),
+        ):
+            raise KeyboardInterrupt
+
+    @pytest.mark.parametrize("cancel", [False, True], ids=["success", "cancel"])
+    def test_metadata_cleanup_error_does_not_replace_result_or_cancellation(
+        self, monkeypatch: pytest.MonkeyPatch, *, cancel: bool
+    ) -> None:
+        metadata = MagicMock()
+        prepared = MagicMock()
+        prepared.__enter__.return_value = (MagicMock(), "backend")
+        prepared.__exit__.return_value = False
+        monkeypatch.setattr(
+            runner_mod.tempfile,
+            "TemporaryDirectory",
+            _CleanupErrorTemporaryDirectory,
+        )
+        monkeypatch.setattr(runner_mod, "_read_pyproject", lambda _source: {})
+        monkeypatch.setattr(
+            runner_mod,
+            "_prepared_project",
+            lambda *_args, **_kwargs: prepared,
+        )
+
+        extract = MagicMock(
+            return_value=Path("/tmp/metadata"),
+            side_effect=KeyboardInterrupt if cancel else None,
+        )
+        monkeypatch.setattr(runner_mod, "_extract_metadata_dir", extract)
+        monkeypatch.setattr(runner_mod, "_parse_metadata", lambda _path: metadata)
+
+        if cancel:
+            with pytest.raises(KeyboardInterrupt):
+                run_build_backend(Path("/tmp/source"), config=NabProjectConfig())
+        else:
+            assert (
+                run_build_backend(Path("/tmp/source"), config=NabProjectConfig())
+                is metadata
+            )
 
     def test_render_synthetic_pyproject_empty_requires(self) -> None:
         """The synthetic-pyproject helper renders an empty

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -9722,6 +9722,21 @@ class TestStaticSdistMetadata:
         assert chosen == V("1.0")
 
 
+class _CleanupErrorTemporaryDirectory:
+    """Raise ``PermissionError`` unless cleanup errors are ignored."""
+
+    def __init__(self, *, prefix: str, ignore_cleanup_errors: bool = False) -> None:
+        self.name = f"/tmp/{prefix}in-use"
+        self._ignore_cleanup_errors = ignore_cleanup_errors
+
+    def __enter__(self) -> str:
+        return self.name
+
+    def __exit__(self, *_args: object) -> None:
+        if not self._ignore_cleanup_errors:
+            raise PermissionError("build source is still in use")
+
+
 class TestBuildRemoteFailureModes:
     """Failure paths in :func:`nab_python._provider.build_remote.build_remote_sdist`.
 
@@ -9999,6 +10014,35 @@ class TestBuildRemoteFailureModes:
         provider = self._build_into(monkeypatch, built)
         result = build_remote.build_remote_sdist(provider, "pkg", V("1.0"))
         assert result is built
+
+    @pytest.mark.parametrize("cancel", [False, True], ids=["success", "cancel"])
+    def test_cleanup_error_does_not_replace_result_or_cancellation(
+        self, monkeypatch: pytest.MonkeyPatch, *, cancel: bool
+    ) -> None:
+        built = WheelMetadata(
+            name="pkg",
+            version=V("1.0"),
+            requires_python=None,
+            requires_dist=[],
+            provides_extra=[],
+        )
+        provider = self._build_into(monkeypatch, built)
+        monkeypatch.setattr(
+            build_remote.tempfile,
+            "TemporaryDirectory",
+            _CleanupErrorTemporaryDirectory,
+        )
+
+        if cancel:
+            monkeypatch.setattr(
+                "nab_python.build_backend.extract_metadata",
+                MagicMock(side_effect=KeyboardInterrupt),
+            )
+
+            with pytest.raises(KeyboardInterrupt):
+                build_remote.build_remote_sdist(provider, "pkg", V("1.0"))
+        else:
+            assert build_remote.build_remote_sdist(provider, "pkg", V("1.0")) is built
 
     def test_built_requires_python_no_target_skips_check(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
Building metadata for a local source on Windows could turn a successful `nab lock`, or a `KeyboardInterrupt`, into a raw `PermissionError` raised from teardown, because an open file handle makes the directory undeletable.

Cleanup is now best effort for all three temporary trees:

- the isolated build environment
- the source directory
- the metadata directory

Teardown leaves the original outcome intact, so a success stays a success and a cancellation still reads as a cancellation.
