### PR TITLE
Isolate cached source trees from build backends

### DIFF
--- a/docs/reference/cache.md
+++ b/docs/reference/cache.md
@@ -31,13 +31,15 @@ fills a bucket of its own:
 
 | Bucket | Holds |
 | ------ | ----- |
-| `vcs/` | a shallow clone, at `vcs/vcs/<repo key>/<commit sha>/` |
-| `archive/` | an extracted archive, at `archive/<archive digest>/` |
+| `vcs-v1/` | a shallow clone, at `vcs-v1/vcs/<repo key>/<commit sha>/` |
+| `archive-v1/` | an extracted archive, at `archive-v1/<archive digest>/` |
 
-Both hold upstream files rather than nab records, so neither is versioned
-or keyed per index. Under `--no-cache` there is no root to write to, so
-the run materialises them in a temporary directory and discards them at
-the end.
+Both hold upstream files rather than nab records and are not keyed per
+index. Their bucket versions let nab retire trees whose reuse rules have
+changed. Resolves ignore the older unversioned `vcs/` and `archive/`
+buckets, while `nab cache clear` continues to remove them. Under
+`--no-cache` there is no root to write to, so the run materialises source
+trees in a temporary directory and discards them at the end.
 
 ## Freshness
 

--- a/nab-index/src/nab_index/cache.py
+++ b/nab-index/src/nab_index/cache.py
@@ -30,8 +30,8 @@ rendering also needs the suffix bumped to reach warm caches.
 A resolve writes two more buckets under the same root, holding upstream
 source trees:
 
-    vcs/vcs/<repo key>/<commit sha>/   <- shallow clone
-    archive/<archive digest>/          <- extracted archive
+    vcs-v1/vcs/<repo key>/<commit sha>/   <- shallow clone
+    archive-v1/<archive digest>/          <- extracted archive
 """
 
 from __future__ import annotations
@@ -74,15 +74,19 @@ CACHE_VERSION_SIMPLE_PARSED = "v0"
 CACHE_VERSION_SIMPLE_NEG = "v0"
 CACHE_VERSION_METADATA = "v1"
 CACHE_VERSION_SDIST = "v1"
+CACHE_VERSION_VCS = "v1"
+CACHE_VERSION_ARCHIVE = "v1"
 
 # Buckets of nab-written records. simple-neg-* is covered by the simple- prefix.
 ENTRY_BUCKET_PREFIXES = ("simple-", "metadata-", "sdist-")
 
 # Buckets a resolve fills with upstream source trees. nab owns the directories,
 # not the files inside them.
-VCS_BUCKET = "vcs"
-ARCHIVE_BUCKET = "archive"
+VCS_BUCKET = f"vcs-{CACHE_VERSION_VCS}"
+ARCHIVE_BUCKET = f"archive-{CACHE_VERSION_ARCHIVE}"
 SOURCE_BUCKETS = (VCS_BUCKET, ARCHIVE_BUCKET)
+_LEGACY_SOURCE_BUCKETS = ("vcs", "archive")
+_RECOGNIZED_SOURCE_BUCKETS = SOURCE_BUCKETS + _LEGACY_SOURCE_BUCKETS
 
 DEFAULT_PYPI_URLS = frozenset(
     [
@@ -134,7 +138,7 @@ def _is_entry_bucket(name: str) -> bool:
 
 def is_recognized_bucket(name: str) -> bool:
     """Whether ``name`` is a bucket directory nab owns under a cache root."""
-    return _is_entry_bucket(name) or name in SOURCE_BUCKETS
+    return _is_entry_bucket(name) or name in _RECOGNIZED_SOURCE_BUCKETS
 
 
 def _index_dirname(index_url: str) -> str:

--- a/nab-python/src/nab_python/_provider/sources.py
+++ b/nab-python/src/nab_python/_provider/sources.py
@@ -9,9 +9,11 @@ downloads and hash-verifies a ``.tar.gz`` and extracts it; both reuse the
 
 from __future__ import annotations
 
+import os
 import shutil
+import stat
 import tempfile
-from contextlib import suppress
+from contextlib import contextmanager, suppress
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -22,6 +24,8 @@ from nab_index.vcs import VcsCloneError, VcsRequest
 from .._vendor.packaging.utils import canonicalize_name
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from .._vendor.packaging.version import Version
     from ..metadata import WheelMetadata
     from ..provider import ArchiveSource, LocalSource, Provider, VcsSource
@@ -31,6 +35,63 @@ if TYPE_CHECKING:
 _TREE_DIR = "tree"
 _COMPLETE_MARKER = ".nab-complete"
 _HASHES_MARKER = ".nab-hashes"
+
+
+class _SourceCopyError(Exception):
+    """Raised when a cached source cannot be copied for a backend build."""
+
+
+class _CopyWithHardlinks:
+    """Copy regular files while retaining source hard-link groups."""
+
+    def __init__(self) -> None:
+        self._destinations: dict[tuple[int, int], Path] = {}
+
+    def __call__(self, source: str, destination: str) -> str:
+        source_path = Path(source)
+        source_stat = source_path.stat(follow_symlinks=False)
+        if source_stat.st_nlink <= 1 or not stat.S_ISREG(source_stat.st_mode):
+            return shutil.copy2(source_path, destination)
+
+        key = (source_stat.st_dev, source_stat.st_ino)
+        existing = self._destinations.get(key)
+        if existing is None:
+            copied = shutil.copy2(source_path, destination)
+            self._destinations[key] = Path(copied)
+            return copied
+
+        os.link(existing, destination)
+        return destination
+
+
+@contextmanager
+def _source_for_build(path: Path, persistent_root: Path | None) -> Iterator[Path]:
+    """Yield the matching path in a disposable copy of a persistent source tree."""
+    if persistent_root is None:
+        yield path
+        return
+
+    relative_path = path.relative_to(persistent_root)
+    try:
+        temporary = tempfile.TemporaryDirectory(
+            prefix="nab-source-build-", ignore_cleanup_errors=True
+        )
+    except OSError as exc:
+        msg = f"could not create a temporary build tree for {persistent_root}: {exc}"
+        raise _SourceCopyError(msg) from exc
+
+    with temporary as temporary_path:
+        try:
+            build_root = shutil.copytree(
+                persistent_root,
+                Path(temporary_path) / persistent_root.name,
+                symlinks=True,
+                copy_function=_CopyWithHardlinks(),
+            )
+        except OSError as exc:
+            msg = f"could not copy cached source tree at {persistent_root}: {exc}"
+            raise _SourceCopyError(msg) from exc
+        yield build_root / relative_path
 
 
 def index_local_sources(
@@ -88,6 +149,7 @@ def extract_source_metadata(
     descriptor: str,
     package: str,
     kind: str,
+    persistent_root: Path | None = None,
 ) -> WheelMetadata:
     """Read metadata from a directory; gates the backend path on policy.
 
