### PR TITLE
Reject case-folded download filename collisions

### DIFF
--- a/nab-python/src/nab_python/download.py
+++ b/nab-python/src/nab_python/download.py
@@ -154,28 +154,33 @@ def _iter_index_pin(canonical: str, pin: IndexPin) -> Iterable[DownloadEntry]:
         )
 
 
-def _reject_colliding_targets(artefacts: list[DownloadEntry]) -> None:
-    """Refuse two distinct artefacts that would write to one output filename.
+def _coalesce_download_targets(
+    artefacts: list[DownloadEntry],
+) -> list[DownloadEntry]:
+    """Coalesce casefold-equivalent names sharing ``(hash_algo, digest)``.
 
-    Index sdist/wheel filenames embed the package name and version, so they
-    never collide.  A direct-URL archive's filename is the bare basename of
-    its URL, which is arbitrary: two archives from different repositories
-    commonly share one (e.g. a GitHub ``v1.0.0.tar.gz`` tag tarball).  Two
-    artefacts with different digests but the same basename would clobber each
-    other in the flat output dir, silently dropping one, so refuse it loudly.
+    The first spelling wins; a different identity raises :class:`DownloadError`.
     """
     by_name: dict[str, DownloadEntry] = {}
+    unique: list[DownloadEntry] = []
     for entry in artefacts:
-        prior = by_name.get(entry.filename)
-        if prior is not None and prior.digest != entry.digest:
+        key = entry.filename.casefold()
+        prior = by_name.get(key)
+        if prior is not None and (prior.hash_algo, prior.digest) != (
+            entry.hash_algo,
+            entry.digest,
+        ):
             msg = (
-                f"artefacts collide on output filename {entry.filename!r}:"
-                f" {prior.package}=={prior.version} and"
-                f" {entry.package}=={entry.version} differ."
+                "artefacts collide on casefold-equivalent output filenames"
+                f" {prior.filename!r} and {entry.filename!r}, but their entries"
+                " record different hash identities."
                 " Download them to separate directories."
             )
             raise DownloadError(msg)
-        by_name[entry.filename] = entry
+        if prior is None:
+            by_name[key] = entry
+            unique.append(entry)
+    return unique
 
 
 def download_lock(
@@ -199,8 +204,7 @@ def download_lock(
     served.
     """
     output_dir.mkdir(parents=True, exist_ok=True)
