### PR TITLE
Memoise marker literal comparison, ~0.36% off an offline lock's instructions

### DIFF
--- a/nab-provider/src/nab_provider/_vendor/packaging/_markersets.py
+++ b/nab-provider/src/nab_provider/_vendor/packaging/_markersets.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import re
 import sys
 import threading
+from functools import lru_cache
 from itertools import pairwise, product
 from typing import TYPE_CHECKING, NamedTuple, cast
 
@@ -111,8 +112,20 @@ def is_pure_version(variable: str) -> bool:
     return DOMAIN_REGISTRY[variable] == DOMAIN_VERSION
 
 
-def _apply(lhs: str, op: str, rhs: str, key: str) -> bool:
+@lru_cache(maxsize=8192)
+def _apply_memoised(lhs: str, op: str, rhs: str, key: str, _limit: int) -> bool:
+    """Bounded memo behind :func:`_apply`; ``_limit`` only widens the cache key."""
     return _eval_op(lhs, Op(op), rhs, key=key)
+
+
+def _apply(lhs: str, op: str, rhs: str, key: str) -> bool:
+    """Evaluate ``op`` on a pair of literals under ``key``'s domain, memoised.
+
+    The int-string limit joins the four strings in the cache key: a version key
+    parses both operands, so a literal that compares under one limit raises
+    under another.
+    """
+    return _apply_memoised(lhs, op, rhs, key, sys.get_int_max_str_digits())
 
 
 # --------------------------------------------------------------------- version util
@@ -172,7 +185,7 @@ class Atom:
     lazily from its own literal. Equality and hashing run off a field tuple
     precomputed at construction. A decision re-reads the same atom on the same point
     across partitions of one axis; that memo belongs to the operation, not here, so
-    ``holds`` recomputes.
+    ``holds`` recomputes. The comparison it runs is memoised in :func:`_apply`.
     """
 
     __slots__ = (

--- a/nab-provider/tests/test_marker_algebra.py
+++ b/nab-provider/tests/test_marker_algebra.py
@@ -12,7 +12,7 @@ import traceback
 
 import pytest
 
-from nab_provider._vendor.packaging import markersets
+from nab_provider._vendor.packaging import _markersets, markersets
 from nab_provider._vendor.packaging.markers import (
     InvalidMarker,
     Marker,
@@ -1066,6 +1066,29 @@ def test_oversized_literal_allowed_when_int_limit_disabled() -> None:
         assert isinstance(ms(f'python_full_version >= "{lit}"').is_empty(), bool)
     finally:
         sys.set_int_max_str_digits(original)
+
+
+def test_apply_memo_reuses_a_repeated_comparison() -> None:
+    assert _markersets._apply("3.11.4", ">=", "3.9", key="python_full_version") is True
+
+    hits = _markersets._apply_memoised.cache_info().hits
+    assert _markersets._apply("3.11.4", ">=", "3.9", key="python_full_version") is True
+    assert _markersets._apply_memoised.cache_info().hits == hits + 1
+
+
+def test_apply_memo_misses_when_int_limit_changes() -> None:
+    # A version comparison parses both operands, so a result memoised under one
+    # int-string limit must not be replayed under a limit that forbids the parse.
+    lit = "1." + "9" * 5000
+    original = sys.get_int_max_str_digits()
+    sys.set_int_max_str_digits(0)
+    try:
+        assert _markersets._apply(lit, ">=", "3.9", key="python_full_version") is False
+    finally:
+        sys.set_int_max_str_digits(original)
+
+    with pytest.raises(ValueError, match="limit"):
+        _markersets._apply(lit, ">=", "3.9", key="python_full_version")
 
 
 def test_mint_overflow_at_parse_limit_reports_complexity() -> None:

--- a/tasks/vendoring/packaging.patch
+++ b/tasks/vendoring/packaging.patch
@@ -1,9 +1,9 @@
 diff --git a/nab-provider/src/nab_provider/_vendor/packaging/_markersets.py b/nab-provider/src/nab_provider/_vendor/packaging/_markersets.py
 new file mode 100644
-index 0000000..a1cd981
+index 0000000..d51010d
 --- /dev/null
 +++ b/nab-provider/src/nab_provider/_vendor/packaging/_markersets.py
-@@ -0,0 +1,1809 @@
+@@ -0,0 +1,1822 @@
 +"""Marker algebra engine: reason about PEP 508 markers as sets of environments.
 +
 +The private engine behind :class:`~packaging.markersets.MarkerSet`. Parses a
