### PR TITLE
Name the self-dependency edge in resolution failure reports

### DIFF
--- a/nab-resolver/src/nab_resolver/report.py
+++ b/nab-resolver/src/nab_resolver/report.py
@@ -59,8 +59,8 @@ def format_error(
     return "\n".join(lines) if lines else "Resolution impossible"
 
 
-# DEPENDENCY/ROOT clauses always have two terms (parent + dependency);
-# synthetic single-term test clauses fall through to the prefix renderer.
+# DEPENDENCY/ROOT clauses have two terms (parent + dependency); a
+# self-dependency merges them into one.
 _ATTRIBUTION_CLAUSE_TERMS = 2
 
 # Prefixes that name the package themselves ("no versions of a"), so their
@@ -241,6 +241,31 @@ def _narrowed_away(
     return found
 
 
+def _dependency_pair(
+    incompatibility: Incompatibility[Any, Any], terms: Sequence[Term[Any, Any]]
+) -> tuple[Term[Any, Any], Term[Any, Any]] | None:
+    """Return the parent and dependency terms of a DEPENDENCY clause, else None.
+
+    ``terms`` are the clause's terms as the line renders them, which is not
+    ``incompatibility.terms`` once narrowing has been applied.  A package
+    depending on itself merges the two terms into one, so the dependency side
+    is rebuilt from the range the clause carries.
+    """
+    if incompatibility.cause is not IncompatibilityCause.DEPENDENCY:
+        return None
+
+    if len(terms) == _ATTRIBUTION_CLAUSE_TERMS:
+        parent, dependency = terms
+        return parent, dependency
+
+    dependency_range = incompatibility.dependency_range
+    if len(terms) != 1 or dependency_range is None:
+        return None
+
+    (parent,) = terms
+    return parent, Term(parent.package, dependency_range, positive=False)
+
+
 def _render_line(
     incompatibility: Incompatibility[Any, Any],
     narrow: _NarrowFn | None,
@@ -254,12 +279,9 @@ def _render_line(
     if narrow is not None and cause is not IncompatibilityCause.NO_VERSIONS:
         terms = [_narrow_positive(term, narrow) for term in terms]
 
-    # Attribution form for the two standard two-term clauses.
-    if (
-        cause is IncompatibilityCause.DEPENDENCY
-        and len(terms) == _ATTRIBUTION_CLAUSE_TERMS
-    ):
-        parent, dep = terms
+    attributed = _dependency_pair(incompatibility, terms)
+    if attributed is not None:
+        parent, dep = attributed
         plural = _is_full(parent)
         # A negative dep term holds the parent's required range (negate to
         # show it); a positive dep term holds a version the parent forbids.

--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -616,8 +616,13 @@ class Resolver(Generic[PackageType, VersionType]):
                     Term(next_package, parent_range, positive=True),
                     Term(dependency_package, dependency_range, positive=False),
                 ]
+
+            # The merged term drops the required range, so the clause carries
+            # it for the report.
             incompatibility = Incompatibility(
-                terms, cause=IncompatibilityCause.DEPENDENCY
+                terms,
+                cause=IncompatibilityCause.DEPENDENCY,
+                dependency_range=None if cross_package else dependency_range,
             )
             incompat_index.add_incompatibility(self, incompatibility)
 

--- a/nab-resolver/src/nab_resolver/types.py
+++ b/nab-resolver/src/nab_resolver/types.py
@@ -322,6 +322,10 @@ class Incompatibility(Generic[PackageType, VersionType]):
     clause. The clause's term carries the requirement range that backtracking
     needs, so the user's constraint is kept here for the message.
 
+    ``dependency_range`` holds the required range for a ``DEPENDENCY`` clause
+    of a package on itself, whose two terms merge into one because a clause
+    holds at most one term per package.
+
     ``origin`` holds the caller's :class:`RootRequirement` origin for a
     ``ROOT`` clause, opaque to the resolver and never read by it.
 
@@ -333,6 +337,7 @@ class Incompatibility(Generic[PackageType, VersionType]):
         "cause_left",
         "cause_right",
         "constraint_range",
+        "dependency_range",
         "origin",
         "terms",
     )
@@ -345,6 +350,7 @@ class Incompatibility(Generic[PackageType, VersionType]):
         cause_right: Incompatibility[PackageType, VersionType] | None = None,
         constraint_range: RangeProtocol[VersionType] | None = None,
         origin: Any = None,
+        dependency_range: RangeProtocol[VersionType] | None = None,
     ) -> None:
         """Create an incompatibility with terms and a cause."""
         self.terms = terms
@@ -353,6 +359,7 @@ class Incompatibility(Generic[PackageType, VersionType]):
         self.cause_right = cause_right
         self.constraint_range = constraint_range
         self.origin = origin
+        self.dependency_range = dependency_range
 
     @override
     def __repr__(self) -> str:

--- a/nab-resolver/tests/test_resolver.py
+++ b/nab-resolver/tests/test_resolver.py
@@ -534,12 +534,20 @@ class TestSelfDependency:
     def test_self_dep_excluding_own_version_unsat(self) -> None:
         """The only version foo@1 depends on foo==2, which doesn't exist.
 
-        Must fail with an unsat proof, not by hitting max_iterations.
+        Must fail with an unsat proof, not by hitting max_iterations, and the
+        proof must name the self-dependency edge the merged term cannot state.
         """
         provider = DictProvider({"foo": {1: {"foo": Range.singleton(2)}}})
         resolver = Resolver(provider, max_iterations=100)
-        with pytest.raises(ResolutionError, match="because"):
+        with pytest.raises(ResolutionError) as exc_info:
             resolver.resolve({"foo": Range.full()})
+        assert str(exc_info.value).splitlines() == [
+            "because no versions of foo (-inf, 1) | (1, +inf) are available",
+            "because foo 1 depends on foo 2",
+            "so all versions of foo",
+            "because your project depends on foo",
+            "so your project's requirements cannot be satisfied",
+        ]
 
     def test_self_dep_containing_own_version_is_vacuous(self) -> None:
         """foo@1 depends on foo=={1}: satisfied by itself, resolves."""
@@ -550,8 +558,9 @@ class TestSelfDependency:
     def test_self_dep_empty_range_unsat(self) -> None:
         """foo@1 depends on foo in the empty range: unsatisfiable."""
         provider = DictProvider({"foo": {1: {"foo": Range.empty()}}})
-        with pytest.raises(ResolutionError, match="because"):
+        with pytest.raises(ResolutionError) as exc_info:
             Resolver(provider).resolve({"foo": Range.full()})
+        assert "because foo 1 depends on foo <empty>" in str(exc_info.value)
 
 
 class TestNoExtraPackages:
@@ -2068,6 +2077,25 @@ class TestErrorMessages:
         )
         message = format_error(clause)
         assert message == "because foo 2 depends on bar [3, +inf)"
