### PR TITLE
Raise restart threshold to 8 conflicts on one package, 3.4% fewer decisions

### DIFF
--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -407,7 +407,8 @@ class Resolver(Generic[PackageType, VersionType]):
     Reference: https://github.com/dart-lang/pub/blob/master/doc/solver.md#the-algorithm
     """
 
-    _RESTART_THRESHOLD = 5
+    # Compared against one package's conflict count, not the total.
+    _RESTART_THRESHOLD = 8
     _MAX_RESTARTS = 3
 
     # A package re-queues every multiple of CULPRIT_THRESHOLD so persistent

--- a/nab-resolver/tests/test_range_benchmark.py
+++ b/nab-resolver/tests/test_range_benchmark.py
@@ -58,14 +58,14 @@ class Profile(NamedTuple):
 
 SUITE_PROFILE = {
     "wrong-package-backtracking": Profile(
-        rounds=41,
-        decisions=27,
+        rounds=40,
+        decisions=26,
         conflicts=14,
-        membership_tests=448,
-        intervals_seen=892,
+        membership_tests=435,
+        intervals_seen=827,
         largest_range=8,
-        hash_misses=111,
-        equality_calls=471,
+        hash_misses=102,
+        equality_calls=412,
     ),
     "conflict-free-fanout": Profile(
         rounds=8,

--- a/nab-resolver/tests/test_resolver.py
+++ b/nab-resolver/tests/test_resolver.py
@@ -125,7 +125,11 @@ class DictProvider:
 
 
 class PromotingProvider(DictProvider):
-    """DictProvider that promotes packages with 5+ conflicts."""
+    """DictProvider that promotes packages with 5+ conflicts.
+
+    The threshold is the provider's own, not the resolver's restart
+    threshold.
+    """
 
     _CONFLICT_THRESHOLD = 5
 
@@ -1585,19 +1589,19 @@ class TestBackjumpToRoot:
 class TestRestart:
     """Verify the resolver restarts when a package causes many conflicts."""
 
-    def test_restart_reduces_decisions(self) -> None:
-        """Restart with conflict-driven promotion avoids re-deciding
-        downstream packages on every backtrack.
+    def test_restart_fires_on_repeated_conflicts(self) -> None:
+        """A package that keeps conflicting triggers a restart, and the
+        resolve still lands on the only solution.
 
         root -> a (any), b (any)
         a has versions 10..1, each requiring b >= v (so a@10 -> b>=10, etc.)
         b only has version 1.
         Only a@1 is compatible (b>=1 satisfied by b@1).
 
-        Without restart: resolver decides b first (fewer versions),
-        then tries a@10, conflict, backtracks, re-decides b, tries a@9, etc.
-        With restart: after 5 conflicts, a is promoted, decided first,
-        and b is only decided once at the end.
+        The resolver decides b first (fewer versions), then walks a down
+        from 10, conflicting on each version. Ten versions are too few
+        for a restart to pay for itself, so the decision count asserted
+        below is a ceiling rather than a saving.
         """
         a_versions = {}
         for v in range(10, 0, -1):
@@ -1619,12 +1623,12 @@ class TestRestart:
 
     def test_restarts_are_bounded(self) -> None:
         """Resolver stops restarting after _MAX_RESTARTS."""
-        # 50 versions of "a", each requiring b >= v. Only a@1 works.
-        # With threshold=5 and max_restarts=3, restarts fire at
-        # conflicts 5, 10, 20. After 3 restarts (exhausting the
-        # budget), resolution continues without further restarts.
+        # 70 versions of "a", each requiring b >= v. Only a@1 works.
+        # "a" takes every conflict and the threshold doubles per restart,
+        # so restarts fire at 8, 16 and 32. The corpus reaches the 64 a
+        # fourth would need, so the spent budget is what stops it.
         a_versions = {}
-        for v in range(50, 0, -1):
+        for v in range(70, 0, -1):
             a_versions[v] = {"b": Range.at_least(v)}
 
         provider = PromotingProvider(


### PR DESCRIPTION
Decisions fall 3.42% on the benchmark scenarios that resolve in every run, 126,587 -> 122,254, against a 0.05% run-to-run spread.

| set | before | after | delta |
| --- | --- | --- | --- |
| decisions, 33 scenarios that resolve in every run | 126,587 | 122,254 | -3.42% |
| decisions, 42 scenarios that resolve in both arms | 132,454 | 124,103 | -6.30% |
| packages visited, the same 42 | 5,143 | 5,154 | +11 |

Zero pass to fail. Packages visited is the only counter that went the other way, by 11 across those 42 scenarios. Both are resolver counts taken with `PYTHONHASHSEED=0`, not timings; metadata arrival order still shifts them a little run to run, which is what the 0.05% spread measures.

`_RESTART_THRESHOLD` is checked against one package's conflict count (`max(stats.package_conflict_counts.values())`), `TARGETED_BT_MIN_CONFLICTS` against the resolve's running total, so 5 sitting below 30 was never an ordering between the two. A restart throws away the partial solution and clears the pending targeted backtracks, and at 5 it does that early enough to cost decisions on the conflict-heavy scenarios.

What stays put:

- `_MAX_RESTARTS` at 3 and `MAX_TARGETED_BACKTRACKS` at 64. Neither was varied.
- `TARGETED_BT_MIN_CONFLICTS` at 30. Dropping it to 5 alongside costs +5.70% decisions over the 228 non-live scenarios that resolve once `pip:pip-13281-airflow-crest` is set aside, and more than doubles 29 of them.
- The easy corpus, which cannot reach this knob: it needs 8 conflicts on one package, and only 3 of the 434 non-live scenarios reach 5 conflicts in total.

The 10-version restart test credited the restart with saving decisions on its graph. It does not. Counts on the tests' own `PromotingProvider`, one run per arm:

| graph | restarts off | threshold 5 | threshold 8 |
| --- | --- | --- | --- |
| 10 versions of `a` | 13 decisions | 20 | 23 |
| 50 versions of `a` | 86 decisions | 60 | 63 |

Promotion on that graph is the provider's own 5-conflict rule, which fires before any restart. The test is renamed for what it checks, and its decision bound is documented as a ceiling. The bounded-restart test grows to 70 versions of `a` so the corpus reaches the 64 conflicts a fourth restart would need: the threshold doubles per restart, firing at 8, 16 and 32, and the spent budget is what stops it.

Locally, 12 interleaved canary pairs show nothing on the clock: wall +0.1% (p=0.91), CPU +0.2% (p=0.91), peak RSS -0.1% (p=0.26). Those runs could not have resolved a wall effect below about 5%, so this is a non-regression check, not a speed claim.
