### PR TITLE
Fix OverflowError escaping the corrupt cache policy guard

### DIFF
--- a/nab-index/src/nab_index/cache.py
+++ b/nab-index/src/nab_index/cache.py
@@ -614,6 +614,12 @@ def _policy_etag(value: object) -> str | None:
 
 
 def _decode_policy(policy_bytes: bytes) -> CachePolicy | None:
+    """Decode stored policy bytes, or ``None`` when they are not a policy.
+
+    ``json`` decodes a number outside float range (``1e400``, ``Infinity``) to
+    an infinity, and ``int()`` on one raises :class:`OverflowError` rather than
+    :class:`ValueError`.
+    """
     try:
         doc = json.loads(policy_bytes)
         return CachePolicy(
@@ -623,7 +629,7 @@ def _decode_policy(policy_bytes: bytes) -> CachePolicy | None:
             page_url=_policy_page_url(doc.get("page_url")),
             body_digest=doc.get("body_digest"),
         )
-    except (ValueError, KeyError, TypeError):
+    except (ValueError, KeyError, TypeError, OverflowError):
         return None
 
 

--- a/nab-index/tests/test_read_fresh_parsed_listing.py
+++ b/nab-index/tests/test_read_fresh_parsed_listing.py
@@ -69,6 +69,7 @@ _ZIP_ONLY_BYTES = json.dumps(
 
 # Derived so a bucket-version bump does not need every path updated.
 _JSON_PATH_PARTS = (f"simple-{CACHE_VERSION_SIMPLE}", "pypi", "pkg.json")
+_POLICY_PATH_PARTS = (f"simple-{CACHE_VERSION_SIMPLE}", "pypi", "pkg.policy")
 
 
 def _run(coro: Coroutine[Any, Any, _T]) -> _T:
@@ -161,6 +162,20 @@ class TestReadFreshParsedListing:
 
     def test_absent_policy_returns_none(self, tmp_path: Path) -> None:
         assert read_fresh_parsed_listing(_cache(tmp_path), "pkg", offline=False) is None
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            b"not json",
+            b'{"fetched_at": Infinity, "max_age": 99999, "etag": null}',
+            b'{"fetched_at": 2000000000, "max_age": 1e400, "etag": null}',
+        ],
+    )
+    def test_corrupt_policy_returns_none(self, tmp_path: Path, raw: bytes) -> None:
+        cache = _cache(tmp_path)
+        _warm_bound(cache)
+        tmp_path.joinpath(*_POLICY_PATH_PARTS).write_bytes(raw)
+        assert read_fresh_parsed_listing(cache, "pkg", offline=False) is None
 
     def test_stale_online_returns_none(self, tmp_path: Path) -> None:
         cache = _cache(tmp_path)

--- a/nab-project/tests/test_cache.py
+++ b/nab-project/tests/test_cache.py
@@ -747,6 +747,21 @@ class TestReadCacheEntry:
         path.write_bytes(b"not json")
         assert cache.read_cache_entry(path) is not None
 
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            b'{"fetched_at": Infinity, "max_age": 600, "etag": null}',
+            b'{"fetched_at": -Infinity, "max_age": 600, "etag": null}',
+            b'{"fetched_at": 1, "max_age": 1e400, "etag": null}',
+        ],
+    )
+    def test_out_of_range_policy_number(self, tmp_path: Path, raw: bytes) -> None:
+        cache = self._cache(tmp_path)
+        path = tmp_path / SIMPLE_BUCKET / "pypi" / "foo.policy"
+        path.parent.mkdir(parents=True)
+        path.write_bytes(raw)
+        assert cache.read_cache_entry(path) == "policy not decodable"
+
     def test_valid_policy(self, tmp_path: Path) -> None:
         cache = self._cache(tmp_path)
         cache.put_simple("foo", b"{}", _FRESH)


### PR DESCRIPTION
A cached `.policy` or `.neg` sidecar whose `fetched_at` or `max_age` decodes to an infinity gets past the corrupt-entry guard, so `nab cache verify` raises instead of naming the bad file:

```
  File "nab-index/src/nab_index/cache.py", line 521, in read_cache_entry
    return None if _decode_policy(raw) is not None else "policy not decodable"
  File "nab-index/src/nab_index/cache.py", line 619, in _decode_policy
    fetched_at=int(doc["fetched_at"]),
OverflowError: cannot convert float infinity to integer
```

`json` reads `Infinity` as a literal and `1e400` as an infinity, and `int()` on either raises `OverflowError`. `_decode_policy` caught `(ValueError, KeyError, TypeError)`, which does not cover it, so none of the four callers got the `None` they handle:

- `get_simple`, `get_simple_policy` and `get_negative`, which log the corrupt sidecar and treat the entry as a miss
- `read_cache_entry`, which reports `policy not decodable`

`OverflowError` joins the caught tuple. `NaN` was already covered, since `int()` on it raises `ValueError`.