-    artefacts = list(iter_artifacts(lock_input))
-    _reject_colliding_targets(artefacts)
+    artefacts = _coalesce_download_targets(list(iter_artifacts(lock_input)))
     return asyncio.run(
         _run_downloads(
             artefacts, transport, output_dir, max_concurrency, offline=offline

--- a/nab-python/tests/test_archive.py
+++ b/nab-python/tests/test_archive.py
@@ -34,8 +34,10 @@ from nab_python._provider.sources import _fetch_archive_bytes
 from nab_python._vendor.packaging.utils import canonicalize_name
 from nab_python._vendor.packaging.version import Version
 from nab_python.download import (
+    DownloadEntry,
     DownloadError,
-    _reject_colliding_targets,
+    _coalesce_download_targets,
+    download_lock,
     iter_artifacts,
 )
 from nab_python.fetch import FetchCoordinator, InMemoryIndex
@@ -180,6 +182,32 @@ def _lock_input(pins: Mapping[str, PinShape]) -> LockInput:
     """Wrap ``pins`` as the one-target lock input the downloader reads."""
     target = ResolveTarget.for_host()
     return LockInput(targets={target.label: TargetLock(target=target, pins=pins)})
+
+
+def _archive_download_entries(
+    *,
+    first_filename: str = "v1.0.0.tar.gz",
+    second_filename: str = "v1.0.0.tar.gz",
+    first_digest: str = "a" * 64,
+    second_digest: str = "b" * 64,
+    second_algorithm: str = "sha256",
+) -> list[DownloadEntry]:
+    """Return two archive entries from different URLs."""
+    pins = {
+        "alpha": ArchivePin(
+            name="alpha",
+            version="1.0",
+            url=f"https://a.example.com/dist/{first_filename}",
+            hashes=(("sha256", first_digest),),
+        ),
+        "beta": ArchivePin(
+            name="beta",
+            version="2.0",
+            url=f"https://b.example.com/dist/{second_filename}",
+            hashes=((second_algorithm, second_digest),),
+        ),
+    }
+    return list(iter_artifacts(_lock_input(pins)))
 
 
 # Extraction requires the tar data filter (PEP 706), so skip the paths that
@@ -876,41 +904,102 @@ class TestArchiveDownload:
         with pytest.raises(ValueError, match="no acceptable hash"):
             _ = pin.primary_digest
 
-    def test_colliding_basenames_rejected(self) -> None:
-        # Two archives from different repos sharing a URL basename would clobber
-        # each other in the flat output dir, so the collision is refused.
-        pins = {
-            "foo": ArchivePin(
-                name="foo",
-                version="1.0",
-                url="https://a.example.com/dist/v1.0.0.tar.gz",
-                hashes=(("sha256", "a" * 64),),
-            ),
-            "bar": ArchivePin(
-                name="bar",
-                version="2.0",
-                url="https://b.example.com/dist/v1.0.0.tar.gz",
-                hashes=(("sha256", "b" * 64),),
-            ),
-        }
-        entries = list(iter_artifacts(_lock_input(pins)))
-        with pytest.raises(DownloadError, match="collide on output filename"):
-            _reject_colliding_targets(entries)
+    def test_different_hash_same_filename_rejected(self) -> None:
+        with pytest.raises(DownloadError, match="different hash identities"):
+            _coalesce_download_targets(_archive_download_entries())
 
-    def test_same_basename_same_digest_allowed(self) -> None:
-        # The same archive pinned under two names writes identical bytes, so it
-        # is not a collision.
-        url = "https://a.example.com/dist/v1.0.0.tar.gz"
+    def test_different_hash_casefold_equivalent_filenames_rejected(self) -> None:
+        with pytest.raises(DownloadError, match="different hash identities") as excinfo:
+            _coalesce_download_targets(
+                _archive_download_entries(
+                    first_filename="Artifact.tar.gz",
+                    second_filename="artifact.tar.gz",
+                )
+            )
+
+        assert "'Artifact.tar.gz' and 'artifact.tar.gz'" in str(excinfo.value)
+
+    def test_same_hash_identity_same_filename_coalesced(self) -> None:
+        entries = _archive_download_entries(second_digest="a" * 64)
+
+        assert entries[0].url != entries[1].url
+        assert _coalesce_download_targets(entries) == [entries[0]]
+
+    def test_same_hash_identity_casefold_equivalent_filenames_coalesced(self) -> None:
+        entries = _archive_download_entries(
+            first_filename="Artifact.tar.gz",
+            second_filename="artifact.tar.gz",
+            second_digest="a" * 64,
+        )
+        assert _coalesce_download_targets(entries) == [entries[0]]
+
+    def test_unicode_casefold_equivalent_filenames_coalesced(self) -> None:
+        entries = _archive_download_entries(
+            first_filename="Straße.tar.gz",
+            second_filename="STRASSE.tar.gz",
+            second_digest="a" * 64,
+        )
+        assert _coalesce_download_targets(entries) == [entries[0]]
+
+    @pytest.mark.parametrize(
+        ("first_filename", "second_filename"),
+        [
+            pytest.param("artifact.tar.gz", "artifact.tar.gz", id="exact"),
+            pytest.param("Artifact.tar.gz", "artifact.tar.gz", id="casefold"),
+        ],
+    )
+    def test_same_hash_identity_casefold_equivalent_filename_written_once(
+        self,
+        tmp_path: Path,
+        first_filename: str,
+        second_filename: str,
+    ) -> None:
+        payload = b"ARCHIVE"
+        digest = hashlib.sha256(payload).hexdigest()
+        first = tmp_path / "first" / first_filename
+        second = tmp_path / "second" / second_filename
+        first.parent.mkdir()
+        second.parent.mkdir()
+        first.write_bytes(payload)
+        second.write_bytes(payload)
         pins = {
-            "foo": ArchivePin(
-                name="foo", version="1.0", url=url, hashes=(("sha256", "a" * 64),)
+            "alpha": ArchivePin(
+                name="alpha",
+                version="1.0",
+                url=first.as_uri(),
+                hashes=(("sha256", digest),),
             ),
-            "bar": ArchivePin(
-                name="bar", version="1.0", url=url, hashes=(("sha256", "a" * 64),)
+            "beta": ArchivePin(
+                name="beta",
+                version="1.0",
+                url=second.as_uri(),
+                hashes=(("sha256", digest),),
             ),
         }
-        entries = list(iter_artifacts(_lock_input(pins)))
-        _reject_colliding_targets(entries)
+
+        output = tmp_path / "output"
+        result = download_lock(
+            _lock_input(pins),
+            HttpxAsyncTransport(),
+            output,
+        )
+
+        expected = output / first_filename
+        assert result.written == (expected,)
+        assert result.skipped == ()
+        assert expected.read_bytes() == payload
+        assert list(output.iterdir()) == [expected]
+
+    def test_same_digest_text_under_different_algorithms_rejected(self) -> None:
+        with pytest.raises(DownloadError, match="different hash identities"):
+            _coalesce_download_targets(
+                _archive_download_entries(
+                    first_filename="Artifact.tar.gz",
+                    second_filename="artifact.tar.gz",
+                    second_digest="a" * 64,
+                    second_algorithm="sha384",
+                )
+            )
 
 
 class TestExtractArchive:


### PR DESCRIPTION
Two direct archives whose output names are case-fold equivalent can target the same path on a case-insensitive filesystem, allowing the last download to overwrite the first.

Reject aliases that record different hash identities. Coalesce identical aliases before scheduling so the result reports one output path.
