### PR TITLE
Validate cache key segments with basename instead of building a Path

### DIFF
--- a/nab-index/src/nab_index/cache.py
+++ b/nab-index/src/nab_index/cache.py
@@ -163,8 +163,14 @@ def _require_single_segment(component: str) -> str:
     an embedded separator expands to a nested path, and ``.`` or ``..``
     names a parent, so either would read or write a different file than
     the key describes and return the wrong cache entry.
+
+    Separator syntax follows the running platform: on Windows a backslash
+    separates segments and ``C:`` prefixes a drive, while POSIX reads both
+    as ordinary filename characters.
     """
-    if component in ("", ".", "..") or component != Path(component).name:
+    # A string test, not path handling: Path.name would build a path object per call.
+    basename = os.path.basename(component)  # noqa: PTH119
+    if component in ("", ".", "..") or component != basename:
         msg = f"cache key component is not a single path segment: {component!r}"
         raise ValueError(msg)
     return component

--- a/nab-project/tests/test_cache.py
+++ b/nab-project/tests/test_cache.py
@@ -33,6 +33,7 @@ from nab_index.cache import (
     _atomic_write,
     _encode_policy,
     _index_dirname,
+    _require_single_segment,
 )
 from nab_index.vcs import VcsRequest, prepare_clone
 from nab_provider.serialization import SimpleSerialization
@@ -201,6 +202,32 @@ class TestAtomicWrite:
         monkeypatch.setattr("nab_index.atomic.os.replace", spy_replace)
         atomic_write_text(tmp_path / "x.txt", "data")
         assert calls == ["fsync", "replace"]
+
+
+class TestRequireSingleSegment:
+    def test_single_segment_component_is_returned(self) -> None:
+        assert _require_single_segment("foo-1.0") == "foo-1.0"
+
+    @pytest.mark.parametrize("component", ["", ".", "..", "foo/", "foo/bar"])
+    def test_component_that_is_not_one_segment_is_rejected(
+        self, component: str
+    ) -> None:
+        with pytest.raises(ValueError, match="not a single path segment"):
+            _require_single_segment(component)
+
+    @pytest.mark.parametrize("component", ["foo\\bar", "C:", "C:x"])
+    def test_windows_path_syntax_follows_the_running_platform(
+        self, component: str
+    ) -> None:
+        """Windows reads a backslash as a separator and ``C:`` as a drive prefix.
+
+        POSIX reads both as ordinary filename characters.
+        """
+        if os.sep == "\\":
+            with pytest.raises(ValueError, match="not a single path segment"):
+                _require_single_segment(component)
+        else:
+            assert _require_single_segment(component) == component
 
 
 class TestOnDiskCache:


### PR DESCRIPTION
`_require_single_segment` guards every cache key component, and it was building a `Path` and reading `.name` to answer a question about a string. It now asks `os.path.basename` directly:

    basename = os.path.basename(component)
    if component in ("", ".", "..") or component != basename:

The guard goes from 1,438 ns per call to 209 ns, timed over the 727 components a warm `pip:google-bigquery-soda` run actually passes it, ten interleaved pairs, p=0.002. Instructions agree: 19,519 per call to 3,043.

That scenario makes 729 such calls, so the saving is about 0.9 ms against a run of roughly 800 ms. Small, and worth stating plainly rather than dressing up: this is a cheaper guard, not a faster resolve.

The end-to-end canary A/B rules out a regression above about 8%, which is all a run that size can say about an effect this small.

Behaviour is unchanged where it matters. `basename` is what decides where a separator is, so a backslash component is still accepted on POSIX and rejected on Windows, and `C:x` stays rejected. Across 22,634 strings on both posixpath and ntpath under 3.10 to 3.14 the old and new forms agree everywhere but one case: on Windows under 3.10 and 3.11 the new form also rejects `<non-letter>:<rest>`, such as `1:a`, which pathlib accepted. A key component is a canonical package name or a version string, and neither can contain a colon.
