### PR TITLE
Test that a resolve passes the project config into a PEP 517 build

### DIFF
--- a/nab-python/tests/test_resolve_targets.py
+++ b/nab-python/tests/test_resolve_targets.py
@@ -50,6 +50,7 @@ from nab_python.lockfile import (
     write_requirements_with_hashes,
     write_requirements_without_hashes,
 )
+from nab_python.metadata import WheelMetadata
 from nab_python.provider import (
     ArchiveSource,
     BuildPolicy,
@@ -1672,6 +1673,55 @@ class TestCutoffAndOverridePlumbing:
 
         override = '[tool.nab.index.pypi]\nuploaded-prior-to = "2024-03-01T00:00:00Z"\n'
         assert self._pins(tmp_path, override) == {"foo": Version("1.0")}
+
+
+class TestBuildConfigPlumbing:
+    """The project's config reaches the PEP 517 build a resolve triggers.
+
+    Only a source with dynamic metadata gets that far: the static reader
+    returns ``None`` for it, so the provider falls through to
+    ``build_backend.extract_metadata``, which refuses without a config.
+    The backend run itself is stubbed, so no build venv is created.
+    """
+
+    def _project(self, tmp_path: Path) -> Path:
+        """Write a project whose only dependency is a dynamic local source."""
+        source = tmp_path / "dyn"
+        source.mkdir()
+        (source / "pyproject.toml").write_text(
+            '[project]\nname = "dyn"\ndynamic = ["version"]\n', encoding="utf-8"
+        )
+
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "proj"\nversion = "0"\ndependencies = ["dyn"]\n'
+            "[tool.nab]\n"
+            'build-policy = "build-local"\n'
+            "[[tool.nab.local-sources]]\n"
+            'name = "dyn"\n'
+            'path = "dyn"\n',
+            encoding="utf-8",
+        )
+        return pyproject
+
+    def test_dynamic_local_source_builds_under_the_project_config(
+        self, tmp_path: Path
+    ) -> None:
+        """The config the resolve runs under is the one the build receives."""
+        config = read_pyproject_config(self._project(tmp_path))
+        built = WheelMetadata(name="dyn", version=Version("7.0"))
+
+        with patch(
+            "nab_python._build.runner.run_build_backend", return_value=built
+        ) as runner:
+            result = resolve_with_coordinator(
+                _make_coordinator({}), _one_target(), _reqs("dyn"), config=config
+            )
+
+        assert result.success
+        assert result.target_results[0].pins == {"dyn": Version("7.0")}
+
+        assert runner.call_args.kwargs["config"] is config
 
 
 class TestRunPassSerial:


### PR DESCRIPTION
Deleting `build_config=config` from the `Provider` construction in `resolve.py` leaves the suite green. It is the only route the project's config has into a PEP 517 build. `extract_metadata` refuses the dynamic path without one ("dynamic-metadata path requires a NabProjectConfig"), so dropping it stops anything that has to be built from resolving:

- a `[[tool.nab.local-sources]]` directory with dynamic metadata
- a VCS clone or an extracted archive source
- a remote sdist under `build-policy = "build-remote"`

The provider end is covered, but only against itself. `test_provider.py` asserts the kwargs reaching `extract_metadata` equal `{"config": provider.build_config, "offline": False}`, which holds whatever the provider was handed, `None` included. Nothing read a config off a `pyproject.toml` and then ran a resolve that got as far as a build.

`TestBuildConfigPlumbing` resolves a project whose only dependency is a local source declaring `dynamic = ["version"]`, so the static reader returns `None` and the provider falls through to the backend. The build runner is stubbed, so no build venv is created. The test asserts the pin comes back as `dyn 7.0` and that the runner received the same config object `read_pyproject_config` returned.
