### PR TITLE
Reuse the decision scan's sort keys, 14% fewer instructions on langchain

### DIFF
--- a/nab-resolver/src/nab_resolver/conflict.py
+++ b/nab-resolver/src/nab_resolver/conflict.py
@@ -167,6 +167,7 @@ def conflict_resolution(
             resolver.stats.package_conflict_counts[
                 conflict_credit_target(most_recent_satisfier)
             ] += 1
+            resolver.priority_epoch += 1
 
             update_culprit_counts(
                 resolver,
@@ -237,6 +238,7 @@ def update_culprit_counts(
     threshold = resolver.CULPRIT_THRESHOLD
     for package in culprit_packages:
         resolver.stats.package_culprit_counts[package] += 1
+        resolver.priority_epoch += 1
         count = resolver.stats.package_culprit_counts[package]
         if (
             count >= threshold
@@ -481,6 +483,7 @@ def maybe_restart(
         contradiction_epoch=resolver.solution.contradiction_epoch + 1,
     )
     resolver.solution.decide(ROOT, resolver.root_version)
+    resolver.decision_queue.clear()
     resolver.pending_targeted_backtrack.clear()
     resolver.stats.targeted_backtracks = 0
 
@@ -507,6 +510,7 @@ def force_targeted_backtrack(
         current = resolver.stats.package_culprit_counts[package]
         if current < threshold:
             resolver.stats.package_culprit_counts[package] = threshold
+            resolver.priority_epoch += 1
         if package not in resolver.pending_targeted_backtrack:
             resolver.pending_targeted_backtrack.append(package)
 

--- a/nab-resolver/src/nab_resolver/decide.py
+++ b/nab-resolver/src/nab_resolver/decide.py
@@ -32,8 +32,9 @@ def choose_package_to_decide(resolver: Resolver[Any, Any]) -> Any | None:
     Prefers ``is_ready`` packages so resolution keeps making progress while
     other listings/metadata are still in flight.  ``begin_decision_scan`` marks
     the start of the scan so a provider fed by another thread can hold the
-    state behind its sort key still: ``min`` only picks correctly over a key
-    that does not move while it runs.
+    state behind its sort key still. The queue keeps that key across scans, so
+    one that moves without the solution or ``priority_epoch`` moving is never
+    read again.
     """
     undecided = resolver.solution.undecided_packages()
     undecided.discard(ROOT)
@@ -67,7 +68,12 @@ def choose_package_to_decide(resolver: Resolver[Any, Any]) -> Any | None:
             tiebreak_cache[package] = tiebreak
         return (ready_penalty, priority, tiebreak)
 
-    return min(undecided, key=sort_key)
+    return resolver.decision_queue.pick(
+        undecided,
+        sort_key,
+        resolver.solution.take_changed_packages(),
+        resolver.priority_epoch,
+    )
 
 
 def choose_version(resolver: Resolver[Any, Any], package: Any) -> Any | None:

--- a/nab-resolver/src/nab_resolver/decision_queue.py
+++ b/nab-resolver/src/nab_resolver/decision_queue.py
@@ -1,0 +1,164 @@
+"""A lazy min-heap over the undecided packages' decision sort keys.
+
+``choose_package_to_decide`` needs the smallest sort key in the undecided set,
+and a scan moves the keys of only the handful of packages it assigns. The queue
+holds the keys in a heap and calls ``sort_key`` again only for the packages a
+scan marks stale. It still walks the whole undecided set, which keeps those
+calls in the order a full scan made them.
+"""
+
+from __future__ import annotations
+
+from heapq import heapify, heappop, heappush
+from typing import TYPE_CHECKING, Any, Generic
+
+from .types import PackageType
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+__all__ = ["DecisionQueue"]
+
+# The heap's rebuild threshold never falls below this.
+_REBUILD_MINIMUM = 32
+
+
+class DecisionQueue(Generic[PackageType]):
+    """The undecided packages ordered by sort key, refreshed incrementally.
+
+    A key is re-evaluated when the partial solution reports the package's range
+    or decided state as moved, when the caller passes a new ``epoch``, and on
+    every scan while the package is not ready, since a listing lands without the
+    solution seeing it. Superseded heap entries stay in place until they reach
+    the top, or until a rebuild drops the ones that never do.
+    """
+
+    def __init__(self) -> None:
+        """Start empty; every key arrives through :meth:`pick`."""
+        self._heap: list[tuple[tuple[Any, ...], int, PackageType]] = []
+        self._keys: dict[PackageType, tuple[Any, ...]] = {}
+        self._unready: set[PackageType] = set()
+        self._epoch = 0
+        self._pushes = 0
+        self._rebuild_at = _REBUILD_MINIMUM
+
+    def clear(self) -> None:
+        """Drop every key, for a resolve that starts over."""
+        self._heap.clear()
+        self._keys.clear()
+        self._unready.clear()
+        self._epoch = 0
+        self._rebuild_at = _REBUILD_MINIMUM
+
+    def pick(
+        self,
+        undecided: set[PackageType],
+        sort_key: Callable[[PackageType], tuple[Any, ...]],
+        changed: set[PackageType],
+        epoch: int,
+    ) -> PackageType:
+        """Return the undecided package with the smallest sort key.
+
+        ``undecided`` must be non-empty, and a package entering or leaving it
+        must reach ``changed`` on the same scan, which is what gives it a key
+        or drops the one it left behind. ``changed`` holds the packages whose
+        range or decided state the partial solution moved since the previous
+        scan; a new ``epoch`` stands for a move in the counts every key reads,
+        so it re-evaluates all of them.
+
+        ``sort_key`` must lead with the ready penalty: a truthy first field
+        keeps the package on the re-evaluate list until it clears.
+        """
+        stale = self._stale_packages(undecided, changed, epoch)
+        self._refresh(undecided, stale, sort_key)
+        self._compact()
+        return self._live_top()
+
+    def _stale_packages(
+        self, undecided: set[PackageType], changed: set[PackageType], epoch: int
+    ) -> set[PackageType]:
+        """Return the packages this scan has to evaluate again.
+
+        Also forgets the key of any stale package that has left the undecided set.
+        """
+        if epoch != self._epoch:
+            self._epoch = epoch
+            stale = undecided | changed
+        elif self._unready:
+            stale = changed | self._unready
+        else:
+            stale = changed
+
+        for package in stale - undecided:
+            self._keys.pop(package, None)
+            self._unready.discard(package)
+
+        return stale
+
+    def _refresh(
+        self,
+        undecided: set[PackageType],
+        stale: set[PackageType],
+        sort_key: Callable[[PackageType], tuple[Any, ...]],
+    ) -> None:
+        """Re-evaluate the stale keys, pushing an entry for each one that moved.
+
+        Walks ``undecided`` rather than ``stale`` so which packages are stale
+        cannot change the order ``sort_key`` is called in, since a provider can
+        fetch while answering one.
+        """
+        keys = self._keys
+        heap = self._heap
+        unready = self._unready
+        pushes = self._pushes
+
+        for package in undecided:
+            if package not in stale:
+                continue
+
+            key = sort_key(package)
+            if key[0]:
+                unready.add(package)
+            else:
+                unready.discard(package)
+
+            # Keep the tuple the heap entry was pushed with rather than paying
+            # for a second entry that sorts the same.
+            live = keys.get(package)
+            if live is not None and live == key:
+                continue
+
+            keys[package] = key
+            heappush(heap, (key, pushes, package))
+            pushes += 1
+
+        self._pushes = pushes
+
+    def _compact(self) -> None:
+        """Rebuild the heap from the live keys once it outgrows ``_rebuild_at``."""
+        if len(self._heap) <= self._rebuild_at:
+            return
+
+        self._heap[:] = [
+            (key, index, package)
+            for index, (package, key) in enumerate(self._keys.items(), self._pushes)
+        ]
+        heapify(self._heap)
+        self._pushes += len(self._heap)
+        self._rebuild_at = 4 * len(self._keys) + _REBUILD_MINIMUM
+
+    def _live_top(self) -> PackageType:
+        """Drop superseded entries until the top holds a package's current key.
+
+        Current is identity rather than equality: ``_refresh`` keeps the tuple
+        an entry was pushed with whenever a re-evaluated key compares equal, so
+        an entry survives here only while ``_keys`` still points at it.
+        """
+        keys = self._keys
+        heap = self._heap
+
+        while True:
+            key, _, package = heap[0]
+            if keys.get(package) is key:
+                return package
+            heappop(heap)

--- a/nab-resolver/src/nab_resolver/partial_solution.py
+++ b/nab-resolver/src/nab_resolver/partial_solution.py
@@ -102,6 +102,10 @@ class PartialSolution(Generic[PackageType, VersionType]):
         # Incrementally maintained as set(positive) - set(decided).
         self._undecided: set[PackageType] = set()
 
+        # Packages whose effective range or decided state moved since the last
+        # drain.
+        self._changed: set[PackageType] = set()
+
         # Memoises positive - negative per package.
         self._effective_range_cache: dict[
             PackageType, RangeProtocol[VersionType] | None
@@ -175,6 +179,7 @@ class PartialSolution(Generic[PackageType, VersionType]):
     def _refresh_effective_range(self, package: PackageType) -> None:
         """Recompute the package's range, advancing the epoch if it emptied."""
         self._effective_range_cache.pop(package, None)
+        self._changed.add(package)
         effective = self.get(package)
         assert effective is not None
         if effective.is_empty:
@@ -264,7 +269,9 @@ class PartialSolution(Generic[PackageType, VersionType]):
         # target_level; every other package keeps the positive and negative ranges
         # its cached effective range was derived from.
         while self._assignments and self._assignments[-1].decision_level > target_level:
-            self._effective_range_cache.pop(self._assignments.pop().package, None)
+            package = self._assignments.pop().package
+            self._effective_range_cache.pop(package, None)
+            self._changed.add(package)
 
         self._decision_level = target_level
 
@@ -333,6 +340,16 @@ class PartialSolution(Generic[PackageType, VersionType]):
     def decisions(self) -> dict[PackageType, VersionType]:
         """Return the current decision map: ``{package: version}``."""
         return dict(self._decided_versions)
+
+    def take_changed_packages(self) -> set[PackageType]:
+        """Return the packages whose state moved since the last call, and reset.
+
+        Every path that moves a package's effective range or its decided state
+        records it here, backtracking included.
+        """
+        changed = self._changed
+        self._changed = set()
+        return changed
 
     def undecided_packages(self) -> set[PackageType]:
         """Return packages with positive constraints but no decision yet.

--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -26,6 +26,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Generic, Protocol
 
 from . import conflict, decide, incompat_index, propagate
+from .decision_queue import DecisionQueue
 from .errors import ResolutionError
 from .partial_solution import PartialSolution
 from .ranges import Range
@@ -482,6 +483,12 @@ class Resolver(Generic[PackageType, VersionType]):
         # Memoises the tiebreak tuple in choose_package_to_decide.
         self.tiebreak_cache: dict[PackageType, tuple[int, int, str]] = {}
 
+        # The undecided packages ordered by sort key. priority_epoch advances
+        # when a count a key reads moves: the conflict and culprit counts, and
+        # the provider's force-backtrack count. It invalidates every key.
+        self.decision_queue: DecisionQueue[PackageType] = DecisionQueue()
+        self.priority_epoch = 0
+
         # Memoises term_relation's pre-adjustment SetRelation, keyed by
         # (positive, assignment, constraint). Cleared on overflow.
         self.relation_cache: dict[
@@ -608,6 +615,7 @@ class Resolver(Generic[PackageType, VersionType]):
         # blockers before the candidate is decided.
         force_targets = list(self.provider.consume_force_backtrack_targets())
         if force_targets:
+            self.priority_epoch += 1
             triggering = conflict.force_targeted_backtrack(self, force_targets)
             if triggering is not None:
                 return triggering
@@ -691,6 +699,8 @@ class Resolver(Generic[PackageType, VersionType]):
         self.root_package_order.clear()
         self.pending_targeted_backtrack.clear()
         self.tiebreak_cache.clear()
+        self.decision_queue.clear()
+        self.priority_epoch = 0
         self.relation_cache.clear()
 
     def _add_root_requirements(

--- a/nab-resolver/tests/test_decision_queue.py
+++ b/nab-resolver/tests/test_decision_queue.py
@@ -1,0 +1,308 @@
+"""Unit tests for :mod:`nab_resolver.decision_queue`.
+
+``DecisionQueue`` answers the same question as ``min(undecided, key=sort_key)``
+while evaluating only the keys that can have moved, so these tests pin the
+invalidation: which packages a scan re-evaluates, and that the answer matches
+the one a full scan would give.
+
+Most of them hand the queue its signals directly, over a synthetic
+:class:`KeyBook`. That leaves the other half of the contract untested, because
+a signal the resolver never sends reaches the queue as no signal at all, and
+the resolve then goes somewhere else without failing. The last test in the
+module covers that by driving a real resolve and checking every cached key
+against a fresh one.
+
+The sort keys here have the shape ``choose_package_to_decide`` builds,
+``(ready_penalty, priority, tiebreak)``, since a truthy first field is what
+marks a package whose listing has not settled.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from typing import Any
+
+from nab_resolver.decision_queue import DecisionQueue
+from nab_resolver.ranges import Range
+from nab_resolver.resolver import Resolver
+from nab_resolver.types import RangeProtocol
+
+from .property.providers import FuzzProvider
+
+
+class KeyBook:
+    """The sort keys of a scan, and a record of which ones were read."""
+
+    def __init__(self, keys: dict[str, tuple[Any, ...]]) -> None:
+        """Hold one key per package, with nothing read yet."""
+        self.keys = keys
+        self.read: list[str] = []
+
+    def sort_key(self, package: str) -> tuple[Any, ...]:
+        """Return the package's key, recording that it was read."""
+        self.read.append(package)
+        return self.keys[package]
+
+    def take_read(self) -> set[str]:
+        """Return the packages read since the last call, and start over."""
+        read = set(self.read)
+        self.read.clear()
+        return read
+
+
+def test_first_scan_evaluates_every_package_and_picks_the_smallest() -> None:
+    book = KeyBook({"a": (0, 2, "a"), "b": (0, 1, "b"), "c": (0, 3, "c")})
+    queue: DecisionQueue[str] = DecisionQueue()
+
+    picked = queue.pick({"a", "b", "c"}, book.sort_key, {"a", "b", "c"}, 0)
+
+    assert picked == "b"
+    assert book.take_read() == {"a", "b", "c"}
+
+
+def test_an_unchanged_scan_reads_no_keys() -> None:
+    """The saving being measured: a scan that moved nothing re-reads nothing."""
+    book = KeyBook({"a": (0, 2, "a"), "b": (0, 1, "b")})
+    queue: DecisionQueue[str] = DecisionQueue()
+    queue.pick({"a", "b"}, book.sort_key, {"a", "b"}, 0)
+    book.take_read()
+
+    picked = queue.pick({"a", "b"}, book.sort_key, set(), 0)
+
+    assert picked == "b"
+    assert book.take_read() == set()
+
+
+def test_a_changed_package_takes_the_lead_on_its_new_key() -> None:
+    book = KeyBook({"a": (0, 2, "a"), "b": (0, 1, "b")})
+    queue: DecisionQueue[str] = DecisionQueue()
+    queue.pick({"a", "b"}, book.sort_key, {"a", "b"}, 0)
+    book.take_read()
+
+    book.keys["a"] = (0, 0, "a")
+    picked = queue.pick({"a", "b"}, book.sort_key, {"a"}, 0)
+
+    assert picked == "a"
+    assert book.take_read() == {"a"}
+
+
+def test_a_superseded_entry_loses_to_the_key_that_replaced_it() -> None:
+    """A leader whose key worsens must not stay on top of the heap."""
+    book = KeyBook({"a": (0, 1, "a"), "b": (0, 2, "b")})
+    queue: DecisionQueue[str] = DecisionQueue()
+    assert queue.pick({"a", "b"}, book.sort_key, {"a", "b"}, 0) == "a"
+
+    book.keys["a"] = (0, 9, "a")
+
+    assert queue.pick({"a", "b"}, book.sort_key, {"a"}, 0) == "b"
+
+
+def test_a_package_reporting_the_same_key_is_not_pushed_again() -> None:
+    book = KeyBook({"a": (0, 1, "a"), "b": (0, 2, "b")})
+    queue: DecisionQueue[str] = DecisionQueue()
+    queue.pick({"a", "b"}, book.sort_key, {"a", "b"}, 0)
+    entries = len(queue._heap)
+
+    queue.pick({"a", "b"}, book.sort_key, {"a"}, 0)
+
+    assert len(queue._heap) == entries
+
+
+def test_an_unready_package_is_re_evaluated_until_it_is_ready() -> None:
+    """An unready package is rescanned until its listing settles.
+
+    A listing lands without the partial solution seeing it, so the ready
+    penalty is what keeps the package on the list.
+    """
+    book = KeyBook({"a": (1, 0, "a"), "b": (0, 2, "b")})
+    queue: DecisionQueue[str] = DecisionQueue()
+    queue.pick({"a", "b"}, book.sort_key, {"a", "b"}, 0)
+    book.take_read()
+
+    assert queue.pick({"a", "b"}, book.sort_key, set(), 0) == "b"
+    assert book.take_read() == {"a"}
+
+    book.keys["a"] = (0, 1, "a")
+    assert queue.pick({"a", "b"}, book.sort_key, set(), 0) == "a"
+    book.take_read()
+
+    assert queue.pick({"a", "b"}, book.sort_key, set(), 0) == "a"
+    assert book.take_read() == set()
+
+
+def test_a_new_epoch_re_evaluates_every_key() -> None:
+    """The conflict and culprit counts every key reads move outside ``changed``."""
+    book = KeyBook({"a": (0, 2, "a"), "b": (0, 1, "b")})
+    queue: DecisionQueue[str] = DecisionQueue()
+    queue.pick({"a", "b"}, book.sort_key, {"a", "b"}, 0)
+    book.take_read()
+
+    book.keys["a"] = (0, 0, "a")
+    picked = queue.pick({"a", "b"}, book.sort_key, set(), 1)
+
+    assert picked == "a"
+    assert book.take_read() == {"a", "b"}
+
+
+def test_a_decided_package_leaves_and_comes_back_on_a_fresh_key() -> None:
+    book = KeyBook({"a": (0, 1, "a"), "b": (0, 2, "b")})
+    queue: DecisionQueue[str] = DecisionQueue()
+    queue.pick({"a", "b"}, book.sort_key, {"a", "b"}, 0)
+    book.take_read()
+
+    assert queue.pick({"b"}, book.sort_key, {"a"}, 0) == "b"
+    assert book.take_read() == set()
+
+    assert queue.pick({"a", "b"}, book.sort_key, {"a"}, 0) == "a"
+    assert book.take_read() == {"a"}
+
+
+def test_clear_forgets_every_key() -> None:
+    """A restart replaces the solution, so the queue starts from its packages."""
+    book = KeyBook({"a": (0, 1, "a"), "b": (0, 2, "b")})
+    queue: DecisionQueue[str] = DecisionQueue()
+    queue.pick({"a", "b"}, book.sort_key, {"a", "b"}, 0)
+    book.take_read()
+
+    queue.clear()
+    picked = queue.pick({"a", "b"}, book.sort_key, {"a", "b"}, 0)
+
+    assert picked == "a"
+    assert book.take_read() == {"a", "b"}
+    assert len(queue._heap) == 2
+
+
+def test_the_heap_is_rebuilt_once_superseded_entries_pile_up() -> None:
+    """Without compaction a long resolve carries every key it ever evaluated.
+
+    The keys improve each round, which is the direction compaction is for: a
+    superseded entry then sorts behind the key that replaced it, so it never
+    reaches the top and only a rebuild removes it. Keys that worsen leave their
+    old entries in front, where the ordinary drain takes them.
+    """
+    packages = [f"p{index:03d}" for index in range(40)]
+    book = KeyBook(
+        {package: (0, index, package) for index, package in enumerate(packages)}
+    )
+    queue: DecisionQueue[str] = DecisionQueue()
+    undecided = set(packages)
+    queue.pick(undecided, book.sort_key, undecided, 0)
+
+    for round_number in range(1, 11):
+        for index, package in enumerate(packages):
+            book.keys[package] = (0, index - 100 * round_number, package)
+        queue.pick(undecided, book.sort_key, undecided, 0)
+
+    assert len(queue._heap) <= 4 * len(packages) + 32
+    assert queue.pick(undecided, book.sort_key, set(), 0) == packages[0]
+
+
+class ConflictSensitiveProvider(FuzzProvider):
+    """A provider whose sort keys move with no assignment behind them.
+
+    Two of the things a sort key reads sit outside the partial solution, and
+    this drives both. ``prioritize`` ranks a package by how far its culprit
+    count trails the leading one, so crediting the leading culprit moves every
+    other package's key; ``is_ready`` holds one package back for the first
+    scans, the way a listing still in flight does.
+    """
+
+    def __init__(
+        self,
+        graph: dict[str, dict[int, dict[str, Range[int]]]],
+        *,
+        unready: str,
+        ready_scan: int,
+    ) -> None:
+        """Hold ``unready`` back until the resolve's ``ready_scan``-th scan."""
+        super().__init__(graph)
+        self._unready_package = unready
+        self._ready_scan = ready_scan
+        self.scans = 0
+
+    def begin_decision_scan(self) -> None:
+        """Count the scan, which is what ``is_ready`` answers from."""
+        self.scans += 1
+
+    def prioritize(
+        self,
+        package: str,
+        version_range: RangeProtocol[int],
+        conflict_counts: Mapping[str, int],
+        culprit_counts: Mapping[str, int] | None = None,
+    ) -> int:
+        """Rank the package by how far its culprit count trails the leading one."""
+        del version_range, conflict_counts
+        counts = culprit_counts or {}
+        return max(counts.values(), default=0) - counts.get(package, 0)
+
+    def is_ready(self, package: str) -> bool:
+        """Report every package ready but the held-back one, until its scan."""
+        return package != self._unready_package or self.scans >= self._ready_scan
+
+
+class RecheckingDecisionQueue(DecisionQueue[str]):
+    """A queue that re-derives every key it holds once the pick is made.
+
+    The cached keys are what the resolver decides on, so a move the queue is
+    never told about shows up here as a key the scan's own ``sort_key`` no
+    longer agrees with.
+    """
+
+    def __init__(self) -> None:
+        """Start empty, with no scan yet seen holding an unready package."""
+        super().__init__()
+        self.unready_picks = 0
+
+    def pick(
+        self,
+        undecided: set[str],
+        sort_key: Callable[[str], tuple[Any, ...]],
+        changed: set[str],
+        epoch: int,
+    ) -> str:
+        """Pick as usual, then check the cached keys against a fresh scan."""
+        picked = super().pick(undecided, sort_key, changed, epoch)
+
+        if self._unready:
+            self.unready_picks += 1
+
+        assert self._keys.keys() == undecided
+        for package in undecided:
+            assert self._keys[package] == sort_key(package), package
+
+        return picked
+
+
+BACKJUMPING_GRAPH: dict[str, dict[int, dict[str, Range[int]]]] = {
+    "root": {1: {"a": Range.full(), "c": Range.full(), "d": Range.full()}},
+    "a": {2: {"b": Range.at_least(2)}, 1: {"e": Range.full()}},
+    "b": {2: {"c": Range.at_least(3)}, 1: {"e": Range.at_least(2)}},
+    "c": {2: {}, 1: {}},
+    "d": {2: {"b": Range.less_than(2), "e": Range.less_than(2)}, 1: {}},
+    "e": {2: {}, 1: {}},
+}
+
+
+def test_a_resolve_that_backjumps_keeps_every_cached_key_current() -> None:
+    """Drives a real resolve rather than handing the queue its signals.
+
+    ``a@2`` and ``d@2`` both dead-end, so the resolve backjumps and credits
+    culprits, and ``c`` arrives unready. Both move sort keys of packages the
+    partial solution reports as unchanged, so a queue that misses either
+    signal decides on a stale key and resolves somewhere else in silence.
+    """
+    provider = ConflictSensitiveProvider(BACKJUMPING_GRAPH, unready="c", ready_scan=3)
+    resolver: Resolver[str, int] = Resolver(provider)
+    queue = RecheckingDecisionQueue()
+    resolver.decision_queue = queue
+
+    result = resolver.resolve({"root": Range.singleton(1)})
+
+    assert result == {"root": 1, "a": 1, "c": 2, "d": 1, "e": 2}
+
+    # The check inside the queue is vacuous unless the resolve raised each of
+    # the signals it is there to catch.
+    assert resolver.stats.backjumps > 0
+    assert resolver.priority_epoch > 0
+    assert queue.unready_picks > 0

--- a/nab-resolver/tests/test_range_benchmark.py
+++ b/nab-resolver/tests/test_range_benchmark.py
@@ -61,8 +61,8 @@ SUITE_PROFILE = {
         rounds=40,
         decisions=26,
         conflicts=14,
-        membership_tests=435,
-        intervals_seen=827,
+        membership_tests=363,
+        intervals_seen=755,
         largest_range=8,
         hash_misses=102,
         equality_calls=412,
@@ -71,8 +71,8 @@ SUITE_PROFILE = {
         rounds=8,
         decisions=8,
         conflicts=0,
-        membership_tests=1058,
-        intervals_seen=1058,
+        membership_tests=308,
+        intervals_seen=308,
         largest_range=1,
         hash_misses=12,
         equality_calls=48,
@@ -169,10 +169,10 @@ def test_scenario_pins_its_search_and_membership_profile(
 
     The regime assertions pass on any graph that merely conflicts or merely
     fans out, and most of the membership tests come from ``GraphProvider``
-    scanning its own release lists rather than from the resolver. An edit that
-    leaves the answer correct can still move what a comparison between two
-    ``Range`` implementations is read off, so these numbers change deliberately
-    or not at all.
+    scanning a release list once per sort key the decision scan asks for. An
+    edit that leaves the answer correct can still move what a comparison
+    between two ``Range`` implementations is read off, so these numbers change
+    deliberately or not at all.
     """
     measurement = measure_small(benchmark, scenario_id)
     stats = measurement.resolution.stats


### PR DESCRIPTION
On `pip:langchain-ml-course --resolution lowest` the resolve executes 42,940,392,606 instructions where main executes 49,996,652,497: 7,056,259,891 fewer, 14.1% of the run. On my machine it also runs about 7% faster and uses about 11% less CPU, with peak memory inside 0.2% either way. Those timings are local and loose, bounding the wall saving between 1.4% and 14%; the instruction count reproduces anywhere.

`choose_package_to_decide` ended in `min(undecided, key=sort_key)`, so every scan evaluated a sort key for every undecided package: 694,087 evaluations over 14,185 decisions.

The keys now live in a heap. The scan still walks the whole undecided set, which is what keeps listings settling in the same order, but it re-evaluates a key only when

- the partial solution moved that package's range or decided state,
- the package is not ready, since a listing can land without the solution seeing it,
- a conflict or culprit count moved, or the provider forced a backtrack, either of which invalidates every key.

That leaves 67,282 evaluations. The 626,805 that go away work out at about 11,300 instructions apiece, most of it recounting a package's matching versions when the caches behind the key miss.

The search is untouched: all 23 counters the resolver reports match except the key evaluations, at 14,185 decisions, 148 conflicts and 207 packages.

This is one scenario's win, and it grows with the decision count and the undecided set at each. `pip:langchain-ml-course` alone is 90% of the 767,907 key evaluations across my 19 canary scenarios, so a small resolve gains nothing.
