### PR TITLE
Treat an unreadable archive cache entry as a miss

### DIFF
--- a/nab-project/src/nab_project/_sources.py
+++ b/nab-project/src/nab_project/_sources.py
@@ -31,6 +31,8 @@ from nab_provider.policy import (
 )
 from nab_provider.vcs_request import VcsCloneError, VcsRequest
 
+from .paths import PathState, path_state
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
@@ -317,24 +319,34 @@ def _prepare_archive_tree(
     target = cache_dir / digest
 
     declared = set(parsed.hashes)
-    if (target / _COMPLETE_MARKER).is_file() and declared <= _verified_hashes(target):
+    if _is_published(target) and declared <= _verified_hashes(target):
         return _extracted_root(target), parsed
 
     data = _fetch_archive_bytes(request.package, source, parsed, port=port)
     return _extract_archive(cache_dir, digest, data, parsed.hashes), parsed
 
 
+def _is_published(target: Path) -> bool:
+    """Whether the entry at ``target`` holds a completed extraction.
+
+    A marker whose stat fails counts as unpublished, so an entry this process
+    cannot read is a miss rather than an error.
+    """
+    return path_state(target / _COMPLETE_MARKER) is PathState.FILE
+
+
 def _verified_hashes(target: Path) -> set[tuple[str, str]]:
     """Return the hashes the tree at ``target`` was verified against.
 
-    The record is written with the completion marker, so a tree with no record
-    covers nothing and is refetched rather than trusted.
+    The record is written with the completion marker, so a tree whose record is
+    missing or unreadable covers nothing and is refetched rather than trusted.
     """
     record = target / _HASHES_MARKER
-    if not record.is_file():
+    try:
+        lines = record.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError):
         return set()
 
