### PR TITLE
Index each listing by version once, 5% fewer instructions on pip:trustllm

### DIFF
--- a/nab-provider/src/nab_provider/_provider/listing.py
+++ b/nab-provider/src/nab_provider/_provider/listing.py
@@ -23,7 +23,7 @@ from ..iso8601 import parse_iso_datetime
 from ..metadata import intern_version as _intern_version
 from ..policy import DistPolicy
 from ..vcs_admission import UnsupportedVcsError
-from .metadata_resolver import pick_dist, pick_dist_for_metadata
+from .metadata_resolver import pick_dist_for_metadata, version_dists
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -111,31 +111,6 @@ def versions_only(
                 seen.add(version)
                 cached.append(version)
         provider.versions_only_cache[normalized] = cached
-    return cached
-
-
-def wheel_by_version(
-    provider: Provider,
-    normalized: str,
-    version_list: list[tuple[Version, DistFile]],
-) -> dict[Version, DistFile]:
-    """Return the cached ``Version -> DistFile`` mapping for ``normalized``.
-
-    Each version maps to the dist
-    :func:`~nab_provider._provider.metadata_resolver.pick_dist` picks, so a
-    prefetch keyed off this mapping warms the metadata the read asks for.
-    """
-    cached = provider.wheel_by_version_cache.get(normalized)
-    if cached is None:
-        grouped: dict[Version, list[DistFile]] = {}
-        for version, dist in version_list:
-            grouped.setdefault(version, []).append(dist)
-
-        cached = {
-            version: pick_dist(dists, provider.wheel_tags, provider.target)
-            for version, dists in grouped.items()
-        }
-        provider.wheel_by_version_cache[normalized] = cached
     return cached
 
 
@@ -671,7 +646,8 @@ def prefetch_walk_ahead(
     first ``PREFETCH_BATCH`` window hits cache instead of paying one RTT
     per visit.
 
-    Takes each version's artifact from :func:`wheel_by_version`, so the
+    Takes each version's artifact from
+    :func:`~nab_provider._provider.metadata_resolver.version_dists`, so the
     sidecar it warms is the one the read asks for.  Skips already-cached
     versions, versions whose artifact publishes no sidecar, and versions
     whose metadata the coordinator already holds.  Fire-and-forget.
@@ -679,7 +655,7 @@ def prefetch_walk_ahead(
     versions_list = provider.versions_cache.get(normalized)
     if not versions_list:
         return
-    picked = wheel_by_version(provider, normalized, versions_list)
+    picked = version_dists(provider, normalized, versions_list).picked
     coordinator_index = provider.coordinator.index
 
     # Reverse out of place: ``versions_list`` is the shared cached listing.

--- a/nab-provider/src/nab_provider/_provider/metadata_resolver.py
+++ b/nab-provider/src/nab_provider/_provider/metadata_resolver.py
@@ -9,7 +9,7 @@ each ``Requires-Dist`` entry into base deps vs per-extra deps.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, TypeGuard
+from typing import TYPE_CHECKING, NamedTuple, TypeGuard
 from urllib.parse import urlsplit
 
 from nab_provider._vendor.packaging.ranges import VersionRange
@@ -88,9 +88,7 @@ def resolve_metadata(
     # Sibling wheels of one version can declare different dependencies, so the
     # read is keyed by the artifact this target would install.  ``versions`` is
     # the target's own tag-filtered listing, so the pick is per-target.
-    dist = pick_dist_for_metadata(
-        versions, version, provider.wheel_tags, provider.target
-    )
+    dist = version_dists(provider, normalized, versions).picked.get(version)
 
     # A wheel keys on its sidecar URL, or on its own URL when it publishes none.
     if isinstance(dist, WheelFile):
@@ -333,6 +331,53 @@ def pick_dist_for_metadata(
     """Pick the dist whose metadata answers for ``version``. See :func:`pick_dist`."""
     dists = [d for v, d in versions if v == version]
     return pick_dist(dists, tags, target) if dists else None
+
+
+class VersionDists(NamedTuple):
+    """One package's listing indexed by version.
+
+    ``picked`` is the dist :func:`pick_dist` answers with for each version.
+    ``sibling_wheels`` holds only the versions publishing more than one wheel:
+    the tie candidates for that version's pick.
+    """
+
+    picked: dict[Version, DistFile]
+    sibling_wheels: dict[Version, list[WheelFile]]
+
+
+def version_dists(
+    provider: Provider,
+    normalized: str,
+    version_list: Sequence[tuple[Version, DistFile]],
+) -> VersionDists:
+    """Index ``version_list`` by version, through the per-package memo.
+
+    Only the provider's own cached listing is memoised: another listing under
+    the same name is a different set of artifacts, so it is indexed fresh.
+    """
+    cacheable = version_list is provider.versions_cache.get(normalized)
+    if cacheable:
+        cached = provider.version_dists_cache.get(normalized)
+        if cached is not None:
+            return cached
+
+    grouped: dict[Version, list[DistFile]] = {}
+    for version, dist in version_list:
+        grouped.setdefault(version, []).append(dist)
+
+    picked: dict[Version, DistFile] = {}
+    sibling_wheels: dict[Version, list[WheelFile]] = {}
+    for version, dists in grouped.items():
+        picked[version] = pick_dist(dists, provider.wheel_tags, provider.target)
+        if len(dists) > 1:
+            wheels = [d for d in dists if isinstance(d, WheelFile)]
+            if len(wheels) > 1:
+                sibling_wheels[version] = wheels
+
+    indexed = VersionDists(picked, sibling_wheels)
+    if cacheable:
+        provider.version_dists_cache[normalized] = indexed
+    return indexed
 
 
 def pick_dist(
@@ -960,11 +1005,12 @@ def check_sibling_metadata_divergence(
     legitimately install.
     """
     tags = provider.wheel_tags
-    pick = pick_dist_for_metadata(versions, version, tags, provider.target)
+    _, _, normalized = provider.split_and_normalize(package)
+    indexed = version_dists(provider, normalized, versions)
+    pick = indexed.picked.get(version)
     if not isinstance(pick, WheelFile):
         return
 
-    _, _, normalized = provider.split_and_normalize(package)
     ver_str = str(version)
     index = provider.coordinator.index
 
@@ -972,10 +1018,7 @@ def check_sibling_metadata_divergence(
     if pick_text is None:
         return
 
-    wheels = [d for v, d in versions if v == version and isinstance(d, WheelFile)]
-    if tags is None:
-        # The pick came off the same narrowing, so it is one of these.
-        wheels = _python_axis_narrowed(provider.target, wheels)
+    wheels = _tie_candidate_wheels(provider, indexed, version, tags)
     if len(wheels) <= 1:
         return
 
@@ -1002,6 +1045,26 @@ def check_sibling_metadata_divergence(
             f" per-package dependencies override to resolve this version."
         )
         raise SiblingMetadataDivergenceError(msg)
+
+
+def _tie_candidate_wheels(
+    provider: Provider,
+    indexed: VersionDists,
+    version: Version,
+    tags: TagSet | None,
+) -> list[WheelFile]:
+    """Return the wheels of ``version`` that could tie the pick.
+
+    ``sibling_wheels`` holds only the versions publishing more than one wheel,
+    so a version missing from it ties nothing and answers empty.
+    """
+    wheels = indexed.sibling_wheels.get(version)
+    if wheels is None:
+        return []
+    if tags is None:
+        # The pick came off the same narrowing, so it is one of these.
+        return _python_axis_narrowed(provider.target, wheels)
+    return wheels
 
 
 def _tie_sibling_signature(

--- a/nab-provider/src/nab_provider/provider.py
+++ b/nab-provider/src/nab_provider/provider.py
@@ -579,7 +579,7 @@ class Provider:
 
         # Derived views of versions_cache, built lazily alongside the listing.
         self.versions_only_cache: dict[str, list[Version]] = {}
-        self.wheel_by_version_cache: dict[str, dict[Version, DistFile]] = {}
+        self.version_dists_cache: dict[str, _metadata_resolver.VersionDists] = {}
 
         # Widening state: the ascending versions_only view per normalized
         # name, the span-widened parent range per decided (name, version),
@@ -1035,8 +1035,11 @@ class Provider:
         normalized: str,
         version_list: list[tuple[Version, DistFile]],
     ) -> dict[Version, DistFile]:
-        """See :func:`nab_provider._provider.listing.wheel_by_version`."""
-        return _listing.wheel_by_version(self, normalized, version_list)
+        """Return the picked-dist view of ``normalized``'s listing.
+
+        See :func:`nab_provider._provider.metadata_resolver.version_dists`.
+        """
+        return _metadata_resolver.version_dists(self, normalized, version_list).picked
 
     def speculative_prefetch(
         self,


### PR DESCRIPTION
`Version.__eq__` on `pip:trustllm --resolution lowest` drops from 563,720 calls to 208,301, taking 8.4% off the resolve's total call count and 5.0% off its instruction count. It runs once per listing element scanned: each metadata read walked the package's whole `(Version, DistFile)` listing to find one version's artifacts, and the sibling-divergence check walked it again.

| Scenario | `Version.__eq__` | All calls | Instructions |
| --- | --- | --- | --- |
| `pip:trustllm` (lowest) | 563,720 -> 208,301 (-63.0%) | -8.37% | -5.01% |
| `pip:promptflow-vectordb` (lowest) | 135,559 -> 56,909 (-58.0%) | -1.64% | -1.07% |
| `uv:boto3-urllib3-transient` (lowest) | 133,601 -> 63,116 (-52.8%) | -3.30% | -1.94% |
| `big-packages:spacy` | 22,270 -> 8,131 (-63.5%) | -0.64% | -0.38% |

Both instruments are deterministic with `PYTHONHASHSEED=0` pinned, so the numbers reproduce on any machine. boto3 is in there as a small-listing control and still halves.

The clock did not move here: 12 interleaved pairs give wall -0.0% (p=0.38) and CPU -0.3% (p=0.09), on a run that could not have seen anything under about 9% of wall.

What the change does:

- `version_dists()` walks a package's listing once and returns two maps: the dist `pick_dist` answers with per version, and, for versions publishing more than one wheel, the wheels that could tie that pick.
- `resolve_metadata` and `check_sibling_metadata_divergence` read those maps instead of filtering the listing. `prefetch_transitive_best` still picks directly, since indexing there would build the map for packages no read reaches.
- The index is memoised per package, and only for the provider's own cached listing. A caller-supplied listing under the same name is a different set of artifacts, so it is indexed fresh.

The read path now indexes packages the prefetch path never did, so tracemalloc peak rises: about 0.04% on promptflow, and 0.02% to 0.37% (277 KB at the top) on boto3. Process peak RSS is flat over the 12 pairs (+0.00%, p=0.79).
