### PR TITLE
Fix nab lock traceback on an extra name PEP 751 rejects

### DIFF
--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -38,9 +38,10 @@ from .._vendor.packaging.pylock import (
     PackageVcs,
     PackageWheel,
     Pylock,
+    PylockValidationError,
 )
 from .._vendor.packaging.specifiers import SpecifierSet
-from .._vendor.packaging.utils import canonicalize_name
+from .._vendor.packaging.utils import canonicalize_name, is_normalized_name
 from .._vendor.packaging.version import Version
 from ..config import conflict_exclusion_groups, conflict_member_groups
 from .builder import require_artifact_hashes
@@ -64,6 +65,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "DivergentBaseDependencyError",
+    "LockValidationError",
     "UnsoundSimplificationError",
     "build_pylock",
     "write_lock",
@@ -180,6 +182,14 @@ class DivergentBaseDependencyError(ValueError):
     """
 
 
+class LockValidationError(ValueError):
+    """The document a render would emit is not a valid PEP 751 lock.
+
+    Covers nab's own checks and the vendored validator's refusals, so a
+    caller catches one class instead of the vendored exceptions.
+    """
+
+
 def write_lock(
     lock_input: LockInput,
     *,
@@ -196,6 +206,9 @@ def write_lock(
     ``output_path``'s parent so the lockfile stays portable between
     machines (PEP 751 records those paths relative to the lock file).
     With no ``output_path`` the current directory is the base.
+
+    Raises :class:`LockValidationError` when the input would not build a
+    valid lock, before anything is written.
     """
     lock_dir = Path(output_path).parent if output_path is not None else None
     text = render_lock(lock_input, lock_dir=lock_dir)
@@ -211,11 +224,35 @@ def render_lock(lock_input: LockInput, *, lock_dir: Path | None = None) -> str:
     and sdist paths are emitted relative to it so the lock stays portable.
     Defaults to the current directory.  Used by ``write_lock`` and by
     ``nab lock --locked`` to render the would-be lock for comparison.
