### PR TITLE
Compare cached version keys in bound ordering, ~3.5% off a pandas resolve

### DIFF
--- a/nab-provider/src/nab_provider/_vendor/packaging/PROVENANCE.md
+++ b/nab-provider/src/nab_provider/_vendor/packaging/PROVENANCE.md
@@ -24,7 +24,11 @@ most one checked-in patch.
   - `_ranges.py`: an unbounded end canonicalizes its inclusivity, and
     `LowerBound.__gt__`, `LowerBound.__le__`, and `UpperBound.__gt__` are
     written out beside `functools.total_ordering`, which still derives the
-    rest.
+    rest. Those three, `LowerBound.__lt__`, and `UpperBound.__lt__` order two
+    versions by comparing their cached `Version._key_cache` tuples, and fall
+    back to the version operators when either side has no key yet.
+    `BoundaryVersion` carries a class-level `_key_cache = None` so a boundary
+    operand takes that fallback without a type check.
   - `markersets.py` and `_markersets.py`: the marker-algebra module and the
     private engine behind it, both new files, plus the `Marker.to_set`
     accessor on `markers.py`.

--- a/nab-provider/src/nab_provider/_vendor/packaging/_ranges.py
+++ b/nab-provider/src/nab_provider/_vendor/packaging/_ranges.py
@@ -82,6 +82,10 @@ class BoundaryVersion:
         "version",
     )
 
+    #: A boundary has no PEP 440 comparison key. Bound ordering reads this off
+    #: either operand type, so a boundary falls back to the version operators.
+    _key_cache: None = None
+
     def __init__(self, version: Version, kind: BoundaryKind) -> None:
         self.version = version
         self.kind = kind
@@ -223,7 +227,13 @@ class LowerBound:
             return other.version is not None
         if other.version is None:
             return False
-        if self.version != other.version:
+        # A boundary has no key, and a version's is computed on first use.
+        self_key = self.version._key_cache
+        other_key = other.version._key_cache
+        if self_key is not None and other_key is not None:
+            if self_key != other_key:
+                return self_key < other_key
+        elif self.version != other.version:
             return self.version < other.version
         # [v < (v: inclusive starts earlier.
         return self.inclusive and not other.inclusive
@@ -237,7 +247,12 @@ class LowerBound:
             return False
         if other.version is None:
             return True
-        if self.version != other.version:
+        self_key = self.version._key_cache
+        other_key = other.version._key_cache
+        if self_key is not None and other_key is not None:
+            if self_key != other_key:
+                return not self_key < other_key
+        elif self.version != other.version:
             return not self.version < other.version
         return other.inclusive and not self.inclusive
 
@@ -248,7 +263,12 @@ class LowerBound:
             return True
         if other.version is None:
             return False
-        if self.version != other.version:
+        self_key = self.version._key_cache
+        other_key = other.version._key_cache
+        if self_key is not None and other_key is not None:
+            if self_key != other_key:
+                return self_key < other_key
+        elif self.version != other.version:
             return self.version < other.version
         return self.inclusive or not other.inclusive
 
@@ -310,7 +330,13 @@ class UpperBound:
             return False
         if other.version is None:
             return True
-        if self.version != other.version:
+        # See LowerBound.__lt__ for why this reads the cached keys.
+        self_key = self.version._key_cache
+        other_key = other.version._key_cache
+        if self_key is not None and other_key is not None:
+            if self_key != other_key:
+                return self_key < other_key
+        elif self.version != other.version:
             return self.version < other.version
         # v) < v]: exclusive ends earlier.
         return not self.inclusive and other.inclusive
@@ -323,7 +349,12 @@ class UpperBound:
             return other.version is not None
         if other.version is None:
             return False
-        if self.version != other.version:
+        self_key = self.version._key_cache
+        other_key = other.version._key_cache
+        if self_key is not None and other_key is not None:
+            if self_key != other_key:
+                return not self_key < other_key
+        elif self.version != other.version:
             return not self.version < other.version
         return self.inclusive and not other.inclusive
 

--- a/nab-provider/tests/test_vendor_bound_ordering.py
+++ b/nab-provider/tests/test_vendor_bound_ordering.py
@@ -12,6 +12,7 @@ constructor collapses to one point.
 from __future__ import annotations
 
 import itertools
+import operator
 from typing import TYPE_CHECKING, TypeVar
 
 import pytest
