### PR TITLE
Drop a non-hex index digest before it splits a requirements.txt pin

### DIFF
--- a/nab-index/src/nab_index/_pep503.py
+++ b/nab-index/src/nab_index/_pep503.py
@@ -15,6 +15,8 @@ from urllib.parse import unquote, urljoin, urlsplit
 
 from typing_extensions import override
 
+from nab_provider.digest import is_hex_digest
+
 __all__ = [
     "Anchor",
     "hash_fragment",
@@ -165,17 +167,15 @@ def hash_fragment(fragment: str) -> tuple[tuple[str, str], ...]:
     place the hash appears when the index has not opted into :pep:`691` JSON.
     The fragment is a ``&``-separated list of ``key=value`` parts, so a hash
     can sit beside ``egg`` or ``subdirectory`` in any order.  A part keyed by
-    a ``hashlib`` algorithm and carrying a digest is a hash; anything else is
-    not.
+    a ``hashlib`` algorithm and carrying a hex digest is a hash; anything else
+    is not.
     """
     hashes: list[tuple[str, str]] = []
 
     for part in fragment.split("&"):
-        algo, sep, digest = part.partition("=")
-        if not sep or not digest:
-            continue
+        algo, _, digest = part.partition("=")
         algo = algo.lower()
-        if algo in hashlib.algorithms_guaranteed:
+        if algo in hashlib.algorithms_guaranteed and is_hex_digest(digest):
             hashes.append((algo, digest.lower()))
 
     return tuple(hashes)

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -23,6 +23,7 @@ from urllib.parse import urljoin, urlsplit, urlunsplit
 from packaging.utils import canonicalize_name, parse_sdist_filename
 from packaging.version import Version
 
+from nab_provider.digest import is_hex_digest
 from nab_provider.errors import (
     MalformedSimpleResponseError,
     MetadataHashMismatchError,
@@ -548,21 +549,20 @@ def _parse_hashes(value: object) -> tuple[tuple[str, str], ...]:
     # Both halves are lowercased: PEP 503/691 don't mandate a case, pip
     # treats them case-insensitively, and the acceptable-algorithm filter
     # and hashlib.hexdigest() both expect the lowercase form.
-    # An empty digest carries no integrity claim and can never match a real
-    # file, so it is dropped rather than recorded and later failed against.
+    # A digest that is not hex can never match a file's bytes, so it is dropped.
     if not isinstance(value, dict):
         return ()
 
     # The common case is a single hash; skip the list build.
     if len(value) == 1:
         ((algo, digest),) = value.items()
-        if isinstance(algo, str) and isinstance(digest, str) and digest:
+        if isinstance(algo, str) and isinstance(digest, str) and is_hex_digest(digest):
             return ((sys.intern(algo.lower()), digest.lower()),)
         return ()
 
     out: list[tuple[str, str]] = []
     for algo, digest in value.items():
-        if isinstance(algo, str) and isinstance(digest, str) and digest:
+        if isinstance(algo, str) and isinstance(digest, str) and is_hex_digest(digest):
             out.append((sys.intern(algo.lower()), digest.lower()))
 
     return tuple(out)
@@ -606,8 +606,8 @@ def _has_metadata(file_info: _FileEntry) -> bool:
 def _metadata_hash(file_info: _FileEntry) -> tuple[str, str] | None:
     """Return the sidecar's published ``(algo, hex)`` to verify, or None.
 
-    A bare ``true`` (sidecar exists, no hash), an empty digest, or a table with
-    no accepted algorithm yields None, so no check runs.
+    A bare ``true`` (sidecar exists, no hash), a digest that is not hex, or a
+    table with no accepted algorithm yields None, so no check runs.
     """
     value = _metadata_value(file_info)
     if not isinstance(value, dict):
@@ -616,7 +616,7 @@ def _metadata_hash(file_info: _FileEntry) -> tuple[str, str] | None:
     published = tuple(
         (algo, digest)
         for algo, digest in value.items()
-        if isinstance(algo, str) and isinstance(digest, str)
+        if isinstance(algo, str) and isinstance(digest, str) and is_hex_digest(digest)
     )
     return _select_artifact_hash(published)
 

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -395,11 +395,10 @@ def _parse_files(
     ``package`` is the package the index was queried for; files whose
     parsed canonical name does not match are dropped.  PyPI hosts a
     handful of legacy sdists with embedded build tags
-    (``cffi-1.0.2-2.tar.gz`` and similar) that
-    :func:`_parse_sdist_filename` interprets as a
-    different project (``cffi-1-0-2`` at version ``2``).  Without the
-    name check those leak into the listing as a phantom version, and
-    show up in the resolved lockfile as ``cffi==2``.
+    (``cffi-1.0.2-2.tar.gz`` and similar) that :func:`_parse_sdist_filename`
+    interprets as a different project (``cffi-1-0-2`` at version ``2``).
+    Without the name check those leak into the listing as a phantom
+    version, and show up in the resolved lockfile as ``cffi==2``.
 
     ``page_url`` is the URL the project page was retrieved from, the base a
     relative entry resolves against. ``None`` falls back to the page URL

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -441,6 +441,31 @@ def _parse_files(
     return files
 
 
+def _normalized_url(url: str) -> str:
+    """Return ``urlunsplit(urlsplit(url))``, skipping a rebuild that returns ``url``.
+
+    The parse still runs on every URL, so a malformed authority raises the
+    same ``ValueError`` as the round trip.  A nonempty netloc reassembles
+    as ``[scheme:]//netloc`` plus the remaining parts; when those parts and
+    their separators add back up to ``len(url)``, the parse stripped no
+    character and dropped no empty ``?``/``#`` marker, leaving an
+    upper-cased scheme as the one length-preserving rewrite to rule out.
+    """
+    parts = urlsplit(url)
+    scheme, netloc, path, query, fragment = parts
+    if netloc:
+        rebuilt_len = len(scheme) + len(netloc) + len(path) + 2
+        if scheme:
+            rebuilt_len += 1
+        if query:
+            rebuilt_len += 1 + len(query)
+        if fragment:
+            rebuilt_len += 1 + len(fragment)
+        if rebuilt_len == len(url) and url.startswith(scheme):
+            return url
+    return urlunsplit(parts)
+
+
 def _resolve_file_url(raw_url: str, base_url: str) -> str | None:
     """Return the entry's absolute URL, or None when it is not usable.
 
@@ -461,7 +486,7 @@ def _resolve_file_url(raw_url: str, base_url: str) -> str | None:
             if raw_url.startswith(("https://", "http://"))
             else urljoin(base_url, raw_url)
         )
