### PR TITLE
Report look-ahead metadata bans in failure diagnostics

### DIFF
--- a/nab-python/src/nab_python/_provider/lookahead.py
+++ b/nab-python/src/nab_python/_provider/lookahead.py
@@ -281,6 +281,8 @@ def flush_pending_blocks(provider: Provider) -> None:
 
     for candidate_pkg, versions in provider.pending_metadata_blocks.items():
         unusable[candidate_pkg] |= _candidate_union(provider, candidate_pkg, versions)
+        # The ban outlives this flush, so its reason has to as well.
+        provider.record_metadata_ban(candidate_pkg, versions)
 
     for candidate_pkg, rejected in unusable.items():
         provider.pending_clauses.append(

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -478,6 +478,28 @@ def _unset_if_none(value: object) -> object:
     return value
 
 
+def _metadata_block_summary(blocks: Mapping[Version, str]) -> str:
+    """Summarise a package's metadata rejections as one diagnostic line.
+
+    Several collapse into a count plus the first message.  ``blocks`` must
+    not be empty.
+    """
+    first_msg = next(iter(blocks.values()))
+    if len(blocks) == 1:
+        return first_msg
+    return f"{len(blocks)} versions failed metadata extraction (first: {first_msg})"
+
+
+# The two reasons that name no cause beyond "nothing matched".
+_NO_MATCH_REASON = "no version matches the requirement"
+_FILTERED_IN_RANGE_REASON = (
+    "found on index but every version matching the requirement"
+    " was filtered (by requires-python, wheel tags, dist-policy,"
+    " or upload-time)"
+)
+_GENERIC_NO_VERSIONS_REASONS = frozenset({_NO_MATCH_REASON, _FILTERED_IN_RANGE_REASON})
+
+
 # Past this many exclusions the requirement reads worse than the range it states.
 _MAX_EXCLUSIONS = 3
 
@@ -874,6 +896,10 @@ class Provider:
         # Last NO_VERSIONS reason per package; consumed by resolve.py to
         # enrich ResolutionError messages.
         self._no_versions_reasons: dict[str, str] = {}
+
+        # Metadata errors behind the permanent bans, keyed by canonical name
+        # and unioned across scans.
+        self._metadata_ban_blocks: dict[str, dict[Version, str]] = {}
 
         # Blocker packages queued for force back-track by the resolver after
         # the next ``choose_version`` returns.  Populated by the look-ahead
@@ -1781,13 +1807,9 @@ class Provider:
         elif version_range is not None and _listing.has_filtered_in_range_release(
             self, normalized, version_range, all_versions
         ):
-            reason = (
-                "found on index but every version matching the requirement"
-                " was filtered (by requires-python, wheel tags, dist-policy,"
-                " or upload-time)"
-            )
+            reason = _FILTERED_IN_RANGE_REASON
         else:
-            reason = "no version matches the requirement"
+            reason = _NO_MATCH_REASON
         self._no_versions_reasons[package] = reason
 
     def _capture_lookahead_blockers(self, normalized: str) -> list[str]:
@@ -1835,29 +1857,43 @@ class Provider:
                 f" but root has it in {self.format_range(root_range)}"
             )
 
-        # Collapse repeated metadata-error blockers (one per version) into
-        # a single "N versions failed (first: <msg>)" line.
         meta = self.pending_metadata_blocks.get(normalized)
         if meta:
-            count = len(meta)
-            first_msg = next(iter(meta.values()))
-            if count == 1:
-                out.append(first_msg)
-            else:
-                out.append(
-                    f"{count} versions failed metadata extraction (first: {first_msg})"
-                )
+            out.append(_metadata_block_summary(meta))
 
         return out
 
+    def record_metadata_ban(
+        self, normalized: str, blocks: Mapping[Version, str]
+    ) -> None:
+        """Accumulate the metadata errors behind ``normalized``'s permanent ban.
+
+        The ban lasts the whole resolve, so its reason has to outlive the scan
+        that raised it, and bans from several scans union into one line.
+        """
+        recorded = self._metadata_ban_blocks.setdefault(normalized, {})
+        for version, message in blocks.items():
+            recorded.setdefault(version, message)
+
     def get_no_versions_reason(self, package: str) -> str | None:
         """Return the recorded reason for ``package``'s NO_VERSIONS clause.
+
+        Ranked by specificity, not by which pass wrote first: a recorded
+        reason that names a cause wins, and a metadata ban beats the two
+        that say only that nothing matched.
 
         Returns ``None`` if no diagnostic was captured (e.g. the
         package was decided successfully or failed for a non-listing
         reason such as a metadata parse error).
         """
