### PR TITLE
Serialise a marker item with an f-string, 0.6% off a universal lock

### DIFF
--- a/nab-provider/src/nab_provider/_vendor/packaging/PROVENANCE.md
+++ b/nab-provider/src/nab_provider/_vendor/packaging/PROVENANCE.md
@@ -31,13 +31,18 @@ most one checked-in patch.
   - `markers.py`: `prepare_environment` with its `__all__` entry, and the
     `Marker.evaluate_prepared` it feeds, so code evaluating many markers
     against one environment builds it once. `evaluate` is now the two of them
-    composed.
+    composed. `_format_marker` tests for a marker item first and serialises it
+    by unpacking its three nodes into an f-string instead of joining a list
+    comprehension, which puts the `[[...]]` unwrap under the list branch.
+    Upstream's opening `assert isinstance(marker, (list, tuple, str))` is
+    dropped, so a value of any other type now returns unchanged instead of
+    tripping the assertion.
 
   Upstream PRs are planned for the bound ordering, the direct subset and
   disjoint walks, `filter`'s `assume_sorted` fast path,
-  `from_bounds`/`snap_bounds`/`release_intervals`, and the prepared marker
-  environment. `relation` is not proposed yet: most of its win is available
-  from the direct walks alone.
+  `from_bounds`/`snap_bounds`/`release_intervals`, the prepared marker
+  environment, and the marker-item serialisation. `relation` is not proposed
+  yet: most of its win is available from the direct walks alone.
 - `tasks/vendor-packaging.sh` fetches `pypa/packaging` at the pin, replaces this
   package with the pristine `src/packaging/` tree plus the repo-root license
   texts, and reapplies the patch. `--check` rebuilds into a temp location and

--- a/nab-provider/src/nab_provider/_vendor/packaging/markers.py
+++ b/nab-provider/src/nab_provider/_vendor/packaging/markers.py
@@ -208,27 +208,23 @@ def _normalize_extra_values(results: MarkerList) -> MarkerList:
 def _format_marker(
     marker: list[str] | MarkerAtom | str, first: bool | None = True
 ) -> str:
-    assert isinstance(marker, (list, tuple, str))
-
-    # Unwrap a redundant [[...]] wrapper, but keep the nesting context so a
-    # nested group keeps the parentheses its and/or precedence needs.
-    if (
-        isinstance(marker, list)
-        and len(marker) == 1
-        and isinstance(marker[0], (list, tuple))
-    ):
-        return _format_marker(marker[0], first=first)
+    """Serialize parser output: a marker list, a three-node item, or an operator."""
+    if isinstance(marker, tuple):
+        lhs, op, rhs = marker
+        return f"{lhs.serialize()} {op.serialize()} {rhs.serialize()}"
 
     if isinstance(marker, list):
-        inner = (_format_marker(m, first=False) for m in marker)
+        # Unwrap a redundant [[...]] wrapper, but keep the nesting context so a
+        # nested group keeps the parentheses its and/or precedence needs.
+        if len(marker) == 1 and isinstance(marker[0], (list, tuple)):
+            return _format_marker(marker[0], first=first)
+
+        inner = [_format_marker(m, first=False) for m in marker]
         if first:
             return " ".join(inner)
