### PR TITLE
Share the listing parse across a matrix's Pythons, ~6% off a 3-Python lock

### DIFF
--- a/nab-project/src/nab_project/resolve.py
+++ b/nab-project/src/nab_project/resolve.py
@@ -34,6 +34,7 @@ from nab_provider._vendor.packaging.ranges import VersionRange
 from nab_provider._vendor.packaging.requirements import Requirement
 from nab_provider._vendor.packaging.utils import canonicalize_name
 from nab_provider.marker_holds import dependency_marker_holds
+from nab_provider.provider import ListingFilterCache
 from nab_provider.requirements_file import (
     expand_extra_requirements,
     expand_group_includes,
@@ -283,6 +284,9 @@ def resolve_with_coordinator(  # noqa: PLR0913 - the knobs of a bare resolve
                 dependency_marker_holds if marker_holds is None else marker_holds
             ),
             progress=progress,
+            listing_filter_cache=ListingFilterCache(
+                len({target.python_full_version for target in targets})
+            ),
         )
 
         fork_list = (

--- a/nab-project/tests/test_resolve_targets.py
+++ b/nab-project/tests/test_resolve_targets.py
@@ -13,7 +13,7 @@ import logging
 import subprocess
 import tarfile
 from pathlib import Path
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 from unittest.mock import patch
 
 import pytest
@@ -2735,6 +2735,22 @@ class TestSharedListingFilter:
 
         return calls, counting
 
+    def _record_parse_passes(self) -> tuple[list[bool], object]:
+        """Return each parse pass's ``target_drops``, and the patch that records them.
+
+        False is the pass a matrix's Pythons share; True is the pass that
+        carries the drops, which a resolve with nothing to share runs per
+        Python.
+        """
+        passes: list[bool] = []
+        real = listing_mod._prepare_listing
+
+        def recording(*args: Any, **kwargs: Any) -> Any:
+            passes.append(bool(kwargs["target_drops"]))
+            return real(*args, **kwargs)
+
+        return passes, recording
+
     def test_platform_targets_share_one_base_filter(self) -> None:
         """Targets differing only by platform reuse the base filter result."""
         wheels = [self._wheel("1.0"), self._wheel("2.0")]
@@ -2797,6 +2813,60 @@ class TestSharedListingFilter:
             for tr in result.target_results
         }
         assert pinned == {"3.11": "1.0", "3.12": "2.0"}
+
+    def test_a_matrix_of_pythons_parses_the_listing_once(self) -> None:
+        """The Pythons filter separately over one shared parse-and-policy pass."""
+        wheels = [self._wheel("1.0"), self._wheel("2.0", requires_python=">=3.12")]
+        calls, counting = self._count_base_filters()
+        passes, recording = self._record_parse_passes()
+
+        with (
+            patch.object(listing_mod, "_filter_base", counting),
+            patch.object(listing_mod, "_prepare_listing", recording),
+        ):
+            result = resolve_with_coordinator(
+                self._coordinator(wheels),
+                self._targets(">=3.11,<3.13"),
+                _reqs("pkg"),
+                config=_no_build(),
+                align_across_targets=False,
+            )
+
+        assert result.success
+        assert sorted(calls) == ["pkg@3.11.0", "pkg@3.12.0"]
+        assert passes == [False]
+
+    def test_two_micros_of_one_minor_are_two_pythons(self) -> None:
+        """Sharing follows the release the memo keys on, not the PEP 508 minor."""
+        wheels = [self._wheel("1.0"), self._wheel("2.0")]
+        calls, counting = self._count_base_filters()
+        passes, recording = self._record_parse_passes()
+
+        with (
+            patch.object(listing_mod, "_filter_base", counting),
+            patch.object(listing_mod, "_prepare_listing", recording),
+        ):
+            result = resolve_with_coordinator(
+                self._coordinator(wheels),
+                [
+                    ResolveTarget.for_declared(
+                        python_version="3.11",
+                        spec=PlatformSpec(platform),
+                        python_full_version=micro,
+                    )
+                    for platform, micro in (
+                        ("linux_x86_64", "3.11.2"),
+                        ("windows_amd64", "3.11.5"),
+                    )
+                ],
+                _reqs("pkg"),
+                config=_no_build(),
+                align_across_targets=False,
+            )
+
+        assert result.success
+        assert sorted(calls) == ["pkg@3.11.2", "pkg@3.11.5"]
+        assert passes == [False]
 
     def test_reused_filter_still_counts_distributions_per_target(self) -> None:
         """Every target reports the files it saw, memo hit or not."""

