### PR TITLE
Build each dependency specifier's range once, ~2% off a resolve

### DIFF
--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -3010,29 +3010,43 @@ class TestAddClassifiedDep:
 
     def test_base_deps_intersect(self) -> None:
         """A name seen twice as a base dep folds to the intersection."""
+        ranges: dict[str, VersionRange] = {}
         base: dict[str, VersionRange] = {}
         extra_map: dict[str, dict[str, VersionRange]] = {}
-        add_classified_dep(Requirement("bar>=2.0"), set(), base, extra_map)
-        add_classified_dep(Requirement("bar<5.0"), set(), base, extra_map)
+        add_classified_dep(Requirement("bar>=2.0"), set(), base, extra_map, ranges)
+        add_classified_dep(Requirement("bar<5.0"), set(), base, extra_map, ranges)
+
         assert V("3.0") in base["bar"]
         assert V("1.0") not in base["bar"]
         assert V("9.0") not in base["bar"]
+
+        # The memoized range is shared, so folding must leave it as it was.
+        assert V("9.0") in ranges[">=2.0"]
 
     def test_extra_deps_intersect(self) -> None:
         """A name seen twice under one extra folds to the intersection."""
         base: dict[str, VersionRange] = {}
         extra_map: dict[str, dict[str, VersionRange]] = {"x": {}}
-        add_classified_dep(Requirement("bar>=2.0"), {"x"}, base, extra_map)
-        add_classified_dep(Requirement("bar<5.0"), {"x"}, base, extra_map)
+        add_classified_dep(Requirement("bar>=2.0"), {"x"}, base, extra_map, {})
+        add_classified_dep(Requirement("bar<5.0"), {"x"}, base, extra_map, {})
         assert V("3.0") in extra_map["x"]["bar"]
         assert V("1.0") not in extra_map["x"]["bar"]
         assert V("9.0") not in extra_map["x"]["bar"]
+
+    def test_repeated_specifier_builds_one_range(self) -> None:
+        """Two deps spelling one specifier share the range built for it."""
+        ranges: dict[str, VersionRange] = {}
+        base: dict[str, VersionRange] = {}
+        add_classified_dep(Requirement("bar>=2.0"), set(), base, {}, ranges)
+        add_classified_dep(Requirement("baz >= 2.0"), set(), base, {}, ranges)
+        assert list(ranges) == [">=2.0"]
+        assert base["bar"] is base["baz"]
 
     def test_base_multi_extra_splits_into_one_proxy_each(self) -> None:
         """``bar[a,b]`` as a base dep records ``bar`` plus a proxy per extra."""
         base: dict[str, VersionRange] = {}
         extra_map: dict[str, dict[str, VersionRange]] = {}
-        add_classified_dep(Requirement("bar[a,b]>=1.0"), set(), base, extra_map)
+        add_classified_dep(Requirement("bar[a,b]>=1.0"), set(), base, extra_map, {})
         assert V("2.0") in base["bar"]
         assert V("0.5") not in base["bar"]
         assert base["bar[a]"] == VersionRange.full(admit_arbitrary=False)
@@ -3042,7 +3056,7 @@ class TestAddClassifiedDep:
         """``bar[a,b]`` under extra ``x`` records both proxies in that bucket."""
         base: dict[str, VersionRange] = {}
         extra_map: dict[str, dict[str, VersionRange]] = {"x": {}}
-        add_classified_dep(Requirement("bar[a,b]>=1.0"), {"x"}, base, extra_map)
+        add_classified_dep(Requirement("bar[a,b]>=1.0"), {"x"}, base, extra_map, {})
         assert V("2.0") in extra_map["x"]["bar"]
         assert extra_map["x"]["bar[a]"] == VersionRange.full(admit_arbitrary=False)
         assert extra_map["x"]["bar[b]"] == VersionRange.full(admit_arbitrary=False)
