### PR TITLE
Clean up interrupted VCS clone attempts

### DIFF
--- a/nab-index/src/nab_index/vcs.py
+++ b/nab-index/src/nab_index/vcs.py
@@ -231,18 +231,20 @@ def prepare_clone(
         shutil.rmtree(dest)
 
     tmp = Path(tempfile.mkdtemp(dir=dest.parent, prefix=f"{sha}.", suffix=".tmp"))
-    _shallow_clone(request.repo_url, sha, tmp)
     try:
-        tmp.rename(dest)
-    except OSError as exc:
-        # A concurrent run renamed its own finished clone first: use it.
+        _shallow_clone(request.repo_url, sha, tmp)
+        try:
+            tmp.rename(dest)
+        except OSError as exc:
+            # A concurrent run renamed its own finished clone first: use it.
+            if not _clone_complete(dest):
+                msg = (
+                    f"clone of {request.repo_url} @ {sha} could not be"
+                    f" moved into place: {exc}"
+                )
+                raise VcsCloneError(msg) from exc
+    finally:
         shutil.rmtree(tmp, ignore_errors=True)
-        if not _clone_complete(dest):
-            msg = (
-                f"clone of {request.repo_url} @ {sha} could not be"
-                f" moved into place: {exc}"
-            )
-            raise VcsCloneError(msg) from exc
 
     return VcsClone(
         path=dest,

--- a/nab-python/tests/test_vcs.py
+++ b/nab-python/tests/test_vcs.py
@@ -466,6 +466,29 @@ class TestPrepareClone:
                     or not list(entry.iterdir())
                 ), f"partial clone left behind at {entry}"
 
+    def test_interrupted_fetch_leaves_no_temp_clone(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        sha = "f" * 40
+
+        def fake_run(cmd: list[str], **kwargs: object) -> object:
+            cwd = Path(str(kwargs["cwd"]))
+            if cmd[:2] == ["git", "init"]:
+                (cwd / ".git").mkdir()
+            if cmd[:2] == ["git", "fetch"]:
+                (cwd / ".git" / "partial").touch()
+                raise KeyboardInterrupt
+            return type("P", (), {"returncode": 0})()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        req = VcsRequest("git", "https://example/repo.git", sha, "")
+        with pytest.raises(KeyboardInterrupt):
+            prepare_clone(tmp_path, req, require_pin=True)
+
+        assert list((tmp_path / "vcs").rglob("*.tmp")) == []
+
     def test_subdirectory_propagates(
         self,
         tmp_path: Path,


### PR DESCRIPTION
Ctrl-C during `git fetch` can leave a partial `*.tmp` clone beside the VCS cache entry.

Keep cloning and publication inside a `try`/`finally` that tries to remove the temporary directory on every exit. `KeyboardInterrupt` still propagates, and a concurrent clone that publishes first is still reused.