--- a/nab-provider/src/nab_provider/_provider/listing.py
+++ b/nab-provider/src/nab_provider/_provider/listing.py
@@ -37,6 +37,12 @@ if TYPE_CHECKING:
     from ..provider import DistFile, Provider
     from ..tags import TagSet
 
+    _PreparedListing = tuple[
+        list[tuple[Version, DistFile]],
+        Mapping[Version, DistPolicy],
+        bool,
+    ]
+
 
 # Matched to the provider's look-ahead abort threshold: prefetching 8 versions
 # covers the worst-case abort scan without overshooting.  Used by the
@@ -332,6 +338,75 @@ def _filter_base(
         provider.uploaded_prior_to is not None or provider.overrides_set_time
     )
 
+    cache = provider.listing_filter_cache
+    if cache is None or not cache.shares_pythons:
+        result, policy_by_version, sort_with_wheel_first = _prepare_listing(
+            provider,
+            normalized,
+            files,
+            index_name,
+            target_drops=True,
+            time_filter_active=time_filter_active,
+        )
+    else:
+        parsed, policy_by_version, sort_with_wheel_first = cache.prepared(
+            normalized,
+            provider.stats,
+            partial(
+                _prepare_listing,
+                provider,
+                normalized,
+                files,
+                index_name,
+                target_drops=False,
+                time_filter_active=time_filter_active,
+            ),
+        )
+        result = [
+            pair
+            for pair in parsed
+            if not _excluded_by_python_or_time(
+                provider,
+                normalized,
+                pair[0],
+                pair[1],
+                index_name=index_name,
+                time_filter_active=time_filter_active,
+            )
+        ]
+
+    result = _drop_sdist_install_wheel_only(result, policy_by_version)
+
+    if sort_with_wheel_first:
+        result.sort(
+            key=lambda pair: (pair[0], isinstance(pair[1], WheelFile)),
+            reverse=True,
+        )
+    else:
+        result.sort(key=lambda pair: pair[0], reverse=True)
+    return _canonicalize_equal_versions(result)
+
+
+def _prepare_listing(
+    provider: Provider,
+    normalized: str,
+    files: Sequence[WheelFile | SdistFile],
+    index_name: str | None,
+    *,
+    target_drops: bool,
+    time_filter_active: bool,
+) -> _PreparedListing:
+    """Parse and dist-policy-filter the listing.
+
+    With ``target_drops`` the Requires-Python and upload-cutoff drops run
+    here as well, which is what a one-Python resolve asks for.  A matrix
+    leaves them off so its Pythons can share the pass, and runs them over
+    the result instead.
+
+    Returns the surviving (version, file) pairs in listing order, the dist
+    policy every version that cleared that filter was judged under, and
+    whether any of those policies wants wheels sorted ahead of sdists.
+    """
     result: list[tuple[Version, DistFile]] = []
     sort_with_wheel_first = False
     policy_by_version: dict[Version, DistPolicy] = {}
