### PR TITLE
Fix conflicts.md: an `at-least-one` set never forks on co-selection

### DIFF
--- a/docs/explanation/conflicts.md
+++ b/docs/explanation/conflicts.md
@@ -112,7 +112,7 @@ conflicts = [[{ group = "base" }, { group = "build" }, { group = "dev" }]]
 ```
 
 That forks three ways when the run selects `dev`, and two otherwise,
-since a set forks only over the members the selection activates. With
+since the set forks only over the members the selection activates. With
 `dev` selected, an install choosing it gets that group without the
 project's own dependencies. Declare two sets instead if
 `dev` should install alongside them, remembering that `build` can be in
@@ -126,9 +126,10 @@ only one of them.
 
 ## Forking co-selected members
 
-When the selection activates two or more members of a set, nab does not
-reject it: it forks the resolve. For example `nab lock --extras cpu gpu`,
-or `nab lock --all-groups` over the `black*` groups above, resolves each
+When the selection activates two or more members of an exclusive set
+(`at-most-one` or `exactly-one`), nab does not reject it: it forks the
+resolve. For example `nab lock --extras cpu gpu`, or
+`nab lock --all-groups` over the `black*` groups above, resolves each
 member separately and writes every result into one lockfile. This is the
 same in specific and universal mode; the resolve mode does not change how
 a conflict is handled. Two cases are refused rather than forked, both
@@ -160,8 +161,8 @@ crossed with `isort{5,6,7}` is nine forks. Non-conflicting selections
 stay active in every fork.
 
 Forking needs one member per fork. If a single selection forces two
-members of one set together, no fork can separate them, so the resolve
-is refused before any network work:
+members of one exclusive set together, no fork can separate them, so the
+resolve is refused before any network work:
 
 ```console
 $ nab lock --extras all
@@ -175,7 +176,9 @@ all-in-one umbrella cannot resolve disjointly, so it is rejected.
 
 The require-one policies still raise. Declaring `exactly-one` or
 `at-least-one` and selecting none of its members is rejected before the
-resolve, regardless of mode; co-selection forks instead.
+resolve, regardless of mode. Co-selection forks under `exactly-one`;
+`at-least-one` permits it, so its members stay active together in one
+resolve.
 
 Groups named in `[tool.nab].default-groups` count as part of the
 selection for every conflict check. A project with
@@ -219,8 +222,8 @@ package whose version does depend on the combination keeps the
 conjunction, and so does anything that requires it: an entry never
 fires where one of its own dependencies would not.
 
-A set forks only over the members the selection activates. The rest of
-its declared members are absent from the lock's `extras` and
+An exclusive set forks only over the members the selection activates.
+The rest of its declared members are absent from the lock's `extras` and
 `dependency-groups` arrays and from every marker, so a set with an
 unselected member gates an entry exactly as one without it would.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3512,6 +3512,45 @@ def _console_block(text: str, command: str) -> list[str]:
     raise AssertionError(msg)
 
 
+def _doc_paragraph(text: str, needle: str) -> str:
+    """The blank-line-delimited paragraph of ``text`` that contains ``needle``."""
+    for paragraph in text.split("\n\n"):
+        if needle in paragraph:
+            return paragraph
+
+    msg = f"no paragraph containing {needle!r}"
+    raise AssertionError(msg)
+
+
+def _emitted_labels(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    body: str,
+    *,
+    extras: tuple[str, ...] = (),
+    groups: tuple[str, ...] = (),
+) -> list[str]:
+    """The ``# label`` headers a ``nab lock`` over ``body`` prints for the selection.
+
+    The requirements formats label one block per emitted target and omit
+    the header when there is only one, so for these single-target
+    specific-mode locks the headers count the forks.
+    """
+    pyproject = _make_pyproject(tmp_path, body)
+    lock(
+        pyproject,
+        cache_dir=tmp_path / "cache",
+        offline=True,
+        extras=extras,
+        groups=groups,
+        format="requirements-without-hashes",
+        output=Path("-"),
+    )
+
+    printed = capsys.readouterr().out
+    return [line for line in printed.splitlines() if line.startswith("# ")]
+
+
 class TestConflictsDocTranscript:
     """The conflicts page quotes the refusal lines the CLI prints."""
 
@@ -3560,6 +3599,61 @@ class TestConflictsDocTranscript:
         assert printed in _console_block(doc, "$ nab lock")
 
 
