### PR TITLE
Fire the look-ahead abort at 4 rejections instead of 8, 9% fewer decisions

### DIFF
--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -929,9 +929,9 @@ class TestHasSatisfyingVersion:
     def test_true_when_a_usable_version_sits_past_the_abort_threshold(self) -> None:
         """Suppressing the abort still finds a usable version deep in the scan.
 
-        The newest eight candidates are rejected by the decided blocker, so a
-        fired abort would stop before the ninth, usable one.  The probe keeps
-        scanning and reports True.
+        The newest eight candidates are rejected by the decided blocker and the
+        trigger is pinned to that count, so a fired abort would stop before the
+        ninth, usable one.  The probe keeps scanning and reports True.
         """
         usable, blocked = "1.0", [f"{n}.0" for n in range(9, 1, -1)]
         wheels = [make_wheel(v) for v in [*blocked, usable]]
@@ -948,6 +948,7 @@ class TestHasSatisfyingVersion:
         root_reqs = {"foo": VersionRange.full(admit_arbitrary=False)}
         provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         provider.receive_partial_solution_hint({}, {"bar": V("5.0")})
+        provider._LOOKAHEAD_ABORT_THRESHOLD = len(blocked)  # type: ignore[misc]
         assert provider.has_satisfying_version("foo", VersionRange.full())
 
     def test_false_when_conflicts_exceed_the_reject_cap(self) -> None:

--- a/nab-provider/src/nab_provider/provider.py
+++ b/nab-provider/src/nab_provider/provider.py
@@ -410,7 +410,7 @@ class Provider:
     # Set low because the trigger is conservative: a unique
     # ``(blocker_pkg, blocker_version)`` repeating across every rejection
     # is already a strong signal.
-    _LOOKAHEAD_ABORT_THRESHOLD = 8
+    _LOOKAHEAD_ABORT_THRESHOLD = 4
 
     # Max force-backtracks one blocker can drive per resolution.
     # One-shot misses sustained culprits; unlimited oscillates on


### PR DESCRIPTION
Decisions drop about 9% where the look-ahead abort fires, from a median 100,227.5 to 91,218, once the trigger moves from 8 same-blocker rejections to 4. Conflicts go 1,136.5 to 931 on the same runs and metadata fetches 4,528.5 to 4,295.

That is the 17 scenarios that fire the abort and resolve in every run, each figure the median of four runs. The counts are not stable between runs: the per-run sums span 91,174 to 91,891 at 4 and 94,359 to 100,465 at 8.

8 arrived with the abort itself, one of four knobs tuned together against cold wall time on a single scenario, and has not been revisited. The counters rank it against its neighbours:

| threshold | decisions | conflicts | metadata fetched |
| --- | --- | --- | --- |
| 4 | 91,218 | 931 | 4,295 |
| 8 | 100,227.5 | 1,136.5 | 4,528.5 |
| 16 | 91,922 | 1,675.5 | 4,899.5 |
| 32 | 111,259 | 1,563 | 4,805.5 |

16 lands near 4 on decisions and pays for it in conflicts and fetches; 32 is worse than 8 on all three. 4 is also the steadiest: its per-run totals move 0.79% across the four runs where 8 moves 6.09%, because at 8 `airflow:airflow-october-regression-py310` drops into a search that ranges over 6,177 decisions between runs of the same cell.

Counting a move only when it clears that scenario's own range at 8, 4 is better on 5 of the 17, worse on 2, and inside noise on 10. The large moves are all in the airflow family:

- `airflow:airflow-october-regression-py310` 15,571 -> 8,632 and `airflow:airflow-october-regression-py312` 32,145 -> 29,181.
- `pip:airflow-october-regression` 14,951 -> 16,025 and `pip:apache-airflow-311-full` 14,912 -> 15,595 spend more.

The sweep covered 527 scenarios; the other 434 ran once at 4 and once at 8. 229 resolve on both sides, none goes from pass to fail, and of the 24 whose counters moved and that resolve in every run, two improve and two regress.

Pins move on 5 of the 17 and on 1 of the 434, with the package count held everywhere. In the airflow family they move as trade-off pairs whose upper bounds exclude each other: 4 takes `google-auth` 2.42.1 with `google-auth-oauthlib` 1.2.2, 8 takes 2.41.1 with 1.2.3. Two of those scenarios, `airflow:airflow-october-regression-py313` and `pip:apache-airflow-311-full`, do not return the same map on every run at 4.

`uv:uv-issue-17257-trcli-jsonschema` is the exception, and the one scenario that states the answer it wants: at 8 nab pins `openapi-spec-validator` 0.5.5, the pin the uv issue behind the scenario is about, and at 4 it pins 0.7.2.

The canary set reads the same way: 13,543 decisions against 17,383 over the 17 of its 19 scenarios that produce numbers here, though `pip:langchain-ml-course` alone accounts for 3,969 of the 3,840 net and everything else together spends 129 more.

The clock cannot see a change this size here. Timing `airflow:airflow-october-regression-py312` 12 runs each way locally rules out a wall or CPU regression above about 7%, and puts peak memory inside about 0.3% either way.
