### PR TITLE
Prepare the marker environment once per resolve, 37% off each evaluation

### DIFF
--- a/nab-provider/src/nab_provider/_provider/metadata_resolver.py
+++ b/nab-provider/src/nab_provider/_provider/metadata_resolver.py
@@ -18,7 +18,6 @@ from nab_provider._vendor.packaging.utils import canonicalize_name
 from nab_provider._vendor.packaging.version import InvalidVersion
 from nab_provider.records import RangeOutcome, SdistFile, WheelFile
 
-from ..conflict_kind import EMPTY_MEMBERSHIP_SETS
 from ..errors import (
     ForeignMetadataError,
     IncompatiblePythonError,
@@ -594,7 +593,7 @@ def marker_matches_base(provider: Provider, marker: Marker, marker_id: int) -> b
     result = provider.marker_base_cache.get(marker_id)
     if result is None:
         provider.consulted_markers.add(marker)
-        result = marker.evaluate({**provider.environment, **EMPTY_MEMBERSHIP_SETS})
+        result = marker.evaluate_prepared(provider.prepared_environment)
         provider.marker_base_cache[marker_id] = result
     return result
 
@@ -614,17 +613,22 @@ def marker_matched_extras(
     marker_id: int,
     provided_extras: set[str],
 ) -> set[str]:
-    """Return the extras for which the marker evaluates to True."""
+    """Return the extras for which the marker evaluates to True.
+
+    Writing ``extra`` straight into a prepared environment skips the
+    canonicalization ``prepare_environment`` does, so ``provided_extras`` must
+    already be canonical.
+    """
     per_marker = provider.marker_extra_cache.get(marker_id)
     if per_marker is None:
         per_marker = provider.marker_extra_cache[marker_id] = {}
-    env = provider.env_with_extra
+    env = provider.prepared_extra_environment
     matched: set[str] = set()
     for extra_name in provided_extras:
         result = per_marker.get(extra_name)
         if result is None:
             env["extra"] = extra_name
-            result = marker.evaluate(env)
+            result = marker.evaluate_prepared(env)
             per_marker[extra_name] = result
         if result:
             matched.add(extra_name)
@@ -876,15 +880,15 @@ def _classify_requirement_uncached(
     marker = req.marker
     if marker is None:
         return set()
-    if marker.evaluate({**provider.environment, **EMPTY_MEMBERSHIP_SETS}):
+    if marker.evaluate_prepared(provider.prepared_environment):
         return set()
     if "extra" not in str(marker):
         return None
-    env = dict(provider.env_with_extra)
+    env = dict(provider.prepared_extra_environment)
     matched: set[str] = set()
     for extra_name in provided_extras:
         env["extra"] = extra_name
-        if marker.evaluate(env):
+        if marker.evaluate_prepared(env):
             matched.add(extra_name)
     return matched or None
 

--- a/nab-provider/src/nab_provider/_vendor/packaging/PROVENANCE.md
+++ b/nab-provider/src/nab_provider/_vendor/packaging/PROVENANCE.md
@@ -28,11 +28,16 @@ most one checked-in patch.
   - `markersets.py` and `_markersets.py`: the marker-algebra module and the
     private engine behind it, both new files, plus the `Marker.to_set`
     accessor on `markers.py`.
+  - `markers.py`: `prepare_environment` with its `__all__` entry, and the
+    `Marker.evaluate_prepared` it feeds, so code evaluating many markers
+    against one environment builds it once. `evaluate` is now the two of them
+    composed.
 
   Upstream PRs are planned for the bound ordering, the direct subset and
-  disjoint walks, `filter`'s `assume_sorted` fast path, and
-  `from_bounds`/`snap_bounds`/`release_intervals`. `relation` is not proposed
-  yet: most of its win is available from the direct walks alone.
+  disjoint walks, `filter`'s `assume_sorted` fast path,
+  `from_bounds`/`snap_bounds`/`release_intervals`, and the prepared marker
+  environment. `relation` is not proposed yet: most of its win is available
+  from the direct walks alone.
 - `tasks/vendor-packaging.sh` fetches `pypa/packaging` at the pin, replaces this
   package with the pristine `src/packaging/` tree plus the repo-root license
   texts, and reapplies the patch. `--check` rebuilds into a temp location and

--- a/nab-provider/src/nab_provider/_vendor/packaging/markers.py
+++ b/nab-provider/src/nab_provider/_vendor/packaging/markers.py
@@ -30,6 +30,7 @@ __all__ = [
     "UndefinedComparison",
     "UndefinedEnvironmentName",
     "default_environment",
+    "prepare_environment",
 ]
 
 
@@ -378,6 +379,51 @@ def default_environment() -> Environment:
     return cast("Environment", dict(_cached_default_environment()))
 
 
+def prepare_environment(
+    environment: Mapping[str, str | AbstractSet[str]] | None = None,
+    context: EvaluateContext = "metadata",
+) -> dict[str, str | AbstractSet[str]]:
+    """Build the environment a marker is evaluated against.
+
+    The detected process environment merged with the ``context`` defaults and
+    ``environment``, with ``extra`` canonicalized. Code evaluating many markers
+    against one environment can build it once here and pass the result to
+    :meth:`Marker.evaluate_prepared`, rather than having :meth:`Marker.evaluate`
+    rebuild it on every call.
+
+    :param environment: Mapping containing keys and values to override the
+       detected environment.
+    :param EvaluateContext context: The context in which the marker is
+        evaluated, which influences what marker names are considered valid.
+        Accepted values are ``"metadata"`` (for core metadata; default),
+        ``"lock_file"``, and ``"requirement"`` (i.e. all other situations).
+    :returns: A fresh dict on every call, which the caller may mutate.
+
+    .. versionadded:: 26.3
+    """
+    current_environment = cast(
+        "dict[str, str | AbstractSet[str]]", default_environment()
+    )
+    if context == "lock_file":
+        current_environment |= {
+            "extras": frozenset(),
+            "dependency_groups": frozenset(),
+        }
+    elif context == "metadata":
+        current_environment["extra"] = ""
+
+    if environment is not None:
+        current_environment |= environment
+        if "extra" in current_environment:
+            # The API used to allow setting extra to None. We need to handle
+            # this case for backwards compatibility. Also skip running
+            # normalize name if extra is empty.
+            extra = cast("str | None", current_environment["extra"])
+            current_environment["extra"] = canonicalize_name(extra) if extra else ""
+
+    return _repair_python_full_version(current_environment)
+
+
 class Marker:
     """Represents a parsed dependency marker expression.
 
@@ -530,29 +576,22 @@ class Marker:
             Added the ``context`` parameter, which influences which marker names
             are considered valid.
         """
-        current_environment = cast(
-            "dict[str, str | AbstractSet[str]]", default_environment()
-        )
-        if context == "lock_file":
-            current_environment |= {
-                "extras": frozenset(),
-                "dependency_groups": frozenset(),
-            }
-        elif context == "metadata":
-            current_environment["extra"] = ""
+        return self.evaluate_prepared(prepare_environment(environment, context))
 
-        if environment is not None:
-            current_environment |= environment
-            if "extra" in current_environment:
-                # The API used to allow setting extra to None. We need to handle
-                # this case for backwards compatibility. Also skip running
-                # normalize name if extra is empty.
-                extra = cast("str | None", current_environment["extra"])
-                current_environment["extra"] = canonicalize_name(extra) if extra else ""
+    def evaluate_prepared(self, environment: dict[str, str | AbstractSet[str]]) -> bool:
+        """Evaluate a marker against an already-prepared environment.
 
-        return _evaluate_markers(
-            self._markers, _repair_python_full_version(current_environment)
-        )
+        :param environment: The result of a :func:`prepare_environment` call.
+        :raises UndefinedComparison: If the marker uses a comparison on values
+            that are not valid versions per the :ref:`specification of version
+            specifiers <pypug:version-specifiers>`.
+        :raises UndefinedEnvironmentName: If the marker references a value that
+            is missing from the evaluation environment.
+        :returns: ``True`` if the marker matches, otherwise ``False``.
+
+        .. versionadded:: 26.3
+        """
+        return _evaluate_markers(self._markers, environment)
 
 
 def _pep440_python_full_version(python_full_version: str) -> str:

--- a/nab-provider/src/nab_provider/provider.py
+++ b/nab-provider/src/nab_provider/provider.py
@@ -13,6 +13,7 @@ from collections import defaultdict, deque
 from dataclasses import dataclass, fields
 from typing import TYPE_CHECKING, cast
 
+from nab_provider._vendor.packaging.markers import prepare_environment
 from nab_provider._vendor.packaging.ranges import VersionRange
 from nab_provider._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
 from nab_provider._vendor.packaging.utils import canonicalize_name
@@ -467,12 +468,11 @@ class Provider:
             self, archive_sources or []
         )
 
-        # ``environment`` backs every marker evaluation; ``env_with_extra``
-        # is the reused per-evaluation copy of it, seeded with the empty
+        # ``env_with_extra`` is the marker environment plus the empty
         # lockfile-only set variables (see EMPTY_MEMBERSHIP_SETS).  Without a
-        # target both come from the host and ``python_version`` stays None,
-        # which turns the Requires-Python filter off: nothing has declared
-        # the Python a candidate could be rejecting (see _provider.listing).
+        # target it comes from the host and ``python_version`` stays None,
+        # which turns the Requires-Python filter off: nothing has declared the
+        # Python a candidate could be rejecting (see _provider.listing).
         if target is None:
             self.python_version: str | None = None
             self.environment: dict[str, str] = host_environment()
@@ -566,6 +566,13 @@ class Provider:
         self.marker_extra_cache: dict[int, dict[str, bool]] = {}
         # Memoised str(marker) for the cheap "extra" in marker_text gate.
         self.marker_text_cache: dict[int, str] = {}
+
+        # ``Marker.evaluate`` rebuilds its environment on every call, and this
+        # resolve's is fixed, so prepare it up front.  The base environment is
+        # never mutated; the extras one has ``extra`` written into it before
+        # each evaluation.
+        self.prepared_environment = prepare_environment(self.env_with_extra)
+        self.prepared_extra_environment = prepare_environment(self.env_with_extra)
 
         # (base, extra, normalized_name) per input package string.
         self._package_parts: dict[str, tuple[str, str | None, str]] = {}

--- a/tasks/vendoring/packaging.patch
+++ b/tasks/vendoring/packaging.patch
@@ -1890,6 +1890,116 @@ index e312a1f..9a611c3 100644
      def __hash__(self) -> int:
          return hash((self.version, self.inclusive))
  
+diff --git a/nab-provider/src/nab_provider/_vendor/packaging/markers.py b/nab-provider/src/nab_provider/_vendor/packaging/markers.py
+index 609099c..518aaed 100644
+--- a/nab-provider/src/nab_provider/_vendor/packaging/markers.py
++++ b/nab-provider/src/nab_provider/_vendor/packaging/markers.py
+@@ -30,6 +30,7 @@ __all__ = [
+     "UndefinedComparison",
+     "UndefinedEnvironmentName",
+     "default_environment",
++    "prepare_environment",
+ ]
+ 
+ 
+@@ -378,6 +379,51 @@ def default_environment() -> Environment:
+     return cast("Environment", dict(_cached_default_environment()))
+ 
+ 
++def prepare_environment(
++    environment: Mapping[str, str | AbstractSet[str]] | None = None,
++    context: EvaluateContext = "metadata",
++) -> dict[str, str | AbstractSet[str]]:
++    """Build the environment a marker is evaluated against.
++
++    The detected process environment merged with the ``context`` defaults and
++    ``environment``, with ``extra`` canonicalized. Code evaluating many markers
++    against one environment can build it once here and pass the result to
++    :meth:`Marker.evaluate_prepared`, rather than having :meth:`Marker.evaluate`
++    rebuild it on every call.
++
++    :param environment: Mapping containing keys and values to override the
++       detected environment.
++    :param EvaluateContext context: The context in which the marker is
++        evaluated, which influences what marker names are considered valid.
++        Accepted values are ``"metadata"`` (for core metadata; default),
++        ``"lock_file"``, and ``"requirement"`` (i.e. all other situations).
++    :returns: A fresh dict on every call, which the caller may mutate.
++
++    .. versionadded:: 26.3
++    """
++    current_environment = cast(
++        "dict[str, str | AbstractSet[str]]", default_environment()
++    )
++    if context == "lock_file":
++        current_environment |= {
++            "extras": frozenset(),
++            "dependency_groups": frozenset(),
++        }
++    elif context == "metadata":
++        current_environment["extra"] = ""
++
++    if environment is not None:
++        current_environment |= environment
++        if "extra" in current_environment:
++            # The API used to allow setting extra to None. We need to handle
++            # this case for backwards compatibility. Also skip running
++            # normalize name if extra is empty.
++            extra = cast("str | None", current_environment["extra"])
++            current_environment["extra"] = canonicalize_name(extra) if extra else ""
++
++    return _repair_python_full_version(current_environment)
++
++
+ class Marker:
+     """Represents a parsed dependency marker expression.
+ 
+@@ -530,29 +576,22 @@ class Marker:
+             Added the ``context`` parameter, which influences which marker names
+             are considered valid.
+         """
+-        current_environment = cast(
+-            "dict[str, str | AbstractSet[str]]", default_environment()
+-        )
+-        if context == "lock_file":
+-            current_environment |= {
+-                "extras": frozenset(),
+-                "dependency_groups": frozenset(),
+-            }
+-        elif context == "metadata":
+-            current_environment["extra"] = ""
+-
+-        if environment is not None:
+-            current_environment |= environment
+-            if "extra" in current_environment:
+-                # The API used to allow setting extra to None. We need to handle
+-                # this case for backwards compatibility. Also skip running
+-                # normalize name if extra is empty.
+-                extra = cast("str | None", current_environment["extra"])
+-                current_environment["extra"] = canonicalize_name(extra) if extra else ""
+-
+-        return _evaluate_markers(
+-            self._markers, _repair_python_full_version(current_environment)
+-        )
++        return self.evaluate_prepared(prepare_environment(environment, context))
++
++    def evaluate_prepared(self, environment: dict[str, str | AbstractSet[str]]) -> bool:
++        """Evaluate a marker against an already-prepared environment.
++
++        :param environment: The result of a :func:`prepare_environment` call.
++        :raises UndefinedComparison: If the marker uses a comparison on values
++            that are not valid versions per the :ref:`specification of version
++            specifiers <pypug:version-specifiers>`.
++        :raises UndefinedEnvironmentName: If the marker references a value that
++            is missing from the evaluation environment.
++        :returns: ``True`` if the marker matches, otherwise ``False``.
++
++        .. versionadded:: 26.3
++        """
++        return _evaluate_markers(self._markers, environment)
+ 
+ 
+ def _pep440_python_full_version(python_full_version: str) -> str:
 diff --git a/nab-provider/src/nab_provider/_vendor/packaging/markersets.py b/nab-provider/src/nab_provider/_vendor/packaging/markersets.py
 new file mode 100644
 index 0000000..638bc9e


### PR DESCRIPTION
`ai-stack:vllm-transformers-floor@highest` retires 11,454,927,780 instructions against 11,520,113,077 on main, 0.57% fewer, from building the marker environment once per resolve instead of once per marker. A repeat pair reads 11,520,234,222 -> 11,455,364,518. The counts here are exact; the timings at the end are local.

`Marker.evaluate` builds the environment it evaluates against: copy the cached defaults, merge the caller's overrides, canonicalize `extra`, repair `python_full_version`. That resolve evaluates 5,917 markers against an environment identical every time, so it built the same mapping 5,917 times.

The vendored packaging gains `prepare_environment()` and `Marker.evaluate_prepared()`, `evaluate` is the two composed, and the provider prepares its base and extras environments in `__init__`.

| calls | main | branch |
| --- | --- | --- |
| `default_environment` | 5,919 | 4 |
| `_repair_python_full_version` | 5,917 | 2 |
| `_pep440_python_full_version` | 5,917 | 2 |
| `canonicalize_name` | 18,001 | 12,384 |
| `typing.cast` | 66,740 | 37,463 |
| `str.replace` | 46,334 | 35,100 |
| all Python-level calls | 8,978,545 | 8,903,072 |

Measured on its own over a 2,000-marker corpus captured from that resolve, one evaluation costs 16,745 instructions instead of 26,548: 9,803 fewer, 37% off, at 5,917 calls a resolve.

The clock cannot see 0.57% and does not. Over 12 interleaved pairs of the full canary, locally, wall came out about 0.8% lower (p=0.09), CPU about 0.3% lower (p=0.20), peak RSS about 0.1% higher (p=0.57). The smallest differences those runs could have resolved are 7.0%, 4.8% and 2.4%, so none of the three moved.

`evaluate_prepared` sees the mapping `evaluate` would have built, so resolutions are unchanged. The extras path reuses one dict and rewrites `extra` before each call rather than holding a prepared dict per extra, which costs about 200 KB across the resolve and reads as an RSS regression (+0.06%, p=0.002).
