### PR TITLE
Fix nab lock writing invalid TOML when the cutoff offset has seconds

### DIFF
--- a/docs/reference/lockfile.md
+++ b/docs/reference/lockfile.md
@@ -436,9 +436,9 @@ the same frozen index. See "Decision order" in the
 
 With both set, a fresh resolve produces the same pin set, and an
 absolute `uploaded-prior-to` also becomes the lockfile's
-`created-at`, so two locks from identical inputs are
-byte-for-byte identical. `--upgrade` is the exception: it stamps
-the run time instead.
+`created-at`, written in UTC, so two locks from identical inputs
+are byte-for-byte identical. `--upgrade` is the exception: it
+stamps the run time instead.
 
 Both settings assume an index that does not move. Several things
 move it. Yanking is a property of the listing as it stands, not

--- a/nab-python/src/nab_python/lockfile.py
+++ b/nab-python/src/nab_python/lockfile.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field, replace
+from datetime import timezone
 from typing import TYPE_CHECKING, Any
 
 from ._lockfile.builder import (
@@ -305,10 +306,20 @@ class Provenance:
     package_metadata_overrides: tuple[tuple[str, tuple[str, ...]], ...] = ()
 
     def to_block(self) -> dict[str, Any]:
-        """Render to the dict the TOML writer drops under ``[tool.nab]``."""
+        """Render to the dict the TOML writer drops under ``[tool.nab]``.
+
+        ``created-at`` is emitted in UTC because TOML offset date-times are
+        RFC 3339, whose offset has no seconds field, so an offset such as
+        ``+00:19:32`` cannot be written.  A naive value is taken as UTC, the
+        way ``read_lockfile_anchor`` reads one back.
+        """
+        created_at = self.created_at
+        if created_at.tzinfo is None:
+            created_at = created_at.replace(tzinfo=timezone.utc)
+
         block: dict[str, Any] = {
             "nab-version": self.nab_version,
-            "created-at": self.created_at,
+            "created-at": created_at.astimezone(timezone.utc),
             "command-line": list(self.command_line),
             "input-path": self.input_path,
             "mode": self.mode,

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -10,7 +10,7 @@ import sys
 from collections.abc import Callable, Mapping, Sequence
 from contextlib import AbstractContextManager
 from dataclasses import replace
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import ClassVar
 
@@ -1675,6 +1675,50 @@ class TestProvenance:
         assert "python-specifier" not in data["tool"]["nab"]
         assert "platforms" not in data["tool"]["nab"]
         assert "cli-project-overrides" not in data["tool"]["nab"]
+
+    @pytest.mark.parametrize(
+        "offset",
+        [
+            timezone.utc,
+            timezone(timedelta(hours=5, minutes=30)),
+            timezone(timedelta(minutes=19, seconds=32)),
+            timezone(-timedelta(seconds=30)),
+        ],
+        ids=["utc", "half-hour", "plus-seconds", "minus-seconds"],
+    )
+    def test_created_at_is_emitted_in_utc(self, offset: timezone) -> None:
+        """RFC 3339 offsets stop at minutes, so ``+00:19:32`` has to become UTC."""
+        created = datetime(2026, 5, 7, 12, 0, 0, tzinfo=offset)
+        prov = Provenance(
+            nab_version="9.9.9",
+            created_at=created,
+            command_line=("nab", "lock"),
+            input_path="pyproject.toml",
+            mode="specific",
+        )
+        text = write_lock(
+            LockInput(targets=_one({"foo": _index_pin()}), provenance=prov)
+        )
+
+        emitted = tomllib.loads(text)["tool"]["nab"]["created-at"]
+        assert emitted == created
+        assert emitted.utcoffset() == timedelta(0)
+
+    def test_naive_created_at_is_stamped_utc(self) -> None:
+        """A naive ``created_at`` is stamped UTC rather than read as local time."""
+        stamped = datetime(2026, 5, 7, 12, 0, 0, tzinfo=timezone.utc)
+        prov = Provenance(
+            nab_version="9.9.9",
+            created_at=stamped.replace(tzinfo=None),
+            command_line=("nab", "lock"),
+            input_path="pyproject.toml",
+            mode="specific",
+        )
+        text = write_lock(
+            LockInput(targets=_one({"foo": _index_pin()}), provenance=prov)
+        )
+
+        assert tomllib.loads(text)["tool"]["nab"]["created-at"] == stamped
 
     def test_emits_cli_project_overrides(self) -> None:
         prov = Provenance(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4051,6 +4051,24 @@ class TestLockAnchorReuse:
 
         assert read_lockfile_anchor(out) == absolute
 
+    def test_sub_minute_offset_cutoff_stays_readable(self, tmp_path: Path) -> None:
+        # A cutoff offset carrying seconds is valid ISO 8601 but not valid TOML.
+        absolute = datetime(
+            2026, 5, 1, tzinfo=timezone(timedelta(minutes=19, seconds=32))
+        )
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\ndependencies = ["foo"]\n'
+            f'[tool.nab]\nuploaded-prior-to = "{absolute.isoformat()}"\n',
+        )
+        out = tmp_path / "pylock.toml"
+        with patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()):
+            lock(pyproject, output=out)
+        from nab_python.lockfile import read_lockfile_anchor
+
+        assert tomli.loads(out.read_text())["tool"]["nab"]["created-at"] == absolute
+        assert read_lockfile_anchor(out) == absolute
+
     def test_relative_cutoff_window_uses_reused_anchor(self, tmp_path: Path) -> None:
         # The reused created-at sets the resolve window, not just the recorded
         # provenance.


### PR DESCRIPTION
`nab lock` writes a `pylock.toml` no TOML parser can read when `uploaded-prior-to` is an absolute cutoff whose offset carries seconds. The cutoff becomes the lockfile's `created-at` and goes out verbatim:

```
created-at = 2026-05-01 00:00:00+00:19:32
```

`tomllib` rejects that line with `Expected newline or end of document after a statement`.

TOML offset date-times are RFC 3339, whose offset has no seconds field. Python accepts one on the way in: `fromisoformat` parses `+00:19:32`, and `zoneinfo` returns such an offset for pre-standard local mean time. So the value clears config validation and only breaks when it is written.

`created-at` is now converted to UTC before it is written, which also changes two things:

- a whole-minute offset is normalized too: a `+05:30` cutoff is recorded as `2026-04-30 18:30:00+00:00`, the same instant, and a re-lock reads back the same anchor.
- a naive `created_at` passed to `Provenance` is stamped UTC, the way `read_lockfile_anchor` already reads one back.