@@ -3052,7 +3066,7 @@ class TestAddClassifiedDep:
         """Proxy keys for the dep's extras are PEP 685 normalized."""
         base: dict[str, VersionRange] = {}
         extra_map: dict[str, dict[str, VersionRange]] = {}
-        add_classified_dep(Requirement("bar[A_x,B.y]"), set(), base, extra_map)
+        add_classified_dep(Requirement("bar[A_x,B.y]"), set(), base, extra_map, {})
         assert "bar[a-x]" in base
         assert "bar[b-y]" in base
 
@@ -3063,7 +3077,7 @@ class TestAddClassifiedDep:
         req = Requirement("bar[x,y,z]")
         monkeypatch.setattr(req, "extras", ["z", "y", "x"])
         base: dict[str, VersionRange] = {}
-        add_classified_dep(req, set(), base, {})
+        add_classified_dep(req, set(), base, {}, {})
         assert list(base) == ["bar", "bar[x]", "bar[y]", "bar[z]"]
 
     def test_extra_gated_multi_extra_proxy_keys_sorted(
@@ -3073,7 +3087,7 @@ class TestAddClassifiedDep:
         req = Requirement("bar[x,y,z]")
         monkeypatch.setattr(req, "extras", ["z", "y", "x"])
         extra_map: dict[str, dict[str, VersionRange]] = {"g": {}}
-        add_classified_dep(req, {"g"}, {}, extra_map)
+        add_classified_dep(req, {"g"}, {}, extra_map, {})
         assert list(extra_map["g"]) == ["bar", "bar[x]", "bar[y]", "bar[z]"]
 
 

--- a/nab-provider/src/nab_provider/_provider/metadata_resolver.py
+++ b/nab-provider/src/nab_provider/_provider/metadata_resolver.py
@@ -881,7 +881,9 @@ def cache_deps_from_metadata(
                         (req, req.url)
                     )
             continue
-        add_classified_dep(req, req_extras, base_deps, extra_deps_map)
+        add_classified_dep(
+            req, req_extras, base_deps, extra_deps_map, provider.specifier_ranges
+        )
     provider.deps_cache[cache_key] = base_deps
     provider.extra_deps_map[cache_key] = extra_deps_map
     provider.deferred_url_extras[cache_key] = deferred_url_extras
@@ -982,7 +984,9 @@ def target_dep_signature(
             for key in req_extras or {None}:
                 url_buckets.setdefault(key, set()).add(entry)
             continue
-        add_classified_dep(req, req_extras, base_deps, extra_deps_map)
+        add_classified_dep(
+            req, req_extras, base_deps, extra_deps_map, provider.specifier_ranges
+        )
     return (base_deps, extra_deps_map, url_buckets)
 
 
@@ -1235,11 +1239,32 @@ def _flatten_signature(signature: TargetDepSignature) -> dict[str, object]:
     return flat
 
 
+def _specifier_range(
+    specifier: SpecifierSet, ranges: dict[str, VersionRange]
+) -> VersionRange:
+    """Return the range ``specifier`` accepts, memoized in ``ranges``.
+
+    Keyed by the specifier text: hashing a ``SpecifierSet`` instead would
+    canonicalize every version it holds on each lookup.
+    """
+    if not specifier:
+        # A bare dependency enters the solver without arbitrary-string admission.
+        return VersionRange.full(admit_arbitrary=False)
+
+    key = str(specifier)
+    cached = ranges.get(key)
+    if cached is None:
+        cached = specifier.to_range()
+        ranges[key] = cached
+    return cached
+
+
 def add_classified_dep(
     req: Requirement,
     req_extras: set[str],
     base_deps: dict[str, VersionRange],
     extra_deps_map: dict[str, dict[str, VersionRange]],
+    specifier_ranges: dict[str, VersionRange],
 ) -> None:
     """Add a classified requirement to the appropriate dep set.
 
@@ -1247,22 +1272,18 @@ def add_classified_dep(
     into one range.
     """
     name = canonicalize_name(req.name)
-    # A bare dependency enters the solver without arbitrary-string admission;
-    # the accumulator identities stay arbitrary-admitting for === literals.
-    vi = (
-        req.specifier.to_range()
-        if req.specifier
-        else VersionRange.full(admit_arbitrary=False)
-    )
+    dep_range = _specifier_range(req.specifier, specifier_ranges)
     dep_extras: set[str] = req.extras
 
     if not req_extras:
-        base_deps[name] = base_deps.get(name, VersionRange.full()) & vi
+        existing = base_deps.get(name)
+        base_deps[name] = dep_range if existing is None else existing & dep_range
         for re in sorted(dep_extras):
             base_deps[join_extra(name, re)] = VersionRange.full(admit_arbitrary=False)
     else:
         for extra_name in req_extras:
             edeps = extra_deps_map[extra_name]
-            edeps[name] = edeps.get(name, VersionRange.full()) & vi
+            existing = edeps.get(name)
+            edeps[name] = dep_range if existing is None else existing & dep_range
             for re in sorted(dep_extras):
                 edeps[join_extra(name, re)] = VersionRange.full(admit_arbitrary=False)

--- a/nab-provider/src/nab_provider/provider.py
+++ b/nab-provider/src/nab_provider/provider.py
@@ -513,6 +513,9 @@ class Provider:
         self.constraints: Mapping[str, VersionRange] = constraints or {}
         self.versions_cache: dict[str, list[tuple[Version, DistFile]]] = {}
         self.deps_cache: dict[tuple[str, Version], dict[str, VersionRange]] = {}
+        # One range per distinct dependency specifier text, shared by every
+        # parent that names it.
+        self.specifier_ranges: dict[str, VersionRange] = {}
         # Deliberately unbounded and never evicted mid-resolve: it keeps every
         # parsed Requirement (hence every Marker) alive for the whole resolve,
         # which is what makes the id(marker)-keyed marker caches below safe


### PR DESCRIPTION
Locally, about 2% off wall time, 1.5% off CPU and 0.9% off peak memory across the benchmark set (medians on main: 23.0 s, 363 MB). Those figures come off this machine; the call counts below reproduce anywhere. A warm `ecosystem:apache-beam-sdist-build` resolve makes 39,526,161 Python calls instead of 42,342,861, 2,816,700 fewer, or 6.65% of every call it makes.

`add_classified_dep` built a `VersionRange` from `req.specifier` for every requirement it classified. Metadata names the same specifier text over and over across parents, so 26,559 of the 27,193 range builds on that scenario, 97.7%, rebuilt a range that already existed. The provider now keeps one range per distinct specifier text and hands the same object to every parent that names it, so parents share a range instead of each holding a copy.

| calls on `ecosystem:apache-beam-sdist-build` | before | after |
| --- | --- | --- |
| `VersionRange._from_specifier_set` | 27,193 | 634 |
| `VersionRange._build` | 202,791 | 51,732 |
| `VersionRange.intersection` | 55,699 | 7,228 |
| `VersionRange.full` | 79,542 | 30,072 |

The `full` row is a second saving. The accumulator started at `VersionRange.full()` and intersected the new range into it, so the first dep recorded for a name paid a `full()` build plus an intersection that returned an equal range. It now stores that first range directly: 49,470 fewer `full()` builds here, one per classified requirement.

The memo is keyed by `str(specifier)` rather than by the `SpecifierSet`. Hashing a `SpecifierSet` hashes each `Specifier`, and that canonicalizes the version on every lookup, so an object key came out a net loss (+389 calls on `pip:google-bigquery-soda`), while `Specifier.__str__` only formats the stored operator and version. Two spellings that canonicalize equal cost a miss and never a wrong answer, and these specifiers come from `Requires-Dist`, so none carries the explicit prerelease policy that the text would drop.

The search is unchanged: the same 168 decisions over the same 118,927 distributions on apache-beam, and the same 51 decisions on `pip:google-bigquery-soda`. A scenario that reads little metadata sees little of this: google-bigquery-soda drops 10,628 calls of 3,860,996, 0.275%.