+class TestConflictsDocForkingPolicies:
+    """The conflicts page names which policies fork a co-selecting run.
+
+    Only the exclusive policies do; ``at-least-one`` permits co-selection.
+    """
+
+    _GROUPS = (
+        '[project]\nname = "proj"\nversion = "0.1.0"\ndependencies = []\n'
+        "[dependency-groups]\n"
+        "a = []\n"
+        "b = []\n"
+    )
+
+    def _body(self, policy: str) -> str:
+        """The two-group project with ``a`` and ``b`` conflicting under ``policy``."""
+        members = '[{ group = "a" }, { group = "b" }]'
+        return (
+            self._GROUPS
+            + "[tool.nab]\n"
+            + f'conflicts = [{{ members = {members}, policy = "{policy}" }}]\n'
+        )
+
+    def _unwrapped_claim(self, needle: str) -> str:
+        """The page's paragraph holding ``needle``, rejoined onto one line.
+
+        The page hard-wraps, so a claim spanning a line break only matches unwrapped.
+        """
+        doc = _CONFLICTS_DOC.read_text(encoding="utf-8")
+        return " ".join(_doc_paragraph(doc, needle).split())
+
+    def test_exactly_one_forks_co_selected_members(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """An exclusive set resolves each co-selected member on its own."""
+        labels = _emitted_labels(
+            tmp_path, capsys, self._body("exactly-one"), groups=("a", "b")
+        )
+        assert labels == ["# host-group-a", "# host-group-b"]
+
+        claim = self._unwrapped_claim("When the selection activates")
+        assert "an exclusive set (`at-most-one` or `exactly-one`)" in claim
+
+    def test_at_least_one_co_selection_stays_one_resolve(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """An at-least-one set permits co-selection, so the run does not fork."""
+        labels = _emitted_labels(
+            tmp_path, capsys, self._body("at-least-one"), groups=("a", "b")
+        )
+        assert labels == []
+
+        claim = self._unwrapped_claim("The require-one policies")
+        assert "`at-least-one` permits it" in claim
+
+
 _CLI_REFERENCE_DOC = (
     Path(__file__).resolve().parents[1] / "docs" / "reference" / "cli.md"
 )
@@ -3567,16 +3661,6 @@ _CLI_REFERENCE_DOC = (
 
 def _doc_section(text: str, heading: str) -> str:
     return text.partition(f"\n{heading}\n")[2].partition("\n## ")[0]
-
-
-def _doc_paragraph(text: str, needle: str) -> str:
-    """The blank-line-delimited paragraph of ``text`` that contains ``needle``."""
-    for paragraph in text.split("\n\n"):
-        if needle in paragraph:
-            return paragraph
-
-    msg = f"no paragraph containing {needle!r}"
-    raise AssertionError(msg)
 
 
 def _names_flag(text: str, flag: str) -> bool:
@@ -3603,27 +3687,6 @@ class TestCliReferenceSelectionShape:
 
     _CONFLICT = '[tool.nab]\nconflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]\n'
 
-    def _emitted_labels(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str], body: str
-    ) -> list[str]:
-        """The ``# label`` headers ``nab lock --extras cpu gpu`` prints for ``body``.
-
-        The requirements formats label one block per emitted target and omit
-        the header when there is only one, so for these single-target
-        specific-mode locks the headers count the forks.
-        """
-        pyproject = _make_pyproject(tmp_path, body)
-        lock(
-            pyproject,
-            cache_dir=tmp_path / "cache",
-            offline=True,
-            extras=("cpu", "gpu"),
-            format="requirements-without-hashes",
-            output=Path("-"),
-        )
-        printed = capsys.readouterr().out
-        return [line for line in printed.splitlines() if line.startswith("# ")]
-
     def _selection_paragraph(self) -> str:
         """The ``nab lock`` paragraph that states what a selection resolves to."""
         text = _doc_section(
@@ -3635,7 +3698,8 @@ class TestCliReferenceSelectionShape:
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
         """Two extras with no conflict declared resolve once, as the page says."""
-        assert self._emitted_labels(tmp_path, capsys, self._EXTRAS) == []
+        labels = _emitted_labels(tmp_path, capsys, self._EXTRAS, extras=("cpu", "gpu"))
+        assert labels == []
 
         assert "single union resolve" in self._selection_paragraph()
 
@@ -3643,7 +3707,9 @@ class TestCliReferenceSelectionShape:
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
         """Declaring the same two extras exclusive resolves each separately."""
-        labels = self._emitted_labels(tmp_path, capsys, self._EXTRAS + self._CONFLICT)
+        labels = _emitted_labels(
+            tmp_path, capsys, self._EXTRAS + self._CONFLICT, extras=("cpu", "gpu")
+        )
         assert labels == ["# host-extra-cpu", "# host-extra-gpu"]
 
         paragraph = self._selection_paragraph()


### PR DESCRIPTION
`docs/explanation/conflicts.md` says that when a selection activates two or more members of a conflict set, nab forks and resolves each member separately. That is only true of the exclusive policies.

`conflict_forks` skips `at-least-one` sets before it looks at their members, so co-selecting them resolves once with both active. The page says as much further down: "`at-least-one` permits co-selection, so all of its members may be defaults."

Two groups `a` and `b` in one set, locked with `nab lock --groups a b`:

| policy | requirements output |
| --- | --- |
| `exactly-one` | two blocks, `# host-group-a` and `# host-group-b` |
| `at-least-one` | one block, no header |

The code is right, so the fix is to the page: each forking claim is qualified to `at-most-one` and `exactly-one`, and the require-one paragraph says what `at-least-one` does instead. The new tests pin both shapes against the paragraphs that state them.
