### PR TITLE
Intern relation-cache range operands as int tokens, ~4% fewer instructions

### DIFF
--- a/nab-resolver/src/nab_resolver/propagate.py
+++ b/nab-resolver/src/nab_resolver/propagate.py
@@ -17,7 +17,7 @@ from .types import IncompatibilityState, SetRelation, Term
 
 if TYPE_CHECKING:
     from .resolver import Resolver
-    from .types import Incompatibility
+    from .types import Incompatibility, RangeProtocol
 
 __all__ = [
     "classify_relation",
@@ -28,6 +28,11 @@ __all__ = [
 
 # Upper bound on relation_cache size; cleared on overflow to bound memory.
 RELATION_CACHE_MAX = 100_000
+
+# Upper bound on the address-keyed token memo, cleared on overflow together
+# with the range objects it holds alive.  A larger cap wipes less often and so
+# holds on to more ranges, which costs peak memory.
+RANGE_ID_MEMO_MAX = 8_192
 
 
 def unit_propagation(
@@ -128,6 +133,31 @@ def evaluate_incompatibility(
     return IncompatibilityState.CONFLICT
 
 
+def _intern_range(resolver: Resolver[Any, Any], range_: RangeProtocol[Any]) -> int:
+    """Return the token for ``range_``, minting one the first time it is seen.
+
+    Equal ranges share a token, so the relation cache keys on range value
+    rather than on identity.  The address memo the caller reads first is only
+    sound while the object it answers for is alive, so ``interned_ranges``
+    holds on to every range that memo records.
+    """
+    tokens = resolver.range_tokens
+    token = tokens.get(range_)
+    if token is None:
+        token = resolver.next_range_token
+        resolver.next_range_token = token + 1
+        tokens[range_] = token
+
+    id_tokens = resolver.range_token_by_id
+    if len(id_tokens) >= RANGE_ID_MEMO_MAX:
+        id_tokens.clear()
+        resolver.interned_ranges.clear()
+    id_tokens[id(range_)] = token
+    resolver.interned_ranges.append(range_)
+
+    return token
+
+
 def term_relation(resolver: Resolver[Any, Any], term: Term[Any, Any]) -> SetRelation:
     """Check how the partial solution relates to this term.
 
@@ -142,11 +172,23 @@ def term_relation(resolver: Resolver[Any, Any], term: Term[Any, Any]) -> SetRela
         return SetRelation.UNDETERMINED
 
     positive = term.is_positive()
+    constraint = term.constraint
+
+    # Both lookups stay inline because the memo answers nearly every probe;
+    # only a miss pays for the call into _intern_range.
+    id_tokens = resolver.range_token_by_id
+    assignment_token = id_tokens.get(id(assignment))
+    if assignment_token is None:
+        assignment_token = _intern_range(resolver, assignment)
+    constraint_token = id_tokens.get(id(constraint))
+    if constraint_token is None:
+        constraint_token = _intern_range(resolver, constraint)
+
     cache = resolver.relation_cache
-    key = (positive, assignment, term.constraint)
+    key = (positive, assignment_token, constraint_token)
     result = cache.get(key)
     if result is None:
-        relation = assignment.relation(term.constraint)
+        relation = assignment.relation(constraint)
         result = classify_relation(
             term, subset=relation.is_subset, disjoint=relation.is_disjoint
         )

--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -483,10 +483,21 @@ class Resolver(Generic[PackageType, VersionType]):
         self.tiebreak_cache: dict[PackageType, tuple[int, int, str]] = {}
 
         # Memoises term_relation's pre-adjustment SetRelation, keyed by
-        # (positive, assignment, constraint). Cleared on overflow.
-        self.relation_cache: dict[
-            tuple[bool, RangeProtocol[Any], RangeProtocol[Any]], SetRelation
-        ] = {}
+        # (positive, assignment token, constraint token). Cleared on overflow.
+        self.relation_cache: dict[tuple[bool, int, int], SetRelation] = {}
+
+        # One token per distinct range, so a relation-cache probe compares ints
+        # rather than bound structures. The counter never rewinds, so clearing
+        # this table alone only strands relation_cache entries; it can never
+        # point a live one at a different range.
+        self.range_tokens: dict[RangeProtocol[Any], int] = {}
+        self.next_range_token = 0
+
+        # range_token_by_id is keyed by id(), and interned_ranges keeps those
+        # objects alive so an address is never reused under a live entry, which
+        # is why the two are wiped together.
+        self.range_token_by_id: dict[int, int] = {}
+        self.interned_ranges: list[RangeProtocol[Any]] = []
 
     def as_term_range(self, range_: RangeProtocol[Any]) -> RangeProtocol[VersionType]:
         """Return the term constraint to record for a supplied range.
@@ -692,6 +703,9 @@ class Resolver(Generic[PackageType, VersionType]):
         self.pending_targeted_backtrack.clear()
         self.tiebreak_cache.clear()
         self.relation_cache.clear()
+        self.range_tokens.clear()
+        self.range_token_by_id.clear()
+        self.interned_ranges.clear()
 
     def _add_root_requirements(
         self, requirements: Sequence[RootRequirement[PackageType, VersionType]]

--- a/nab-resolver/tests/test_range_benchmark.py
+++ b/nab-resolver/tests/test_range_benchmark.py
@@ -65,7 +65,7 @@ SUITE_PROFILE = {
         intervals_seen=827,
         largest_range=8,
         hash_misses=102,
-        equality_calls=412,
+        equality_calls=199,
     ),
     "conflict-free-fanout": Profile(
         rounds=8,
@@ -75,7 +75,7 @@ SUITE_PROFILE = {
         intervals_seen=1058,
         largest_range=1,
         hash_misses=12,
-        equality_calls=48,
+        equality_calls=29,
     ),
 }
 

--- a/nab-resolver/tests/test_resolver.py
+++ b/nab-resolver/tests/test_resolver.py
@@ -3015,6 +3015,19 @@ class TestHashOrderIndependence:
 
 
 class TestRelationCache:
+    @staticmethod
+    def _token_key(
+        resolver: Resolver[str, Any], term: Term[str, Any]
+    ) -> tuple[bool, int, int]:
+        """Return the relation-cache key a positive ``term`` probes for."""
+        assignment = resolver.solution.get(term.package)
+        assert assignment is not None
+        return (
+            True,
+            resolver.range_tokens[assignment],
+            resolver.range_tokens[term.constraint],
+        )
+
     def test_caches_relation_and_reuses_it(self) -> None:
         resolver: Resolver[str, int] = Resolver(DictProvider({}))
         resolver.solution.decide("foo", 2)
@@ -3022,25 +3035,67 @@ class TestRelationCache:
 
         assert resolver.relation_cache == {}
         first = term_relation(resolver, term)
-        key = (True, resolver.solution.get("foo"), term.constraint)
+        key = self._token_key(resolver, term)
         assert resolver.relation_cache == {key: first}
 
         assert term_relation(resolver, term) is first
         assert resolver.relation_cache == {key: first}
 
+    def test_equal_ranges_share_a_token(self) -> None:
+        resolver: Resolver[str, int] = Resolver(DictProvider({}))
+        resolver.solution.decide("foo", 2)
+        term = Term("foo", Range.at_least(1), positive=True)
+        equal_term = Term("foo", Range.at_least(1), positive=True)
+        assert equal_term.constraint is not term.constraint
+
+        first = term_relation(resolver, term)
+
+        assert term_relation(resolver, equal_term) is first
+        assert len(resolver.relation_cache) == 1
+
     def test_clears_cache_on_overflow(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(propagate, "RELATION_CACHE_MAX", 1)
         resolver: Resolver[str, int] = Resolver(DictProvider({}))
         resolver.solution.decide("foo", 2)
-        resolver.relation_cache[(False, Range.full(), Range.full())] = (
-            SetRelation.SATISFIED
-        )
+        # Filler for another range pair, to put the cache at its cap.
+        resolver.relation_cache[(False, 0, 0)] = SetRelation.SATISFIED
 
         term = Term("foo", Range.at_least(1), positive=True)
         result = term_relation(resolver, term)
 
-        key = (True, resolver.solution.get("foo"), term.constraint)
-        assert resolver.relation_cache == {key: result}
+        assert resolver.relation_cache == {self._token_key(resolver, term): result}
+
+    def test_wiped_token_table_does_not_reissue_tokens(self) -> None:
+        """A token is minted once, so a wipe cannot point it at another range."""
+        resolver: Resolver[str, int] = Resolver(DictProvider({}))
+        resolver.solution.decide("foo", 2)
+        term_relation(resolver, Term("foo", Range.at_least(1), positive=True))
+        minted = set(resolver.range_tokens.values())
+
+        resolver.range_tokens.clear()
+        resolver.range_token_by_id.clear()
+        term_relation(resolver, Term("foo", Range.at_least(3), positive=True))
+
+        assert minted
+        assert minted.isdisjoint(resolver.range_tokens.values())
+
+    def test_clears_address_memo_on_overflow(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(propagate, "RANGE_ID_MEMO_MAX", 1)
+        resolver: Resolver[str, int] = Resolver(DictProvider({}))
+        resolver.solution.decide("foo", 2)
+        term = Term("foo", Range.at_least(1), positive=True)
+
+        first = term_relation(resolver, term)
+        key = self._token_key(resolver, term)
+
+        assert len(resolver.range_token_by_id) == 1
+        assert len(resolver.interned_ranges) == 1
+
+        assert term_relation(resolver, term) is first
+        assert self._token_key(resolver, term) == key
+        assert resolver.relation_cache == {key: first}
 
 
 class LowestVersionProvider(DictProvider):


### PR DESCRIPTION
On `pip:langchain-ml-course --resolution lowest`, the resolve retires about 1.9 billion fewer instructions out of 49.7 billion, roughly 4% of the process, and makes 2,953,944 fewer Python-level calls (52,736,036 down to 49,782,092). Both sides resolve at 14,185 decisions and 148 conflicts.

The call counts are exact and reproduce anywhere. The instruction share is approximate: this workload reads an HTTP cache and drives asyncio, so three base-and-branch runs read -3.9%, -5.0% and -5.4%, while the base alone varies 4.7% between runs.

`term_relation` probed `relation_cache` with `(positive, assignment, constraint)`. Neither the tuple nor a `VersionRange` caches its hash, so every probe rebuilt both bound structures, and a hit compared them again. Each distinct range now mints an int token and the key is `(positive, int, int)`.

An address-keyed memo sits in front of the token table. This scenario makes about 158,700 probes and looks up two operands per probe, and 35,249 of those roughly 317,000 lookups miss, so nine in ten never hash a range.

Where the calls went:

| function | base | branch |
| --- | --- | --- |
| `builtins.hash` | 1,831,450 | 763,825 |
| `version.Version.__hash__` | 1,851,370 | 1,294,689 |
| `ranges.VersionRange.__hash__` | 509,522 | 220,207 |
| `ranges.VersionRange.__eq__` | 446,423 | 296,470 |
| `builtins.id` | 7,910 | 360,038 |
| `dict.get` | 7,167,836 | 7,520,575 |

The `__eq__` row is work no hash memo could have reached.

Timing on the same scenario, locally: the CPU of the thread that runs the solver is down about 2%. The whole-process CPU sum does not move, because the fetch threads carry most of it. The clock cannot see a change this small end to end, so those runs only rule out a slowdown above about 5%.

The cost is memory. Peak RSS is up 0.17%, about 600 KB of 350 MB. The address memo and its pin list are capped at 8,192 entries and wiped together, which costs 0.43 MB of traced peak. At 32,768 the memo stops wiping on this scenario, pins all 32,376 interned ranges, and peak goes up 11.8 MB.

`range_tokens` is uncapped on purpose. A token has to mean the same range for the whole resolve, or a live `relation_cache` entry answers for a different one, so the two can only be cleared together, as they are on reset. The token counter never rewinds, so bounding the table later would cost cache misses and nothing worse.
