### PR TITLE
Gate the relation memo on its hit rate, ~7% off pandas-with-aws-s3 lowest

### DIFF
--- a/nab-resolver/src/nab_resolver/propagate.py
+++ b/nab-resolver/src/nab_resolver/propagate.py
@@ -29,6 +29,14 @@ __all__ = [
 # Upper bound on relation_cache size; cleared on overflow to bound memory.
 RELATION_CACHE_MAX = 100_000
 
+# A probe that misses builds its key for nothing, and on a conflict-heavy
+# resolve most probes miss.  So the memo runs only while its hit rate over a
+# window of probes pays for the key, and a longer window re-samples it later in
+# case the resolve changes shape.
+RELATION_GATE_WINDOW = 4_096
+RELATION_GATE_MIN_HITS = 1_024
+RELATION_GATE_RECHECK = 65_536
+
 # Upper bound on the address-keyed token memo, cleared on overflow together
 # with the range objects it holds alive.  A larger cap wipes less often and so
 # holds on to more ranges, which costs peak memory.
@@ -158,6 +166,25 @@ def _intern_range(resolver: Resolver[Any, Any], range_: RangeProtocol[Any]) -> i
     return token
 
 
+def _resample_relation_gate(resolver: Resolver[Any, Any]) -> None:
+    """Judge the window of probes that just ended and open the next one.
+
+    While the memo is on, the window counts hits, and too few switch the memo
+    off and drop the entries it collected.  While it is off, the window is only
+    the wait before the memo is tried again.
+    """
+    if not resolver.relation_cache_on:
+        resolver.relation_cache_on = True
+    elif resolver.relation_gate_hits < RELATION_GATE_MIN_HITS:
+        resolver.relation_cache_on = False
+        resolver.relation_cache.clear()
+        resolver.relation_gate_countdown = RELATION_GATE_RECHECK
+        return
+
+    resolver.relation_gate_hits = 0
+    resolver.relation_gate_countdown = RELATION_GATE_WINDOW
+
+
 def term_relation(resolver: Resolver[Any, Any], term: Term[Any, Any]) -> SetRelation:
     """Check how the partial solution relates to this term.
 
@@ -174,27 +201,41 @@ def term_relation(resolver: Resolver[Any, Any], term: Term[Any, Any]) -> SetRela
     positive = term.is_positive()
     constraint = term.constraint
 
-    # Both lookups stay inline because the memo answers nearly every probe;
-    # only a miss pays for the call into _intern_range.
-    id_tokens = resolver.range_token_by_id
-    assignment_token = id_tokens.get(id(assignment))
-    if assignment_token is None:
-        assignment_token = _intern_range(resolver, assignment)
-    constraint_token = id_tokens.get(id(constraint))
-    if constraint_token is None:
-        constraint_token = _intern_range(resolver, constraint)
+    countdown = resolver.relation_gate_countdown - 1
+    if countdown:
+        resolver.relation_gate_countdown = countdown
+    else:
+        _resample_relation_gate(resolver)
 
     cache = resolver.relation_cache
-    key = (positive, assignment_token, constraint_token)
-    result = cache.get(key)
+    # key stays None while the memo is off, so a miss below stores nothing.
+    key = None
+    result = None
+    if resolver.relation_cache_on:
+        # Both lookups stay inline because most probes hit while the memo is
+        # on; only a miss pays for the call into _intern_range.
+        id_tokens = resolver.range_token_by_id
+        assignment_token = id_tokens.get(id(assignment))
+        if assignment_token is None:
+            assignment_token = _intern_range(resolver, assignment)
+        constraint_token = id_tokens.get(id(constraint))
+        if constraint_token is None:
+            constraint_token = _intern_range(resolver, constraint)
+
+        key = (positive, assignment_token, constraint_token)
+        result = cache.get(key)
+
     if result is None:
         relation = assignment.relation(constraint)
         result = classify_relation(
             term, subset=relation.is_subset, disjoint=relation.is_disjoint
         )
-        if len(cache) >= RELATION_CACHE_MAX:
-            cache.clear()
-        cache[key] = result
+        if key is not None:
+            if len(cache) >= RELATION_CACHE_MAX:
+                cache.clear()
+            cache[key] = result
+    else:
+        resolver.relation_gate_hits += 1
 
     needs_positive = (positive and result is SetRelation.SATISFIED) or (
         not positive and result is SetRelation.CONTRADICTED

--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -493,6 +493,13 @@ class Resolver(Generic[PackageType, VersionType]):
         # (positive, assignment token, constraint token). Cleared on overflow.
         self.relation_cache: dict[tuple[bool, int, int], SetRelation] = {}
 
+        # relation_cache_on goes off while the memo's hit rate does not pay for
+        # the key it builds. relation_gate_countdown is the probes left in the
+        # window that rate is judged over, and relation_gate_hits its hits.
+        self.relation_cache_on = True
+        self.relation_gate_countdown = propagate.RELATION_GATE_WINDOW
+        self.relation_gate_hits = 0
+
         # One token per distinct range, so a relation-cache probe compares ints
         # rather than bound structures. The counter never rewinds, so clearing
         # this table alone only strands relation_cache entries; it can never
@@ -713,6 +720,9 @@ class Resolver(Generic[PackageType, VersionType]):
         self.decision_queue.clear()
         self.priority_epoch = 0
         self.relation_cache.clear()
+        self.relation_cache_on = True
+        self.relation_gate_countdown = propagate.RELATION_GATE_WINDOW
+        self.relation_gate_hits = 0
         self.range_tokens.clear()
         self.range_token_by_id.clear()
         self.interned_ranges.clear()

--- a/nab-resolver/tests/test_resolver.py
+++ b/nab-resolver/tests/test_resolver.py
@@ -3118,6 +3118,11 @@ class TestRelationCache:
     def test_gate_keeps_the_memo_while_probes_hit(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """A window that closes well starts the next one, so the count restarts.
+
+        The final hit count is the probe that closed the window, counted after
+        the reset rather than the one asserted before it.
+        """
         monkeypatch.setattr(propagate, "RELATION_GATE_MIN_HITS", 1)
         resolver: Resolver[str, int] = Resolver(DictProvider({}))
         resolver.solution.decide("foo", 2)

--- a/nab-resolver/tests/test_resolver.py
+++ b/nab-resolver/tests/test_resolver.py
@@ -3097,6 +3097,76 @@ class TestRelationCache:
         assert self._token_key(resolver, term) == key
         assert resolver.relation_cache == {key: first}
 
+    def test_gate_switches_the_memo_off_when_probes_mostly_miss(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The window closes on probes alone, and the entries it collected go too."""
+        monkeypatch.setattr(propagate, "RELATION_GATE_WINDOW", 3)
+        resolver: Resolver[str, int] = Resolver(DictProvider({}))
+        resolver.solution.decide("foo", 2)
+        # Filler for another range pair, to show the whole memo is dropped.
+        resolver.relation_cache[(False, 0, 0)] = SetRelation.SATISFIED
+
+        # A distinct constraint each time, so no probe in the window hits.
+        for lower in (1, 3, 5):
+            term_relation(resolver, Term("foo", Range.at_least(lower), positive=True))
+
+        assert resolver.relation_cache_on is False
+        assert resolver.relation_cache == {}
+        assert resolver.relation_gate_countdown == propagate.RELATION_GATE_RECHECK
+
+    def test_gate_keeps_the_memo_while_probes_hit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(propagate, "RELATION_GATE_MIN_HITS", 1)
+        resolver: Resolver[str, int] = Resolver(DictProvider({}))
+        resolver.solution.decide("foo", 2)
+        term = Term("foo", Range.at_least(1), positive=True)
+        term_relation(resolver, term)
+        term_relation(resolver, term)
+        assert resolver.relation_gate_hits == 1
+
+        resolver.relation_gate_countdown = 1
+        term_relation(resolver, term)
+
+        assert resolver.relation_cache_on is True
+        assert resolver.relation_gate_countdown == propagate.RELATION_GATE_WINDOW
+        assert resolver.relation_gate_hits == 1
+
+    def test_gate_tries_the_memo_again_after_the_recheck_window(self) -> None:
+        resolver: Resolver[str, int] = Resolver(DictProvider({}))
+        resolver.solution.decide("foo", 2)
+        resolver.relation_cache_on = False
+        resolver.relation_gate_countdown = 1
+        term = Term("foo", Range.at_least(1), positive=True)
+
+        result = term_relation(resolver, term)
+
+        assert resolver.relation_cache_on is True
+        assert resolver.relation_gate_countdown == propagate.RELATION_GATE_WINDOW
+        assert resolver.relation_cache == {self._token_key(resolver, term): result}
+
+    def test_relation_is_unchanged_while_the_memo_is_off(self) -> None:
+        resolver: Resolver[str, int] = Resolver(DictProvider({}))
+        resolver.solution.decide("foo", 2)
+        term = Term("foo", Range.at_least(1), positive=True)
+        expected = term_relation(resolver, term)
+
+        resolver.relation_cache_on = False
+        resolver.relation_cache.clear()
+
+        assert term_relation(resolver, term) is expected
+        assert resolver.relation_cache == {}
+
+    def test_a_second_resolve_starts_with_the_memo_on(self) -> None:
+        resolver: Resolver[str, int] = Resolver(DictProvider({"foo": {1: {}}}))
+        resolver.resolve({"foo": Range.at_least(1)})
+        resolver.relation_cache_on = False
+
+        resolver.resolve({"foo": Range.at_least(1)})
+
+        assert resolver.relation_cache_on is True
+
 
 class LowestVersionProvider(DictProvider):
     """Provider that picks the lowest matching version rather than the highest."""


### PR DESCRIPTION
Locally, `ecosystem:pandas-with-aws-s3 --resolution lowest` resolves between about 4% and 9% faster, with a middle estimate near 7%. CPU drops about 8% and peak memory about 4.5%. The two scenarios the memo actually serves do not move: those runs rule out a wall change above about 2% either way on `pip:apache-airflow-311-full` and about 4% on `ecosystem:apache-beam-sdist-build`, and put peak memory inside about 0.1% on both.

`term_relation` has to build a key before it can probe the memo, so a probe that misses pays for the key and gets nothing back. Counting probes on pandas shows the hit rate collapsing as the resolve goes deeper:

- first 100,000 probes: about half hit
- next 50,000: about 11%
- every 50,000 after that: under 1.5%

Airflow and beam sit at 96% and 91% across the whole resolve.

So the memo now runs only while it pays for itself. `term_relation` counts hits over a window of 4,096 probes and switches the memo off, dropping its entries, when fewer than a quarter of them hit; after 65,536 probes it tries again, so a resolve that changes shape gets the memo back.

Pandas switches off partway through and stays off apart from those retries, and a memory trace of the same scenario counts 1,262 gen-0 collections against 2,135, which is the memo's entries no longer being allocated. Airflow and beam stay well clear of the threshold. Switching the memo off changes no answer, only what gets recomputed.

The threshold is a first cut. Deleting the memo outright measures about 19% faster on pandas, so this gate takes roughly 40% of what is there; the rest sits in the early phase where the memo still hits about half the time and the gate keeps it on. Break-even therefore looks higher than a quarter, and raising the threshold is the next thing to measure.