@@ -96,6 +158,10 @@ def extract_source_metadata(
     for :class:`VcsSource` clones and ``"archive"`` for extracted
     :class:`ArchiveSource` trees both build only at
     :attr:`BuildPolicy.BUILD_REMOTE`, like a remote sdist.
+
+    ``persistent_root`` identifies the complete cached clone or archive tree.
+    Dynamic builds receive a disposable copy of that root; local-source builds
+    keep using the caller's path.
 
     An unreadable ``pyproject.toml`` is reported as a read failure at
     every policy level: the build path cannot read it either, so calling
@@ -131,12 +197,13 @@ def extract_source_metadata(
         )
         raise UnsupportedSdistError(msg)
     try:
-        return build_backend.extract_metadata(
-            path,
-            config=provider.build_config,
-            offline=provider.coordinator.offline,
-        )
-    except BuildBackendError as exc:
+        with _source_for_build(path, persistent_root) as build_path:
+            return build_backend.extract_metadata(
+                build_path,
+                config=provider.build_config,
+                offline=provider.coordinator.offline,
+            )
+    except (BuildBackendError, _SourceCopyError) as exc:
         msg = f"{descriptor}: {exc}"
         raise UnsupportedSdistError(msg) from exc
 
@@ -262,6 +329,7 @@ def materialize_vcs_source(
         descriptor=descriptor,
         package=canonicalize_name(source.name),
         kind="vcs",
+        persistent_root=root,
     )
     return seed_synthetic_listing(provider, normalized, path, metadata, descriptor)
 
@@ -426,6 +494,7 @@ def materialize_archive_source(
         descriptor=descriptor,
         package=canonicalize_name(source.name),
         kind="archive",
+        persistent_root=root,
     )
     return seed_synthetic_listing(provider, normalized, path, metadata, descriptor)
 

--- a/nab-python/tests/test_archive.py
+++ b/nab-python/tests/test_archive.py
@@ -13,6 +13,7 @@ import gzip
 import hashlib
 import inspect
 import io
+import os
 import tarfile
 import textwrap
 import zlib
@@ -31,6 +32,7 @@ from nab_index.subdir import subdirectory_escapes
 from nab_index.transport import HttpError
 from nab_python._provider import sources
 from nab_python._provider.sources import _fetch_archive_bytes
+from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.utils import canonicalize_name
 from nab_python._vendor.packaging.version import Version
 from nab_python.download import (
@@ -124,14 +126,19 @@ def _corrupt_deflate_sdist() -> bytes:
     return clean + deflate.flush(zlib.Z_SYNC_FLUSH) + _INVALID_DEFLATE_BLOCK
 
 
-def _provider(archive_sources: list[ArchiveSource], cache_dir: Path | None) -> Provider:
+def _provider(
+    archive_sources: list[ArchiveSource],
+    cache_dir: Path | None,
+    *,
+    build_policy: BuildPolicy = BuildPolicy.NEVER,
+) -> Provider:
     coordinator = MagicMock()
     coordinator.index = InMemoryIndex()
     return Provider(
         coordinator,
         archive_sources=archive_sources,
         archive_cache_dir=cache_dir,
-        build_policy=BuildPolicy.NEVER,
+        build_policy=build_policy,
     )
 
 
@@ -174,6 +181,17 @@ def _warm_extracted_tree(cache: Path, digest: str) -> None:
     (tree / "pyproject.toml").write_text(_PYPROJECT, encoding="utf-8")
     (target / ".nab-hashes").write_text(f"sha256={digest}", encoding="utf-8")
     (target / ".nab-complete").touch()
+
+
+def _warm_dynamic_archive_tree(cache: Path, digest: str) -> Path:
+    """Return a cached archive tree whose dependency metadata needs a backend."""
+    _warm_extracted_tree(cache, digest)
+    tree = cache / digest / "tree"
+    (tree / "pyproject.toml").write_text(
+        '[project]\nname = "foo"\nversion = "1.0.0"\ndynamic = ["dependencies"]\n',
+        encoding="utf-8",
+    )
+    return tree
 
 
 def _lock_input(pins: Mapping[str, PinShape]) -> LockInput:
@@ -463,6 +481,104 @@ class TestArchiveMaterialize:
 
         assert str(versions[0][0]) == "1.0.0"
         assert sentinel.exists()
+
+    def test_dynamic_backend_mutation_does_not_poison_cached_tree(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        digest = "a" * 64
+        source = ArchiveSource(
+            name="foo", url=f"https://ex.com/foo-1.0.0.tar.gz#sha256={digest}"
+        )
+        cache = tmp_path / "arch"
+        tree = _warm_dynamic_archive_tree(cache, digest)
+        dependency = tree / "dependency.txt"
+        dependency.write_text("dep-one==1", encoding="utf-8")
+        dependency_alias = tree / "dependency-alias.txt"
+        os.link(dependency, dependency_alias)
+
+        def mutating_backend(path: Path, **_kwargs: object) -> WheelMetadata:
+            assert path.name == tree.name
+            backend_input = path / "dependency.txt"
+            backend_alias = path / "dependency-alias.txt"
+            assert backend_input.samefile(backend_alias)
+            backend_input.write_text("dep-two==2", encoding="utf-8")
+            requires_dist = [Requirement(backend_alias.read_text(encoding="utf-8"))]
+            return WheelMetadata(
+                name="foo",
+                version=Version("1.0.0"),
+                requires_python=None,
+                requires_dist=requires_dist,
+                provides_extra=[],
+            )
+
+        monkeypatch.setattr(
+            "nab_python.build_backend.extract_metadata", mutating_backend
+        )
+
+        first = _provider([source], cache, build_policy=BuildPolicy.BUILD_REMOTE)
+        first.fetch_versions("foo")
+        second = _provider([source], cache, build_policy=BuildPolicy.BUILD_REMOTE)
+        second.fetch_versions("foo")
+
+        metadata_key = ("foo", Version("1.0.0"))
+        assert [
+            str(first.metadata_cache[metadata_key].requires_dist[0]),
+            str(second.metadata_cache[metadata_key].requires_dist[0]),
+        ] == ["dep-two==2", "dep-two==2"]
+        assert dependency.read_text(encoding="utf-8") == "dep-one==1"
+        assert dependency_alias.read_text(encoding="utf-8") == "dep-one==1"
+        assert dependency.samefile(dependency_alias)
+        first.coordinator.request_direct_archive.assert_not_called()
+        second.coordinator.request_direct_archive.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("failure_target", "expected"),
+        [
+            (
+                "nab_python._provider.sources.tempfile.TemporaryDirectory",
+                "could not create a temporary build tree",
+            ),
+            (
+                "nab_python._provider.sources.shutil.copytree",
+                "could not copy cached source tree",
+            ),
+            (
+                "nab_python._provider.sources.os.link",
+                "could not copy cached source tree",
+            ),
+        ],
+    )
+    def test_cached_tree_copy_failure_names_archive_source(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        failure_target: str,
+        expected: str,
+    ) -> None:
+        digest = "a" * 64
+        source = ArchiveSource(
+            name="foo", url=f"https://ex.com/foo-1.0.0.tar.gz#sha256={digest}"
+        )
+        cache = tmp_path / "arch"
+        tree = _warm_dynamic_archive_tree(cache, digest)
+        dependency = tree / "dependency.txt"
+        dependency.write_text("dep-one==1", encoding="utf-8")
+        os.link(dependency, tree / "dependency-alias.txt")
+        monkeypatch.setattr(
+            failure_target, MagicMock(side_effect=OSError("simulated copy failure"))
+        )
+
+        provider = _provider([source], cache, build_policy=BuildPolicy.BUILD_REMOTE)
+        with pytest.raises(UnsupportedSdistError) as excinfo:
+            provider.fetch_versions("foo")
+
+        message = str(excinfo.value)
+        assert "archive source 'foo'" in message
+        assert expected in message
+        assert "simulated copy failure" in message
+        provider.coordinator.request_direct_archive.assert_not_called()
 
     @requires_data_filter
     def test_every_verified_hash_is_recorded_for_reuse(self, tmp_path: Path) -> None:

--- a/nab-python/tests/test_cache.py
+++ b/nab-python/tests/test_cache.py
@@ -18,6 +18,7 @@ import pytest
 
 from nab_index.atomic import atomic_write, atomic_write_text
 from nab_index.cache import (
+    ARCHIVE_BUCKET,
     CACHE_VERSION_METADATA,
     CACHE_VERSION_SDIST,
     CACHE_VERSION_SIMPLE,
@@ -913,7 +914,7 @@ class TestSourceBuckets:
         (tree / "pyproject.toml").write_text("[project]\n")
         return tree
 
-    def test_clear_removes_the_clone_tree(
+    def test_clear_removes_the_legacy_clone_tree(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         root = tmp_path / "cache"
@@ -924,13 +925,23 @@ class TestSourceBuckets:
         assert not clone.exists()
         assert not (root / "vcs").exists()
 
-    def test_clear_removes_the_archive_tree(self, tmp_path: Path) -> None:
+    def test_clear_removes_the_legacy_archive_tree(self, tmp_path: Path) -> None:
         root = tmp_path / "cache"
         cache = _populate(root)
         tree = self._extract_into(root / "archive")
         assert "archive" in cache.clear_cache()
         assert not tree.exists()
         assert not (root / "archive").exists()
+
+    def test_clear_removes_current_source_buckets(self, tmp_path: Path) -> None:
+        root = tmp_path / "cache"
+        cache = OnDiskCache(root, "https://pypi.org/simple")
+        (root / VCS_BUCKET).mkdir(parents=True)
+        (root / ARCHIVE_BUCKET).mkdir()
+
+        assert set(cache.clear_cache()) == {VCS_BUCKET, ARCHIVE_BUCKET}
+        assert not (root / VCS_BUCKET).exists()
+        assert not (root / ARCHIVE_BUCKET).exists()
 
     def test_clear_removes_a_read_only_clone(self, tmp_path: Path) -> None:
         root = tmp_path / "cache"

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -3386,7 +3386,8 @@ class TestLocalSources:
         )
         captured: dict[str, object] = {}
 
-        def fake_build(_path: Path, **kwargs: object) -> WheelMetadata:
+        def fake_build(path: Path, **kwargs: object) -> WheelMetadata:
+            captured["path"] = path
             captured.update(kwargs)
             return built
 
@@ -3399,7 +3400,11 @@ class TestLocalSources:
             build_policy=BuildPolicy.BUILD_LOCAL,
         )
         assert len(provider.fetch_versions("foo")) == 1
-        assert captured == {"config": provider.build_config, "offline": False}
+        assert captured == {
+            "path": tmp_path,
+            "config": provider.build_config,
+            "offline": False,
+        }
 
     def test_local_source_build_refused_under_an_offline_coordinator(
         self,

--- a/nab-python/tests/test_resolve_targets.py
+++ b/nab-python/tests/test_resolve_targets.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from nab_index import vcs as vcs_mod
+from nab_index.cache import ARCHIVE_BUCKET, VCS_BUCKET
 from nab_index.client import SdistFile, WheelFile
 from nab_index.multi_index import IndexConfig
 from nab_python import resolve as resolve_mod
@@ -1599,6 +1600,53 @@ class TestVcsConfigPlumbing:
         assert result.success
         assert result.target_results[0].pins == {"pkg": Version("1.0")}
 
+    def test_poisoned_legacy_cached_clone_is_not_reused(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A clone written before source-cache isolation cannot affect a resolve."""
+        repo_key = "repo-key"
+        legacy = tmp_path / "vcs" / "vcs" / repo_key / _FORTY_SHA
+        (legacy / ".git").mkdir(parents=True)
+        (legacy / ".git" / "nab-complete").touch()
+        legacy_pyproject = legacy / "pyproject.toml"
+        legacy_pyproject.write_text(
+            '[project]\nname = "pkg"\nversion = "99.0"\n', encoding="utf-8"
+        )
+
+        git_commands: list[str] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess:
+            git_commands.append(cmd[1])
+            cwd = Path(str(kwargs["cwd"]))
+            if cmd[:2] == ["git", "init"]:
+                (cwd / ".git").mkdir(exist_ok=True)
+            if cmd[:2] == ["git", "checkout"]:
+                (cwd / "pyproject.toml").write_text(
+                    '[project]\nname = "pkg"\nversion = "1.0"\n', encoding="utf-8"
+                )
+            return subprocess.CompletedProcess(cmd, 0)
+
+        monkeypatch.setattr(vcs_mod, "_repo_key", lambda _url: repo_key)
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        result = resolve_with_coordinator(
+            _make_coordinator({}),
+            _one_target(),
+            _reqs("pkg"),
+            config=_no_build(vcs=self._allow(), vcs_sources=(self._source(),)),
+            cache_dir=tmp_path,
+        )
+
+        current = tmp_path / VCS_BUCKET / "vcs" / repo_key / _FORTY_SHA
+        assert result.success
+        assert result.target_results[0].pins == {"pkg": Version("1.0")}
+        assert git_commands == ["init", "fetch", "checkout"]
+        assert (current / ".git" / "nab-complete").is_file()
+        assert 'version = "1.0"' in (current / "pyproject.toml").read_text(
+            encoding="utf-8"
+        )
+        assert 'version = "99.0"' in legacy_pyproject.read_text(encoding="utf-8")
+
 
 class TestCutoffAndOverridePlumbing:
     """The upload cutoff and the two override tables reach the provider.
@@ -2505,6 +2553,43 @@ class TestArchiveSourceAcrossTargets:
         for target_result in result.target_results:
             assert str(target_result.pins["foo"]) == "1.0"
             assert str(target_result.pins["bar"]) == "2.0"
+
+    def test_poisoned_legacy_cached_tree_is_not_reused(self, tmp_path: Path) -> None:
+        """A tree written before source-cache isolation cannot affect a resolve."""
+        fresh = '[project]\nname = "foo"\nversion = "1.0"\n'
+        data = _archive_bytes("foo", "1.0", fresh)
+        digest = hashlib.sha256(data).hexdigest()
+        source = ArchiveSource(
+            name="foo", url=f"https://ex.com/foo-1.0.tar.gz#sha256={digest}"
+        )
+
+        legacy_entry = tmp_path / "archive" / digest
+        legacy_tree = legacy_entry / "tree"
+        legacy_tree.mkdir(parents=True)
+        (legacy_tree / "pyproject.toml").write_text(
+            '[project]\nname = "foo"\nversion = "99.0"\n', encoding="utf-8"
+        )
+        (legacy_entry / ".nab-hashes").write_text(f"sha256={digest}", encoding="utf-8")
+        (legacy_entry / ".nab-complete").touch()
+
+        coord = make_coordinator([], package="foo")
+        coord.index.store_sdist_archive("foo", digest, data)
+
+        result = resolve_with_coordinator(
+            coord,
+            _one_target(),
+            _reqs("foo"),
+            config=NabProjectConfig(archive_sources=(source,)),
+            cache_dir=tmp_path,
+        )
+
+        assert result.success
+        assert str(result.target_results[0].pins["foo"]) == "1.0"
+        assert (tmp_path / ARCHIVE_BUCKET / digest / ".nab-complete").is_file()
+        assert 'version = "99.0"' in (legacy_tree / "pyproject.toml").read_text(
+            encoding="utf-8"
+        )
+        coord.request_direct_archive.assert_called_once()
 
     def test_resolves_with_caching_off(self) -> None:
         """``nab lock --no-cache`` still extracts and pins the declared archive."""

--- a/nab-python/tests/test_vcs.py
+++ b/nab-python/tests/test_vcs.py
@@ -24,9 +24,11 @@ from nab_index.vcs import (
     _split_repo_ref,
     prepare_clone,
 )
+from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.version import Version
 from nab_python.fetch import FetchCoordinator, InMemoryIndex
 from nab_python.lockfile import VcsPin, build_target_lock
+from nab_python.metadata import WheelMetadata
 from nab_python.provider import (
     BuildPolicy,
     LocalSource,
@@ -1144,6 +1146,79 @@ class TestProviderVcsIntegration:
         )
         with pytest.raises(UnsupportedSdistError, match="build-policy 'build-remote'"):
             provider.fetch_versions("foo")
+
+    def test_dynamic_backend_mutation_does_not_poison_cached_clone(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        sha = "a" * 40
+        clone_dir = tmp_path / "cache" / "vcs" / "k" / sha
+        _mark_complete(clone_dir)
+        project = clone_dir / "pkg"
+        project.mkdir()
+        (project / "pyproject.toml").write_text(
+            '[project]\nname = "foo"\nversion = "1.0.0"\ndynamic = ["dependencies"]\n',
+            encoding="utf-8",
+        )
+        dependency = project / "dependency.txt"
+        dependency.write_text("dep-one==1", encoding="utf-8")
+        (clone_dir / "shared.txt").write_text("parent context", encoding="utf-8")
+
+        monkeypatch.setattr("nab_index.vcs._repo_key", lambda _url: "k")
+        monkeypatch.setattr(subprocess, "run", _refuse_git)
+
+        def mutating_backend(path: Path, **_kwargs: object) -> WheelMetadata:
+            assert path.parent.name == clone_dir.name
+            assert (path.parent / "shared.txt").read_text(encoding="utf-8") == (
+                "parent context"
+            )
+            assert (path.parent / ".git" / _COMPLETE_MARKER).is_file()
+            backend_input = path / "dependency.txt"
+            requires_dist = [Requirement(backend_input.read_text(encoding="utf-8"))]
+            backend_input.write_text("dep-two==2", encoding="utf-8")
+            return WheelMetadata(
+                name="foo",
+                version=Version("1.0.0"),
+                requires_python=None,
+                requires_dist=requires_dist,
+                provides_extra=[],
+            )
+
+        monkeypatch.setattr(
+            "nab_python.build_backend.extract_metadata", mutating_backend
+        )
+
+        def make_provider() -> Provider:
+            return Provider(
+                self.coordinator(),
+                vcs_config=VcsConfig(
+                    policy=VcsPolicy.ALLOW,
+                    allowed_schemes=frozenset({"git+https"}),
+                    allowed_repos=("https://example.com/",),
+                    require_pin=True,
+                ),
+                vcs_sources=[
+                    VcsSource(
+                        name="foo",
+                        url=(f"git+https://example.com/foo.git@{sha}#subdirectory=pkg"),
+                    )
+                ],
+                vcs_cache_dir=tmp_path / "cache",
+                build_policy=BuildPolicy.BUILD_REMOTE,
+            )
+
+        first = make_provider()
+        first.fetch_versions("foo")
+        second = make_provider()
+        second.fetch_versions("foo")
+
+        metadata_key = ("foo", Version("1.0.0"))
+        assert [
+            str(first.metadata_cache[metadata_key].requires_dist[0]),
+            str(second.metadata_cache[metadata_key].requires_dist[0]),
+        ] == ["dep-one==1", "dep-one==1"]
+        assert dependency.read_text(encoding="utf-8") == "dep-one==1"
 
     def test_duplicate_source_across_local_vcs_raises(self, tmp_path: Path) -> None:
         with pytest.raises(ValueError, match="duplicate source"):


### PR DESCRIPTION
Dynamic archive and VCS build backends can modify source trees that later resolves reuse as verified cache entries, so one resolve can change the metadata returned by the next.

Run those backends against disposable copies that preserve repository context, hard links, and source basenames. Version the source-cache buckets to retire entries written before isolation while keeping the legacy buckets removable by `nab cache clear`.

This adds copy I/O for dynamic cached-source metadata builds, including the full shallow VCS checkout, to keep persistent source entries immutable.
