### PR TITLE
Fix markers proved disjoint that both hold at python_full_version 3.10.0

### DIFF
--- a/nab-python/src/nab_python/_vendor/packaging/_markersets.py
+++ b/nab-python/src/nab_python/_vendor/packaging/_markersets.py
@@ -681,9 +681,7 @@ def _version_neighbors(text: str) -> list[str]:
     major = release[0]
     release_str = ".".join(str(part) for part in release)
     pre_part = f"{version.pre[0]}{version.pre[1]}" if version.pre is not None else ""
-    out = [base]
-    if version.local is not None:
-        out.extend(_local_twins(version, release_str, pre_part))
+    out = [base, *_equal_twins(version)]
 
     # Bumps stay in the literal's own epoch: the release bump of 1!3.9 is 1!3.10,
     # which outranks it, not 3.10, which sorts below and leaves the band above the
@@ -738,19 +736,19 @@ def _suffix_neighbors(version: Version, release_str: str, pre_part: str) -> list
     return out
 
 
-def _local_twins(version: Version, release_str: str, pre_part: str) -> list[str]:
-    """Mint the shared points of a local-tagged literal.
+def _equal_twins(version: Version) -> list[str]:
+    """Mint the points equal to the literal as a version but not as a string.
 
-    A specifier built from a public point ignores a candidate's local label
-    (PEP 440 version matching), so the local-stripped release realises truth
-    vectors the tagged point cannot. The zero-padded twin is equal to the
-    literal as a version but not as a string, so the invalid-specifier
-    string fall-through tells the two apart.
+    ``in``/``not in`` and an invalid specifier fall through to a raw string
+    test, so separating that reading from PEP 440 matching needs a point the
+    version test accepts and the string test rejects: the release, zero-padded.
+    A local-tagged literal also needs the local-stripped release, since a
+    specifier built from a public point ignores a candidate's local label.
     """
-    post_part = f".post{version.post}" if version.post is not None else ""
-    dev_part = f".dev{version.dev}" if version.dev is not None else ""
-    stem = f"{version.epoch}!{release_str}.0{pre_part}{post_part}{dev_part}"
-    return [version.public, str(Version(f"{stem}+{version.local}"))]
+    padded = version.__replace__(release=(*version.release, 0))
+    if version.local is None:
+        return [str(padded)]
+    return [version.public, str(padded)]
 
 
 def _between(vlow: Version, low: str, vhigh: Version) -> str | None:

--- a/nab-python/tests/test_marker_algebra.py
+++ b/nab-python/tests/test_marker_algebra.py
@@ -164,6 +164,40 @@ def test_local_literal_padded_twin_refutes_subset() -> None:
     assert not eq.is_subset(le)
 
 
+def test_membership_reads_padded_twin_as_a_string() -> None:
+    # CPython 3.10.0 satisfies both: the swapped == builds the specifier ==3.10.0,
+    # which zero-pads the literal, while not in is a raw string test "3.10.0" passes.
+    swapped_eq = ms('"3.10" == python_full_version')
+    absent = ms('python_full_version not in "3.9 3.10"')
+    shared = {"python_full_version": "3.10.0", "python_version": "3.10"}
+
+    assert swapped_eq.evaluate(shared)
+    assert absent.evaluate(shared)
+    assert not swapped_eq.is_disjoint(absent)
+
+    both = swapped_eq & absent
+    assert not both.is_empty()
+
+    env = both.witness()
+    assert env is not None
+    assert Marker(
+        '"3.10" == python_full_version and python_full_version not in "3.9 3.10"'
+    ).evaluate(env)
+
+
+def test_membership_padded_twin_on_a_version_or_string_axis() -> None:
+    # platform_release dispatches as a version yet admits arbitrary strings, so its
+    # pool needs the padded twin as much as a version-only axis does.
+    marker = ms('"5.10" == platform_release and platform_release not in "5.10 5.11"')
+    assert not marker.is_empty()
+
+    env = marker.witness()
+    assert env is not None
+    assert Marker(
+        '"5.10" == platform_release and platform_release not in "5.10 5.11"'
+    ).evaluate(env)
+
+
 def test_m1_string_ordering_non_negation() -> None:
     less = ms('sys_platform < "linux"')
     greater_equal = ms('sys_platform >= "linux"')

--- a/nab-python/tests/test_markersets.py
+++ b/nab-python/tests/test_markersets.py
@@ -600,7 +600,7 @@ def test_one_operation_reads_each_atom_truth_once(
     """An atom's truth on one point is evaluated once per operation.
 
     Partitions of one axis over overlapping atom sets re-read the same atom on the
-    same point, which is why the memo pays. 156 evaluations here, against 208 with
+    same point, which is why the memo pays. 164 evaluations here, against 218 with
     the memo bypassed.
     """
     left = ms('python_version < "3.12"' + _SPREAD)
@@ -609,7 +609,7 @@ def test_one_operation_reads_each_atom_truth_once(
     truths = _truth_counter(monkeypatch)
     assert left.equivalent_within(right, _row_universe()) is True
 
-    assert truths() == 156
+    assert truths() == 164
 
 
 def test_atoms_keep_no_truths_between_operations(
@@ -709,7 +709,7 @@ def test_a_shared_store_serves_the_next_decision_its_truths(
     """A decision handed the previous one's store re-reads no stored atom truth.
 
     Only restriction repeats, one read for each of the six rows' two operands,