@@ -23,6 +23,7 @@ index 0000000..a1cd981
 +import re
 +import sys
 +import threading
++from functools import lru_cache
 +from itertools import pairwise, product
 +from typing import TYPE_CHECKING, NamedTuple, cast
 +
@@ -117,8 +118,20 @@ index 0000000..a1cd981
 +    return DOMAIN_REGISTRY[variable] == DOMAIN_VERSION
 +
 +
-+def _apply(lhs: str, op: str, rhs: str, key: str) -> bool:
++@lru_cache(maxsize=8192)
++def _apply_memoised(lhs: str, op: str, rhs: str, key: str, _limit: int) -> bool:
++    """Bounded memo behind :func:`_apply`; ``_limit`` only widens the cache key."""
 +    return _eval_op(lhs, Op(op), rhs, key=key)
++
++
++def _apply(lhs: str, op: str, rhs: str, key: str) -> bool:
++    """Evaluate ``op`` on a pair of literals under ``key``'s domain, memoised.
++
++    The int-string limit joins the four strings in the cache key: a version key
++    parses both operands, so a literal that compares under one limit raises
++    under another.
++    """
++    return _apply_memoised(lhs, op, rhs, key, sys.get_int_max_str_digits())
 +
 +
 +# --------------------------------------------------------------------- version util
@@ -178,7 +191,7 @@ index 0000000..a1cd981
 +    lazily from its own literal. Equality and hashing run off a field tuple
 +    precomputed at construction. A decision re-reads the same atom on the same point
 +    across partitions of one axis; that memo belongs to the operation, not here, so
-+    ``holds`` recomputes.
++    ``holds`` recomputes. The comparison it runs is memoised in :func:`_apply`.
 +    """
 +
 +    __slots__ = (


### PR DESCRIPTION
An offline 30-environment `nab lock --groups tests --project-default-group tests --no-emit-workspace` over a warm cache retires 21,447,780,521 instructions here against 21,526,874,090 on main: -79,093,569, or -0.367%. A second callgrind pair over the same two commits gave -77,588,511 (-0.361%).

The absolute counts drift about 0.04% between invocations because the offline run reads a cache directory it also writes, so pin the anchor to the committed lock's created-at when reproducing. The delta holds either way.

`_markersets._apply` compares two literals under a marker key, and a version key means building a `Specifier` and parsing both operands. The truth memo above it is keyed on the atom and scoped to one operation's `Memo`, so a new decision, a different tree, or a `store=None` call pays for the comparison again. The comparison is a pure function of its four strings, so it can be cached for the process instead.

Counts off the same lock, exact and reproducible on any machine:

| | main | branch |
| --- | ---: | ---: |
| `_apply` calls | 10,299 | 10,299 |
| comparisons run | 10,299 | 460 |
| `markers._eval_op` | 31,064 | 21,225 |
| `Specifier.__init__` | 8,803 | 7,888 |
| `Version.__init__` | 40,123 | 38,293 |
| total Python calls | 21,994,195 | 21,920,859 |

460 distinct comparisons back all 10,299 calls, ending at `hits=9839 misses=460 currsize=460` against a maxsize of 8192, so nothing is evicted. The widest lock in the suite, `release`, reaches `hits=29,770` on the same 460 entries.

The clock does not move. Interleaved paired A/B, locally:

| workload | wall | CPU | peak RSS |
| --- | ---: | ---: | ---: |
| lock, 20 pairs | +0.7% | +0.2% | -0.03% |
| canary, 12 pairs | +1.6% | +1.0% | -0.04% |

Every one is a no-difference result (p 0.30 to 0.59), and the smallest wall effect these runs could have resolved is 2.2% on the lock and 14% on the canary. The A/B is here to rule out a regression; the instruction count is the measurement, and RSS is flat to a 0.2% floor on the lock.

`sys.get_int_max_str_digits()` joins the cache key: a version comparison parses both operands, so a literal that compares under one int-string limit raises under a tighter one.

The change is in the vendored packaging tree, so `tasks/vendoring/packaging.patch` carries it too.