+
+    def test_self_dependency_clause_names_the_edge(self) -> None:
+        """A self-dependency clause names the range its merged term cannot hold."""
+        clause = Incompatibility(
+            [Term("foo", Range.singleton(2), positive=True)],
+            cause=IncompatibilityCause.DEPENDENCY,
+            dependency_range=Range.at_least(3),
+        )
+        message = format_error(clause)
+        assert message == "because foo 2 depends on foo [3, +inf)"
+
+    def test_dependency_clause_without_a_range_reads_as_a_prefix(self) -> None:
+        """A one-term clause carrying no range names no dependency edge."""
+        clause = Incompatibility(
+            [Term("foo", Range.singleton(2), positive=True)],
+            cause=IncompatibilityCause.DEPENDENCY,
+        )
+        message = format_error(clause)
+        assert message == "because foo 2"
 
     def test_positive_dependency_term_reads_as_incompatible(self) -> None:
         """A both-positive DEPENDENCY clause reads as an incompatibility.


### PR DESCRIPTION
When the only version of a package depends on a version of itself that does not exist, the failure report prints a line with no verb:

    because foo 1

It should read `because foo 1 depends on foo 2`.

A dependency clause holds a parent term and a dependency term, and the report builds its "depends on" line from the pair. A self-dependency merges the two, because a clause holds at most one term per package, and the required range goes with the term that held it. The clause now carries that range, so the line reads like every other dependency line.