@@ -199,13 +200,37 @@ class TestBoundOrdering:
         assert _relate_bounds(right, left) is RangeRelation.OVERLAPPING
         assert _subset_bounds(left, right)
 
-    @pytest.mark.parametrize("operator", ["__lt__", "__gt__", "__ge__", "__le__"])
+    @pytest.mark.parametrize("compare", [operator.lt, operator.gt, operator.le])
+    @pytest.mark.parametrize("cls", [LowerBound, UpperBound])
+    def test_the_order_is_the_same_before_and_after_the_key_is_cached(
+        self,
+        cls: type[BoundT],
+        compare: Callable[[BoundT, BoundT], bool],
+    ) -> None:
+        # A version gains its comparison key on first use, so the first compare
+        # runs the operator path and later ones the key path. Any compare caches
+        # both keys, so each operator needs a fresh pair to see the cold path.
+        versions = ("1.0", "1.0+local", "1.0.post1", "2.0")
+        cases = itertools.product(versions, versions, (True, False), (True, False))
+        for left_text, right_text, left_inclusive, right_inclusive in cases:
+            left = cls(V(left_text), left_inclusive)
+            right = cls(V(right_text), right_inclusive)
+            assert left.version._key_cache is None
+            assert right.version._key_cache is None
+
+            cold = compare(left, right)
+
+            assert left.version._key_cache is not None
+            assert right.version._key_cache is not None
+            assert compare(left, right) == cold, (left, right)
+
+    @pytest.mark.parametrize("method", ["__lt__", "__gt__", "__ge__", "__le__"])
     @pytest.mark.parametrize("cls", [LowerBound, UpperBound])
     def test_bound_returns_not_implemented_for_other_types(
-        self, cls: type[LowerBound | UpperBound], operator: str
+        self, cls: type[LowerBound | UpperBound], method: str
     ) -> None:
         bound = cls(V("1.0"), inclusive=True)
-        assert getattr(bound, operator)("1.0") is NotImplemented
+        assert getattr(bound, method)("1.0") is NotImplemented
         assert bound != "1.0"
 
     def test_mixing_bound_kinds_is_a_type_error(self) -> None:

--- a/tasks/vendoring/packaging.patch
+++ b/tasks/vendoring/packaging.patch
@@ -1827,10 +1827,21 @@ index 0000000..d51010d
 +    )
 +    return make_and([*lead, inner])
 diff --git a/nab-provider/src/nab_provider/_vendor/packaging/_ranges.py b/nab-provider/src/nab_provider/_vendor/packaging/_ranges.py
-index e312a1f..9a611c3 100644
+index e312a1f..29c32bc 100644
 --- a/nab-provider/src/nab_provider/_vendor/packaging/_ranges.py
 +++ b/nab-provider/src/nab_provider/_vendor/packaging/_ranges.py
-@@ -186,6 +186,11 @@ class LowerBound:
+@@ -82,6 +82,10 @@ class BoundaryVersion:
+         "version",
+     )
+ 
++    #: A boundary has no PEP 440 comparison key. Bound ordering reads this off
++    #: either operand type, so a boundary falls back to the version operators.
++    _key_cache: None = None
++
+     def __init__(self, version: Version, kind: BoundaryKind) -> None:
+         self.version = version
+         self.kind = kind
+@@ -186,6 +190,11 @@ class LowerBound:
      __slots__ = ("_above", "inclusive", "version")
  
      def __init__(self, version: _VersionOrBoundary, inclusive: bool) -> None:
@@ -1842,7 +1853,19 @@ index e312a1f..9a611c3 100644
          self.version = version
          self.inclusive = inclusive
          # Pre-bind a predicate "is parsed at or above this lower
-@@ -223,6 +228,30 @@ class LowerBound:
+@@ -218,11 +227,51 @@ class LowerBound:
+             return other.version is not None
+         if other.version is None:
+             return False
+-        if self.version != other.version:
++        # A boundary has no key, and a version's is computed on first use.
++        self_key = self.version._key_cache
++        other_key = other.version._key_cache
++        if self_key is not None and other_key is not None:
++            if self_key != other_key:
++                return self_key < other_key
++        elif self.version != other.version:
+             return self.version < other.version
          # [v < (v: inclusive starts earlier.
          return self.inclusive and not other.inclusive
  
@@ -1855,7 +1878,12 @@ index e312a1f..9a611c3 100644
 +            return False
 +        if other.version is None:
 +            return True
