### PR TITLE
Bump the Simple listing cache bucket, warm caches serve the old rendering

### DIFF
--- a/docs/reference/cache.md
+++ b/docs/reference/cache.md
@@ -14,7 +14,7 @@ directory is harmless and `nab cache clear` reclaims it.
 
 | Bucket | Holds |
 | ------ | ----- |
-| `simple-v1/` | the Simple-API listing body and a `.policy` sidecar |
+| `simple-v2/` | the Simple-API listing body and a `.policy` sidecar |
 | `simple-parsed-v0/` | the parsed listing, an accelerator for the body |
 | `simple-neg-v0/` | a short-lived record that a name returned a 404 |
 | `metadata-v1/` | PEP 658 metadata and recovered wheel `METADATA`, immutable |

--- a/nab-index/src/nab_index/cache.py
+++ b/nab-index/src/nab_index/cache.py
@@ -7,8 +7,8 @@ before any HTTP transport call.
 
 Layout under ``root``:
 
-    simple-v1/<index>[-<serialization>]/<package>.json    <- PEP 691 JSON body
-    simple-v1/<index>[-<serialization>]/<package>.policy  <- {fetched_at, max_age,
+    simple-v2/<index>[-<serialization>]/<package>.json    <- PEP 691 JSON body
+    simple-v2/<index>[-<serialization>]/<package>.policy  <- {fetched_at, max_age,
                                                               etag, page_url,
                                                               body_digest}
     simple-parsed-v0/<index>[-<serialization>]/<package>.parsed  <- parsed blob
@@ -19,7 +19,7 @@ Layout under ``root``:
 An index pinned to one serialization gets its own listings directory,
 since a stored body records nothing about which serialization it came from.
 
-A versioned bucket name (``simple-v1``) gives zero-cost schema
+A versioned bucket name (``simple-v2``) gives zero-cost schema
 migration: when the on-disk format changes, bump the suffix and the
 old directory is harmless.
 
@@ -70,7 +70,7 @@ __all__ = [
 ]
 
 
-CACHE_VERSION_SIMPLE = "v1"
+CACHE_VERSION_SIMPLE = "v2"
 CACHE_VERSION_SIMPLE_PARSED = "v0"
 CACHE_VERSION_SIMPLE_NEG = "v0"
 CACHE_VERSION_METADATA = "v1"

--- a/nab-project/tests/test_cached_client.py
+++ b/nab-project/tests/test_cached_client.py
@@ -2643,6 +2643,108 @@ class TestSerializationCacheFlip:
         assert [f.filename for f in files] == ["pkg-1.0-py3-none-any.whl"]
 
 
+class _UnchangedPageTransport:
+    """Index whose page has not changed since it issued ``etag``.
+
+    A conditional request gets a 304; an unconditional one gets the page.
+    """
+
+    def __init__(self, page: bytes, etag: str) -> None:
+        self._page = page
+        self._etag = etag
+        self.calls: list[dict[str, str] | None] = []
+
+    async def get(
+        self, url: str, *, headers: dict[str, str] | None = None
+    ) -> _FakeResponse:
+        self.calls.append(headers)
+        if headers is not None and "If-None-Match" in headers:
+            return _FakeResponse(b"", status=304, headers={"etag": self._etag}, url=url)
+        return _FakeResponse(
+            self._page,
+            headers={"content-type": "text/html", "etag": self._etag},
+            url=url,
+        )
+
+    async def aclose(self) -> None:
+        return None
+
+
+class TestRetiredListingBucket:
+    """A body an older nab wrote into a retired bucket never answers.
+
+    A 304 keeps the stored body, so an obsolete rendering of a PEP 503
+    page is only retired by the bucket's version suffix.
+    """
+
+    _INDEX = "https://pypi.org/simple/"
+    _PAGE_URL = "https://pypi.org/simple/pkg/"
+    _ETAG = "unchanged"
+    _DIGEST = "b" * 64
+    _WHEEL = "pkg-1.0-py3-none-any.whl"
+    _PAGE = f'<a href="{_WHEEL}#sha256={_DIGEST}&amp;egg=pkg">pkg</a>'.encode()
+    # The page as an older nab rendered it, taking the fragment as one hash.
+    _RETIRED_BODY = json.dumps(
+        {
+            "files": [
+                {
+                    "filename": _WHEEL,
+                    "url": f"{_PAGE_URL}{_WHEEL}",
+                    "hashes": {"sha256": f"{_DIGEST}&egg=pkg"},
+                }
+            ]
+        }
+    ).encode()
+
+    def _seed_retired_bucket(self, root: Path) -> Path:
+        """Write the older body and a stale policy into ``simple-v1``.
+
+        Returns the seeded bucket directory.
+        """
+        bucket = root / "simple-v1" / "pypi"
+        bucket.mkdir(parents=True)
+        (bucket / "pkg.json").write_bytes(self._RETIRED_BODY)
+        (bucket / "pkg.policy").write_bytes(
+            json.dumps(
+                {
+                    "fetched_at": 0,
+                    "max_age": 1,
+                    "etag": self._ETAG,
+                    "page_url": self._PAGE_URL,
+                }
+            ).encode()
+        )
+        return bucket
+
+    def _get_files(self, root: Path, transport: _UnchangedPageTransport) -> list:
+        """Resolve ``pkg`` through a client backed by the cache under ``root``."""
+        cache = OnDiskCache(root, self._INDEX)
+
+        async def go() -> list:
+            client = CachedAsyncSimpleClient(transport, cache, self._INDEX)
+            try:
+                return await client.get_files("pkg")
+            finally:
+                await client.aclose()
+
+        return asyncio.run(go())
+
+    def test_retired_body_is_refetched_not_revalidated(self, tmp_path: Path) -> None:
+        bucket = self._seed_retired_bucket(tmp_path)
+        transport = _UnchangedPageTransport(self._PAGE, self._ETAG)
+
+        (wheel,) = self._get_files(tmp_path, transport)
+
+        assert wheel.hashes == (("sha256", self._DIGEST),)
+
+        assert len(transport.calls) == 1
+        sent = transport.calls[0]
+        assert sent is not None
+        assert "If-None-Match" not in sent
+
+        assert (bucket / "pkg.json").read_bytes() == self._RETIRED_BODY
+
+
 class TestGetMetadataText:
     def test_cold_cache_fetches_and_stores(self, tmp_path: Path) -> None:
         cache = _make_cache(tmp_path)


### PR DESCRIPTION
Two fixes to how nab renders a PEP 503 page shipped without bumping `CACHE_VERSION_SIMPLE`, so a cache warmed before them keeps serving the old rendering. `simple-v1/` holds that rendering, not the page as the index sent it.

| Rendering fix | Warm-cache symptom |
| --- | --- |
| href wrapped in HTML whitespace (0.0.12) | the wheel drops out of the listing |
| every hash part of the URL fragment (0.0.13) | `sha256` recorded as `<hex>&egg=pkg` |

Revalidation does not replace it. An unchanged page answers `If-None-Match` with a 304, which slides the freshness window forward and leaves the body alone, so on a project with no new upload the old rendering is permanent.

Bumping the bucket to `simple-v2` turns those entries into a cold miss, so the page is refetched unconditionally and re-rendered by the current parser. Only an index answering in HTML is affected; a JSON body is stored as served.

`simple-parsed-v0` needs no bump of its own. A parsed blob is served only against the `body_digest` in the policy sidecar, and the sidecar lives in the bucket that moved.

The old `simple-v1/` directory stays on disk until `nab cache clear`.
