### PR TITLE
Add the missing vcs/ and archive/ buckets to the cache reference

### DIFF
--- a/docs/reference/cache.md
+++ b/docs/reference/cache.md
@@ -8,9 +8,9 @@ and reset it with [`nab cache`](cli.md).
 
 ## Layout
 
-Each entry is one file under a versioned bucket directory. Bumping a
-bucket's version suffix retires the old format: the stale directory is
-harmless and `nab cache clear` reclaims it.
+Each record nab writes is one file under a versioned bucket directory.
+Bumping a bucket's version suffix retires the old format: the stale
+directory is harmless and `nab cache clear` reclaims it.
 
 | Bucket | Holds |
 | ------ | ----- |
@@ -20,11 +20,24 @@ harmless and `nab cache clear` reclaims it.
 | `metadata-v1/` | PEP 658 metadata and recovered wheel `METADATA`, immutable |
 | `sdist-v1/` | an sdist's `PKG-INFO` and `pyproject.toml`, immutable |
 
-Buckets are keyed per index, so two indexes never share an entry. A
-listing body is stored as PEP 691 JSON; when the index answers in PEP 503
-HTML the stored body is nab's own JSON rendering of the page. An index
-pinned to one `serialization` gets its own listing directories, since the
-stored body records nothing about which form it came from.
+Record buckets are keyed per index, so two indexes never share an entry.
+A listing body is stored as PEP 691 JSON; when the index answers in PEP
+503 HTML the stored body is nab's own JSON rendering of the page. An
+index pinned to one `serialization` gets its own listing directories,
+since the stored body records nothing about which form it came from.
+
+A declared VCS or archive source (see [Configuration](configuration.md))
+fills a bucket of its own:
+
+| Bucket | Holds |
+| ------ | ----- |
+| `vcs/` | a shallow clone, at `vcs/vcs/<repo key>/<commit sha>/` |
+| `archive/` | an extracted archive, at `archive/<archive digest>/` |
+
+Both hold upstream files rather than nab records, so neither is versioned
+or keyed per index. Under `--no-cache` there is no root to write to, so
+the run materialises them in a temporary directory and discards them at
+the end.
 
 ## Freshness
 
@@ -61,10 +74,12 @@ formats nab cannot read.
 
 ## Verifying and clearing
 
-`nab cache verify` walks every bucket read-only and reports any entry that
-will not parse, including a parsed blob that is not decodable. It checks
-structure only, not freshness: a stale-but-valid parsed blob is not
-corrupt, since the digest binding retires it at read time. `nab cache
-clear` removes every bucket, returning the cache to cold. Both refuse a
-root that does not look like a nab cache and never follow a symlink out of
-it.
+`nab cache verify` walks the record buckets read-only and reports any
+entry that will not parse, including a parsed blob that is not decodable.
+It checks structure only, not freshness: a stale-but-valid parsed blob is
+not corrupt, since the digest binding retires it at read time. Clones and
+extracted archives hold no nab records, so `verify` skips them.
+
+`nab cache clear` removes every bucket, clones and archives included,
+returning the cache to cold. `verify` and `clear` both refuse a root that
+does not look like a nab cache and never follow a symlink out of it.

--- a/nab-python/tests/test_cache.py
+++ b/nab-python/tests/test_cache.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import stat
 import subprocess
 import time
@@ -21,6 +22,7 @@ from nab_index.cache import (
     CACHE_VERSION_SDIST,
     CACHE_VERSION_SIMPLE,
     CACHE_VERSION_SIMPLE_NEG,
+    SOURCE_BUCKETS,
     VCS_BUCKET,
     CachePolicy,
     NullCache,
@@ -963,6 +965,41 @@ class TestSourceBuckets:
         assert "fixture.json" not in names
         assert "data.json" not in names
         assert "foo.json" in names
+
+
+class TestCacheReferenceLayout:
+    """The cache reference's Layout tables name every bucket the root holds."""
+
+    def _documented_buckets(self) -> set[str]:
+        """Return the bucket names the Layout section's tables list."""
+        doc = Path(__file__).resolve().parents[2] / "docs" / "reference" / "cache.md"
+        text = doc.read_text(encoding="utf-8")
+
+        start = text.index("## Layout")
+        end = text.index("\n## ", start + 1)
+        section = text[start:end]
+
+        return set(re.findall(r"^\| `([^`]+)/` \|", section, flags=re.MULTILINE))
+
+    def _record_buckets(self, cache: OnDiskCache) -> set[str]:
+        """Return the root-level directories ``cache`` writes its records under.
+
+        Read off the cache's own paths rather than a populated root, so a
+        bucket added to ``OnDiskCache`` fails this test until the reference
+        names it too.
+        """
+        root = cache._root
+        return {
+            path.relative_to(root).parts[0]
+            for path in vars(cache).values()
+            if isinstance(path, Path) and path != root
+        }
+
+    def test_tables_name_every_bucket(self, tmp_path: Path) -> None:
+        cache = OnDiskCache(tmp_path / "cache", "https://pypi.org/simple")
+
+        expected = self._record_buckets(cache) | set(SOURCE_BUCKETS)
+        assert self._documented_buckets() == expected
 
 
 class TestAddOwnerMode:


### PR DESCRIPTION
`docs/reference/cache.md` lists 5 of the 7 bucket directories a cache root holds; `vcs/` and `archive/` are missing. `nab cache clear` removes all 7, so nothing on the page tells a reader that clearing the cache throws away every cloned repo and extracted archive.

Two of its claims are wrong:

- `nab cache verify` "walks every bucket": `iter_cache_entries` walks the record buckets only (`simple-*`, `metadata-*`, `sdist-*`), so a file inside a clone or an extracted archive is never parsed.
- "Each entry is one file under a versioned bucket directory": neither source bucket is versioned or keyed per index, and both hold upstream files rather than nab records.

Layout gains a second table for the two source buckets and their on-disk shape (`vcs/vcs/<repo key>/<commit sha>/`, `archive/<archive digest>/`), and notes that `--no-cache` materialises them in a temporary directory instead. Verifying and clearing now separates the two commands: `verify` skips the source buckets, `clear` removes them.

A test compares the Layout tables against the cache's own bucket paths and `SOURCE_BUCKETS`, so a new bucket fails until the reference names it.
