### PR TITLE
Prefetch oldest candidate under a lowest strategy, 116 wasted fetches -> 15

### DIFF
--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -274,6 +274,52 @@ class TestSpeculativePrefetch:
         _package, version, _url, _hash = coordinator.calls_to("request_metadata")[-1]
         assert version == "2.0"
 
+    @pytest.mark.parametrize(
+        "strategy",
+        [ResolutionStrategy.LOWEST, ResolutionStrategy.LOWEST_DIRECT],
+    )
+    def test_transitive_prefetch_is_oldest_under_lowest(
+        self, strategy: ResolutionStrategy
+    ) -> None:
+        """Under a lowest strategy the warmed version is the one the scan starts on."""
+        wheels = [make_wheel(f"{i}.0") for i in range(20, 0, -1)]
+        coordinator = make_coordinator(wheels, package="foo")
+        provider = Provider(
+            coordinator,
+            target=_PY312,
+            resolution_strategy=strategy,
+            direct_packages=frozenset({"foo"}),
+        )
+        provider.fetch_versions("foo")
+        _package, version, _url, _hash = coordinator.calls_to("request_metadata")[-1]
+        assert version == "1.0"
+
+    @pytest.mark.parametrize(
+        "strategy",
+        [ResolutionStrategy.LOWEST, ResolutionStrategy.LOWEST_DIRECT],
+    )
+    def test_unconstrained_root_prefetch_is_oldest_under_lowest(
+        self, strategy: ResolutionStrategy
+    ) -> None:
+        """A root requirement that constrains nothing takes the same oldest-first pick.
+
+        ``speculative_prefetch`` routes a full root range to the single-candidate
+        path, so ``pick_best_candidate`` is what reads the strategy here.
+        """
+        wheels = [make_wheel(f"{i}.0") for i in range(20, 0, -1)]
+        coordinator = make_coordinator(wheels, package="foo")
+        provider = Provider(
+            coordinator,
+            target=_PY312,
+            root_requirements={"foo": VersionRange.full()},
+            resolution_strategy=strategy,
+            direct_packages=frozenset({"foo"}),
+        )
+        provider.fetch_versions("foo")
+        assert not coordinator.calls_to("request_metadata_batch")
+        _package, version, _url, _hash = coordinator.calls_to("request_metadata")[-1]
+        assert version == "1.0"
+
     def test_get_dependencies_uses_speculative_future(self) -> None:
         """get_dependencies picks up the speculatively prefetched metadata."""
         coordinator = make_coordinator(
@@ -7992,8 +8038,10 @@ class TestPrefetchWalkAhead:
         provider.prefetch_walk_ahead("foo")
         items = coordinator.calls_to("request_metadata_batch")[-1][0]
         versions = [ver for _, ver, _, _ in items]
+        # fetch_versions already prefetched 1.0, the oldest; it fills a window
+        # slot but is skipped as already-held.
         assert versions == [
-            f"{i}.0" for i in range(1, provider.DEEP_PREFETCH_COUNT + 1)
+            f"{i}.0" for i in range(2, provider.DEEP_PREFETCH_COUNT + 1)
         ]
 
     def test_skips_versions_with_cached_deps(self) -> None:

--- a/nab-provider/src/nab_provider/_provider/listing.py
+++ b/nab-provider/src/nab_provider/_provider/listing.py
@@ -26,7 +26,7 @@ from ..vcs_admission import UnsupportedVcsError
 from .metadata_resolver import pick_dist_for_metadata, version_dists
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Iterable, Mapping, Sequence
     from datetime import datetime
 
     from nab_provider._vendor.packaging.ranges import VersionRange
@@ -210,16 +210,21 @@ def pick_best_candidate(
     normalized: str,
     versions: list[tuple[Version, DistFile]],
 ) -> tuple[Version, DistFile] | None:
-    """Pick the version the resolver will most likely try first."""
-    if not versions:
-        return None
-    if normalized in provider.root_requirements:
-        version_range = provider.root_requirements[normalized]
-        for version, dist in versions:
-            if version in version_range:
-                return (version, dist)
-        return None
-    return versions[0]
+    """Pick the version the resolver will most likely try first.
+
+    ``versions`` is newest-first, the order a highest strategy scans, so a
+    package under a lowest strategy is read from the other end.
+    """
+    # Reverse out of place: ``versions`` is the shared cached listing.
+    ordered: Iterable[tuple[Version, DistFile]] = (
+        reversed(versions) if provider.wants_lowest(normalized) else versions
+    )
+
+    version_range = provider.root_requirements.get(normalized)
+    for version, dist in ordered:
+        if version_range is None or version in version_range:
+            return (version, dist)
+    return None
 
 
 def filter_distributions(


### PR DESCRIPTION
Under `--resolution lowest` the transitive prefetch warmed 134 versions across six scenarios and the resolve read metadata for 18 of them. Warming the version the candidate scan starts on takes that to 40 warmed and 25 read: warmed-but-never-read metadata requests go 116 -> 15, an overlap of 13.4% -> 62.5%.

`pick_best_candidate` returned `versions[0]` off a newest-first listing whatever the strategy, so `prefetch_transitive_best` warmed the newest version while the candidate scan walked from the oldest end. It now reads the listing from the oldest end when `wants_lowest` holds, the same reversal `prefetch_root_batch` and `prefetch_walk_ahead` already do.

Warmed-but-never-read per scenario under `--resolution lowest`, from `pip.toml` and `ecosystem.toml`:

| scenario | before | after |
| --- | --- | --- |
| `pip:sphinx` | 50 | 7 |
| `ecosystem:ultralytics-modern` | 33 | 1 |
| `ecosystem:ray-tune-sklearn` | 25 | 5 |
| `ecosystem:boto3-pin-botocore` | 4 | 1 |
| `pip:starlette-fastapi` | 3 | 1 |
| `pip:django-stubs` | 1 | 0 |

Those counts repeat for anyone running both arms off the same HTTP cache with `PYTHONHASHSEED=0`. The timings below are local.

- `--resolution lowest-direct` is flat, 37 never-read on both arms: a direct package with a constrained root range already takes the batch path.
- Pins are identical on all 12 legs and `metadata_fetched` is identical at 296, so the resolve reads the same metadata and only the wasted warming drops.
- Wall and CPU do not move over 12 interleaved pairs, +0.3% and +1.0%; the smallest effect these legs could have resolved was 6.3% wall and 4.7% CPU. Peak RSS is about 0.5% lower.
- One decision count moves, `pip:sphinx --resolution lowest` 422 -> 417. `prioritize` scores a package whose listing has not arrived as `_NO_LISTING_PRIOR`, so changing what is in flight changes decision order. Both arms are stable at their own value.