-    against 156 for the decision itself.
+    against 164 for the decision itself.
     """
     universe = _row_universe()
     left = ms('python_version < "3.12"' + _SPREAD)
@@ -721,7 +721,7 @@ def test_a_shared_store_serves_the_next_decision_its_truths(
     first = truths()
     left.equivalent_within(right, universe, store=store)
 
-    assert first == 156
+    assert first == 164
     assert truths() - first == 12
 
 

--- a/tasks/vendoring/packaging.patch
+++ b/tasks/vendoring/packaging.patch
@@ -1,9 +1,9 @@
 diff --git a/nab-python/src/nab_python/_vendor/packaging/_markersets.py b/nab-python/src/nab_python/_vendor/packaging/_markersets.py
 new file mode 100644
-index 0000000..72eee6b
+index 0000000..a1cd981
 --- /dev/null
 +++ b/nab-python/src/nab_python/_vendor/packaging/_markersets.py
-@@ -0,0 +1,1811 @@
+@@ -0,0 +1,1809 @@
 +"""Marker algebra engine: reason about PEP 508 markers as sets of environments.
 +
 +The private engine behind :class:`~packaging.markersets.MarkerSet`. Parses a
@@ -687,9 +687,7 @@ index 0000000..72eee6b
 +    major = release[0]
 +    release_str = ".".join(str(part) for part in release)
 +    pre_part = f"{version.pre[0]}{version.pre[1]}" if version.pre is not None else ""
-+    out = [base]
-+    if version.local is not None:
-+        out.extend(_local_twins(version, release_str, pre_part))
++    out = [base, *_equal_twins(version)]
 +
 +    # Bumps stay in the literal's own epoch: the release bump of 1!3.9 is 1!3.10,
 +    # which outranks it, not 3.10, which sorts below and leaves the band above the
@@ -744,19 +742,19 @@ index 0000000..72eee6b
 +    return out
 +
 +
-+def _local_twins(version: Version, release_str: str, pre_part: str) -> list[str]:
-+    """Mint the shared points of a local-tagged literal.
++def _equal_twins(version: Version) -> list[str]:
++    """Mint the points equal to the literal as a version but not as a string.
 +
-+    A specifier built from a public point ignores a candidate's local label
-+    (PEP 440 version matching), so the local-stripped release realises truth
-+    vectors the tagged point cannot. The zero-padded twin is equal to the
-+    literal as a version but not as a string, so the invalid-specifier
-+    string fall-through tells the two apart.
++    ``in``/``not in`` and an invalid specifier fall through to a raw string
++    test, so separating that reading from PEP 440 matching needs a point the
++    version test accepts and the string test rejects: the release, zero-padded.
++    A local-tagged literal also needs the local-stripped release, since a
++    specifier built from a public point ignores a candidate's local label.
 +    """
-+    post_part = f".post{version.post}" if version.post is not None else ""
-+    dev_part = f".dev{version.dev}" if version.dev is not None else ""
-+    stem = f"{version.epoch}!{release_str}.0{pre_part}{post_part}{dev_part}"
-+    return [version.public, str(Version(f"{stem}+{version.local}"))]
++    padded = version.__replace__(release=(*version.release, 0))
++    if version.local is None:
++        return [str(padded)]
++    return [version.public, str(padded)]
 +
 +
 +def _between(vlow: Version, low: str, vhigh: Version) -> str | None:
@@ -1893,7 +1891,7 @@ index 5370ec8..b305068 100644
          return hash((self.version, self.inclusive))
  
 diff --git a/nab-python/src/nab_python/_vendor/packaging/markers.py b/nab-python/src/nab_python/_vendor/packaging/markers.py
-index c78fd5d..0d7ee1d 100644
+index 51b6036..38b2c26 100644
 --- a/nab-python/src/nab_python/_vendor/packaging/markers.py
 +++ b/nab-python/src/nab_python/_vendor/packaging/markers.py
 @@ -21,6 +21,8 @@ from .utils import canonicalize_name
@@ -1905,7 +1903,7 @@ index c78fd5d..0d7ee1d 100644
  __all__ = [
      "Environment",
      "EvaluateContext",
-@@ -543,6 +545,12 @@ class Marker:
+@@ -553,6 +555,12 @@ class Marker:
              self._markers, _repair_python_full_version(current_environment)
          )
  


### PR DESCRIPTION
`"3.10" == python_full_version` and `python_full_version not in "3.9 3.10"` come out disjoint, though CPython 3.10.0 satisfies both:

    >>> a = Marker('"3.10" == python_full_version').to_set()
    >>> b = Marker('python_full_version not in "3.9 3.10"').to_set()
    >>> env = {"python_full_version": "3.10.0", "python_version": "3.10"}
    >>> a.evaluate(env), b.evaluate(env)
    (True, True)
    >>> a.is_disjoint(b)
    True
    >>> print((a & b).witness())
    None

The two atoms read the same value differently. The swapped `==` compares as PEP 440 versions, where 3.10 and 3.10.0 are equal; `in`/`not in` is a raw string test, where they are not.

Telling those readings apart needs a point that equals the literal as a version and differs from it as a string, which is the zero-padded release, and `_version_neighbors` seeded that twin only for local-tagged literals. With no pool point where both atoms hold, the cell decomposition behind `is_empty`, `is_disjoint`, `is_subset` and `witness` never sampled the case.

Where it surfaces:

- `_self_ref_edges` reads the false empty as a path that never activates, so `expand_extra_requirements` drops the reached extra's requirements.
- An axis that dispatches as a version yet admits strings has the same hole: `"5.10" == platform_release and platform_release not in "5.10 5.11"` is proved empty too.
- The lockfile side reads the same proofs (`_lockfile/disjointness.py`, `_lockfile/pylock.py`).

`_equal_twins` now seeds the padded twin for every version literal, keeping the local-stripped release for the local-tagged case. That is one more pool point per version literal: 164 atom evaluations rather than 156 across the algebra's widest decomposition.
