### PR TITLE
Cut the Test workflow from 52 jobs to 22, ~30% less runner time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Run property-based tests
         # CrossHair tests run in the dedicated crosshair-tests job; the
         # crosshair backend is not installed here, so skip that file.
-        run: python -m pytest -m property --ignore=nab-resolver/tests/property/test_crosshair_ranges.py
+        run: python -m pytest -n auto -m property --ignore=nab-resolver/tests/property/test_crosshair_ranges.py
 
   crosshair-tests:
     name: CrossHair property tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,6 @@ jobs:
         name: Install Python ${{ matrix.python-version }}
         with:
           python-version: ${{ matrix.python-version }}
-          check-latest: true
           cache: pip
           cache-dependency-path: |
             .github/requirements/pylock.nox.toml
@@ -87,7 +86,6 @@ jobs:
         name: Install Python ${{ matrix.python-version }}
         with:
           python-version: ${{ matrix.python-version }}
-          check-latest: true
           cache: pip
           cache-dependency-path: |
             .github/requirements/pylock.nox.toml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,16 +18,14 @@ env:
 
 jobs:
   test:
-    name: ${{ matrix.workspace }} / ${{ matrix.os }} / ${{ matrix.python-version }}
+    name: ${{ matrix.os }} / ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu, windows, macos]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        # noxfile.py maps each workspace to its tests and coverage gates.
-        workspace: [resolver, python, umbrella]
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -50,13 +48,11 @@ jobs:
       - name: Install nox
         run: pip install -r .github/requirements/pylock.nox.toml
 
-      # Test and coverage logic lives in noxfile.py. The workspace goes through
-      # env, not inline ${{ }}, for zizmor; shell: bash expands it on Windows.
-      - name: Test the ${{ matrix.workspace }} workspace
-        run: nox -s "tests(workspace='${WORKSPACE}')"
-        shell: bash
-        env:
-          WORKSPACE: ${{ matrix.workspace }}
+      # Test and coverage logic lives in noxfile.py. The tests session is
+      # parametrized by workspace, so this runs all three, each in its own
+      # venv and gated on its own packages.
+      - name: Test every workspace
+        run: nox -s tests
 
   benchmarks:
     name: benchmark harness / ${{ matrix.os }} / ${{ matrix.python-version }}


### PR DESCRIPTION
The `Test` workflow goes from 52 jobs to 22. Measured on this branch's run against the three most recent `main` runs: about 4900 runner-seconds down to about 3500, and 360-380s to green down to about 320s. Job counts are exact; timings are single-run figures.

| Change | Measured now | After |
|---|---|---|
| `check-latest: true` on setup-python | 740 runner-s/run on `Install Python`, worst cell 49s (`python / windows / 3.13`) | ~3s per job, matching the three jobs that never set it |
| `workspace` matrix dimension | 52 jobs, 15 macOS jobs against a 5-job macOS cap, so three waves | 22 jobs, 5 macOS jobs, one wave |
| property tests single-process | 234 passed, 8443 deselected in 210s | `-n auto`, measured 103s |

`check-latest` made every matrix job ask python-versions for the newest patch. The runner image ships an older one, so `python / windows / 3.13` downloaded and unpacked CPython from scratch on every run:

    Version 3.13.15 was not found in the local cache
    Download from ".../python-3.13.15-win32-x64.zip"
    Extract downloaded archive
    ...
    Successfully set up CPython (3.13.15)      # 44s later

The `workspace` dimension gave each of the 15 os/version cells three jobs. `resolver` runs 377 tests in 4.4s and `umbrella` 595 in 10.5s, yet each paid a full job's checkout, Python install and nox bootstrap: about 12s on ubuntu, 27s on macOS, 44s on Windows, 30 times over. `nox -s tests` runs all three parametrizations in one job.

The property job ran single-process while every matrix job already used `-n auto`. pytest-xdist is in `pylock.tests.toml`, which that job installs.

What does not change:

- Hypothesis budgets. The job keeps `HYPOTHESIS_PROFILE: ci` and the per-module `PROPERTY_SETTINGS`, `DEEP_SETTINGS` and `BRUTE_FORCE_SETTINGS`.
- The coverage gates. `nox -s tests` still runs three sessions, each with its own venv, `coverage erase`, scoped pytest paths and `coverage report --include=*/<package>/*`. A failing session does not stop the others, so all three still run and the end-of-run summary names the workspace that failed.
- OS and version coverage: 3 operating systems x 5 Python versions, the three benchmark-harness cells, the CrossHair job, and `fail-fast: false`.