@@ -360,7 +435,7 @@ def _filter_base(
         if effective_dist_policy in (DistPolicy.PREFER_WHEEL, DistPolicy.SDIST_INSTALL):
             sort_with_wheel_first = True
 
-        if _excluded_by_python_or_time(
+        if target_drops and _excluded_by_python_or_time(
             provider,
             normalized,
             version,
@@ -372,16 +447,7 @@ def _filter_base(
 
         result.append((version, dist))
 
-    result = _drop_sdist_install_wheel_only(result, policy_by_version)
-
-    if sort_with_wheel_first:
-        result.sort(
-            key=lambda pair: (pair[0], isinstance(pair[1], WheelFile)),
-            reverse=True,
-        )
-    else:
-        result.sort(key=lambda pair: pair[0], reverse=True)
-    return _canonicalize_equal_versions(result)
+    return result, policy_by_version, sort_with_wheel_first
 
 
 def _apply_wheel_tags(

--- a/nab-provider/src/nab_provider/provider.py
+++ b/nab-provider/src/nab_provider/provider.py
@@ -11,7 +11,7 @@ import bisect
 import logging
 from collections import defaultdict, deque
 from dataclasses import dataclass, fields
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, TypeVar, cast
 
 from nab_provider._vendor.packaging.markers import prepare_environment
 from nab_provider._vendor.packaging.ranges import VersionRange
@@ -113,6 +113,8 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
+_PreparedT = TypeVar("_PreparedT")
+
 
 @dataclass
 class ProviderStats:
@@ -154,6 +156,18 @@ def _counters(stats: ProviderStats) -> tuple[int, ...]:
     return tuple(getattr(stats, name) for name in _STAT_FIELDS)
 
 
+def _replay(stats: ProviderStats, delta: tuple[int, ...]) -> None:
+    """Add the counters a memoised pass raised to ``stats``."""
+    for name, count in zip(_STAT_FIELDS, delta, strict=True):
+        if count:
+            setattr(stats, name, getattr(stats, name) + count)
+
+
+def _since(before: tuple[int, ...], stats: ProviderStats) -> tuple[int, ...]:
+    """Return how far each counter of ``stats`` rose since ``before``."""
+    return tuple(now - was for now, was in zip(_counters(stats), before, strict=True))
+
+
 class ListingFilterCache:
     """Base listing-filter results shared across the targets of one resolve.
 
@@ -164,16 +178,28 @@ class ListingFilterCache:
     identical list.  Memoising it per (package, Python) leaves only the
     wheel-tag pass to run per target.
 
+    Most of that half reads no Python either: the version parse and the
+    dist-policy exclusion do the same work for every Python of a matrix,
+    and only the Requires-Python and upload-cutoff drops differ.  When the
+    resolve spans more than one Python, :attr:`shares_pythons` is set and
+    :meth:`prepared` memoises that inner pass per package, so a
+    three-Python matrix walks each listing's files once rather than three
+    times.  A one-Python resolve has nothing to share and skips the split,
+    since materialising the intermediate list would cost it a pass it does
+    not get back.
+
     One instance is only valid across providers that share a coordinator
     and a policy config, as the targets of one resolve do.
     """
 
-    def __init__(self) -> None:
-        """Create an empty cache."""
+    def __init__(self, pythons: int = 1) -> None:
+        """Create an empty cache for a resolve over ``pythons`` Python releases."""
+        self.shares_pythons = pythons > 1
         self._entries: dict[
             tuple[str, str | None],
             tuple[list[tuple[Version, DistFile]], tuple[int, ...]],
         ] = {}
+        self._prepared: dict[str, tuple[object, tuple[int, ...]]] = {}
 
     def filtered(
         self,
@@ -190,18 +216,38 @@ class ListingFilterCache:
         entry = self._entries.get((package, python_version))
         if entry is not None:
             result, delta = entry
-            for name, count in zip(_STAT_FIELDS, delta, strict=True):
-                if count:
-                    setattr(stats, name, getattr(stats, name) + count)
+            _replay(stats, delta)
             return list(result)
 
         before = _counters(stats)
         result = compute()
 
-        delta = tuple(
-            now - was for now, was in zip(_counters(stats), before, strict=True)
-        )
-        self._entries[(package, python_version)] = (list(result), delta)
+        self._entries[(package, python_version)] = (list(result), _since(before, stats))
+        return result
+
+    def prepared(
+        self,
+        package: str,
+        stats: ProviderStats,
+        compute: Callable[[], _PreparedT],
+    ) -> _PreparedT:
+        """Return the Python-invariant filter half, running ``compute`` once.
+
+        Keyed by package alone, so every Python of a matrix shares one
+        result.  A hit replays that pass's counters onto ``stats`` the way
+        :meth:`filtered` does, and the caller must treat the result as
+        read-only, since the other Pythons hold it too.
+        """
+        entry = self._prepared.get(package)
+        if entry is not None:
+            result, delta = entry
+            _replay(stats, delta)
+            return cast("_PreparedT", result)
+
+        before = _counters(stats)
+        result = compute()
+
+        self._prepared[package] = (result, _since(before, stats))
         return result
 
 

--- a/nab-provider/tests/test_provider_declared_target.py
+++ b/nab-provider/tests/test_provider_declared_target.py
@@ -14,10 +14,12 @@ from __future__ import annotations
 import random
 import threading
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, cast
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 
+from nab_provider._provider import listing as listing_mod
 from nab_provider._vendor.packaging.ranges import VersionRange
 from nab_provider._vendor.packaging.requirements import Requirement
 from nab_provider._vendor.packaging.version import Version
@@ -54,6 +56,7 @@ def _make_wheel(
     *,
     package: str = "pkg",
     requires_python: str | None = None,
+    upload_time: str | None = None,
 ) -> WheelFile:
     return WheelFile(
         filename=f"{package}-{version}-py3-none-any.whl",
@@ -61,7 +64,7 @@ def _make_wheel(
         version=version,
         requires_python=requires_python,
         has_metadata=True,
-        upload_time=None,
+        upload_time=upload_time,
     )
 
 
@@ -808,6 +811,145 @@ class TestEqualVersionCanonicalization:
         assert windows.fetch_versions("pkg") == []
         assert windows.stats.excluded_by_wheel_tags == 2
         assert windows.stats.excluded_versions_no_compatible_wheel == 1
+
+
+class TestListingFilterSharedAcrossPythons:
+    """A matrix shares the parse and dist-policy pass, not the Python drops."""
+
+    @staticmethod
+    def _files() -> list[WheelFile | SdistFile]:
+        """Three releases: 1.0 for both Pythons, 2.0 from 3.12 up, 3.0 below it."""
+        return [
+            _make_wheel("1.0"),
+            _make_wheel("2.0", requires_python=">=3.12"),
+            _make_wheel("3.0", requires_python="<3.12"),
+        ]
+
+    def _providers(
+        self,
+        cache: ListingFilterCache,
+        *,
+        files: Sequence[WheelFile | SdistFile] | None = None,
+        uploaded_prior_to: datetime | None = None,
+        dist_policy: DistPolicy = DistPolicy.WHEEL_OR_SDIST,
+    ) -> tuple[Provider, Provider]:
+        """A 3.11 and a 3.12 provider over one listing, sharing ``cache``."""
+        coordinator = _index_with_files(self._files() if files is None else files)
+
+        def for_python(python: str) -> Provider:
+            return Provider(
+                coordinator,
+                ResolveTarget.for_declared(
+                    python_version=python, spec=PlatformSpec("linux_x86_64")
+                ),
+                uploaded_prior_to=uploaded_prior_to,
+                dist_policy=dist_policy,
+                listing_filter_cache=cache,
+            )
+
+        return for_python("3.11"), for_python("3.12")
+
+    def _parse_passes(
+        self, monkeypatch: pytest.MonkeyPatch, cache: ListingFilterCache
+    ) -> int:
+        """Count the parse-and-policy passes both Pythons run over ``cache``."""
+        passes = 0
+        real = listing_mod._prepare_listing
+
+        def counting(*args: Any, **kwargs: Any) -> Any:
+            nonlocal passes
+            passes += 1
+            return real(*args, **kwargs)
+
+        monkeypatch.setattr(listing_mod, "_prepare_listing", counting)
+        for provider in self._providers(cache):
+            provider.fetch_versions("pkg")
+        return passes
+
+    def test_the_matrix_walks_the_listing_once(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """One parse and policy pass answers both Pythons."""
+        assert self._parse_passes(monkeypatch, ListingFilterCache(2)) == 1
+
+    def test_without_sharing_each_python_walks_the_listing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A one-Python cache keeps the drops in the pass, so it runs per Python."""
+        assert self._parse_passes(monkeypatch, ListingFilterCache()) == 2
+
+    def test_each_python_keeps_the_releases_it_admits(self) -> None:
+        """The shared pass carries no Requires-Python verdict between Pythons."""
+        py311, py312 = self._providers(ListingFilterCache(2))
+
+        assert [str(v) for v, _ in py311.fetch_versions("pkg")] == ["3.0", "1.0"]
+        assert [str(v) for v, _ in py312.fetch_versions("pkg")] == ["2.0", "1.0"]
+
+    def test_sharing_does_not_change_what_a_python_sees(self) -> None:
+        """Same answers and same counters as a resolve that shares nothing."""
+        shared_py311, shared_py312 = self._providers(ListingFilterCache(2))
+        alone_py311, alone_py312 = self._providers(ListingFilterCache())
+
+        for shared, alone in ((shared_py311, alone_py311), (shared_py312, alone_py312)):
+            assert shared.fetch_versions("pkg") == alone.fetch_versions("pkg")
+            assert shared.stats == alone.stats
+
+    def test_the_cutoff_and_policy_drops_reach_every_python(self) -> None:
+        """The shared drop and the per-Python drops both reach the right counters.
+
+        The dist policy drops the sdist in the shared pass, so both
+        Pythons count it.  The cutoff runs per Python, and only 3.11
+        reaches it, since 3.12 has already lost 3.0 to Requires-Python.
+        """
+        files: list[WheelFile | SdistFile] = [
+            _make_wheel("1.0", upload_time="2026-01-01T00:00:00Z"),
+            _make_wheel(
+                "2.0", requires_python=">=3.12", upload_time="2026-01-01T00:00:00Z"
+            ),
+            _make_wheel(
+                "3.0", requires_python="<3.12", upload_time="2026-06-01T00:00:00Z"
+            ),
+            _sdist("4.0"),
+        ]
+        cutoff = datetime(2026, 3, 1, tzinfo=timezone.utc)
+
+        shared = self._providers(
+            ListingFilterCache(2),
+            files=files,
+            uploaded_prior_to=cutoff,
+            dist_policy=DistPolicy.WHEEL_ONLY,
+        )
+        alone = self._providers(
+            ListingFilterCache(),
+            files=files,
+            uploaded_prior_to=cutoff,
+            dist_policy=DistPolicy.WHEEL_ONLY,
+        )
+
+        for one, other in zip(shared, alone, strict=True):
+            assert one.fetch_versions("pkg") == other.fetch_versions("pkg")
+            assert one.stats == other.stats
+
+        py311, py312 = shared
+        assert [str(v) for v, _ in py311.fetch_versions("pkg")] == ["1.0"]
+        assert py311.stats.excluded_by_time == 1
+        assert py312.stats.excluded_by_time == 0
+
+        assert py311.stats.excluded_by_dist_policy == 1
+        assert py312.stats.excluded_by_dist_policy == 1
+
+    def test_every_python_reports_the_files_it_walked(self) -> None:
+        """The memo replays its counters, so the second Python still sees three."""
+        py311, py312 = self._providers(ListingFilterCache(2))
+
+        py311.fetch_versions("pkg")
+        py312.fetch_versions("pkg")
+
+        assert py311.stats.distributions_seen == 3
+        assert py312.stats.distributions_seen == 3
+
+        assert py311.stats.excluded_by_python == 1
+        assert py312.stats.excluded_by_python == 1
 
 
 class TestUnsetKnobAcceptsAnyLevel:


### PR DESCRIPTION
On `transformers-cpu-multi-python` (3 Pythons x 2 platforms, 59 packages) a resolve retires 12,688,706,168 instructions against 13,481,442,517 on main, 792,736,349 fewer, 5.9% of the run. Locally that is about 1.6 s down to 1.5 s.

The base listing filter is memoised per (package, Python), but only the Requires-Python and upload-cutoff drops read the Python. The version parse and the dist-policy exclusion give every Python of a matrix the same answer, so a 3-Python lock walked each listing's files three times to reach one result. `_prepare_listing` now holds that half and `ListingFilterCache.prepared` memoises it per package. The two per-Python drops still run over the result in the same call and the same order, so the drop counters are unchanged.

| Workload | files walked in the parse pass | instructions |
| --- | --- | --- |
| `transformers-cpu-multi-python`, 3 Pythons x 2 platforms | 163,510 -> 54,530 | -792,736,349 (-5.9%) |
| `scientific-python-multi`, 4 Pythons x 3 platforms | 84,785 -> 21,413 | -376,681,519 (-4.5%) |
| `scientific-lowest`, one Python | unchanged | +913,228 (+0.05%) |

`_filter_base` still runs 175 and 74 times; what drops is the pass inside it, now once per package (59 and 20 calls), so the files walked fall by the Pythons per package. Those file counts are exact.

The instruction counts are not quite: a second run of each gave -785,029,189, -443,374,780 and +395,664. The transformers counts repeat to within 0.06%, so that saving is 5.8% either way. `scientific-python-multi` repeats 0.8% apart, since the look-ahead consumes whatever metadata has arrived and does not always walk the same path, so read its saving as between about 4.5% and 5.3%.

Twelve timed runs of each, alternated, on `transformers-cpu-multi-python`, all local: wall between about 3% and 9% faster with a middle estimate near 7%, CPU between about 6% and 9% lower, peak memory about 2.5% lower. All 24 runs resolved in 315 decisions, and the pins match main on `transformers-cpu-multi-python`, `scientific-python-multi`, `max-25-tuples` and `scientific-lowest`.

A one-Python resolve has nothing to share, so `ListingFilterCache` takes the resolve's Python count and keeps the original single pass at one. Without that gate the split costs such a resolve a materialised list and a second walk over it, about 0.5% on `scientific-lowest`; with it, that scenario is the +0.05% row above. Hoisting the sort into the shared pass would sort the bigger pre-drop list, so the sort stayed per Python.

The count is of distinct `python_full_version`s, the key the per-Python memo already uses. Counting PEP 508 minors instead would switch the split off for two environments that differ only by micro, which is where it pays.
