### PR TITLE
Skip already-issued speculative prefetch requests, 4.5% off a resolve

### DIFF
--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -260,6 +260,94 @@ class TestPrefetchListings:
         assert coordinator.calls_to("request_listing") == [("bar", True)]
 
 
+class TestSpeculativeRequestDedup:
+    """A repeat speculative request is dropped, the first one is not."""
+
+    def test_repeat_cascade_requests_each_listing_once(self) -> None:
+        """A dep named by three parents gets one speculative listing request."""
+        coordinator = make_coordinator([make_wheel("1.0")], package="foo")
+        provider = Provider(coordinator, target=_PY312)
+        coordinator.reset()
+
+        deps = {"bar": SpecifierSet(">=1.0").to_range()}
+        for _ in range(3):
+            provider.prefetch_new_deps(deps)
+
+        assert coordinator.calls_to("request_listing") == [("bar", True)]
+
+    def test_listing_requests_keep_their_first_occurrence_order(self) -> None:
+        """Every name still reaches the coordinator, in first-occurrence order."""
+        coordinator = make_coordinator([make_wheel("1.0")], package="foo")
+        provider = Provider(coordinator, target=_PY312)
+        coordinator.reset()
+
+        full = SpecifierSet(">=1.0").to_range()
+        provider.prefetch_new_deps({"bar": full})
+        provider.prefetch_new_deps({"bar": full, "baz": full})
+        provider.prefetch_new_deps({"baz": full, "qux": full})
+
+        assert coordinator.calls_to("request_listing") == [
+            ("bar", True),
+            ("baz", True),
+            ("qux", True),
+        ]
+
+    def test_repeat_cascade_requests_transitive_metadata_once(self) -> None:
+        """The best candidate's sidecar is asked for once, not once per parent."""
+        coordinator = make_coordinator(
+            [make_wheel("2.0"), make_wheel("1.0")], package="foo"
+        )
+        provider = Provider(coordinator, target=_PY312)
+        provider.fetch_versions("foo")
+
+        deps = {"foo": SpecifierSet(">=1.0").to_range()}
+        for _ in range(3):
+            provider.prefetch_new_deps(deps)
+
+        calls = coordinator.calls_to("request_metadata")
+        assert [version for _pkg, version, _url, _hash in calls] == ["2.0"]
+
+    def test_new_best_pick_for_the_same_package_is_still_requested(self) -> None:
+        """The candidate memo keys on the version, not on the package alone.
+
+        ``pick_best_candidate`` is patched because within one provider it is
+        constant per package: root requirements, the listing and the strategy
+        are all fixed once the resolve starts.
+        """
+        coordinator = make_coordinator(
+            [make_wheel("2.0"), make_wheel("1.0")], package="foo"
+        )
+        provider = Provider(coordinator, target=_PY312)
+        older = provider.fetch_versions("foo")[-1]
+
+        deps = {"foo": SpecifierSet(">=1.0").to_range()}
+        with patch.object(provider, "pick_best_candidate", return_value=older):
+            provider.prefetch_new_deps(deps)
+            provider.prefetch_new_deps(deps)
+
+        calls = coordinator.calls_to("request_metadata")
+        assert [version for _pkg, version, _url, _hash in calls] == ["2.0", "1.0"]
+
+    def test_metadata_requests_keep_their_first_occurrence_order(self) -> None:
+        """Every candidate still reaches the coordinator, in first-occurrence order."""
+        coordinator = make_coordinator(
+            listings={"foo": [make_wheel("2.0")], "bar": [make_wheel("3.0")]}
+        )
+        provider = Provider(coordinator, target=_PY312)
+        full = SpecifierSet(">=1.0").to_range()
+
+        provider.fetch_versions("foo")
+        provider.prefetch_new_deps({"foo": full})
+        provider.fetch_versions("bar")
+        provider.prefetch_new_deps({"foo": full, "bar": full})
+
+        calls = coordinator.calls_to("request_metadata")
+        assert [(pkg, version) for pkg, version, _url, _hash in calls] == [
+            ("foo", "2.0"),
+            ("bar", "3.0"),
+        ]
+
+
 class TestSpeculativePrefetch:
     def test_metadata_prefetched_after_listing(self) -> None:
         """After listing fetch, metadata for best candidate is in flight."""

--- a/nab-provider/src/nab_provider/_provider/listing.py
+++ b/nab-provider/src/nab_provider/_provider/listing.py
@@ -188,7 +188,14 @@ def prefetch_transitive_best(
     normalized: str,
     versions: list[tuple[Version, DistFile]],
 ) -> None:
-    """Fire metadata prefetch for the single best transitive candidate."""
+    """Fire metadata prefetch for the single best transitive candidate.
+
+    Requests a candidate at most once. A dep with no root constraint reaches
+    here once per parent that names it, and within one resolve the artifact a
+    candidate resolves to is fixed. The mark goes on above the override and
+    artifact checks, so it records a candidate as seen even when no request
+    follows.
+    """
     # Routed through ``provider.pick_best_candidate`` so existing
     # ``patch.object(provider, "pick_best_candidate", ...)`` mocks
     # in the test suite still drive this prefetch path.
