### PR TITLE
Invalidate only the packages a backjump popped, 31% fewer cache misses

### DIFF
--- a/nab-resolver/src/nab_resolver/partial_solution.py
+++ b/nab-resolver/src/nab_resolver/partial_solution.py
@@ -260,8 +260,11 @@ class PartialSolution(Generic[PackageType, VersionType]):
         """
         self._contradiction_epoch += 1
 
+        # Trail levels never decrease, so this pops exactly the assignments above
+        # target_level; every other package keeps the positive and negative ranges
+        # its cached effective range was derived from.
         while self._assignments and self._assignments[-1].decision_level > target_level:
-            self._assignments.pop()
+            self._effective_range_cache.pop(self._assignments.pop().package, None)
 
         self._decision_level = target_level
 
@@ -281,8 +284,6 @@ class PartialSolution(Generic[PackageType, VersionType]):
 
         for package in empty_packages:
             del self._assignments_by_package[package]
-
-        self._effective_range_cache.clear()
 
     def _update_package_state_after_backtrack(
         self,

--- a/nab-resolver/tests/test_partial_solution.py
+++ b/nab-resolver/tests/test_partial_solution.py
@@ -194,6 +194,23 @@ class TestMultipleDerivations:
         assert ps.decisions() == {"foo": 3}
         assert ps.undecided_packages() == set()
 
+    def test_backtrack_keeps_untouched_effective_ranges_cached(self) -> None:
+        """Only a package whose trail the backjump popped loses its cached range."""
+        ps = PartialSolution()
+        inc = Incompatibility([], cause=IncompatibilityCause.ROOT)
+        # foo sits at level 0; the decision on bar puts bar and baz above it.
+        ps.derive("foo", Range.at_least(1), positive=True, cause=inc)
+        ps.decide("bar", 1)
+        ps.derive("baz", Range.at_least(2), positive=True, cause=inc)
+
+        foo_range = ps.get("foo")
+        ps.backtrack(0)
+
+        assert ps._effective_range_cache["foo"] is foo_range
+
+        assert "bar" not in ps._effective_range_cache
+        assert "baz" not in ps._effective_range_cache
+
     def test_satisfier_with_multiple_positive_derivations(self) -> None:
         """satisfier walks through multiple positive derivations."""
         ps = PartialSolution()

--- a/nab-resolver/tests/test_range_benchmark.py
+++ b/nab-resolver/tests/test_range_benchmark.py
@@ -64,7 +64,7 @@ SUITE_PROFILE = {
         membership_tests=448,
         intervals_seen=892,
         largest_range=8,
-        hash_misses=116,
+        hash_misses=111,
         equality_calls=471,
     ),
     "conflict-free-fanout": Profile(


### PR DESCRIPTION
On `ecosystem:pandas-with-aws-s3 --resolution lowest` a resolve refills the effective-range cache 9,685 fewer times: misses drop 30,939 -> 21,254 over an unchanged 784,778 `PartialSolution.get` calls.

`backtrack()` cleared the whole cache. Only the packages it pops can go stale; every other one keeps the positive and negative ranges its cached range was derived from. The trail loop already walks each assignment it removes, and every assignment names its package, so the pop rides that loop.

How much comes off tracks how often a scenario backjumps, not how big the resolve is (pandas-with-aws-s3 backjumps 1,147 times, datacontract-cli 7):

| Scenario | Refills removed | Cache misses | Share |
| --- | --- | --- | --- |
| `pandas-with-aws-s3 --lowest` | 9,685 | 30,939 | 31.3% |
| `vllm-transformers-floor --highest` | 1,313 | 6,622 | 19.8% |
| `datacontract-cli --lowest` | 96 | 728 | 13.2% |
| `pandas-aws-boto3-dandi-frenzy --lowest` | 118 | 906 | 13.0% |
| `promptflow-vectordb --lowest` | 50 | 676 | 7.4% |
| `trustllm --lowest` | 35 | 1,330 | 2.6% |

Those counts are exact and reproduce anywhere. Under callgrind, an offline replay of the captured `PartialSolution` trail with no index and no event loop retires 4.2% fewer instructions on pandas-with-aws-s3, 180,541,590 per resolve, and 0.38% fewer on datacontract-cli, 135,906 per resolve. Some of that is the provider's priority cache, whose entry holds only while the range object is identical (`cached_range is version_range`), so a range that survives a backjump hits there too.

Nothing moves on the clock: 12 interleaved pairs of the canary read about -0.9% wall, -0.5% CPU and +0.01% RSS locally, none of them significant, and those legs could not have resolved a wall effect under about 7%. The search is unchanged, the same 1,373 decisions and 1,082 conflicts on pandas-with-aws-s3.
