### PR TITLE
Memoize WheelFile.metadata_url, 17% fewer instructions on its reads

### DIFF
--- a/nab-provider/src/nab_provider/records.py
+++ b/nab-provider/src/nab_provider/records.py
@@ -32,8 +32,22 @@ __all__ = [
 ACCEPTED_HASH_ALGORITHMS: tuple[str, ...] = ("sha256", "sha384", "sha512")
 
 
+class _MetadataUrlMemo:
+    """Slot holding :attr:`WheelFile.metadata_url` once it has been derived.
+
+    A slot rather than a dataclass field keeps the memo out of ``fields()``, so
+    it reaches neither equality, the repr, nor the pickled state. It sits on a
+    base class because ``@dataclass(slots=True)`` rejects a class that declares
+    ``__slots__`` in its own body.
+    """
+
+    __slots__ = ("_metadata_url",)
+
+    _metadata_url: str
+
+
 @dataclass(frozen=True, slots=True)
-class WheelFile:
+class WheelFile(_MetadataUrlMemo):
     """Wheel file record returned by the Simple-API client.
 
     ``hashes`` is a tuple of ``(algorithm, hex_digest)`` pairs in the
@@ -70,8 +84,13 @@ class WheelFile:
         if not self.has_metadata:
             return None
 
-        parts = urlsplit(self.url)
-        return urlunsplit(parts._replace(path=parts.path + ".metadata", fragment=""))
+        try:
+            return self._metadata_url
+        except AttributeError:
+            parts = urlsplit(self.url)
+            url = urlunsplit(parts._replace(path=parts.path + ".metadata", fragment=""))
+            object.__setattr__(self, "_metadata_url", url)
+            return url
 
 
 @dataclass(frozen=True, slots=True)

--- a/nab-provider/tests/test_records.py
+++ b/nab-provider/tests/test_records.py
@@ -1,0 +1,77 @@
+"""Tests for the value records a resolve is expressed in."""
+
+from __future__ import annotations
+
+import copy
+import pickle
+from collections.abc import Callable
+
+import pytest
+
+from nab_provider.records import WheelFile
+
+WHEEL_URL = "https://pypi.example/pkg-1.0-py3-none-any.whl"
+
+
+def make_wheel(*, has_metadata: bool = True) -> WheelFile:
+    """A wheel whose URL carries a PEP 503 hash fragment."""
+    return WheelFile(
+        filename="pkg-1.0-py3-none-any.whl",
+        url=f"{WHEEL_URL}#sha256=ab",
+        version="1.0",
+        requires_python=None,
+        has_metadata=has_metadata,
+        upload_time=None,
+    )
+
+
+def round_trip_pickle(wheel: WheelFile) -> WheelFile:
+    """A pickled and restored copy of ``wheel``."""
+    return pickle.loads(pickle.dumps(wheel))  # noqa: S301
+
+
+def test_metadata_url_appends_suffix_to_path() -> None:
+    """The suffix goes on the path, so the hash fragment is dropped."""
+    assert make_wheel().metadata_url == f"{WHEEL_URL}.metadata"
+
+
+def test_metadata_url_none_without_sidecar() -> None:
+    """A wheel the index advertised no sidecar for has no metadata URL."""
+    assert make_wheel(has_metadata=False).metadata_url is None
+
+
+def test_metadata_url_reuses_first_result() -> None:
+    """A second read returns the first string, not an equal rebuild."""
+    wheel = make_wheel()
+
+    assert wheel.metadata_url is wheel.metadata_url
+
+
+def test_memo_leaves_equality_and_hashing_alone() -> None:
+    """The memo writes past the frozen guard; the fields still decide both."""
+    read, unread = make_wheel(), make_wheel()
+    assert read.metadata_url is not None
+
+    assert read == unread
+    assert hash(read) == hash(unread)
+    assert len({read, unread}) == 1
+
+
+def test_memo_stays_out_of_repr() -> None:
+    """The memo is not a field, so it never reaches the generated repr."""
+    wheel = make_wheel()
+    assert wheel.metadata_url is not None
+
+    assert "_metadata_url" not in repr(wheel)
+
+
+@pytest.mark.parametrize("clone", [copy.copy, round_trip_pickle])
+def test_wheel_round_trips_either_side_of_first_read(
+    clone: Callable[[WheelFile], WheelFile],
+) -> None:
+    """Copy and pickle go by the fields, so the memo is neither needed nor carried."""
+    unread = make_wheel()
+    assert clone(unread) == unread
+
+    read = make_wheel()
+    assert read.metadata_url == clone(read).metadata_url


### PR DESCRIPTION
Memoizing takes 537,287,192 instructions off the `metadata_url` reads a canary run makes, -17.03%: 3,154,459,347 -> 2,617,172,155 on a replay of the captured read sequence (22,415 wheels, 49,880 reads, in the order the resolve made them). Counts in this body are exact and reproduce anywhere; the timings near the end are off my machine.

The property runs `urlsplit`, `_replace` and `urlunsplit` on every access, and most accesses repeat. Census over the canary scenarios:

| | count |
| --- | --- |
| `WheelFile` constructions | 989,534 |
| of those, `has_metadata=True` | 989,475 |
| `metadata_url` reads | 49,880 |
| distinct instances read | 22,415 |
| reads repeating an instance already read | 27,465 |

So 2.3% of the wheels built are ever asked for a metadata URL, and 55% of the reads are repeats. That is why this memoizes on first read rather than computing in `__post_init__`: precomputing pays for 989,475 wheels to serve 49,880 reads, memoizing pays for 22,415. Precomputing also loses `urlsplit`'s `lru_cache`, since one split per wheel never repeats a key; I measured that shape at +22.1% total calls and +29.6 MB peak traced bytes.

Call counts, offline canary with `PYTHONHASHSEED=0`:

| | before | after |
| --- | --- | --- |
| `urlsplit` (lru_cache misses) | 31,334 | 22,414 |
| `urlunsplit` | 49,895 | 22,421 |
| `namedtuple._replace` / `._make` | 49,888 | 22,414 |
| total calls | 159,615,625 | 159,130,924 |
| gen-0 collections | 8,140 | 8,104 |

The memo costs 8 bytes on every wheel (`sys.getsizeof` 112 -> 120) and about 198 more on each of the 22,415 that are read. Peak traced bytes go 321,899,229 -> 322,857,587.

What did not move: 12 interleaved pairs on the online canary show no wall difference (about -0.1%, p=0.79, and those runs could not have seen anything under 7.4%) and no CPU difference (about +0.4%, p=0.57, floor 5.8%). Peak RSS rises on a tight interval, locally about +0.4%, roughly 1.3 MB of a 364 MB median, agreeing with the +0.96 MB of traced peak.

The memo is a slot on a non-dataclass base, not a dataclass field. `field(default=None, init=False)` was the obvious shape and it regressed +0.827% instructions on a real scenario: under `slots=True` the dataclass emits an `object.__setattr__` for the default, so all 989,534 constructions pay for a memo 97.7% of them never use.

Staying out of `fields()` also keeps `copy` and `pickle` working, since `_dataclass_getstate` walks `fields()` and an unset `init=False` field raises `AttributeError` on a record nobody read. These records are dict and set keys, so `__eq__`, `__hash__` and the repr are untouched.