-    lines = record.read_text(encoding="utf-8").splitlines()
     return {
         (algorithm, hex_digest)
         for algorithm, _, hex_digest in (line.partition("=") for line in lines)
@@ -399,9 +411,8 @@ def _extract_archive(
     cache path never holds a partial tree.
     """
     target = cache_dir / digest
-    marker = target / _COMPLETE_MARKER
 
-    if not marker.is_file():
+    if not _is_published(target):
         cache_dir.mkdir(parents=True, exist_ok=True)
         tmp = Path(tempfile.mkdtemp(dir=cache_dir, prefix=f"{digest}.", suffix=".tmp"))
 
@@ -433,11 +444,11 @@ def _extract_archive(
                 # The cache path is taken.  A marker there means another run
                 # got there first; without one it is a partial left by an
                 # interrupted run.
-                if not marker.is_file():
+                if not _is_published(target):
                     shutil.rmtree(target, ignore_errors=True)
                     with suppress(OSError):
                         tmp.rename(target)
-                if not marker.is_file():
+                if not _is_published(target):
                     msg = f"extracted archive could not be moved into place: {exc}"
                     raise UnsupportedSdistError(msg) from exc
         finally:

--- a/nab-project/tests/test_archive.py
+++ b/nab-project/tests/test_archive.py
@@ -9,6 +9,7 @@ itself is under test.
 from __future__ import annotations
 
 import ast
+import errno
 import gzip
 import hashlib
 import inspect
@@ -17,7 +18,8 @@ import os
 import tarfile
 import textwrap
 import zlib
-from typing import TYPE_CHECKING, NoReturn
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, NoReturn
 
 import httpx
 import pytest
@@ -56,7 +58,6 @@ from nab_provider.target import ResolveTarget
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
     from contextlib import AbstractContextManager
-    from pathlib import Path
 
     from nab_project.lockfile import PinShape
 
@@ -196,6 +197,21 @@ def _warm_dynamic_archive_tree(cache: Path, digest: str) -> Path:
         encoding="utf-8",
     )
     return tree
+
+
+def _deny_access(monkeypatch: pytest.MonkeyPatch, method: str, target: Path) -> None:
+    """Make one ``Path`` call on ``target`` fail with EACCES.
+
+    A real chmod would not do: root ignores the mode bits and Windows has none.
+    """
+    original = getattr(Path, method)
+
+    def failing(self: Path, *args: Any, **kwargs: Any) -> Any:
+        if self == target:
+            raise PermissionError(errno.EACCES, "Permission denied", str(target))
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, method, failing)
 
 
 def _lock_input(pins: Mapping[str, PinShape]) -> LockInput:
@@ -883,6 +899,57 @@ class TestWarmArchiveCache:
         cache = tmp_path / "arch"
         _warm_extracted_tree(cache, digest)
         (cache / digest / ".nab-hashes").unlink()
+        provider = _provider([source], cache)
+
+        with pytest.raises(UnsupportedSdistError, match="download.*failed"):
+            provider.fetch_versions("foo")
+
+    def test_tree_with_undecodable_hash_record_is_not_served(
+        self, tmp_path: Path
+    ) -> None:
+        # A record that will not decode covers no hashes, so the tree is
+        # refetched rather than trusted.
+        digest = "c" * 64
+        source = ArchiveSource(
+            name="foo", url=f"https://ex.com/foo-1.0.0.tar.gz#sha256={digest}"
+        )
+        cache = tmp_path / "arch"
+        _warm_extracted_tree(cache, digest)
+        (cache / digest / ".nab-hashes").write_bytes(b"sha256=\xff\xfe\n")
+        provider = _provider([source], cache)
+
+        with pytest.raises(UnsupportedSdistError, match="download.*failed"):
+            provider.fetch_versions("foo")
+
+    def test_tree_with_unreadable_hash_record_is_not_served(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A record that stats as a file but will not open says as little as
+        # no record at all.
+        digest = "f" * 64
+        source = ArchiveSource(
+            name="foo", url=f"https://ex.com/foo-1.0.0.tar.gz#sha256={digest}"
+        )
+        cache = tmp_path / "arch"
+        _warm_extracted_tree(cache, digest)
+        _deny_access(monkeypatch, "read_text", cache / digest / ".nab-hashes")
+        provider = _provider([source], cache)
+
+        with pytest.raises(UnsupportedSdistError, match="download.*failed"):
+            provider.fetch_versions("foo")
+
+    def test_entry_with_unreadable_marker_is_not_served(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # mkdtemp leaves the entry 0700, so another user's entry is not
+        # traversable and its marker cannot be stat'ed at all.
+        digest = "1" * 64
+        source = ArchiveSource(
+            name="foo", url=f"https://ex.com/foo-1.0.0.tar.gz#sha256={digest}"
+        )
+        cache = tmp_path / "arch"
+        _warm_extracted_tree(cache, digest)
+        _deny_access(monkeypatch, "stat", cache / digest / ".nab-complete")
         provider = _provider([source], cache)
 
         with pytest.raises(UnsupportedSdistError, match="download.*failed"):


### PR DESCRIPTION
An archive-source resolve crashes with a traceback when the cache entry for its digest exists but cannot be read. With a `.nab-hashes` record holding non-UTF-8 bytes:

```
  File "nab_project/_sources.py", line 337, in _verified_hashes
    lines = record.read_text(encoding="utf-8").splitlines()
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 7: invalid start byte
```

An absent entry is a miss and refetches, so a damaged one is handled worse than no entry at all. Two reads were unguarded:

- `.nab-hashes` is opened as UTF-8 behind an `is_file()` check, so a record that will not decode or will not open escapes as `UnicodeDecodeError` or `OSError`.
- `.nab-complete` is checked with `Path.is_file()`, which lets `EACCES` through on Python 3.13 and below. `mkdtemp` leaves an entry at 0700, so in a cache shared with another user every lookup of their digest raises instead of missing.

Both now report the entry as unverified, the path an absent one already takes: download the archive and check it against the whole hash declaration. The rename collision in `_extract_archive` shares the check, so an entry it cannot stat reports the existing "could not be moved into place" error rather than a bare `PermissionError`.

