### PR TITLE
Report an unreadable backend METADATA file instead of a raw OSError

### DIFF
--- a/nab-project/src/nab_project/_build/runner.py
+++ b/nab-project/src/nab_project/_build/runner.py
@@ -81,10 +81,10 @@ def run_build_backend(
     Returns a :class:`~nab_provider.metadata.WheelMetadata` parsed from
     the ``METADATA`` file the backend produces.  Raises
     :class:`BuildBackendError` on any failure: backend import
-    error, a rejected ``backend-path``, hook crash, malformed
-    METADATA, an unreadable built wheel, a build requirement that
-    cannot be installed or built, or build requirements ``offline``
-    bars from being fetched.
+    error, a rejected ``backend-path``, hook crash, METADATA that
+    is unreadable or malformed, an unreadable built wheel, a build
+    requirement that cannot be installed or built, or build
+    requirements ``offline`` bars from being fetched.
 
     The build runs in an isolated venv driven by
     :class:`NabBuildEnv`; nothing in the user's main environment is
@@ -428,11 +428,15 @@ def _build_wheel_and_extract(
 
 def _parse_metadata(metadata_path: Path) -> WheelMetadata:
     """Parse a ``METADATA`` file into :class:`WheelMetadata`."""
-    if not metadata_path.is_file():
+    if not path_state(metadata_path).should_read:
         msg = f"backend produced no METADATA file at {metadata_path}"
         raise BuildBackendError(msg)
+
     try:
         text = metadata_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        msg = f"backend METADATA at {metadata_path} could not be read: {exc}"
+        raise BuildBackendError(msg) from exc
     except UnicodeDecodeError as exc:
         msg = f"backend METADATA at {metadata_path} is not valid UTF-8: {exc}"
         raise BuildBackendError(msg) from exc

--- a/nab-project/tests/test_build_runner.py
+++ b/nab-project/tests/test_build_runner.py
@@ -913,6 +913,27 @@ class TestParseMetadata:
         with pytest.raises(BuildBackendError, match="no METADATA file"):
             _parse_metadata(tmp_path / "DOES-NOT-EXIST")
 
+    def test_unreadable_metadata_reports_the_errno(
+        self,
+        tmp_path: Path,
+        deny_access: Callable[[Path], AbstractContextManager[None]],
+    ) -> None:
+        """A METADATA that cannot be read is a read failure, not an absent file."""
+        from nab_project._build.runner import _parse_metadata
+
+        path = tmp_path / "METADATA"
+        path.write_text(
+            "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\n", encoding="utf-8"
+        )
+
+        with (
+            deny_access(path),
+            pytest.raises(
+                BuildBackendError, match="could not be read.*Permission denied"
+            ),
+        ):
+            _parse_metadata(path)
+
     def test_non_utf8_metadata_raises_build_backend_error(self, tmp_path: Path) -> None:
         from nab_project._build.runner import _parse_metadata
 


### PR DESCRIPTION
A backend whose `prepare_metadata_for_build_wheel` returns a dist-info basename the filesystem cannot carry takes `nab lock` down with a traceback:

```
OSError: [Errno 36] File name too long: '/tmp/nab-build-meta-.../....dist-info/METADATA'
```

`run_build_backend` documents `BuildBackendError` on any failure, but neither of `_parse_metadata`'s I/O calls handled `OSError`:

- `metadata_path.is_file()` re-raises the stat failure on 3.13 and below. On 3.14 it returns False, so the same input is reported as "backend produced no METADATA file at ..." when the stat is what failed.
- The read handled `UnicodeDecodeError` and nothing else.

Nothing downstream converts it into a nab error. The listing path materializes a declared local, VCS, or archive source outside the `except Exception` that turns a metadata parse failure into `MetadataError`, and the CLI catches a fixed list of nab errors.

The presence check now goes through `path_state`, which keeps a failed stat apart from an absent file, and the read names the errno:

```
backend METADATA at <path> could not be read: [Errno 36] File name too long: '<path>'
```
