### PR TITLE
Pin prioritize's counter order; swapping the two decides culprits first

### DIFF
--- a/nab-python/tests/test_decision_scan.py
+++ b/nab-python/tests/test_decision_scan.py
@@ -15,6 +15,10 @@ of two runs can still disagree: what had landed when each scan opened is
 a fact about the HTTP cache.  ``decision-order = "stable"`` closes that.
 Two classes cover the option: one varies only which listings were already
 resident, the other runs the engine, where the config reaches the provider.
+
+The scan is also where the resolver's two search counters reach the sort
+key.  Seeding one counter at a time and reading back which package the
+scan decides is what tells their two roles apart.
 """
 
 from __future__ import annotations
@@ -23,7 +27,11 @@ import threading
 from typing import TYPE_CHECKING, NamedTuple
 
 from nab_index.client import WheelFile
-from nab_python._provider.priority import _NO_LISTING_PRIOR
+from nab_python._provider.priority import (
+    _NO_LISTING_PRIOR,
+    CONFLICT_THRESHOLD,
+    CULPRIT_DEMOTE_THRESHOLD,
+)
 from nab_python._testing.coordinator_fake import make_coordinator
 from nab_python._vendor.packaging.ranges import VersionRange
 from nab_python._vendor.packaging.requirements import Requirement
@@ -216,6 +224,18 @@ def _decided_first(*, resident: bool, decision_order: DecisionOrder) -> str | No
         resident=resident, decision_order=decision_order
     )
     return decide.choose_package_to_decide(resolver)
+
+
+def _counter_resolver() -> Resolver[str, Version]:
+    """The same two packages with both listings already resident.
+
+    Nothing is in flight, so both are ready and the sort key comes down to
+    the tier the search counters give a package, then its candidate count.
+    """
+    resolver, _ = _two_package_resolver(
+        resident=True, decision_order=DecisionOrder.ARRIVAL
+    )
+    return resolver
 
 
 def _cause() -> Incompatibility[str, Version]:
@@ -492,3 +512,31 @@ class TestTheConfiguredOrderReachesTheSearch:
             conflicts=1,
             backjumps=1,
         )
+
+
+class TestTheSearchCountersReachTheSortKey:
+    """The scan ranks on both search counters, each in its own role.
+
+    They pull opposite ways: a package whose own decisions keep being
+    discarded is decided first, one blamed for discarding another's is
+    decided last.  The scan passes them positionally, so only a scan shows
+    each one landing in the role named for it.
+    """
+
+    def test_the_candidate_count_decides_with_no_history(self) -> None:
+        """Baseline: nothing has conflicted, so fewer candidates wins."""
+        assert decide.choose_package_to_decide(_counter_resolver()) == "beta"
+
+    def test_a_runaway_culprit_decides_last(self) -> None:
+        """``beta`` blamed for the conflicts drops behind the wider ``alpha``."""
+        resolver = _counter_resolver()
+        resolver.stats.package_culprit_counts["beta"] = CULPRIT_DEMOTE_THRESHOLD
+
+        assert decide.choose_package_to_decide(resolver) == "alpha"
+
+    def test_a_repeatedly_discarded_package_decides_first(self) -> None:
+        """``alpha``'s own discarded decisions lift it past ``beta``."""
+        resolver = _counter_resolver()
+        resolver.stats.package_conflict_counts["alpha"] = CONFLICT_THRESHOLD
+
+        assert decide.choose_package_to_decide(resolver) == "alpha"

--- a/nab-resolver/tests/test_decide.py
+++ b/nab-resolver/tests/test_decide.py
@@ -8,7 +8,8 @@ PEP 440 semantics.
 
 ``choose_package_to_decide`` calls ``begin_decision_scan`` once before it reads
 any sort key, which is how a provider fed by another thread knows when its
-answers may move.
+answers may move.  The same scan hands the provider both search counters, one
+per parameter.
 """
 
 from __future__ import annotations
@@ -145,6 +146,32 @@ class _InertProvider:
         self, package: Any, constraint: RangeProtocol[int]
     ) -> RangeProtocol[int]:
         return constraint
+
+
+class _CounterRecordingProvider(_InertProvider):
+    """Records the two counter mappings each sort key is built from.
+
+    Copies each one, and records an omitted ``culprit_counts`` as ``None``
+    so a dropped argument does not read back as an empty mapping.
+    """
+
+    def __init__(self) -> None:
+        self.counters: list[tuple[dict[Any, int], dict[Any, int] | None]] = []
+
+    def prioritize(
+        self,
+        package: Any,
+        version_range: RangeProtocol[int],
+        conflict_counts: Mapping[Any, int],
+        culprit_counts: Mapping[Any, int] | None = None,
+    ) -> Any:
+        self.counters.append(
+            (
+                dict(conflict_counts),
+                None if culprit_counts is None else dict(culprit_counts),
+            )
+        )
+        return 0
 
 
 class _ScanOrderProvider(_InertProvider):
@@ -324,3 +351,30 @@ class TestScanBoundary:
 
         assert decide.choose_package_to_decide(resolver) is None
         assert provider.calls == []
+
+
+class TestBothCountersReachTheProvider:
+    """Every sort key is built from both of the resolver's search counters.
+
+    The two mean opposite things: how often a decision on the package was
+    discarded, against how often the package discarded another's.  They are
+    passed positionally, so nothing else pins which parameter each reaches.
+    """
+
+    def test_each_counter_arrives_in_the_parameter_named_for_it(self) -> None:
+        """Conflict counts third, culprit counts fourth, once per package."""
+        provider = _CounterRecordingProvider()
+        resolver, _ = _resolver_with(provider)
+        for package in ("a", "b"):
+            resolver.solution.derive(
+                package,
+                RefiningRange.at_least(1),
+                positive=True,
+                cause=_dependency_cause(),
+            )
+
+        resolver.stats.package_conflict_counts["a"] = 3
+        resolver.stats.package_culprit_counts["b"] = 7
+
+        assert decide.choose_package_to_decide(resolver) is not None
+        assert provider.counters == [({"a": 3}, {"b": 7})] * 2


### PR DESCRIPTION
`choose_package_to_decide` hands `Provider.prioritize` both of the resolver's search counters positionally, and no test pinned which one lands where:

```python
priority = prioritize(
    package,
    get_range(package) or any_range,
    conflict_counts,
    culprit_counts,
)
```

Swap those last two and no test fails. The counters mean opposite things, so the swap inverts the heuristic: a package blamed for discarding other packages' decisions reads as one whose own decisions were discarded, moving from tier 2 (decided last) to tier 0 (decided first).

One test per side of the call:

- `nab-resolver`: a provider that records the two mappings behind every sort key, asserting the conflict counts arrive third and the culprit counts fourth, once per undecided package.
- `nab-python`: the real provider over a one-version `beta` and a three-version `alpha`, seeding one counter at a time. With no history `beta` decides first on candidate count; seeding `beta`'s culprit count drops it behind `alpha`, and seeding `alpha`'s conflict count promotes `alpha` on its own.
