### PR TITLE
Fix the getting-started sample output no resolve can produce

### DIFF
--- a/docs/reference/lockfile.md
+++ b/docs/reference/lockfile.md
@@ -59,28 +59,28 @@ A trimmed example, after resolving the
 
 ```toml
 lock-version = "1.0"
-created-by = "nab"
-requires-python = ">=3.10"
 environments = [
-    'python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64"',
+    'python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64" and platform_system == "Linux"',
 ]
+created-by = "nab"
 
 [[packages]]
 name = "fastapi"
-version = "0.115.2"
+version = "0.109.1"
+requires-python = ">=3.8"
 index = "https://pypi.org/simple/"
 
-[[packages.wheels]]
-name = "fastapi-0.115.2-py3-none-any.whl"
-url = "https://files.pythonhosted.org/.../fastapi-0.115.2-py3-none-any.whl"
-hashes.sha256 = "..."
-size = 94918
-
 [packages.sdist]
-name = "fastapi-0.115.2.tar.gz"
-url = "https://files.pythonhosted.org/.../fastapi-0.115.2.tar.gz"
+name = "fastapi-0.109.1.tar.gz"
+url = "https://files.pythonhosted.org/.../fastapi-0.109.1.tar.gz"
 hashes.sha256 = "..."
-size = 286433
+size = 11720487
+
+[[packages.wheels]]
+name = "fastapi-0.109.1-py3-none-any.whl"
+url = "https://files.pythonhosted.org/.../fastapi-0.109.1-py3-none-any.whl"
+hashes.sha256 = "..."
+size = 92070
 ```
 
 ### Supported keys
@@ -372,10 +372,10 @@ covers.
 using pip's [hash-checking] format:
 
 ```
-fastapi==0.115.2 \
+fastapi==0.109.1 \
     --hash=sha256:... \
     --hash=sha256:...
-starlette==0.36.0 \
+starlette==0.35.1 \
     --hash=sha256:... \
     --hash=sha256:...
 ```

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -38,16 +38,27 @@ nab lock --format requirements-without-hashes --output - pyproject.toml
 ```
 
 ```
-anyio==4.6.2.post1
-fastapi==0.115.2
-idna==3.10
-sniffio==1.3.1
-starlette==0.36.0
-typing_extensions==4.12.2
+annotated-types==0.8.0
+anyio==4.14.2
+fastapi==0.109.1
+idna==3.18
+pydantic==2.13.4
+pydantic-core==2.46.4
+starlette==0.35.1
+typing-extensions==4.16.0
+typing-inspection==0.4.4
 ```
 
+`fastapi` resolves to 0.109.1 rather than its `<=0.115.2` cap because
+every later release requires a starlette that `<=0.36.0` excludes.
+
 The resolver pins one version per package for the host's marker
-environment. For multi-platform / multi-Python locks see
+environment, taking the newest release the constraints allow. That
+block came off CPython 3.12 on Linux, so another host or a later
+resolve gives different versions. Names print in their PEP 503
+canonical form, so `typing_extensions` appears as `typing-extensions`.
+
+For multi-platform / multi-Python locks see
 [universal resolution](../explanation/universal.md).
 
 ## Where to next

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -4735,6 +4735,51 @@ class TestWriteRequirementsPerTarget:
         assert text == "foo==1.0\n"
 
 
+class TestGettingStartedTranscript:
+    """The tutorial's sample output is a block this renderer can print."""
+
+    _COMMAND = "nab lock --format requirements-without-hashes --output - pyproject.toml"
+
+    def _documented_lines(self) -> list[str]:
+        """Return the lines of the output block the tutorial shows for ``_COMMAND``."""
+        doc = (
+            Path(__file__).resolve().parents[2]
+            / "docs"
+            / "tutorial"
+            / "getting-started.md"
+        )
+
+        block = re.search(
+            rf"```bash\n{re.escape(self._COMMAND)}\n```\n\n```\n(.*?)\n```",
+            doc.read_text(encoding="utf-8"),
+            re.DOTALL,
+        )
+        if block is None:
+            msg = f"no output block follows {self._COMMAND!r}"
+            raise AssertionError(msg)
+        return block.group(1).splitlines()
+
+    def test_documented_pins_render_as_written(self) -> None:
+        """Rendering the documented pins reproduces the block verbatim.
+
+        A pin carries a canonical name, so a documented line spelled any
+        other way renders differently. Feeding the pins in reverse leaves
+        the block's order to the renderer's own sort.
+        """
+        documented = self._documented_lines()
+        assert documented
+
+        pins: dict[str, PinShape] = {}
+        for line in reversed(documented):
+            name, separator, version = line.partition("==")
+            assert separator, f"not a pinned requirement: {line}"
+            canonical = canonicalize_name(name)
+            pins[canonical] = _index_pin(name=canonical, version=version)
+
+        text = write_requirements_without_hashes(LockInput(targets=_one(pins)))
+        assert text.splitlines() == documented
+
+
 def test_lock_input_ignores_vcs_policy() -> None:
     """VcsConfig gates the provider, not the lock builder.
 


### PR DESCRIPTION
The tutorial's only sample output is not something `nab lock` can print. Six lines, three problems:

- `fastapi==0.115.2` sits next to `starlette==0.36.0`, but that fastapi requires `starlette>=0.37.2,<0.41.0`. Under the tutorial's own `starlette<=0.36.0` cap, fastapi resolves to 0.109.1.
- pydantic and its dependencies are missing, though fastapi requires pydantic.
- `typing_extensions==4.12.2` uses an underscore. nab writes every pin under its PEP 503 canonical name, so that line reads `typing-extensions`.

The block now shows what the command prints on Linux CPython 3.12, with the reason fastapi lands below its cap and a note that another host or a later resolve gives other versions.

The lockfile reference's trimmed example is a `pylock.toml` for the same project, so it carried those versions too. It also had a shape the writer does not produce: `created-by` ahead of `environments`, a top-level `requires-python` the tutorial's `pyproject.toml` never declares, and wheels ahead of the sdist.

`test_lockfile.py` now feeds the tutorial's pins back through `write_requirements_without_hashes` and asserts the rendering comes back identical, so a non-canonical name or a wrong sort order fails.