+
+    Raises :class:`LockValidationError` when the document it would build
+    does not satisfy PEP 751.
     """
     require_artifact_hashes(lock_input)
+    _check_extra_names(lock_input.extras)
     pylock = build_pylock(lock_input, lock_dir=lock_dir)
-    pylock.validate()
+    try:
+        pylock.validate()
+    except PylockValidationError as e:
+        raise LockValidationError(str(e)) from e
     return tomli_w.dumps(dict(pylock.to_dict()))
+
+
+def _check_extra_names(extras: Sequence[str]) -> None:
+    """Refuse an extra whose canonical form PEP 751 will not accept as a name.
+
+    The lock's ``extras`` array holds canonical names, so the message quotes
+    the declared name alongside the one that fails.
+    """
+    for extra in extras:
+        canonical = canonicalize_name(extra)
+        if not is_normalized_name(canonical):
+            msg = (
+                f"extra {extra!r} normalizes to {canonical!r}, which PEP 751 "
+                "does not accept in 'extras'; a name must start and end with "
+                "a letter or digit."
+            )
+            raise LockValidationError(msg)
 
 
 def build_pylock(lock_input: LockInput, *, lock_dir: Path | None = None) -> Pylock:

--- a/nab-python/src/nab_python/lockfile.py
+++ b/nab-python/src/nab_python/lockfile.py
@@ -28,6 +28,7 @@ from ._lockfile.disjointness import DisjointnessError
 from ._lockfile.groups import BASE_MEMBER
 from ._lockfile.pylock import (
     DivergentBaseDependencyError,
+    LockValidationError,
     build_pylock,
     render_lock,
     write_lock,
@@ -69,6 +70,7 @@ __all__ = [
     "LocalPin",
     "LockDisqualification",
     "LockInput",
+    "LockValidationError",
     "LockfileSyntaxError",
     "MissingHashError",
     "MissingSdistError",

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -64,6 +64,7 @@ from nab_python.lockfile import (
     IndexPin,
     LocalPin,
     LockInput,
+    LockValidationError,
     MissingHashError,
     MissingSdistError,
     MissingVcsCommitError,
@@ -1506,6 +1507,28 @@ class TestBuildPylockReturnsValidPylock:
 
 
 class TestErrorPaths:
+    def test_unnormalizable_extra_names_both_forms(self) -> None:
+        """The refusal quotes the declared extra as well as its canonical form.
+
+        ``_cli`` canonicalizes to ``-cli``, which the lock's ``extras`` array
+        cannot hold, and ``_cli`` is the form the caller wrote.
+        """
+        lock_input = LockInput(targets=_one({"foo": _index_pin()}), extras=("_cli",))
+        with pytest.raises(LockValidationError) as excinfo:
+            write_lock(lock_input)
+
+        assert "extra '_cli' normalizes to '-cli'" in str(excinfo.value)
+
+    def test_vendored_refusal_reraised_as_lock_validation_error(self) -> None:
+        """A refusal from the vendored validator arrives as nab's own class.
+
+        Package names are canonicalized on the way in and checked nowhere
+        else, so ``_foo`` gets as far as ``Pylock.validate``.
+        """
+        lock_input = LockInput(targets=_one({"_foo": _index_pin(name="_foo")}))
+        with pytest.raises(LockValidationError, match="'-foo' is not normalized"):
+            write_lock(lock_input)
+
     def test_unknown_pin_shape_raises(self) -> None:
         class Weird:
             pass

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -42,6 +42,7 @@ from nab_python.lockfile import (
     InvalidLockfileError,
     LockfileSyntaxError,
     LockInput,
+    LockValidationError,
     MissingHashError,
     Provenance,
     RootRequirement,
@@ -726,7 +727,7 @@ def _render_or_exit(render: Callable[[], str]) -> str:
     """Run a lock render, mapping every refusal it raises to a clean exit."""
     try:
         return render()
-    except MissingHashError as e:
+    except (MissingHashError, LockValidationError) as e:
         _cli.printer().error(f"cannot lock: {e}")
         sys.exit(1)
     except (DisjointnessError, DivergentBaseDependencyError) as e:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1203,6 +1203,32 @@ class TestLockCommandSpecific:
         assert "cannot be evaluated" in err
         assert "Traceback" not in err
 
+    def test_unnormalizable_extra_name_exits_cleanly(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """An extra PEP 751 will not accept exits 1, not a traceback.
+
+        ``_cli`` canonicalizes to ``-cli``, which the top-level ``extras``
+        array cannot hold. The refusal quotes the key as the pyproject
+        writes it, and a lock already on disk survives it.
+        """
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\nname = "proj"\nversion = "0.1"\ndependencies = []\n'
+            "[project.optional-dependencies]\n_cli = []\n",
+        )
+        out = tmp_path / "pylock.toml"
+        out.write_text("prior lock\n")
+
+        with pytest.raises(SystemExit, match="1"):
+            lock(pyproject, output=out, all_extras=True, offline=True)
+
+        err = capsys.readouterr().err
+        assert "cannot lock: extra '_cli' normalizes to '-cli'" in err
+        assert "Traceback" not in err
+
+        assert out.read_text() == "prior lock\n"
+
     def test_sibling_metadata_divergence_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:


### PR DESCRIPTION
`nab lock` ends in a traceback when a project declares an extra whose canonical form is not a normalized name. `_cli` under `[project.optional-dependencies]` canonicalizes to `-cli`, which the PEP 751 `extras` array cannot hold:

    nab_python._vendor.packaging.pylock.PylockValidationError: Name '-cli' is not normalized in 'extras[0]'

`_render_or_exit` maps three refusals to a clean error line, and `pylock.validate()` inside `render_lock` raises a fourth it does not know about. nab already maps that class when reading a committed lock; the emit side had no arm for it.

Now:

    error: cannot lock: extra '_cli' normalizes to '-cli', which PEP 751 does not accept in 'extras'; a name must start and end with a letter or digit.

- Extra names are checked in `render_lock` before the document is built, so the message quotes the key as the pyproject writes it. The vendored validator names `-cli` instead, with an `extras[0]` index into a file that was never written, which shifts to `extras[1]` when another extra is declared first.
- Everything else `pylock.validate()` refuses comes back as `LockValidationError`, a new public name in `nab_python.lockfile`. One arm in `_render_or_exit` then covers the write, the stdout render, and `--locked`.

The refusal lands before anything is written, so a lock already on disk survives it. Only `--format pylock` is affected: nothing on the read path checks extra names.