-        else:
-            return "(" + " ".join(inner) + ")"
-    elif isinstance(marker, tuple):
-        return " ".join([m.serialize() for m in marker])
-    else:
-        return marker
+        return "(" + " ".join(inner) + ")"
+
+    return marker
 
 
 _operators: dict[str, Operator] = {

--- a/nab-provider/tests/test_vendor_marker_format.py
+++ b/nab-provider/tests/test_vendor_marker_format.py
@@ -1,0 +1,28 @@
+"""Tests for the vendored patch's ``_format_marker`` dispatch.
+
+The patched helper tests for a marker item first and serialises it from an
+f-string, so the list case owns the ``[[...]]`` unwrap and the parenthesising
+``first`` controls. Each test pins the string one shape serialises to;
+``Marker.__eq__`` and ``__hash__`` both read ``__str__``, so the exact text
+matters.
+"""
+
+from __future__ import annotations
+
+from nab_provider._vendor.packaging.markers import Marker
+
+
+class TestFormatMarker:
+    def test_an_item_serialises_left_to_right(self) -> None:
+        assert str(Marker('python_version > "3.6"')) == 'python_version > "3.6"'
+
+    def test_a_wrapping_group_loses_its_parentheses(self) -> None:
+        marker = Marker('(python_version > "3.6" and os_name == "unix")')
+        assert str(marker) == 'python_version > "3.6" and os_name == "unix"'
+
+    def test_repeated_wrapping_groups_all_unwrap(self) -> None:
+        assert str(Marker('((python_version > "3.6"))')) == 'python_version > "3.6"'
+
+    def test_a_nested_group_keeps_its_parentheses(self) -> None:
+        text = 'os_name == "nt" or (python_version > "3.6" and os_name == "posix")'
+        assert str(Marker(text)) == text

--- a/tasks/vendoring/packaging.patch
+++ b/tasks/vendoring/packaging.patch
@@ -1904,7 +1904,7 @@ index e312a1f..9a611c3 100644
          return hash((self.version, self.inclusive))
  
 diff --git a/nab-provider/src/nab_provider/_vendor/packaging/markers.py b/nab-provider/src/nab_provider/_vendor/packaging/markers.py
-index 609099c..518aaed 100644
+index 609099c..fa29c65 100644
 --- a/nab-provider/src/nab_provider/_vendor/packaging/markers.py
 +++ b/nab-provider/src/nab_provider/_vendor/packaging/markers.py
 @@ -30,6 +30,7 @@ __all__ = [
@@ -1915,7 +1915,48 @@ index 609099c..518aaed 100644
  ]
  
  
-@@ -378,6 +379,51 @@ def default_environment() -> Environment:
+@@ -207,27 +208,23 @@ def _normalize_extra_values(results: MarkerList) -> MarkerList:
+ def _format_marker(
+     marker: list[str] | MarkerAtom | str, first: bool | None = True
+ ) -> str:
+-    assert isinstance(marker, (list, tuple, str))
+-
+-    # Unwrap a redundant [[...]] wrapper, but keep the nesting context so a
+-    # nested group keeps the parentheses its and/or precedence needs.
+-    if (
+-        isinstance(marker, list)
+-        and len(marker) == 1
+-        and isinstance(marker[0], (list, tuple))
+-    ):
+-        return _format_marker(marker[0], first=first)
++    """Serialize parser output: a marker list, a three-node item, or an operator."""
++    if isinstance(marker, tuple):
++        lhs, op, rhs = marker
++        return f"{lhs.serialize()} {op.serialize()} {rhs.serialize()}"
+ 
+     if isinstance(marker, list):
+-        inner = (_format_marker(m, first=False) for m in marker)
++        # Unwrap a redundant [[...]] wrapper, but keep the nesting context so a
++        # nested group keeps the parentheses its and/or precedence needs.
++        if len(marker) == 1 and isinstance(marker[0], (list, tuple)):
++            return _format_marker(marker[0], first=first)
++
++        inner = [_format_marker(m, first=False) for m in marker]
+         if first:
+             return " ".join(inner)
+-        else:
+-            return "(" + " ".join(inner) + ")"
+-    elif isinstance(marker, tuple):
+-        return " ".join([m.serialize() for m in marker])
+-    else:
+-        return marker
++        return "(" + " ".join(inner) + ")"
++
++    return marker
+ 
+ 
+ _operators: dict[str, Operator] = {
+@@ -378,6 +375,51 @@ def default_environment() -> Environment:
      return cast("Environment", dict(_cached_default_environment()))
  
  
@@ -1967,7 +2008,7 @@ index 609099c..518aaed 100644
  class Marker:
      """Represents a parsed dependency marker expression.
  
-@@ -530,29 +576,22 @@ class Marker:
+@@ -530,29 +572,22 @@ class Marker:
              Added the ``context`` parameter, which influences which marker names
              are considered valid.
          """


### PR DESCRIPTION
Serialising a marker item from an f-string takes 40,396,167 instructions off a universal lock over 5 platforms and 5 Pythons (`universal:max-25-tuples`), 0.583% of that run's 6,929,372,768. The lock calls `_format_marker` 21,950 times, so that is 1,840 instructions per call. The counts come from callgrind with `PYTHONHASHSEED=0`, so they reproduce exactly on any machine.

`_format_marker` now tests for a marker item first and unpacks its three nodes into an f-string, instead of falling through two list checks and joining a comprehension. The `[[...]]` unwrap moves under the list branch, the only place a value can need it. The per-call `assert isinstance(marker, (list, tuple, str))` is gone, so a value of any other type returns unchanged instead of tripping it, and the docstring says what the function accepts.

The saving scales with how many markers a run writes out:

| workload | instructions saved | share of the run |
| --- | --- | --- |
| `universal:max-25-tuples` | 40,396,167 | 0.583% |
| `universal:marker-heavy` (3 platforms, 7 requirements) | 3,117,071 | 0.149% |
| `pip:google-bigquery-soda --resolution lowest`, warm | 832,947 | 0.015% |

So this is a lock-emission win: a warm resolve makes 1,059 of those calls against the wide lock's 21,950, and 0.015% would not carry a diff on its own.

The end-to-end runs rule out a wall regression above about 2% and a memory regression above about 0.3%. They cannot see a change the size of this one in either direction.

The change is in the vendored packaging copy, and PROVENANCE lists it with the other patches headed upstream.
