### PR TITLE
Keep the run's flags in the command `--locked` tells you to re-run

### DIFF
--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -14,10 +14,11 @@ from __future__ import annotations
 import contextlib
 import errno
 import os
+import shlex
 import stat
 import sys
 import tempfile
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from string import Formatter
@@ -92,9 +93,12 @@ from .cli import (
 from .output import ProgressReporter
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping, Sequence
+    from collections.abc import Callable, Iterable, Mapping, Sequence
 
     from nab_python.target import ResolveTarget
+
+
+_DEFAULT_PROJECT_PATH = Path("pyproject.toml")
 
 
 def _emit_or_exit(emit: Callable[[], None]) -> None:
@@ -108,7 +112,7 @@ def _emit_or_exit(emit: Callable[[], None]) -> None:
 
 @app.command
 def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config object would hide the user-facing surface
-    path: PathArg = Path("pyproject.toml"),
+    path: PathArg = _DEFAULT_PROJECT_PATH,
     *,
     output: Path | None = None,
     format: LockFormat = "pylock",  # noqa: A002 - shadows builtin by convention
@@ -270,17 +274,22 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
             " experimental and may change without notice"
         )
 
+    run = _LockRun(
+        path=path,
+        output=output,
+        python=python,
+        groups=selected_groups,
+        extras=selected_extras,
+        offline=offline,
+        build_requirements=build_requirements,
+        workspace_discovery=workspace_discovery,
+        no_emit_workspace=no_emit_workspace,
+        cli_overrides=overrides,
+        upgrade=upgrade,
+    )
+
     if locked:
-        _fast_fail_locked(
-            path,
-            config=config,
-            output=output,
-            python=python,
-            extras=selected_extras,
-            groups=selected_groups,
-            build_requirements=build_requirements,
-            workspace_to_drop=workspace_to_drop,
-        )
+        _fast_fail_locked(run, config=config, workspace_to_drop=workspace_to_drop)
 
     transport = _cli._make_transport(settings.http_backend)  # noqa: SLF001
     result = _cli._resolve(  # noqa: SLF001
@@ -310,7 +319,7 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
     lock_input.provenance = provenance
 
     if locked:
-        _check_locked(lock_input, output=output, build_requirements=build_requirements)
+        _check_locked(lock_input, run=run)
         return
     _emit_or_exit(
         lambda: _emit(
@@ -410,32 +419,103 @@ def _refuse_group_selection_with_build_requirements(
     sys.exit(1)
 
 
-def _locked_target_path(output: Path | None, *, build_requirements: bool) -> Path:
-    """Return the file ``--locked`` reads and re-renders against."""
-    if output is not None:
-        return output
-    return _default_output_path("pylock", build_requirements=build_requirements)
+_CMD_SYNTAX = frozenset(' \t\n"&()<>^|')
 
 
-def _refresh_command(*, build_requirements: bool) -> str:
-    """Return the command that would rewrite the lock ``--locked`` just read.
+def _quote_for_cmd(argument: str) -> str:
+    """Quote one argument the way a Windows shell reads it back as one token.
 
-    A build lock is written by a different run than the project's own, so
-    telling the user to run bare ``nab lock`` would send them to overwrite
-    the wrong file and leave the failure in place.
+    cmd.exe has no single quote, and treats ``&``, ``|``, ``<``, ``>``, ``(``,
+    ``)`` and ``^`` as syntax unless they sit inside a double quote.
+    ``subprocess.list2cmdline`` is not enough: it quotes for the C runtime's
+    argv split, which leaves those characters live.
     """
-    return "nab lock --build-requirements" if build_requirements else "nab lock"
+    if argument and _CMD_SYNTAX.isdisjoint(argument):
+        return argument
+    return '"' + argument.replace('"', '""') + '"'
+
+
+def _join_for_cmd(arguments: Iterable[str]) -> str:
+    """Join ``arguments`` into one line a Windows shell splits back into them."""
+    return " ".join(_quote_for_cmd(argument) for argument in arguments)
+
+
+_join_command: Callable[[Iterable[str]], str] = (
+    _join_for_cmd if sys.platform == "win32" else shlex.join
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _LockRun:
+    """The flags that decide which file ``nab lock`` writes and what goes in it.
+
+    ``--locked`` writes nothing, so its failure has to name the run that would
+    rewrite the file it just read.
+    """
+
+    path: Path
+    output: Path | None
+    python: str | None
+    groups: tuple[str, ...]
+    extras: tuple[str, ...]
+    offline: bool | None
+    build_requirements: bool
+    workspace_discovery: bool
+    no_emit_workspace: bool
+    cli_overrides: Mapping[str, object]
+    upgrade: bool
+
+    def refresh_command(self) -> str:
+        """Render this run without ``--locked``, ready to paste into a shell."""
+        return _join_command(
+            ["nab", "lock", *self._file_arguments(), *self._content_arguments()]
+        )
+
+    def _file_arguments(self) -> list[str]:
+        """Return the arguments naming the project read and the file written."""
+        arguments: list[str] = []
+        if self.path != _DEFAULT_PROJECT_PATH:
+            arguments.append(str(self.path))
+        if self.output is not None:
+            arguments += ["--output", str(self.output)]
+        return arguments
+
+    def _content_arguments(self) -> list[str]:
+        """Return the flags that decide what the rewritten lock holds."""
+        arguments: list[str] = []
+        if self.python is not None:
+            arguments += ["--python", self.python]
+        if self.groups:
+            arguments += ["--groups", *self.groups]
+        if self.extras:
+            arguments += ["--extras", *self.extras]
+        if self.offline is not None:
+            arguments += ["--offline", str(self.offline)]
+
+        if self.build_requirements:
+            arguments.append("--build-requirements")
+        if not self.workspace_discovery:
+            arguments.append("--no-workspace-discovery")
+        if self.no_emit_workspace:
+            arguments.append("--no-emit-workspace")
+
+        arguments += _cli.project_override_arguments(self.cli_overrides)
+        if self.upgrade:
+            arguments.append("--upgrade")
+        return arguments
+
+
+def _locked_target_path(run: _LockRun) -> Path:
+    """Return the file ``--locked`` reads and re-renders against."""
+    if run.output is not None:
+        return run.output
+    return _default_output_path("pylock", build_requirements=run.build_requirements)
 
 
 def _fast_fail_locked(
-    path: Path,
+    run: _LockRun,
     *,
     config: NabProjectConfig,
-    output: Path | None,
-    python: str | None,
-    extras: tuple[str, ...],
-    groups: tuple[str, ...],
-    build_requirements: bool,
     workspace_to_drop: frozenset[str],
 ) -> None:
     """Fast-fail ``nab lock --locked`` before any resolve when a mismatch is proven.
@@ -444,20 +524,20 @@ def _fast_fail_locked(
     checks.  On the first disqualification it prints the reason and exits
     non-zero; otherwise it returns and the full resolve runs.
     """
-    target = _locked_target_path(output, build_requirements=build_requirements)
-    refresh = _refresh_command(build_requirements=build_requirements)
+    target = _locked_target_path(run)
+    refresh = run.refresh_command()
 
     # A run whose own requirements cannot be read or evaluated is not the
     # lock's fault, so leave the error to the resolve rather than reporting a
     # stale lock.
     try:
         roots = _active_root_requirements(
-            path,
-            extras=extras,
-            groups=groups,
+            run.path,
+            extras=run.extras,
+            groups=run.groups,
             default_groups=config.default_groups,
             base_group=config.base_group,
-            build_requirements=build_requirements,
+            build_requirements=run.build_requirements,
             build_group=config.build_group,
         )
     except (
@@ -475,14 +555,14 @@ def _fast_fail_locked(
         )
         sys.exit(1)
 
-    resolve_target = _locked_resolve_target(config, python=python)
+    resolve_target = _locked_resolve_target(config, python=run.python)
 
     try:
         disqualification = check_locked(
             target,
             requires_python=config.requires_python,
-            extras=extras,
-            dependency_groups=groups,
+            extras=run.extras,
+            dependency_groups=run.groups,
             default_groups=config.default_groups,
             base_group=config.base_group,
             build_group=config.build_group,
@@ -599,9 +679,7 @@ def _active_root_requirements(
     return roots
 
 
-def _check_locked(
-    lock_input: LockInput, *, output: Path | None, build_requirements: bool
-) -> None:
+def _check_locked(lock_input: LockInput, *, run: _LockRun) -> None:
     """Verify the committed pylock matches a fresh resolve, writing nothing.
 
     The resolve has already run; this renders the lock it would produce and
@@ -609,15 +687,15 @@ def _check_locked(
     both, so only a real change to the locked packages fails.  The committed
     lock is never read back into the resolve.
     """
-    target = _locked_target_path(output, build_requirements=build_requirements)
+    target = _locked_target_path(run)
     new_text = _render_or_exit(lambda: render_lock(lock_input, lock_dir=target.parent))
     committed = _packages_only(target.read_text(encoding="utf-8"))
     if _packages_only(new_text) == committed:
         _cli.printer().done(f"Lockfile {target} is up to date.")
         return
-    refresh = _refresh_command(build_requirements=build_requirements)
     _cli.printer().error(
-        f"--locked: lockfile {target} is out of date; re-run `{refresh}` to update it."
+        f"--locked: lockfile {target} is out of date;"
+        f" re-run `{run.refresh_command()}` to update it."
     )
     sys.exit(1)
 

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -374,6 +374,27 @@ def project_config_overrides(
     return {key: value for key, value in cli_overrides.items() if key in project_keys}
 
 
+def project_override_arguments(cli_overrides: Mapping[str, object]) -> list[str]:
+    """Return the CLI tokens that re-apply this run's ``--project-*`` overrides.
+
+    Takes the raw map :func:`_cli_overrides` built, not the config subset, so
+    ``resolution`` is carried too: it shapes the resolve without entering the
+    merged config.  A repeatable flag is emitted once per element.
+    """
+    arguments: list[str] = []
+    for spec in OPTIONS:
+        flag = spec.cli_flag
+        if spec.scope is not Scope.PROJECT or flag is None:
+            continue
+        value = cli_overrides.get(spec.key)
+        if value is None:
+            continue
+        items = value if isinstance(value, tuple) else (value,)
+        for item in items:
+            arguments += [flag, str(item)]
+    return arguments
+
+
 def _layered_run_settings(
     path: Path, cli_overrides: Mapping[str, object]
 ) -> tuple[RunSettings, Mapping[str, EffectiveValue]]:

--- a/tests/test_lock_locked.py
+++ b/tests/test_lock_locked.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import tomli
 
+from nab._lock import _join_command, _join_for_cmd, _quote_for_cmd
 from nab.cli import app
 from nab_python._vendor.packaging.version import Version
 from nab_python.lockfile import (
@@ -118,6 +119,15 @@ def _run_locked_unmocked(pyproject: Path, out: Path, *extra: str) -> None:
     )
 
 
+def _remedy(*arguments: str) -> str:
+    """Return the command text a --locked failure names for this ``nab lock`` run.
+
+    Joined the way the message is, so a case lists arguments instead of one
+    platform's quoting.
+    """
+    return _join_command(["nab", "lock", *arguments])
+
+
 # --- fire cases: the resolver is never called ---
 
 
@@ -165,7 +175,8 @@ def test_tightened_build_requirement_fires_without_resolving(
     assert exc.value.code == 1
     err = capsys.readouterr().err
     assert "[build-system].requires requires foo>=2.0 but the lock pins foo 1.5" in err
-    assert "re-run `nab lock --build-requirements` to update it" in err
+    remedy = _remedy(str(pyproject), "--output", str(out), "--build-requirements")
+    assert f"re-run `{remedy}` to update it" in err
     mock.assert_not_called()
 
 
@@ -189,7 +200,7 @@ def test_locked_build_lock_defaults_to_the_build_lock_path(
     assert exc.value.code == 1
     err = capsys.readouterr().err
     assert "no lockfile at pylock.build.toml" in err
-    assert "run `nab lock --build-requirements` first" in err
+    assert f"run `{_remedy(str(pyproject), '--build-requirements')}` first" in err
 
 
 def test_locked_build_lock_checks_its_own_default_file(
@@ -538,7 +549,8 @@ def test_a_stale_build_lock_names_the_build_command(
 
     assert exc.value.code == 1
     err = capsys.readouterr().err
-    assert "is out of date; re-run `nab lock --build-requirements` to update it" in err
+    remedy = _remedy(str(pyproject), "--output", str(out), "--build-requirements")
+    assert f"is out of date; re-run `{remedy}` to update it" in err
     mock.assert_called_once()
 
 
@@ -756,7 +768,7 @@ def test_undeclared_group_reports_the_group_error(
     err = capsys.readouterr().err
     assert "Dependency group 'dev' not found" in err
     assert "is out of date" not in err
-    assert "re-run `nab lock`" not in err
+    assert "re-run `nab lock" not in err
 
 
 def test_undeclared_default_group_reports_the_group_error(
@@ -782,7 +794,7 @@ def test_undeclared_default_group_reports_the_group_error(
     err = capsys.readouterr().err
     assert "Dependency group 'dev' not found" in err
     assert "is out of date" not in err
-    assert "re-run `nab lock`" not in err
+    assert "re-run `nab lock" not in err
 
 
 def test_undeclared_project_default_group_reports_the_group_error(
@@ -805,7 +817,7 @@ def test_undeclared_project_default_group_reports_the_group_error(
     err = capsys.readouterr().err
     assert "Dependency group 'dev' not found" in err
     assert "is out of date" not in err
-    assert "re-run `nab lock`" not in err
+    assert "re-run `nab lock" not in err
 
 
 def test_undeclared_extra_reports_the_extra_error(
@@ -831,7 +843,7 @@ def test_undeclared_extra_reports_the_extra_error(
         " defined: ['x']" in err
     )
     assert "is out of date" not in err
-    assert "re-run `nab lock`" not in err
+    assert "re-run `nab lock" not in err
 
 
 def test_missing_build_system_reports_the_project_error(
@@ -849,7 +861,7 @@ def test_missing_build_system_reports_the_project_error(
     assert exc.value.code == 1
     err = capsys.readouterr().err
     assert "declares no [build-system]" in err
-    assert "run `nab lock --build-requirements` first" not in err
+    assert "run `nab lock" not in err
 
 
 def test_unreadable_requirement_with_changed_envelope_reports_the_parse_error(
@@ -995,3 +1007,162 @@ def test_unsearchable_parent_precondition(
     assert "cannot read lockfile" in err
     assert "Permission denied" in err
     mock.assert_not_called()
+
+
+# --- remedy cases: the failure names the run that rewrites the file ---
+
+
+def test_remedy_keeps_the_extras_selection(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Bare `nab lock` would rewrite the lock without the extra it was built for."""
+    body = (
+        '[project]\nname = "proj"\nversion = "0"\ndependencies = []\n'
+        "[project.optional-dependencies]\n"
+    )
+    pyproject = _write_pyproject(tmp_path, body + 'gpu = ["foo"]\n')
+    out = tmp_path / "pylock.toml"
+    _write_lock(pyproject, out, _result({"foo": "1.5"}), "--extras", "gpu")
+    capsys.readouterr()
+    pyproject.write_text(body + 'gpu = ["foo>=2.0"]\n', encoding="utf-8")
+
+    mock = _locked_mock()
+    with pytest.raises(SystemExit) as exc:
+        _run_locked(pyproject, out, mock, "--extras", "gpu")
+
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "the 'gpu' extra requires foo>=2.0 but the lock pins foo 1.5" in err
+    remedy = _remedy(str(pyproject), "--output", str(out), "--extras", "gpu")
+    assert f"re-run `{remedy}` to update it" in err
+    mock.assert_not_called()
+
+
+def test_remedy_names_a_custom_output_path(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A lock kept off the default path must not send the user to ./pylock.toml."""
+    monkeypatch.chdir(tmp_path)
+    _write_pyproject(tmp_path, '[project]\nname = "proj"\ndependencies = []\n')
+    out = Path("locks/pylock.toml")
+
+    with pytest.raises(SystemExit) as exc:
+        app.cli(args=["lock", "--output", str(out), "--locked"], prog="nab")
+
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    remedy = _remedy("--output", str(out))
+    assert f"no lockfile at {out} to check; run `{remedy}` first." in err
+
+
+def test_remedy_carries_every_run_shaping_flag(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Anything that decides what the lock holds belongs in the remedy.
+
+    Driving the CLI with the same arguments the remedy renders proves tyro
+    still accepts them, multi-value ``--groups``/``--extras`` included: a
+    parse failure would exit 2 with a usage error instead of the remedy.
+    """
+    monkeypatch.chdir(tmp_path)
+    pyproject = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "proj"\nversion = "0"\ndependencies = []\n'
+        "[project.optional-dependencies]\n"
+        'cpu = ["foo"]\ngpu = ["foo"]\n'
+        "[dependency-groups]\n"
+        'dev = ["bar"]\ntest = ["bar"]\n',
+    )
+    out = Path("locks/pylock.toml")
+
+    refresh = [
+        str(pyproject),
+        *["--output", str(out)],
+        *["--python", "3.12"],
+        *["--groups", "dev", "test"],
+        *["--extras", "cpu", "gpu"],
+        *["--offline", "True"],
+        "--no-workspace-discovery",
+        "--no-emit-workspace",
+        *["--project-resolution", "lowest"],
+        *["--project-constraint", "foo<2"],
+        *["--project-constraint", "bar<3"],
+        *["--project-requires-python", ">=3.9"],
+        "--upgrade",
+    ]
+
+    with pytest.raises(SystemExit) as exc:
+        app.cli(args=["lock", *refresh, "--locked"], prog="nab")
+
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert f"no lockfile at {out} to check; run `{_remedy(*refresh)}` first." in err
+
+
+def test_remedy_for_a_default_run_stays_bare(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A run that shapes nothing gets the short command, not its own defaults."""
+    monkeypatch.chdir(tmp_path)
+    _write_pyproject(tmp_path, '[project]\nname = "proj"\ndependencies = []\n')
+
+    with pytest.raises(SystemExit) as exc:
+        app.cli(args=["lock", "--locked"], prog="nab")
+
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "no lockfile at pylock.toml to check; run `nab lock` first." in err
+
+
+def test_following_the_remedy_makes_the_check_pass(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Running the printed remedy makes the next --locked check pass."""
+    monkeypatch.chdir(tmp_path)
+    body = (
+        '[project]\nname = "proj"\nversion = "0"\ndependencies = []\n'
+        "[project.optional-dependencies]\n"
+    )
+    pyproject = _write_pyproject(tmp_path, body + 'gpu = ["foo"]\n')
+    out = tmp_path / "locks" / "pylock.toml"
+    out.parent.mkdir()
+    _write_lock(pyproject, out, _result({"foo": "1.5"}), "--extras", "gpu")
+    pyproject.write_text(body + 'gpu = ["foo>=2.0"]\n', encoding="utf-8")
+    capsys.readouterr()
+    refresh = [str(pyproject), "--output", str(out), "--extras", "gpu"]
+
+    with pytest.raises(SystemExit):
+        _run_locked(
+            pyproject, out, _locked_mock(_result({"foo": "2.0"})), "--extras", "gpu"
+        )
+
+    assert f"re-run `{_remedy(*refresh)}` to update it" in capsys.readouterr().err
+
+    with patch("nab.cli.resolve_for_targets", _locked_mock(_result({"foo": "2.0"}))):
+        app.cli(args=["lock", *refresh], prog="nab")
+    capsys.readouterr()
+
+    _run_locked(
+        pyproject, out, _locked_mock(_result({"foo": "2.0"})), "--extras", "gpu"
+    )
+
+    assert f"Lockfile {out} is up to date." in capsys.readouterr().err
+
+
+def test_the_windows_remedy_quotes_what_cmd_reads_as_syntax() -> None:
+    """A cmd.exe remedy wraps what the shell would otherwise read as syntax.
+
+    ``<`` is the case that forces the choice: cmd reads it as a redirect
+    unless it sits inside double quotes, and ``--project-constraint foo<2``
+    is a remedy that carries one.
+    """
+    assert _quote_for_cmd(r"C:\proj\pyproject.toml") == r"C:\proj\pyproject.toml"
+
+    assert _quote_for_cmd(r"C:\Program Files\proj") == r'"C:\Program Files\proj"'
+    assert _quote_for_cmd("foo<2") == '"foo<2"'
+    assert _quote_for_cmd("") == '""'
+    assert _quote_for_cmd('foo; sys_platform == "win32"') == (
+        '"foo; sys_platform == ""win32"""'
+    )
+
+    assert _join_for_cmd(["nab", "lock", "--extras", "gpu"]) == "nab lock --extras gpu"


### PR DESCRIPTION
`nab lock --extras gpu --locked` against a stale lock prints:

    error: --locked: lockfile pylock.toml is out of date; re-run `nab lock` to update it.

Bare `nab lock` rewrites `pylock.toml` without the `gpu` extra. Running what it says replaces the committed lock with one for a different selection, and the next check fails the same way. With `--output` the printed command is worse still: it writes the default path, never the file the same line just named.

The printed command was built from `--build-requirements` alone. Every other flag that decides which file is written, or what goes in it, was dropped: the project path, `--output`, `--extras`, `--groups`, `--python`, `--offline`, `--no-workspace-discovery`, `--no-emit-workspace`, `--upgrade`, and the `--project-*` overrides.

It now renders the run it came from, minus `--locked`, quoted for the shell it will be pasted into. Windows gets cmd quoting rather than `shlex`, since `--project-constraint foo<2` in that line would otherwise be read as a redirect.
