### PR TITLE
Drop a quadratic scan from the root-extra check, 3% fewer instructions

### DIFF
--- a/nab-provider/src/nab_provider/_provider/extras.py
+++ b/nab-provider/src/nab_provider/_provider/extras.py
@@ -166,7 +166,8 @@ def _pick_for_user_extra(
     if constraint is not None:
         root_range = root_range & constraint
 
-    outside = [v for v in root_range.filter(all_versions) if v not in candidates]
+    admitted = set(candidates)
+    outside = [v for v in root_range.filter(all_versions) if v not in admitted]
     if not outside:
         return chosen
 


### PR DESCRIPTION
On `pip:ultralytics-export` the `v not in candidates` test in `_pick_for_user_extra` costs 206,403 element comparisons, walking 642 versions against a 642-element list. Hashing the candidates into a set first makes it 1,284 lookups.

| scenario | calls | walked x candidates | list comparisons | set hashes |
| --- | --- | --- | --- | --- |
| `pip:ultralytics-export` | 1 | 642 x 642 | 206,403 | 1,284 |
| `ecosystem:ultralytics-export-old` | 1 | 534 x 534 | 142,845 | 1,068 |
| `pip:pandas-aws-boto3` | 2 | 97 x 97 | 9,506 | 388 |
| `ecosystem:pandas-aws-boto3-2024` | 1 | 104 x 104 | 5,460 | 208 |
| `ecosystem:pandas-with-aws-s3` | 2 | 3 x 1 | 6 | 8 |
| `pip:kedro-test` | 1 | 1 x 1 | 1 | 2 |

206,403 is 642*643/2, so the scan is quadratic in the versions the root's range admits.

Call counts on `pip:ultralytics-export`, before -> after:

- `Version.__eq__` 227,698 -> 21,937
- `isinstance` 1,144,258 -> 938,491
- `Version.__hash__` 341,080 -> 342,362
- all Python-level calls 6,973,833 -> 6,563,436, -5.9%

The 642 comparisons that match are settled by `PyObject_RichCompareBool`'s identity check; the other 205,761 fall through to `Version.__eq__` and account for all of that drop. The set probe hits the same identity path, so it adds none back.

Instructions retired fall about 3% on `pip:ultralytics-export` (roughly 266M, three paired runs) and about 2.2% on `ecosystem:ultralytics-export-old`, 1,279 and 1,297 instructions per comparison dropped. Locally, about 2% off `pip:ultralytics-export` on CPU over 24 interleaved pairs; wall moves the same way but sits under that run's 2.1% floor, and peak RSS is flat.

Pins, decisions and conflicts are identical on both arms across all six scenarios, including `ecosystem:pandas-with-aws-s3`, where `outside` is non-empty and the function runs past the early return.

The counts are exact and reproduce anywhere; the timings are off my machine.