@@ -198,6 +205,11 @@ def prefetch_transitive_best(
     version, _ = best
     if (normalized, version) in provider.deps_cache:
         return
+
+    if (normalized, version) in provider.speculative_candidates:
+        return
+    provider.speculative_candidates.add((normalized, version))
+
     if _has_complete_override(provider, normalized, version):
         return
 
@@ -860,6 +872,9 @@ def prefetch_new_deps(provider: Provider, deps: Mapping[str, VersionRange]) -> N
     Local, VCS, and archive sources are skipped; they have no PyPI
     listing and the materialise path in ``fetch_versions`` will
     surface them when the resolver asks.
+
+    A dep named by several parents arrives once per parent, so only
+    the first of them requests its listing.
     """
     for dep in deps:
         _, _, normalized = provider.split_and_normalize(dep)
@@ -873,7 +888,9 @@ def prefetch_new_deps(provider: Provider, deps: Mapping[str, VersionRange]) -> N
             # Listing not cached: request it speculatively so its read work
             # overlaps resolver CPU on the fetcher thread. When it arrives,
             # prioritize() notices and fires metadata prefetch.
-            provider.coordinator.request_listing(normalized, speculative=True)
+            if normalized not in provider.speculative_listings:
+                provider.speculative_listings.add(normalized)
+                provider.coordinator.request_listing(normalized, speculative=True)
         else:
             # Listing cached: fire speculative metadata prefetch.
             speculative_prefetch(

--- a/nab-provider/src/nab_provider/provider.py
+++ b/nab-provider/src/nab_provider/provider.py
@@ -633,6 +633,12 @@ class Provider:
             str, tuple[RangeProtocol[Version], str, int, tuple[int, int, bool]]
         ] = {}
 
+        # What the speculative prefetch has already seen: the names it
+        # requested listings for, and the candidates the transitive path
+        # walked. A dep named by several parents reaches both once per parent.
+        self.speculative_listings: set[str] = set()
+        self.speculative_candidates: set[tuple[str, Version]] = set()
+
         # Derived views of versions_cache, built lazily alongside the listing.
         self.versions_only_cache: dict[str, list[Version]] = {}
         self.version_dists_cache: dict[str, _metadata_resolver.VersionDists] = {}


### PR DESCRIPTION
Deduplicating the provider's speculative prefetch requests takes 4,515,720,183 retired instructions off an `apache-airflow-universal` matrix resolve, 4.5% of the process.

The provider issues the same speculative request over and over. A dep named by several parents reaches `prefetch_new_deps` once per parent and asks the coordinator for its listing each time, and the transitive prefetch does the same for the same best candidate. Across that matrix the provider makes 26,072 calls into the coordinator, and 1,564 once the repeats are dropped.

Measured on the whole matrix, all three targets in one process against a warm cache:

| | base | branch |
| --- | ---: | ---: |
| retired instructions | 100,069,300,195 | 95,553,580,012 |
| `request_listing` | 3,988 | 315 |
| `request_metadata` | 22,068 | 1,233 |
| `request_metadata_batch` | 16 | 16 |

The call counts are identical across repeat runs of each side. A second instruction A/B of the same workload gives 4,547,746,162 (4.5%), with the two base runs 0.02% apart.

Each suppressed visit skips a listing walk: `pick_dist_for_metadata` runs 21,905 times on the base and 203 times here, and `Version.__eq__` calls drop from 4,830,782 to 2,674,101.

Locally, between about 3% and 7% faster on that matrix against a warm cache, with a middle estimate near 4% and all 12 interleaved pairs negative. Peak memory sits inside about 0.9% either way, which is about the smallest difference that run could have resolved.

What does not change:

- No fetch is added or removed. `InMemoryIndex` never removes a pending request, so from the second call onward a repeat was already a lookup that submitted nothing. `metadata_fetched` is 151 and 150 on the two targets on both sides.
- The set of requests is the same: 1,252 distinct on the first target and 207 on each repeat of the second, same members. The repeat target is served entirely from the store and its first-occurrence order is identical too. The first target fetches, so its order is not stable on the base either, and two base runs of the same code give those 1,252 requests in a different order.
- `prefetch_root_batch` is untouched: 6 and 5 batch calls submitting 81 and 37 items, both sides.
- The resolve is identical wherever it was compared. On the matrix: 166 and 165 decisions, 165 conflicts, 334 and 333 rounds, 164 backjumps, 21,129 distributions seen, and the same 2,230 character error text. Across the 11 deterministic smoke scenarios every field matches except the timing samples and the fixture directory's own path, inode and stat digest.

One behaviour does change. A suppressed repeat skips the coordinator's fetcher-thread liveness check, which runs 26,087 times on the base and 1,579 times here, so a crashed fetcher surfaces at the next distinct speculative request or the next blocking fetch rather than inside the duplicate.
