### PR TITLE
Name a non-regular pyproject path instead of calling it missing

### DIFF
--- a/nab-project/src/nab_project/workspace.py
+++ b/nab-project/src/nab_project/workspace.py
@@ -29,7 +29,7 @@ from nab_provider._vendor.packaging.utils import canonicalize_name
 from nab_provider.policy import LocalSource
 
 from ._toml import tool_nab_section
-from .paths import path_state, resolve_path
+from .paths import PathState, path_state, resolve_path
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -141,8 +141,9 @@ def workspace_local_sources(
     Each entry must be a literal path; any entry containing ``*``, ``?``
     or ``[`` raises :class:`WorkspaceDiscoveryError` with a message
     naming the offending entry.  For every member directory the function
-    opens ``<member>/pyproject.toml`` and requires ``[project].name``;
-    missing pyproject or missing name is a hard error.
+    opens ``<member>/pyproject.toml`` and requires ``[project].name``; a
+    pyproject that is missing or not a regular file, and a missing name,
+    are hard errors.
 
     Two members declaring the same canonical name raises
     :class:`WorkspaceDiscoveryError`.  The returned tuple preserves
@@ -174,10 +175,18 @@ def workspace_local_sources(
             raise WorkspaceDiscoveryError(msg)
 
         member_pyproject = member_dir / "pyproject.toml"
-        if not path_state(member_pyproject).should_read:
+        state = path_state(member_pyproject)
+        if state is PathState.ABSENT:
             msg = (
                 f"{declared_in}: workspace member {entry!r} has no"
                 f" pyproject.toml at {member_pyproject}"
+            )
+            raise WorkspaceDiscoveryError(msg)
+
+        if not state.should_read:
+            msg = (
+                f"{declared_in}: workspace member {entry!r}:"
+                f" {member_pyproject} exists but is not a regular file"
             )
             raise WorkspaceDiscoveryError(msg)
 

--- a/nab-project/tests/test_workspace.py
+++ b/nab-project/tests/test_workspace.py
@@ -322,6 +322,24 @@ class TestReadWorkspaceMembers:
         with pytest.raises(WorkspaceDiscoveryError, match="has no pyproject.toml"):
             read_workspace_members(root)
 
+    def test_member_pyproject_directory_raises(self, tmp_path: Path) -> None:
+        """A member pyproject that is a directory is there, so do not call it missing.
+
+        An accidental ``mkdir pkg/pyproject.toml`` reported as absent sends the
+        user looking for the wrong problem.
+        """
+        root = _write(
+            tmp_path / "pyproject.toml",
+            '[project]\nname = "ws"\nversion = "0"\n'
+            "[tool.nab.workspace]\n"
+            'members = ["pkg"]\n',
+        )
+        (tmp_path / "pkg" / "pyproject.toml").mkdir(parents=True)
+        with pytest.raises(
+            WorkspaceDiscoveryError, match="exists but is not a regular file"
+        ):
+            read_workspace_members(root)
+
     def test_member_without_project_name_raises(self, tmp_path: Path) -> None:
         root = _write(
             tmp_path / "pyproject.toml",

--- a/src/nab/_config_cmd.py
+++ b/src/nab/_config_cmd.py
@@ -93,8 +93,8 @@ def config_command(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag
     # iterating OPTIONS in one place, not from an if per option.  A new row
     # needs only its tyro param above.
     # Validate the pyproject path the same way the run commands do: a
-    # missing or directory --path is a hard error, not a silently-skipped
-    # source that prints all-built-in defaults.
+    # --path that is missing, a directory, or not a regular file is a hard
+    # error, not a silently-skipped source that prints all-built-in defaults.
     require_pyproject_file(path)
 
     cli_overrides = _cli_overrides(

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -470,11 +470,11 @@ def _is_pylock(path: Path) -> bool:
 def require_pyproject_file(path: Path) -> None:
     """Exit 1 if ``path`` is not a readable pyproject file.
 
-    Shared by every command that takes a project path, so the
-    not-found/directory wording lives in one place.  A missing or
-    directory ``--path`` is a hard error, not a silently-skipped source.
-    A path whose stat fails passes: the config read reports it, naming
-    the errno.
+    Shared by every command that takes a project path, so the rejection
+    wording lives in one place.  A ``--path`` that is missing, a
+    directory, or not a regular file is a hard error, not a
+    silently-skipped source.  A path whose stat fails passes: the config
+    read reports it, naming the errno.
     """
     state = path_state(path)
 
@@ -482,7 +482,11 @@ def require_pyproject_file(path: Path) -> None:
         printer().error(f"{path} is a directory")
         sys.exit(1)
 
-    if not state.should_read:
+    if state is PathState.OTHER:
+        printer().error(f"{path} exists but is not a regular file")
+        sys.exit(1)
+
+    if state is PathState.ABSENT:
         printer().error(f"{path} not found")
         sys.exit(1)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,12 @@ suites (which need not have ``nab`` installed) do not import it.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import os
+import stat
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
 
 import pytest
 
@@ -15,8 +20,8 @@ from nab.output import reset_log_handlers
 from nab_project.config_sources import SourceRoots
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
-    from pathlib import Path
+    from collections.abc import Callable, Iterator
+    from contextlib import AbstractContextManager
 
 
 @pytest.fixture(autouse=True)
@@ -64,3 +69,42 @@ def hermetic_roots(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.delenv("NAB_CACHE_DIR", raising=False)
     monkeypatch.delenv("NAB_RESOLUTION", raising=False)
     return project_dir
+
+
+@contextmanager
+def _as_fifo(target: Path) -> Iterator[None]:
+    real_os_stat, real_path_stat = os.stat, Path.stat
+    piped = os.fspath(target)
+    fifo = os.stat_result((stat.S_IFIFO | 0o644, *([0] * 9)))
+
+    def fifo_os_stat(path: Any, *args: Any, **kwargs: Any) -> Any:
+        if isinstance(path, (str, os.PathLike)) and os.fspath(path) == piped:
+            return fifo
+        return real_os_stat(path, *args, **kwargs)
+
+    def fifo_path_stat(self: Path, *args: Any, **kwargs: Any) -> Any:
+        if os.fspath(self) == piped:
+            return fifo
+        return real_path_stat(self, *args, **kwargs)
+
+    with (
+        patch.object(os, "stat", fifo_os_stat),
+        patch.object(Path, "stat", fifo_path_stat),
+    ):
+        yield
+
+
+@pytest.fixture
+def as_fifo() -> Callable[[Path], AbstractContextManager[None]]:
+    """Simulate a named pipe at a path.
+
+    Inside ``as_fifo(p)`` a stat of ``p`` reports a FIFO, which is what bash
+    process substitution and a piped ``/dev/stdin`` hand a command that takes a
+    project path. ``os.mkfifo`` is POSIX-only, so the state is simulated rather
+    than created.
+
+    Both stat routes are patched. On Python 3.10 ``Path.stat`` calls an
+    ``os.stat`` bound into pathlib at import time, so patching ``os.stat``
+    alone leaves every ``pathlib`` presence check reading the real file.
+    """
+    return _as_fifo

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1553,6 +1553,24 @@ class TestLockCommandSpecific:
             lock(tmp_path)
         assert "is a directory" in capsys.readouterr().err
 
+    def test_pipe_path_exits(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        as_fifo: Callable[[Path], AbstractContextManager[None]],
+    ) -> None:
+        """A pipe is named for what it is, not reported as a missing file.
+
+        ``nab lock <(...)`` hands the CLI a FIFO.  The file is there, so
+        calling it absent sends the user looking for the wrong problem.
+        """
+        pyproject = _make_pyproject(tmp_path)
+        with as_fifo(pyproject), pytest.raises(SystemExit, match="1"):
+            lock(pyproject)
+        err = capsys.readouterr().err
+        assert f"{pyproject} exists but is not a regular file" in err
+        assert "not found" not in err
+
     def test_malformed_toml_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -409,6 +409,21 @@ class TestConfigErrors:
         err = capsys.readouterr().err
         assert "is a directory" in err
 
+    def test_pipe_path_exits(
+        self,
+        hermetic_roots: Path,
+        capsys: pytest.CaptureFixture[str],
+        as_fifo: Callable[[Path], AbstractContextManager[None]],
+    ) -> None:
+        # The shared guard's wording reaches every command that takes a
+        # project path, so a pipe is named here the same way nab lock names it.
+        path = _project(hermetic_roots)
+        with as_fifo(path), pytest.raises(SystemExit):
+            config_command("list", path=path)
+        err = capsys.readouterr().err
+        assert f"{path} exists but is not a regular file" in err
+        assert "not found" not in err
+
     def test_unsearchable_parent_reports_the_errno(
         self,
         hermetic_roots: Path,


### PR DESCRIPTION
`nab lock /dev/null` reported the file as missing:

```
error: /dev/null not found
```

The path is there. It is just not a regular file, and calling it absent sends the user looking for the wrong problem. It now reads:

```
error: /dev/null exists but is not a regular file
```

`config_sources.py` and `_build/runner.py` already print that exact sentence. Two guards did not, and treated an existing non-regular path as absent:

- `require_pyproject_file` in `src/nab/cli.py`, shared by every command that takes a project path, so `nab lock`, `nab download` and `nab config --path` all inherited it.
- `workspace_local_sources` in `nab-project`, which reported an existing member pyproject as `workspace member 'pkg' has no pyproject.toml at ...`.

Three triggers reach the new wording with no special setup: a character device such as `/dev/null`, a process substitution (`nab lock <(...)` hands the CLI a FIFO at `/dev/fd/63`), and an accidental `mkdir pkg/pyproject.toml` inside a declared workspace member.

The workspace site now re-words directories too, which it had also been calling missing.

Nothing else moves. Every `PathState` reaches the same outcome it did before, both sites still exit 1, and `WorkspaceDiscoveryError` is still the error raised. A path whose stat fails still passes both guards and falls through to the config read that names the errno.
