### PR TITLE
Use a deque for the reachability BFS queue, 2.6% off the walk

### DIFF
--- a/nab-resolver/src/nab_resolver/result.py
+++ b/nab-resolver/src/nab_resolver/result.py
@@ -11,6 +11,7 @@ Reference: https://github.com/dart-lang/pub/blob/master/doc/solver.md#result
 
 from __future__ import annotations
 
+from collections import deque
 from typing import TYPE_CHECKING, Any
 
 from .types import IncompatibilityCause, PackageType, VersionType
@@ -60,9 +61,9 @@ def build_solution_data(
     # recording each dependency crossed on the way.
     edges: list[tuple[PackageType, PackageType]] = []
     reachable: set[PackageType] = set()
-    queue: list[PackageType] = list(root_required)
+    queue: deque[PackageType] = deque(root_required)
     while queue:
-        package = queue.pop(0)
+        package = queue.popleft()
         if package in reachable:
             continue
         reachable.add(package)


### PR DESCRIPTION
`build_solution_data` retires 28,666 fewer instructions per call on a graph captured from `forums:so-dbt-core-snowflake-79744735`, and 64,974 fewer on `pip:langchain-ml-course`. Its BFS queue is a list, so `pop(0)` shifts every remaining element on each dequeue; a `collections.deque` and `popleft()` do not.

| graph | pins / edges | dequeues | element shifts | instructions per call |
| --- | --- | --- | --- | --- |
| so-dbt-core-snowflake | 179 / 367 | 242 | 13,101 | -28,666 (-2.60%) |
| langchain-ml-course | 246 / 497 | 397 | 46,847 | -64,974 (-3.99%) |

Callgrind counts with `PYTHONHASHSEED=0`, replaying the real function over graphs captured from real resolves, so they reproduce anywhere; doubling the replays doubles the delta. A harness that instead keeps the provider's real `get_dependencies` behind a live resolve gives -32,425 per call on the so-dbt graph.

The step runs once per successful solve, so the end-to-end saving is small. One pass of the canary set (16 solves) does 2,074 dequeues over 100,461 shifted elements, widest frontier 136; fitting the two graphs above at about 80 instructions per dequeue plus 0.71 per element puts that pass at roughly 237,000 instructions.

Nothing regresses: 12 interleaved pairs give wall -2.3% (p=1), CPU -2.8% (p=0.85) and peak RSS -0.014% (p=0.18), all no-difference, over runs that could not have resolved an effect below 12%, 10% and 0.8%. Those timings are local; the counts above are not.
