### PR TITLE
Stop materialising the whole candidate list in choose_version

### DIFF
--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -720,6 +720,18 @@ class TestFetchVersions:
         assert provider.stats.listings_fetched == 1
 
 
+class _CountingListing(list[Version]):
+    """A version listing that counts how many of its entries are read."""
+
+    def __init__(self, versions: list[Version]) -> None:
+        super().__init__(versions)
+        self.reads = 0
+
+    def __getitem__(self, index: Any) -> Any:
+        self.reads += 1
+        return super().__getitem__(index)
+
+
 class TestChooseVersion:
     def test_picks_newest_in_range(self) -> None:
         """choose_version returns the newest version passing the filter."""
@@ -728,6 +740,32 @@ class TestChooseVersion:
         provider = Provider(coordinator)
         spec = SpecifierSet(">=1.0,<3.0")
         assert provider.choose_version("foo", spec.to_range()) == V("2.0")
+
+    def test_accepted_pick_leaves_the_listing_tail_unread(self) -> None:
+        """An accepted look-ahead pick returns without reading the tail."""
+        versions = [f"1.{minor}" for minor in range(60)]
+        coordinator = make_coordinator(
+            [make_wheel(v) for v in versions],
+            metadata_by_version={
+                v: make_metadata("foo", v, "bar>=1.0") for v in versions
+            },
+            package="foo",
+        )
+        root_reqs = {"foo": VersionRange.full(admit_arbitrary=False)}
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
+
+        # The decided bar==3.0 satisfies bar>=1.0, so look-ahead accepts the pick.
+        provider.receive_partial_solution_hint({}, {"bar": V("3.0")})
+
+        listing = _CountingListing(
+            provider.versions_only("foo", provider.fetch_versions("foo"))
+        )
+        provider.versions_only_cache["foo"] = listing
+
+        assert provider.choose_version("foo", VersionRange.full()) == V("1.59")
+
+        # filter's sortedness check reads both ends; the pick is the third read.
+        assert listing.reads == 3
 
     def test_returns_none_when_no_match(self) -> None:
         """choose_version returns None when nothing matches."""

--- a/nab-provider/src/nab_provider/provider.py
+++ b/nab-provider/src/nab_provider/provider.py
@@ -67,7 +67,7 @@ from .vcs_admission import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping, Sequence
+    from collections.abc import Callable, Iterator, Mapping, Sequence
     from datetime import datetime
     from pathlib import Path
 
@@ -1091,27 +1091,38 @@ class Provider:
 
         version_list = self.fetch_versions(package)
         all_versions = self.versions_only(normalized, version_list)
-        candidates = list(
-            version_range.filter(all_versions, assume_sorted="descending")
-        )
-
-        # VersionRange.filter yields newest-first; reverse for LOWEST so
-        # look-ahead walks oldest -> newest.
-        if self.wants_lowest(normalized):
-            candidates.reverse()
+        candidates = self._ordered_candidates(normalized, version_range, all_versions)
+        first = next(candidates, None)
+        if first is None:
+            self._record_no_versions_reason(
+                package, all_versions, version_range=version_range
+            )
+            return None
 
         no_lookahead = not self.root_requirements and not self.solution_decisions
-        if no_lookahead or not candidates:
-            if not candidates:
-                self._record_no_versions_reason(
-                    package, all_versions, version_range=version_range
-                )
-            return candidates[0] if candidates else None
+        if no_lookahead:
+            return first
 
         wheel_by_version = self._wheel_by_version(normalized, version_list)
         return self._run_full_scan(
-            normalized, candidates, wheel_by_version, package, all_versions
+            normalized, first, candidates, wheel_by_version, package, all_versions
         )
+
+    def _ordered_candidates(
+        self,
+        normalized: str,
+        version_range: VersionRange,
+        all_versions: list[Version],
+    ) -> Iterator[Version]:
+        """Return the in-range versions in the order the strategy walks them.
+
+        ``VersionRange.filter`` yields newest-first, which is the order
+        HIGHEST wants; LOWEST has to read the whole listing to reverse it.
+        """
+        matches = version_range.filter(all_versions, assume_sorted="descending")
+        if self.wants_lowest(normalized):
+            return reversed(list(matches))
+        return matches
 
     def _preferred_version(
         self,
@@ -1230,25 +1241,29 @@ class Provider:
     def _run_full_scan(
         self,
         normalized: str,
-        candidates: list[Version],
+        first: Version,
+        rest: Iterator[Version],
         wheel_by_version: dict[Version, DistFile],
         package: str,
         all_versions: list[Version],
     ) -> Version | None:
-        """Run the decision-aware look-ahead scan over candidates."""
+        """Run the decision-aware look-ahead scan over candidates.
+
+        ``rest`` is only drawn from once ``first`` has been rejected.
+        """
         broad_rejections = 0
-        if self._look_ahead_ok(normalized, candidates[0], check_decisions=True):
+        if self._look_ahead_ok(normalized, first, check_decisions=True):
             self._flush_pending_blocks()
-            return candidates[0]
+            return first
         self.stats.look_ahead_rejections += 1
         broad_rejections += 1
 
         found = self._scan_candidates_pipelined(
             normalized,
-            candidates[1:],
+            list(rest),
             wheel_by_version,
             broad_rejections,
-            first_candidate=candidates[0],
+            first_candidate=first,
         )
         if found is not None:
             self._flush_pending_blocks()


### PR DESCRIPTION
`ai-stack:vllm-transformers-floor@highest` retires 15,345,906 fewer instructions (-0.133%), because an accepted look-ahead pick now reads 3 entries of a 60-entry listing instead of 62.

Instructions retired under callgrind, one run per arm. The counts are exact and reproduce on any machine:

| Scenario | main | branch | Delta |
| --- | --- | --- | --- |
| `ai-stack:vllm-transformers-floor@highest` | 11,523,714,726 | 11,508,368,820 | -15,345,906 (-0.133%) |
| `pip:ultralytics-export@highest` | 9,130,644,735 | 9,125,950,155 | -4,694,580 (-0.051%) |
| `ai-stack:rag-chroma-langchain@highest` | 953,821,636 | 953,826,229 | +4,593 (flat) |

The last row sits under the instrument's ~0.006% repeat floor, so read it as unchanged.

`choose_version` built the whole in-range candidate list on every call and then, in the usual case, used `candidates[0]` and dropped the rest. `_ordered_candidates` returns the `VersionRange.filter` iterator instead: HIGHEST takes its pick off the front and leaves the tail unconsumed, and `_run_full_scan` calls `list(rest)` only when look-ahead rejects that pick. LOWEST still reverses the matches, so it materialises exactly as before.

An effect this size does not show up on the clock. Over 12 interleaved pairs on the vllm scenario, locally: wall -0.4%, CPU -0.3%, peak RSS -0.02%, all no-difference, and the smallest wall effect those runs could have resolved is about 14%. The A/B is there to rule out a regression.