-+        if self.version != other.version:
++        self_key = self.version._key_cache
++        other_key = other.version._key_cache
++        if self_key is not None and other_key is not None:
++            if self_key != other_key:
++                return not self_key < other_key
++        elif self.version != other.version:
 +            return not self.version < other.version
 +        return other.inclusive and not self.inclusive
 +
@@ -1866,14 +1894,19 @@ index e312a1f..9a611c3 100644
 +            return True
 +        if other.version is None:
 +            return False
-+        if self.version != other.version:
++        self_key = self.version._key_cache
++        other_key = other.version._key_cache
++        if self_key is not None and other_key is not None:
++            if self_key != other_key:
++                return self_key < other_key
++        elif self.version != other.version:
 +            return self.version < other.version
 +        return self.inclusive or not other.inclusive
 +
      def __hash__(self) -> int:
          return hash((self.version, self.inclusive))
  
-@@ -243,6 +272,10 @@ class UpperBound:
+@@ -243,6 +292,10 @@ class UpperBound:
      __slots__ = ("_below", "inclusive", "version")
  
      def __init__(self, version: _VersionOrBoundary, inclusive: bool) -> None:
@@ -1884,7 +1917,19 @@ index e312a1f..9a611c3 100644
          self.version = version
          self.inclusive = inclusive
          # Pre-bind a predicate "is parsed at or below this upper
-@@ -282,6 +315,18 @@ class UpperBound:
+@@ -277,11 +330,34 @@ class UpperBound:
+             return False
+         if other.version is None:
+             return True
+-        if self.version != other.version:
++        # See LowerBound.__lt__ for why this reads the cached keys.
++        self_key = self.version._key_cache
++        other_key = other.version._key_cache
++        if self_key is not None and other_key is not None:
++            if self_key != other_key:
++                return self_key < other_key
++        elif self.version != other.version:
+             return self.version < other.version
          # v) < v]: exclusive ends earlier.
          return not self.inclusive and other.inclusive
  
@@ -1896,7 +1941,12 @@ index e312a1f..9a611c3 100644
 +            return other.version is not None
 +        if other.version is None:
 +            return False
-+        if self.version != other.version:
++        self_key = self.version._key_cache
++        other_key = other.version._key_cache
++        if self_key is not None and other_key is not None:
++            if self_key != other_key:
++                return not self_key < other_key
++        elif self.version != other.version:
 +            return not self.version < other.version
 +        return self.inclusive and not other.inclusive
 +


### PR DESCRIPTION
On `ecosystem:pandas-with-aws-s3 --resolution lowest` the branch is between about 1% and 8% faster locally, with a middle estimate near 3.5%, over 40 runs of each side; CPU moves the same way. Peak memory stays inside about 0.7% either way, which is as fine as those runs can measure.

The same resolve makes 5,523,019 fewer calls, 89,590,187 against 95,113,206 on main, while making the same 2,732,387 bound comparisons on both sides:

| function | main | branch |
| --- | --- | --- |
| `Version.__ne__` | 1,387,585 | 3,754 |
| `Version.__lt__` | 1,515,587 | 137,946 |
| `isinstance` | 15,847,650 | 13,086,179 |

`LowerBound.__lt__`/`__gt__`/`__le__` and `UpperBound.__lt__`/`__gt__` each ran `self.version != other.version` and then compared the same two versions again with `<`, so one ordering question dispatched two full version comparisons. They now read both versions' cached comparison keys and compare those once, which leaves the order unchanged.

A boundary operand, or a version whose key has not been computed yet, still takes the operator path: `BoundaryVersion` carries a class-level `_key_cache = None`, so that routing costs no type check.

Replaying one resolve's bound comparisons on their own, the branch retires 1,237,496,925 fewer instructions, 19,914,130,844 against 21,151,627,769, and a second count of the same replay on main lands 0.02% away. Counting the whole resolve instead gives -5.5% and -2.4% on two pairs of counted runs, and the same commit and seed do not always reach the same decisions, so those two readings are the range rather than a spread around one number.

How much there is to remove depends on the scenario: those ordering methods are 2.9% of the pandas run's 95,113,206 calls, and 0.06% of `airflow:airflow-3-0-2-awswrangler --resolution lowest-direct`, 6,981 calls of 11,870,266.

This is the vendored packaging tree, so `tasks/vendoring/packaging.patch` and the vendored `PROVENANCE.md` move with it.
