### PR TITLE
Probe the priority cache before the name split, -12% in prioritize

### DIFF
--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -8542,6 +8542,42 @@ class TestPrioritizeMatchingFromIndex:
             (k, v[0]) for k, v in provider.priority_cache.items()
         ]
 
+    def test_priority_cache_hit_yields_to_force_backtrack(self) -> None:
+        """A force-backtrack after the entry was stored still demotes the package."""
+        wheels = [make_wheel(v) for v in ("1.0", "2.0", "3.0")]
+        coordinator = make_coordinator(wheels, package="foo")
+        provider = Provider(coordinator)
+        intervals = SpecifierSet(">=1.0").to_range()
+        assert provider.prioritize("foo", intervals, {}, {})[0] == Provider.TIER_NORMAL
+
+        provider._force_backtrack_counts["foo"] = 1
+
+        assert provider.prioritize("foo", intervals, {}, {})[0] == Provider.TIER_CULPRIT
+
+    def test_priority_cache_hit_yields_to_dominant_culprit(self) -> None:
+        """A culprit count that crosses the threshold still demotes the package."""
+        wheels = [make_wheel(v) for v in ("1.0", "2.0", "3.0")]
+        coordinator = make_coordinator(wheels, package="foo")
+        provider = Provider(coordinator)
+        intervals = SpecifierSet(">=1.0").to_range()
+        assert provider.prioritize("foo", intervals, {}, {})[0] == Provider.TIER_NORMAL
+
+        demoted = provider.prioritize("foo", intervals, {}, {"foo": 10})
+
+        assert demoted[0] == Provider.TIER_CULPRIT
+
+    def test_priority_cache_hit_yields_to_new_conflict_count(self) -> None:
+        """A conflict count that crosses the threshold still promotes the package."""
+        wheels = [make_wheel(v) for v in ("1.0", "2.0", "3.0")]
+        coordinator = make_coordinator(wheels, package="foo")
+        provider = Provider(coordinator)
+        intervals = SpecifierSet(">=1.0").to_range()
+        assert provider.prioritize("foo", intervals, {}, {})[0] == Provider.TIER_NORMAL
+
+        promoted = provider.prioritize("foo", intervals, {"foo": 5}, {})
+
+        assert promoted[0] == Provider.TIER_AFFECTED
+
     def test_matching_cache_inner_dict_reused_for_new_range(self) -> None:
         """Two distinct ranges for the same package share the inner dict."""
         wheels = [make_wheel(v) for v in ("1.0", "2.0", "3.0")]

--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -8542,8 +8542,21 @@ class TestPrioritizeMatchingFromIndex:
             (k, v[0]) for k, v in provider.priority_cache.items()
         ]
 
+    def test_priority_cache_hit_skips_the_name_split(self) -> None:
+        """A hit answers from the entry's own name, without re-splitting."""
+        wheels = [make_wheel(v) for v in ("1.0", "2.0", "3.0")]
+        coordinator = make_coordinator(wheels, package="foo")
+        provider = Provider(coordinator)
+        intervals = SpecifierSet(">=1.0").to_range()
+        first = provider.prioritize("foo", intervals, {}, {})
+
+        provider._package_parts.clear()
+
+        assert provider.prioritize("foo", intervals, {}, {}) == first
+        assert provider._package_parts == {}
+
     def test_priority_cache_hit_yields_to_force_backtrack(self) -> None:
-        """A force-backtrack after the entry was stored still demotes the package."""
+        """A force-backtrack recorded after the entry was cached still demotes."""
         wheels = [make_wheel(v) for v in ("1.0", "2.0", "3.0")]
         coordinator = make_coordinator(wheels, package="foo")
         provider = Provider(coordinator)
@@ -8551,11 +8564,12 @@ class TestPrioritizeMatchingFromIndex:
         assert provider.prioritize("foo", intervals, {}, {})[0] == Provider.TIER_NORMAL
 
         provider._force_backtrack_counts["foo"] = 1
+        demoted = provider.prioritize("foo", intervals, {}, {})
 
-        assert provider.prioritize("foo", intervals, {}, {})[0] == Provider.TIER_CULPRIT
+        assert demoted[0] == Provider.TIER_CULPRIT
 
     def test_priority_cache_hit_yields_to_dominant_culprit(self) -> None:
-        """A culprit count that crosses the threshold still demotes the package."""
+        """A package that becomes the dominant culprit after caching still demotes."""
         wheels = [make_wheel(v) for v in ("1.0", "2.0", "3.0")]
         coordinator = make_coordinator(wheels, package="foo")
         provider = Provider(coordinator)
@@ -8567,7 +8581,7 @@ class TestPrioritizeMatchingFromIndex:
         assert demoted[0] == Provider.TIER_CULPRIT
 
     def test_priority_cache_hit_yields_to_new_conflict_count(self) -> None:
-        """A conflict count that crosses the threshold still promotes the package."""
+        """A conflict count that reaches the threshold after caching still promotes."""
         wheels = [make_wheel(v) for v in ("1.0", "2.0", "3.0")]
         coordinator = make_coordinator(wheels, package="foo")
         provider = Provider(coordinator)

--- a/nab-provider/src/nab_provider/_provider/priority.py
+++ b/nab-provider/src/nab_provider/_provider/priority.py
@@ -168,6 +168,24 @@ def prioritize(
     listing rather than ranking its absence.
     """
     provider.stats.prioritize_calls += 1
+
+    # A cached entry holds while its Range, conflict count and two demotion
+    # signals are unchanged.  It stores the normalized name so that check can
+    # read the counts without splitting `package` first.
+    cached = provider.priority_cache.get(package)
+    if cached is not None:
+        cached_range, cached_name, cached_affected, cached_priority = cached
+        if (
+            cached_range is version_range
+            and conflict_counts.get(cached_name, 0) == cached_affected
+            and (
+                culprit_counts is None
+                or culprit_counts.get(cached_name, 0) < CULPRIT_DEMOTE_THRESHOLD
+            )
+            and provider.force_backtrack_count(cached_name) == 0
+        ):
+            return cached_priority
+
     _, extra, normalized = provider.split_and_normalize(package)
     affected_count = conflict_counts.get(normalized, 0)
     culprit_count = (
@@ -175,18 +193,8 @@ def prioritize(
     )
     force_backtracked = provider.force_backtrack_count(normalized) > 0
 
-    # Fast path: when culprit_count is below the demote threshold AND the
-    # package was not force-backtracked, the tier depends only on
-    # affected_count and is safe to cache by Range identity.
+    # With neither demotion signal firing the tier depends only on affected_count.
     cacheable = culprit_count < CULPRIT_DEMOTE_THRESHOLD and not force_backtracked
-    if cacheable:
-        cached = provider.priority_cache.get(package)
-        if (
-            cached is not None
-            and cached[0] is version_range
-            and cached[1] == affected_count
-        ):
-            return cached[2]
 
     tier = compute_tier(
         normalized,
@@ -201,5 +209,10 @@ def prioritize(
     # Don't cache the in-flight placeholder; compute_matching's listing-arrival
     # side effect (speculative prefetch) lives in the cache-miss branch.
     if cacheable and normalized in provider.versions_cache:
-        provider.priority_cache[package] = (version_range, affected_count, priority)
+        provider.priority_cache[package] = (
+            version_range,
+            normalized,
+            affected_count,
+            priority,
+        )
     return priority

--- a/nab-provider/src/nab_provider/provider.py
+++ b/nab-provider/src/nab_provider/provider.py
@@ -570,11 +570,11 @@ class Provider:
         # (base, extra, normalized_name) per input package string.
         self._package_parts: dict[str, tuple[str, str | None, str]] = {}
 
-        # Fast-path priority cache, keyed by package + Range identity +
-        # affected count.  Range identity is sound because solution.get
-        # returns the same object until it changes.
+        # Fast-path priority cache: (Range, normalized name, affected count,
+        # priority) per package string.  Range identity is sound because
+        # solution.get returns the same object until it changes.
         self.priority_cache: dict[
-            str, tuple[RangeProtocol[Version], int, tuple[int, int, bool]]
+            str, tuple[RangeProtocol[Version], str, int, tuple[int, int, bool]]
         ] = {}
 
         # Derived views of versions_cache, built lazily alongside the listing.


### PR DESCRIPTION
Replaying the 996,497 `Provider.prioritize` calls captured from a `pip:airflow-october-regression` resolve, instructions drop 12.4%:

| | base | branch |
| --- | --- | --- |
| instructions | 9,113,044,356 | 7,981,778,214 |
| `split_and_normalize` calls | 997,463 | 48,302 |
| Python-level calls | 10,721,871 | 8,870,894 |

That is 1,131,266,142 instructions, or 1,135 per replayed call.

About 95% of those calls hit the memo, and every one of them still paid for the work that decides whether the memo applies before reaching the probe: `split_and_normalize`, two mapping lookups, then `force_backtrack_count`.

The cache entry now carries its own normalized name, `(Range, normalized, affected_count, priority)`. The probe runs first, and a hit revalidates against `conflict_counts`, `culprit_counts` and `force_backtrack_count` using the stored name, so `split_and_normalize` moves to the miss path.

Over a whole resolve on the same scenario that is about 911,000 fewer `split_and_normalize` calls, at an unchanged `prioritize` count.

The clock does not move. An interleaved 12-pair A/B over the canary finds no significant difference in wall, CPU or peak RSS: locally about 4% off wall and about 4% off CPU, both inside what 12 pairs can resolve (about 12% and 10%), and RSS flat.

The instruction and call counts are exact and reproduce with `PYTHONHASHSEED=0`; the timings are off my machine.