-        file_url = urlunsplit(urlsplit(absolute))
+        file_url = _normalized_url(absolute)
 
         # Encode only to reject a string with no UTF-8 form.
         file_url.encode()

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -20,7 +20,7 @@ from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin, urlsplit, urlunsplit
 
-from packaging.utils import canonicalize_name, parse_sdist_filename
+from packaging.utils import canonicalize_name
 from packaging.version import Version
 
 from nab_provider.digest import is_hex_digest
@@ -165,25 +165,34 @@ def _parse_wheel_filename(filename: str) -> tuple[NormalizedName, str] | None:
 def _parse_sdist_filename(filename: str) -> tuple[NormalizedName, str] | None:
     """Parse a ``.tar.gz`` sdist filename to ``(canonical_name, version)``.
 
-    Returns ``None`` for anything packaging rejects, for a version digit
-    run past CPython's int-from-string limit, and for ``.zip`` sdists,
-    which nab does not support (gzip-tar only, and not part of the PEP 625
-    standard).  Never raises.
+    Accepts what nab-provider's vendored ``parse_sdist_filename`` accepts,
+    except ``.zip`` sdists, which nab does not support (gzip-tar only, and
+    not part of the PEP 625 standard).  Returns ``None`` for everything
+    else, including a version digit run past CPython's int-from-string
+    limit, and never raises.  The vendored copy is the one to match, not
+    the released ``packaging`` this package depends on; the two can differ
+    on an empty project name, which releases before 26.3 accept.
 
     Legacy filenames with embedded build tags (e.g. ``cffi-1.0.2-2.tar.gz``)
     parse to a surprising ``(name="cffi-1-0-2", version="2")``, so callers
     MUST drop files whose canonical name does not match the queried
     package.  See :func:`_parse_files`.
     """
-    if filename.endswith(".zip"):
+    if not filename.endswith(".tar.gz"):
+        return None
+
+    stem = filename[: -len(".tar.gz")]
+    name_part, sep, version_part = stem.rpartition("-")
+    if not sep or not name_part:
         return None
 
     try:
-        name, version = parse_sdist_filename(filename)
+        version = _canonical_version(version_part)
     except ValueError:
-        # InvalidSdistFilename, or int() refusing a digit run past CPython's limit.
+        # InvalidVersion, or int() refusing a digit run past CPython's limit.
         return None
-    return (name, str(version))
+
+    return (_intern_name(name_part), version)
 
 
 def holds_unreadable_format(data: object) -> bool:
@@ -387,7 +396,7 @@ def _parse_files(
     parsed canonical name does not match are dropped.  PyPI hosts a
     handful of legacy sdists with embedded build tags
     (``cffi-1.0.2-2.tar.gz`` and similar) that
-    :func:`packaging.utils.parse_sdist_filename` interprets as a
+    :func:`_parse_sdist_filename` interprets as a
     different project (``cffi-1-0-2`` at version ``2``).  Without the
     name check those leak into the listing as a phantom version, and
     show up in the resolved lockfile as ``cffi==2``.

--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -31,7 +31,7 @@ import zlib
 from email.parser import BytesParser, Parser
 from pathlib import Path
 from typing import TYPE_CHECKING
-from urllib.parse import unquote, urljoin, urlparse, urlsplit, urlunsplit
+from urllib.parse import unquote, urljoin, urlparse, urlsplit
 from urllib.request import url2pathname
 
 from packaging.utils import canonicalize_name as _canonical
@@ -44,6 +44,7 @@ from .client import (
     SdistFile,
     WheelFile,
     _extract_sdist_files,
+    _normalized_url,
     _parse_sdist_filename,
     _parse_wheel_filename,
     is_readable_filename,
@@ -310,7 +311,7 @@ def _resolve_local_link(
     # below.  urljoin leaves an href alone when its scheme differs from the
     # page's, so the split round trip is what drops a tab, CR or LF.
     try:
-        url = urlunsplit(urlsplit(urljoin(base_url, href_no_frag)))
+        url = _normalized_url(urljoin(base_url, href_no_frag))
         parsed = urlparse(url)
     except ValueError:
         return (None, href_no_frag, None, hashes)

--- a/nab-index/src/nab_index/parsed_listing.py
+++ b/nab-index/src/nab_index/parsed_listing.py
@@ -45,7 +45,7 @@ __all__ = ["corruption_reason", "decode", "encode"]
 # blob surfacing under the current bucket. Bump it when the row shape changes
 # or when the same body parses to different records: ``body_digest`` pins only
 # the input.
-FORMAT_VERSION = 1
+FORMAT_VERSION = 2
 # Serialization variant that wrote the rows, so a future codec switch
 # self-heals rather than misdecodes.
 CODEC = 1

--- a/nab-index/tests/test_index_client.py
+++ b/nab-index/tests/test_index_client.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import sys
 
 import pytest
+from packaging.utils import parse_sdist_filename
 
 from nab_index.client import (
+    _parse_sdist_filename,
     _sdist_member_top_level,
     holds_unreadable_format,
     is_readable_filename,
@@ -76,6 +78,46 @@ def test_holds_unreadable_format_finds_oversized_version() -> None:
 )
 def test_holds_unreadable_format_false(data: object) -> None:
     assert not holds_unreadable_format(data)
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "foo-1.0.tar.gz",
+        "Foo_Bar.baz-1.0rc1.tar.gz",
+        "foo-1.0.post1.dev2+local.tag.tar.gz",
+        "foo-1!2.0.tar.gz",
+        "cffi-1.0.2-2.tar.gz",
+        "foo-1.0.zip",
+        "foo-1.0.tar.bz2",
+        "foo-1.5.win32.exe",
+        "foo.tar.gz",
+        "-1.0.tar.gz",
+        "foo-.tar.gz",
+        "foo-v1.0.tar.gz",
+        "foo--1.0.tar.gz",
+        "foo-1.0.TAR.GZ",
+        f"foo-{OVERSIZED}.tar.gz",
+    ],
+)
+def test_parse_sdist_filename_parity(filename: str) -> None:
+    """The inline parse matches the vendored parser on everything but ``.zip``.
+
+    Released ``parse_sdist_filename`` is the oracle, corrected on the two
+    known divergences: ``.zip`` sdists, which nab rejects, and an empty
+    project name, which packaging releases before 26.3 accept.
+    """
+    if filename.endswith(".zip"):
+        expected = None
+    else:
+        try:
+            name, version = parse_sdist_filename(filename)
+        except ValueError:
+            expected = None
+        else:
+            expected = (name, str(version)) if name else None
+
+    assert _parse_sdist_filename(filename) == expected
 
 
 def test_sdist_member_top_level_normal() -> None:

--- a/nab-project/tests/test_archive.py
+++ b/nab-project/tests/test_archive.py
@@ -272,6 +272,20 @@ class TestArchiveRequestParse:
         req = ArchiveRequest.parse("https://ex.com/foo%201.0.tar.gz#sha256=abc")
         assert req.url == "https://ex.com/foo%201.0.tar.gz"
 
+    def test_non_hex_digest_raises(self) -> None:
+        with pytest.raises(ArchiveRequestError, match="is not hexadecimal"):
+            ArchiveRequest.parse("https://ex.com/foo.tar.gz#sha256=not-a-digest")
+
+    def test_path_shaped_digest_raises(self) -> None:
+        """The digest names the extraction cache directory, so it cannot escape it."""
+        with pytest.raises(ArchiveRequestError, match="is not hexadecimal"):
+            ArchiveRequest.parse("https://ex.com/foo.tar.gz#sha256=../../x")
+
+    def test_empty_digest_kept_as_unusable(self) -> None:
+        req = ArchiveRequest.parse("https://ex.com/foo.tar.gz#sha256=")
+        assert req.hashes == (("sha256", ""),)
+        assert not req.has_usable_hash
+
     def test_parent_subdirectory_rejected(self) -> None:
         with pytest.raises(ArchiveRequestError, match="unsafe archive subdirectory"):
             ArchiveRequest.parse(

--- a/nab-project/tests/test_cached_client.py
+++ b/nab-project/tests/test_cached_client.py
@@ -351,6 +351,11 @@ class TestMetadataHashParsing:
 
         assert _metadata_hash({"core-metadata": {"sha256": ""}}) is None
 
+    def test_non_hex_digest_yields_none(self) -> None:
+        from nab_index.client import _metadata_hash
+
+        assert _metadata_hash({"core-metadata": {"sha256": "not-a-digest"}}) is None
+
     def test_empty_digest_falls_through_to_valid_algo(self) -> None:
         from nab_index.client import _metadata_hash
 
@@ -795,6 +800,28 @@ class TestParseHashes:
         from nab_index.client import _parse_hashes, _select_artifact_hash
 
         assert _select_artifact_hash(_parse_hashes({"sha256": ""})) is None
+
+    def test_single_non_hex_digest_dropped(self) -> None:
+        from nab_index.client import _parse_hashes
+
+        assert _parse_hashes({"sha256": "not-a-digest"}) == ()
+
+    def test_hex_digest_split_by_whitespace_dropped(self) -> None:
+        from nab_index.client import _parse_hashes
+
+        assert _parse_hashes({"sha256": "0123abcd\nbeef"}) == ()
+
+    def test_non_hex_digest_falls_through_to_valid(self) -> None:
+        from nab_index.client import _parse_hashes
+
+        assert _parse_hashes({"sha256": "deadbeef ", "sha512": "f" * 128}) == (
+            ("sha512", "f" * 128),
+        )
+
+    def test_uppercase_digest_kept_lowercased(self) -> None:
+        from nab_index.client import _parse_hashes
+
+        assert _parse_hashes({"sha256": "A" * 64}) == (("sha256", "a" * 64),)
 
 
 class TestSelectArtifactHash:

--- a/nab-project/tests/test_cached_client.py
+++ b/nab-project/tests/test_cached_client.py
@@ -18,7 +18,7 @@ from dataclasses import replace
 from email.utils import formatdate
 from pathlib import Path
 from typing import Any
-from urllib.parse import urljoin, urlsplit
+from urllib.parse import urljoin, urlsplit, urlunsplit
 
 import pytest
 from packaging.utils import canonicalize_name
@@ -41,6 +41,7 @@ from nab_index.client import (
     SdistHashMismatchError,
     WheelFile,
     WheelHashMismatchError,
+    _normalized_url,
     _parse_files,
     _parse_sdist_filename,
     _select_artifact_hash,
@@ -654,6 +655,38 @@ class TestControlCharacterUrl:
         )
 
         assert from_json.url == from_html.url == self._STRIPPED
+
+
+class TestNormalizedUrl:
+    """_normalized_url returns the same string as the split round trip."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://files.example.com/ab/foo-1.0-py3-none-any.whl",
+            "https://files.example.com/foo-1.0-py3-none-any.whl?token=x",
+            "https://files.example.com/foo-1.0-py3-none-any.whl#sha256=abc",
+            "//files.example.com/foo-1.0-py3-none-any.whl",
+            "file:///mirror/foo-1.0-py3-none-any.whl",
+            "file:/mirror/foo-1.0-py3-none-any.whl",
+            "https://files.example.com/a\tb/foo-1.0-py3-none-any.whl",
+            "https://files.example.com/foo-1.0-py3-none-any.whl?",
+            "https://files.example.com/foo-1.0-py3-none-any.whl#",
+            "HTTPS://files.example.com/foo-1.0-py3-none-any.whl",
+            "https://Files.Example.com/foo-1.0-py3-none-any.whl",
+            "https:foo-1.0-py3-none-any.whl",
+        ],
+    )
+    def test_matches_round_trip(self, url: str) -> None:
+        assert _normalized_url(url) == urlunsplit(urlsplit(url))
+
+    def test_clean_url_is_not_rebuilt(self) -> None:
+        url = "https://files.example.com/ab/foo-1.0-py3-none-any.whl"
+        assert _normalized_url(url) is url
+
+    def test_malformed_authority_raises(self) -> None:
+        with pytest.raises(ValueError, match="IPv6"):
+            _normalized_url("https://[::1/foo-1.0-py3-none-any.whl")
 
 
 class TestMetadataUrl:

--- a/nab-project/tests/test_config.py
+++ b/nab-project/tests/test_config.py
@@ -2855,6 +2855,15 @@ class TestArchiveSources:
         with pytest.raises(ConfigError, match="has no hash"):
             read_pyproject_config(path)
 
+    def test_non_hex_digest_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[[tool.nab.archive-sources]]\nname = "x"\n'
+            'url = "https://ex.com/foo-1.0.tar.gz#sha256=not-a-digest"\n',
+        )
+        with pytest.raises(ConfigError, match="is not hexadecimal"):
+            read_pyproject_config(path)
+
     def test_non_targz_rejected(self, tmp_path: Path) -> None:
         path = write(
             tmp_path,

--- a/nab-project/tests/test_local_index.py
+++ b/nab-project/tests/test_local_index.py
@@ -1195,6 +1195,14 @@ class TestPep503Directory:
         result = run(client.get_files("foo"))
         assert result[0].hashes == (("sha256", "a" * 64),)
 
+    def test_pep503_hash_fragment_non_hex_dropped(self, tmp_path: Path) -> None:
+        body = '<a href="foo-1.0-py3-none-any.whl#sha256=not-a-digest">foo</a>'
+        package_dir = self._make_index(tmp_path, body)
+        (package_dir / "foo-1.0-py3-none-any.whl").write_bytes(b"")
+        client = LocalIndexClient(tmp_path.as_uri())
+        result = run(client.get_files("foo"))
+        assert result[0].hashes == ()
+
     def test_pep503_hash_fragment_algorithm_lowercased(self, tmp_path: Path) -> None:
         body = f'<a href="foo-1.0-py3-none-any.whl#SHA256={"a" * 64}">foo</a>'
         package_dir = self._make_index(tmp_path, body)

--- a/nab-project/tests/test_lockfile.py
+++ b/nab-project/tests/test_lockfile.py
@@ -21,7 +21,7 @@ if sys.version_info >= (3, 11):
 else:
     import tomli as tomllib  # type: ignore[no-redef]
 
-from nab_index.client import SdistFile, WheelFile
+from nab_index.client import SdistFile, WheelFile, _parse_files
 from nab_index.multi_index import IndexConfig
 from nab_project._lockfile.builder import _common_requires_python
 from nab_project._lockfile.coverage import (
@@ -4221,6 +4221,22 @@ class TestMissingHashFormatAware:
         lock = build_target_lock(provider, _HOST, {"foo": Version("1.0")})
         with pytest.raises(MissingHashError, match="no acceptable hash"):
             write_lock(_lock_from(lock))
+
+    def test_listing_digest_carrying_a_newline_leaves_pin_hashless(self) -> None:
+        """The newline would otherwise reach requirements.txt inside the hash."""
+        entry = {
+            "filename": "foo-1.0-py3-none-any.whl",
+            "url": "https://example.com/foo-1.0-py3-none-any.whl",
+            "hashes": {"sha256": "0123abcd\nbar==2.0"},
+        }
+        (wheel,) = _parse_files(
+            {"files": [entry]}, "https://example.com/simple/", "foo"
+        )
+        provider = _FakeProvider(listings={"foo": [(Version("1.0"), wheel)]})
+        lock = build_target_lock(provider, _HOST, {"foo": Version("1.0")})
+
+        with pytest.raises(MissingHashError, match="no acceptable hash"):
+            write_requirements_with_hashes(_lock_from(lock))
 
 
 class TestDirectoryFields:

--- a/nab-provider/src/nab_provider/archive.py
+++ b/nab-provider/src/nab_provider/archive.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from .digest import is_hex_digest
 from .records import ACCEPTED_HASH_ALGORITHMS
 from .subdir import subdirectory_escapes
 
@@ -55,9 +56,10 @@ class ArchiveRequest:
 
         The fragment holds ``&``-separated ``key=value`` parts: a
         recognised hash algorithm (see :data:`ACCEPTED_HASH_ALGORITHMS`)
-        or ``subdirectory``.  Either an unescaped space in the URL or an
-        unrecognised fragment key raises :class:`ArchiveRequestError`;
-        requiring a hash is left to the config layer so the error names the
+        or ``subdirectory``.  An unescaped space in the URL, an unrecognised
+        fragment key, or a digest that is not hexadecimal raises
+        :class:`ArchiveRequestError`; requiring a hash at all is left to the
+        config layer so the error names the
         offending source.
         """
         url, _, fragment = raw_url.partition("#")
@@ -81,6 +83,11 @@ class ArchiveRequest:
             if key == "subdirectory":
                 subdirectory = value
             elif key in ACCEPTED_HASH_ALGORITHMS:
+                # An empty digest is the missing-hash case, left to config.
+                if value and not is_hex_digest(value):
+                    msg = f"{key} digest {value!r} is not hexadecimal in {raw_url!r}"
+                    raise ArchiveRequestError(msg)
+
                 hashes.append((key, value.lower()))
             else:
                 msg = (

--- a/nab-provider/src/nab_provider/digest.py
+++ b/nab-provider/src/nab_provider/digest.py
@@ -1,0 +1,22 @@
+"""Shape check for a published artefact digest.
+
+:pep:`503` and :pep:`691` define an artefact's hash as the hex-encoded digest
+of its bytes, so a value that is not hex is malformed input, not a digest.
+"""
+
+from __future__ import annotations
+
+import re
+
+__all__ = ["is_hex_digest"]
+
+_HEX_DIGEST = re.compile(r"[0-9a-fA-F]+")
+
+
+def is_hex_digest(value: str) -> bool:
+    """Return True if ``value`` is a non-empty run of hexadecimal digits.
+
+    ``bytes.fromhex`` is not a substitute: it ignores ASCII whitespace inside
+    the string it decodes.
+    """
+    return _HEX_DIGEST.fullmatch(value) is not None


### PR DESCRIPTION
A PEP 691 `hashes` value with a newline in it splits the pin nab writes into requirements.txt:

    foo==1.0 \
        --hash=sha256:0123abcd
    bar==2.0

pip reads the tail as another requirement. An empty digest was already dropped (#334), but any other string passed on `isinstance(digest, str)` and reached the pin verbatim.

PEP 503 and 691 define an artifact hash as the hex-encoded digest of its bytes, so `is_hex_digest` now gates every point a digest is read off an index.

Where it surfaces:

- The PEP 691 `hashes` map and the PEP 503 `#sha256=` anchor drop a non-hex digest, which leaves the artifact hashless and lets `require_artifact_hashes` refuse the lock rather than emit a broken pin.
- A PEP 658 sidecar digest was kept as the hash to verify, so the resolve failed on a mismatch no metadata could pass. It now yields no check.
- An archive source's fragment raises at config parse, naming the source. The first digest names the extraction cache directory (`cache_dir / digest`), so `#sha256=../../x` pointed the extracted tree out of the cache.

`bytes.fromhex` is not the check to use: it skips ASCII whitespace inside the string, so it accepts the one above.

The parsed-listing cache moves to `FORMAT_VERSION = 2` so bodies parsed under the old rule are re-read rather than served.
