### PR TITLE
Skip the transitive prefetch pick for cached deps, 9.5% off a listing walk

### DIFF
--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -5893,6 +5893,25 @@ class TestSkipFetch:
         assert not coordinator.calls_to("request_metadata")
         assert not coordinator.calls_to("request_metadata_batch")
 
+    def test_prefetch_transitive_best_skips_pick_for_cached_deps(self) -> None:
+        # The deps_cache guard runs before the artifact pick, so a candidate
+        # with cached deps never reaches pick_dist_for_metadata.
+        coordinator = make_coordinator(
+            [make_wheel("2.0"), make_wheel("1.0")], package="pkg"
+        )
+        provider = Provider(coordinator, target=_PY312)
+        provider.deps_cache[("pkg", V("2.0"))] = {}
+
+        with patch.object(
+            listing_mod,
+            "pick_dist_for_metadata",
+            wraps=listing_mod.pick_dist_for_metadata,
+        ) as pick:
+            provider.fetch_versions("pkg")
+
+        assert not pick.called
+        assert not coordinator.calls_to("request_metadata")
+
     def test_prefetch_walk_ahead_skips_complete_override(self) -> None:
         # The walk-ahead batch excludes a version whose complete override
         # replaces its metadata, but keeps the un-overridden sibling.

--- a/nab-provider/src/nab_provider/_provider/listing.py
+++ b/nab-provider/src/nab_provider/_provider/listing.py
@@ -215,6 +215,8 @@ def prefetch_transitive_best(
     if best is None:
         return
     version, _ = best
+    if (normalized, version) in provider.deps_cache:
+        return
     if _has_complete_override(provider, normalized, version):
         return
 
@@ -222,13 +224,7 @@ def prefetch_transitive_best(
     dist = pick_dist_for_metadata(
         versions, version, provider.wheel_tags, provider.target
     )
-
-    cache_key = (normalized, version)
-    if (
-        cache_key not in provider.deps_cache
-        and isinstance(dist, WheelFile)
-        and (url := dist.metadata_url) is not None
-    ):
+    if isinstance(dist, WheelFile) and (url := dist.metadata_url) is not None:
         provider.coordinator.request_metadata(
             normalized, dist.version, url, dist.metadata_hash
         )


### PR DESCRIPTION
`prefetch_transitive_best` walks 94,335 fewer listing elements on `ecosystem:apache-beam-sdist-build`, 9.5% off that path. It picked the metadata artifact before checking `deps_cache`, so a candidate whose dependencies were already cached still scanned the listing to pick an artifact nobody fetched. The cache check now runs first.

The counts are deterministic; the timings are local.

| `ecosystem:apache-beam-sdist-build` | before | after |
| --- | --- | --- |
| `pick_dist_for_metadata` calls from the prefetch | 8,432 | 8,147 |
| elements walked in those calls | 995,680 | 901,345 |
| `Version.__eq__` calls | 1,587,593 | 1,493,194 |
| total interpreter calls | 42,819,647 | 42,600,520 |

What did not move:

- `ecosystem:pandas-with-aws-s3 --resolution lowest` hits the guard twice, for 124 elements out of 2,870,163. The win is apache-beam's.
- Prefetch requests, decisions, conflicts and pins are unchanged on both scenarios: 11,615 and 2,626 `request_metadata` calls, 167/51 and 1,373/1,082 decisions and conflicts, 27 pins on pandas-lowest.
- Wall, CPU and peak RSS are flat over 12 interleaved pairs on apache-beam, with no regression in any of them. Locally those legs could not have resolved a wall effect below about 4%, so a 0.5% call-count saving was never going to show there.

The override check and the pick are lookups with no side effects, so the reorder prefetches the same artifact. `prefetch_root_batch` already skips a cached candidate before its per-candidate work; the transitive path now matches.