-        return self._no_versions_reasons.get(package)
+        recorded = self._no_versions_reasons.get(package)
+        if recorded is not None and recorded not in _GENERIC_NO_VERSIONS_REASONS:
+            return recorded
+
+        blocks = self._metadata_ban_blocks.get(canonicalize_name(package))
+        if blocks:
+            return _metadata_block_summary(blocks)
+        return recorded
 
     def _prefetch_batch(
         self,

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -1801,6 +1801,54 @@ class TestNoVersionsReasons:
         ].append(V("1.0"))
         assert provider._capture_lookahead_blockers("foo") == []
 
+    def test_metadata_ban_loses_to_a_reason_that_names_a_cause(self) -> None:
+        """A blocker line names a cause, so it outranks the metadata summary."""
+        coordinator = make_coordinator([], package="foo")
+        provider = Provider(coordinator)
+        recorded = "every version in range was rejected: requires bar in ==2.0"
+        provider._no_versions_reasons["foo"] = recorded
+
+        provider.record_metadata_ban("foo", {V("1.0"): "No metadata for foo==1.0"})
+
+        assert provider.get_no_versions_reason("foo") == recorded
+
+    @pytest.mark.parametrize(
+        "recorded",
+        [
+            "no version matches the requirement",
+            (
+                "found on index but every version matching the requirement"
+                " was filtered (by requires-python, wheel tags, dist-policy,"
+                " or upload-time)"
+            ),
+        ],
+    )
+    def test_metadata_ban_outranks_a_generic_reason(self, recorded: str) -> None:
+        """The ban wins over the lines that say only that nothing matched.
+
+        A sibling requirement over a range the ban emptied records one of
+        these first, so arrival order alone would bury the metadata cause.
+        """
+        coordinator = make_coordinator([], package="foo")
+        provider = Provider(coordinator)
+        provider._no_versions_reasons["foo"] = recorded
+
+        provider.record_metadata_ban("foo", {V("1.0"): "No metadata for foo==1.0"})
+
+        assert provider.get_no_versions_reason("foo") == "No metadata for foo==1.0"
+
+    def test_metadata_ban_unions_the_blocks_of_every_scan(self) -> None:
+        """Versions banned by a later scan are counted with the earlier ones."""
+        coordinator = make_coordinator([], package="foo")
+        provider = Provider(coordinator)
+
+        provider.record_metadata_ban("foo", {V("5.0"): "No metadata for foo==5.0"})
+        provider.record_metadata_ban("foo", {V("3.0"): "No metadata for foo==3.0"})
+
+        assert provider.get_no_versions_reason("foo") == (
+            "2 versions failed metadata extraction (first: No metadata for foo==5.0)"
+        )
+
     def test_root_requirement_rejection_names_the_blocker(self) -> None:
         """When the rejection comes from the root-requirement check at
         the top of look_ahead_ok (``foo`` 1.0 requires ``bar==2.0``

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -3374,6 +3374,141 @@ class TestAugmentResolutionError:
         assert "requires lib != 9.0" not in diagnostics
         assert "foo: no version matches the requirement" not in diagnostics
 
+    def test_metadata_ban_outlives_the_scan_that_accepted_an_older_version(
+        self, tmp_path: Path
+    ) -> None:
+        """A ban raised by a scan that succeeded still names its versions.
+
+        ``foo`` 5.0/4.0/3.0 advertise a sidecar the index does not serve and
+        have no sdist to fall back on, so the scan bans them and accepts 2.0.
+        Backtracking then drops 2.0 and 1.0, leaving the ban to close the
+        proof, and only it can say why those three versions went.
+        """
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "proj"\ndependencies = ["foo"]\n',
+            encoding="utf-8",
+        )
+
+        coordinator = make_coordinator(
+            listings={
+                "foo": _index_wheels("foo", "5.0", "4.0", "3.0", "2.0", "1.0"),
+                "lib": _index_wheels("lib", "6.0"),
+            },
+            metadata_by_version={
+                "5.0": None,
+                "4.0": None,
+                "3.0": None,
+                "2.0": _metadata("foo", "2.0", "lib==9.9"),
+                "1.0": _metadata("foo", "1.0", "lib==9.8"),
+                "6.0": _metadata("lib", "6.0"),
+            },
+        )
+
+        with patch("nab_python.resolve.FetchCoordinator") as mock_coord_cls:
+            mock_coord_cls.return_value.__enter__ = lambda _self: coordinator
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            with pytest.raises(ResolutionError) as info:
+                _resolved(pyproject, _FAKE_TRANSPORT, python_version="3.12.0")
+
+        derivation, diagnostics = str(info.value).split("Diagnostics:")
+        assert "no versions of foo" in derivation
+        assert (
+            "foo: 3 versions failed metadata extraction (first: No metadata for"
+            " foo==5.0: no PEP 658 metadata and no sdist available)" in diagnostics
+        )
+        assert "every version in range was rejected" not in diagnostics
+
+    def test_a_sibling_requirement_does_not_bury_the_metadata_ban(
+        self, tmp_path: Path
+    ) -> None:
+        """A generic reason recorded first still loses to the ban.
+
+        ``bar`` 22.0 asks for ``foo>=6.0``, a range nothing matches, so ``foo``
+        gets the bare "no version matches" line before its own scan bans
+        5.0/4.0/3.0.  The failure closes on the ban, so that is what the
+        diagnostic must report.
+        """
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "proj"\ndependencies = ["foo", "bar"]\n',
+            encoding="utf-8",
+        )
+
+        coordinator = make_coordinator(
+            listings={
+                "foo": _index_wheels("foo", "5.0", "4.0", "3.0", "2.0", "1.0"),
+                "bar": _index_wheels("bar", "22.0", "21.0"),
+                "lib": _index_wheels("lib", "6.0"),
+            },
+            metadata_by_version={
+                "5.0": None,
+                "4.0": None,
+                "3.0": None,
+                "2.0": _metadata("foo", "2.0", "lib==9.9"),
+                "1.0": _metadata("foo", "1.0", "lib==9.8"),
+                "22.0": _metadata("bar", "22.0", "foo>=6.0"),
+                "21.0": _metadata("bar", "21.0"),
+                "6.0": _metadata("lib", "6.0"),
+            },
+        )
+
+        with patch("nab_python.resolve.FetchCoordinator") as mock_coord_cls:
+            mock_coord_cls.return_value.__enter__ = lambda _self: coordinator
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            with pytest.raises(ResolutionError) as info:
+                _resolved(pyproject, _FAKE_TRANSPORT, python_version="3.12.0")
+
+        diagnostics = str(info.value).split("Diagnostics:")[1]
+        assert (
+            "foo: 3 versions failed metadata extraction (first: No metadata for"
+            " foo==5.0: no PEP 658 metadata and no sdist available)" in diagnostics
+        )
+        assert "foo: no version matches the requirement" not in diagnostics
+
+    def test_bans_from_separate_scans_are_counted_together(
+        self, tmp_path: Path
+    ) -> None:
+        """Every scan's ban reaches the diagnostic, not just the first one's.
+
+        ``foo`` 5.0 is unreadable and 4.0 is not, so the first scan bans one
+        version; backtracking past 4.0 starts a second scan that bans 3.0.  The
+        derivation carries a ban clause from each.
+        """
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "proj"\ndependencies = ["foo"]\n',
+            encoding="utf-8",
+        )
+
+        coordinator = make_coordinator(
+            listings={
+                "foo": _index_wheels("foo", "5.0", "4.0", "3.0", "2.0"),
+                "lib": _index_wheels("lib", "6.0"),
+            },
+            metadata_by_version={
+                "5.0": None,
+                "4.0": _metadata("foo", "4.0", "lib==9.9"),
+                "3.0": None,
+                "2.0": _metadata("foo", "2.0", "lib==9.8"),
+                "6.0": _metadata("lib", "6.0"),
+            },
+        )
+
+        with patch("nab_python.resolve.FetchCoordinator") as mock_coord_cls:
+            mock_coord_cls.return_value.__enter__ = lambda _self: coordinator
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            with pytest.raises(ResolutionError) as info:
+                _resolved(pyproject, _FAKE_TRANSPORT, python_version="3.12.0")
+
+        derivation, diagnostics = str(info.value).split("Diagnostics:")
+        assert "no versions of foo <VersionRange '(4.0, +inf)'>" in derivation
+        assert "no versions of foo <VersionRange '(2.0, 4.0)'>" in derivation
+        assert (
+            "foo: 2 versions failed metadata extraction (first: No metadata for"
+            " foo==5.0: no PEP 658 metadata and no sdist available)" in diagnostics
+        )
+
     def test_cutoff_filtered_sdist_is_not_reported_as_never_published(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
Failure diagnostics drop the package whose versions a look-ahead scan banned for unreadable metadata, even when that ban is the clause that finishes the resolve. Below, three versions of `foo` have no PEP 658 metadata and no sdist to fall back on, so the scan bans them and the resolve carries on with 2.0. Backtracking exhausts 2.0 and 1.0, and the ban is what ends it, but `foo` is nowhere in the diagnostics:

```
because no versions of foo <VersionRange '(2.0, +inf)'> are available
...
Diagnostics:
  - lib: no version matches the requirement
```

The same failure now reports:

```
  - foo: 3 versions failed metadata extraction (first: No metadata for foo==5.0: no PEP 658 metadata and no sdist available)
```

Two things were dropping it:

- `flush_pending_blocks` writes the NO_VERSIONS clause and then resets `pending_metadata_blocks`, which is the only place the diagnostic reads those messages from.
- `get_no_versions_reason` returned whichever reason was recorded first. Add a `bar` requiring `foo>=6.0` and that empty range records `foo: no version matches the requirement`, for a package with five versions on the index.

Bans now accumulate on the provider for the life of the resolve and union across scans, so a second scan's rejections are counted with the first's. Reason lookup ranks by specificity rather than arrival: one that names a cause wins, and a metadata ban beats a line saying only that nothing matched.
