### PR TITLE
Split extra deps only when they are read, 43% off airflow universal

### DIFF
--- a/nab-project/src/nab_project/_lockfile/builder.py
+++ b/nab-project/src/nab_project/_lockfile/builder.py
@@ -93,8 +93,12 @@ class LockInputProvider(Protocol):
     deps_cache: Mapping[tuple[str, Version], Mapping[str, object]]
     """Direct dependencies per ``(canonical name, version)``."""
 
-    extra_deps_map: Mapping[tuple[str, Version], Mapping[str, Mapping[str, object]]]
-    """Per-extra dependencies per ``(canonical name, version)``."""
+    @property
+    def extra_deps_map(
+        self,
+    ) -> Mapping[tuple[str, Version], Mapping[str, Mapping[str, object]]]:
+        """Per-extra dependencies per ``(canonical name, version)``."""
+        ...
 
     @property
     def coordinator(self) -> _LockInputCoordinator:
@@ -405,6 +409,7 @@ def _reachable_names(
     reached: set[str] = set()
     seen: set[str] = set()
     stack = list(roots)
+    extra_deps_map = provider.extra_deps_map
 
     while stack:
         key = stack.pop()
@@ -422,7 +427,7 @@ def _reachable_names(
         cache_key = (canonical, version)
         stack.extend(provider.deps_cache.get(cache_key, {}))
         if extra is not None:
-            stack.extend(provider.extra_deps_map.get(cache_key, {}).get(extra, {}))
+            stack.extend(extra_deps_map.get(cache_key, {}).get(extra, {}))
 
     return reached
 
@@ -453,6 +458,7 @@ def _forward_dependency_graph(
     pinned = {canonicalize_name(name) for name in pins}
     graph: dict[str, tuple[str, ...]] = {}
     base_graph: dict[str, tuple[str, ...]] = {}
+    extra_deps_map = provider.extra_deps_map
     for raw_name, version in pins.items():
         canonical = canonicalize_name(raw_name)
         cache_key = (canonical, version)
@@ -461,12 +467,18 @@ def _forward_dependency_graph(
             for dep in provider.deps_cache.get(cache_key, {})
         }
         all_deps = set(base_deps)
-        extra_map = provider.extra_deps_map.get(cache_key, {})
-        for extra in activated_extras.get(canonical, ()):
-            all_deps.update(
-                canonicalize_name(split_extra(dep)[0])
-                for dep in extra_map.get(extra, {})
-            )
+
+        # Reading the per-extra map makes the provider split that release's
+        # extras out, so ask only for a package with an activated extra.
+        activated = activated_extras.get(canonical, ())
+        if activated:
+            extra_map = extra_deps_map.get(cache_key, {})
+            for extra in activated:
+                all_deps.update(
+                    canonicalize_name(split_extra(dep)[0])
+                    for dep in extra_map.get(extra, {})
+                )
+
         base_deps &= pinned
         all_deps &= pinned
         # An umbrella extra (pkg[all] pulling pkg[graphviz]) can name its own

--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import asyncio
 import errno
+import gc
 import io
 import json
 import logging
 import sys
 import tarfile
 import threading
+import weakref
 import zipfile
 from collections.abc import Callable
 from datetime import datetime, timezone
@@ -67,6 +69,7 @@ from nab_provider._vendor.packaging.ranges import VersionRange
 from nab_provider._vendor.packaging.requirements import Requirement
 from nab_provider._vendor.packaging.specifiers import SpecifierSet
 from nab_provider._vendor.packaging.tags import Tag
+from nab_provider._vendor.packaging.utils import canonicalize_name
 from nab_provider._vendor.packaging.version import InvalidVersion, Version
 from nab_provider.marker_holds import dependency_marker_holds
 from nab_provider.metadata import WheelMetadata
@@ -3090,6 +3093,223 @@ class TestAddClassifiedDep:
         extra_map: dict[str, dict[str, VersionRange]] = {"g": {}}
         add_classified_dep(req, {"g"}, {}, extra_map, {})
         assert list(extra_map["g"]) == ["bar", "bar[x]", "bar[y]", "bar[z]"]
+
+
+_EXTRAS_METADATA = {
+    "1.0": (
+        "Metadata-Version: 2.1\n"
+        "Name: pkg\n"
+        "Version: 1.0\n"
+        "Provides-Extra: async\n"
+        "Provides-Extra: Google_Auth\n"
+        "Provides-Extra: all\n"
+        "Requires-Dist: attrs>=22.1.0\n"
+        'Requires-Dist: importlib-metadata>=6.5; python_version < "3.12"\n'
+        'Requires-Dist: legacy; extra != "async"\n'
+        'Requires-Dist: aiohttp>=3.9; extra == "async"\n'
+        'Requires-Dist: aiohttp<4; extra == "async"\n'
+        'Requires-Dist: google-auth>=2.15; extra == "google-auth"\n'
+        'Requires-Dist: shared>=1; extra == "async" or extra == "all"\n'
+        'Requires-Dist: pkg[async,google-auth]; extra == "all"\n'
+        'Requires-Dist: rich>=12; extra == "all" and python_version >= "3.9"\n'
+        'Requires-Dist: dataclasses; extra == "all" and python_version < "3.7"\n'
+        'Requires-Dist: unlisted; extra == "no-such-extra"\n'
+        'Requires-Dist: elsewhere; sys_platform == "nonesuch"\n'
+    ),
+    "2.0": (
+        "Metadata-Version: 2.1\n"
+        "Name: pkg\n"
+        "Version: 2.0\n"
+        "Provides-Extra: async\n"
+        "Requires-Dist: attrs>=23\n"
+        'Requires-Dist: anyio>=4; extra == "async"\n'
+    ),
+}
+"""Two releases of one package whose extras differ."""
+
+
+def _one_pass_extra_deps(
+    provider: Provider, cache_key: tuple[str, Version]
+) -> dict[str, dict[str, VersionRange]]:
+    """Split a parsed release's requirements by extra in a single pass.
+
+    The reference the lazily built maps are compared against: it classifies
+    every requirement up front, through the same helpers the provider uses.
+    """
+    metadata = provider.metadata_cache[cache_key]
+    provided: set[str] = {canonicalize_name(e) for e in metadata.provides_extra}
+    base: dict[str, VersionRange] = {}
+    extra_map: dict[str, dict[str, VersionRange]] = {e: {} for e in provided}
+    for req in metadata.requires_dist:
+        req_extras = classify_requirement(provider, req, provided)
+        if req_extras is None or req.url is not None:
+            continue
+        add_classified_dep(req, req_extras, base, extra_map, provider.specifier_ranges)
+    return extra_map
+
+
+class TestLazyExtraDeps:
+    """``extra_deps_map`` builds a release's per-extra deps when first read."""
+
+    @staticmethod
+    def _provider() -> Provider:
+        coordinator = make_coordinator(
+            [make_wheel("1.0"), make_wheel("2.0")],
+            metadata_by_version=_EXTRAS_METADATA,
+            package="pkg",
+        )
+        return Provider(coordinator, target=_PY312)
+
+    def test_matches_a_single_pass_split(self) -> None:
+        """Each built map equals the one-pass split, key order included."""
+        provider = self._provider()
+        for version in ("1.0", "2.0"):
+            cache_key = ("pkg", V(version))
+            provider.get_dependencies("pkg", V(version))
+
+            built = provider.extra_deps_map[cache_key]
+            expected = _one_pass_extra_deps(provider, cache_key)
+
+            assert built == expected
+            assert list(built) == list(expected)
+            for extra, deps in built.items():
+                assert list(deps) == list(expected[extra])
+
+    def test_extras_hold_their_own_deps(self) -> None:
+        """The split lands each dep under the extras whose markers select it."""
+        provider = self._provider()
+        provider.get_dependencies("pkg", V("1.0"))
+
+        built = provider.extra_deps_map[("pkg", V("1.0"))]
+
+        assert set(built) == {"async", "google-auth", "all"}
+        assert set(built["async"]) == {"aiohttp", "shared"}
+        assert set(built["google-auth"]) == {"google-auth"}
+        assert set(built["all"]) == {
+            "pkg",
+            "pkg[async]",
+            "pkg[google-auth]",
+            "rich",
+            "shared",
+        }
+
+        aiohttp = built["async"]["aiohttp"]
+
+        assert V("3.9") in aiohttp
+        assert V("3.0") not in aiohttp
+        assert V("4.0") not in aiohttp
+
+    def test_base_deps_do_not_wait_for_the_split(self) -> None:
+        """The deps the base environment admits come straight from the parse."""
+        provider = self._provider()
+
+        base = provider.get_dependencies("pkg", V("1.0"))
+
+        assert set(base) == {"attrs", "legacy"}
+
+    def test_key_absent_until_the_release_is_parsed(self) -> None:
+        """A key missing means unparsed metadata, not a release without extras."""
+        provider = self._provider()
+        cache_key = ("pkg", V("1.0"))
+
+        assert cache_key not in provider.extra_deps_map
+        assert provider.extra_deps_map.get(cache_key, {}) == {}
+
+        provider.get_dependencies("pkg", V("1.0"))
+
+        assert cache_key in provider.extra_deps_map
+        assert provider.extra_deps_map.get(cache_key, {}) != {}
+
+    def test_no_marker_is_evaluated_against_an_extra_until_a_read(self) -> None:
+        """Parsing leaves the split undone: no marker is bound to an extra yet."""
+        provider = self._provider()
+        provider.get_dependencies("pkg", V("1.0"))
+
+        assert provider.marker_extra_cache == {}
+
+        assert provider.extra_deps_map[("pkg", V("1.0"))]
+
+        assert provider.marker_extra_cache != {}
+
+    def test_membership_leaves_the_split_undone(self) -> None:
+        """Asking whether a release is parsed must not build its split."""
+        provider = self._provider()
+        provider.get_dependencies("pkg", V("1.0"))
+
+        assert ("pkg", V("1.0")) in provider.extra_deps_map
+
+        assert provider.marker_extra_cache == {}
+
+    def test_parsed_releases_enumerate_in_parse_order(self) -> None:
+        """The mapping reports the releases parsed, newest parse last."""
+        provider = self._provider()
+        provider.get_dependencies("pkg", V("2.0"))
+        provider.get_dependencies("pkg", V("1.0"))
+
+        assert list(provider.extra_deps_map) == [("pkg", V("2.0")), ("pkg", V("1.0"))]
+        assert len(provider.extra_deps_map) == 2
+
+    def test_a_built_map_is_kept(self) -> None:
+        """The split runs once per release however often the map is read."""
+        provider = self._provider()
+        provider.get_dependencies("pkg", V("1.0"))
+
+        first = provider.extra_deps_map[("pkg", V("1.0"))]
+
+        assert provider.extra_deps_map[("pkg", V("1.0"))] is first
+
+    def test_base_parse_consults_every_marker(self) -> None:
+        """Parsing the release evaluates each marker, extra-gated ones included."""
+        provider = self._provider()
+        provider.get_dependencies("pkg", V("1.0"))
+
+        metadata = provider.metadata_cache[("pkg", V("1.0"))]
+        markers = {r.marker for r in metadata.requires_dist if r.marker is not None}
+
+        assert provider.consulted_markers == markers
+
+    def test_building_a_map_consults_no_further_markers(self) -> None:
+        """Building the split records no marker the parse had not already."""
+        provider = self._provider()
+        provider.get_dependencies("pkg", V("1.0"))
+        consulted = set(provider.consulted_markers)
+
+        assert provider.extra_deps_map[("pkg", V("1.0"))]
+        assert provider.consulted_markers == consulted
+
+    def test_reading_the_map_does_not_keep_the_provider_alive(self) -> None:
+        """A finished provider dies on its refcount, without waiting for a sweep."""
+        provider = self._provider()
+        provider.get_dependencies("pkg", V("1.0"))
+        assert provider.extra_deps_map[("pkg", V("1.0"))]
+        ref = weakref.ref(provider)
+
+        gc.disable()
+        try:
+            del provider
+            assert ref() is None
+        finally:
+            gc.enable()
+
+    def test_deferred_url_dep_stays_out_of_the_split(self) -> None:
+        """A URL dep under an unrequested extra is deferred, never a dep entry."""
+        coordinator = make_coordinator(
+            [make_wheel("1.0")],
+            metadata_text=(
+                "Metadata-Version: 2.1\n"
+                "Name: pkg\n"
+                "Version: 1.0\n"
+                "Provides-Extra: uvloop\n"
+                'Requires-Dist: bar @ https://example.com/bar.whl ; extra == "uvloop"\n'
+                'Requires-Dist: baz>=1.0; extra == "uvloop"\n'
+            ),
+            package="pkg",
+        )
+        provider = Provider(coordinator, target=_PY312)
+        provider.get_dependencies("pkg", V("1.0"))
+
+        assert set(provider.extra_deps_map[("pkg", V("1.0"))]["uvloop"]) == {"baz"}
+        assert provider.deferred_url_extras[("pkg", V("1.0"))]["uvloop"]
 
 
 class TestTargetDepSignature:

--- a/nab-provider/src/nab_provider/_provider/metadata_resolver.py
+++ b/nab-provider/src/nab_provider/_provider/metadata_resolver.py
@@ -9,13 +9,14 @@ each ``Requires-Dist`` entry into base deps vs per-extra deps.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, NamedTuple, TypeGuard
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Literal, NamedTuple, TypeGuard
 from urllib.parse import urlsplit
 
 from nab_provider._vendor.packaging.ranges import VersionRange
 from nab_provider._vendor.packaging.specifiers import SpecifierSet
 from nab_provider._vendor.packaging.utils import canonicalize_name
-from nab_provider._vendor.packaging.version import InvalidVersion
+from nab_provider._vendor.packaging.version import InvalidVersion, Version
 from nab_provider.records import RangeOutcome, SdistFile, WheelFile
 
 from ..errors import (
@@ -44,11 +45,10 @@ from ..tags import python_axis_accepts
 from ..vcs_admission import admit_vcs_url
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Iterator, Sequence
 
     from nab_provider._vendor.packaging.markers import Marker
     from nab_provider._vendor.packaging.requirements import Requirement
-    from nab_provider._vendor.packaging.version import Version
 
     from ..provider import DistFile, Provider
     from ..store import InMemoryIndex
@@ -60,6 +60,9 @@ TargetDepSignature = tuple[
     dict[str, dict[str, VersionRange]],
     dict[str | None, set[tuple[str, frozenset[str], str]]],
 ]
+
+Gating = Literal["base", "extra", "excluded"]
+"""Whether a requirement is a base dep, gated behind an extra, or excluded."""
 
 logger = logging.getLogger(__name__)
 
@@ -605,6 +608,24 @@ def fetch_sdist_metadata(
     return provider.coordinator.index.get_metadata_with_origin(package, version)
 
 
+def requirement_gating(provider: Provider, req: Requirement) -> Gating:
+    """Say whether ``req`` applies to the base environment, to an extra, or to neither.
+
+    ``"extra"`` reports only that some extra could select it.  Naming them is
+    :func:`marker_matched_extras`, which costs up to one marker evaluation per
+    provided extra.
+    """
+    marker = req.marker
+    if marker is None:
+        return "base"
+    marker_id = id(marker)
+    if marker_matches_base(provider, marker, marker_id):
+        return "base"
+    if "extra" not in marker_text(provider, marker, marker_id):
+        return "excluded"
+    return "extra"
+
+
 def classify_requirement(
     provider: Provider,
     req: Requirement,
@@ -619,12 +640,14 @@ def classify_requirement(
     marker = req.marker
     if marker is None:
         return set()
-    marker_id = id(marker)
-    if marker_matches_base(provider, marker, marker_id):
+    gating = requirement_gating(provider, req)
+    if gating == "base":
         return set()
-    if "extra" not in marker_text(provider, marker, marker_id):
+    if gating == "excluded":
         return None
-    matched_extras = marker_matched_extras(provider, marker, marker_id, provided_extras)
+    matched_extras = marker_matched_extras(
+        provider, marker, id(marker), provided_extras
+    )
     return matched_extras or None
 
 
@@ -687,11 +710,7 @@ def parse_and_cache_metadata(
     *,
     from_sdist: bool = False,
 ) -> None:
-    """Parse metadata text and pre-compute per-extra deps.
-
-    Evaluates markers once for all extras, then caches the base
-    deps and a per-extra mapping so that get_extra_dependencies
-    can do a dict lookup instead of re-iterating requires_dist.
+    """Parse metadata text and classify the deps it declares.
 
     When ``from_sdist`` is set and the PKG-INFO deps are not trusted as
     final (not :pep:`643` static, or a Dynamic dependency field under
@@ -851,42 +870,137 @@ def cache_deps_from_metadata(
     cache_key: tuple[str, Version],
     metadata: WheelMetadata,
 ) -> None:
-    """Populate ``deps_cache`` + ``extra_deps_map`` from a parsed metadata.
+    """Classify a parsed metadata's requirements and cache the base deps.
 
     ``metadata`` may have been parsed from METADATA text, declared by a
     materialised source, or built from a complete ``dependencies`` override.
+
+    Every marker is evaluated against the base environment here, so
+    ``consulted_markers`` sees them all.  Splitting the extra-gated
+    requirements across the extras that select them is left to
+    :class:`ExtraDepsMap`.  Direct-URL requirements are the exception: whether
+    one is refused now or deferred depends on which extras name it.
     """
     metadata = effective_metadata(provider, cache_key, metadata)
 
-    # Split the (possibly overridden) requirements into base deps and
-    # per-extra deps, deferring any direct-URL deps that aren't yet active.
     package = cache_key[0]
     provider.metadata_cache[cache_key] = metadata
     provided_extras: set[str] = {canonicalize_name(e) for e in metadata.provides_extra}
     base_deps: dict[str, VersionRange] = {}
+    deferred_url_extras: dict[str, list[tuple[Requirement, str]]] = {}
+
+    for req in metadata.requires_dist:
+        url = req.url
+        if url is not None:
+            _handle_url_dep(
+                provider, package, req, url, provided_extras, deferred_url_extras
+            )
+        elif requirement_gating(provider, req) == "base":
+            add_base_dep(req, base_deps, provider.specifier_ranges)
+
+    provider.deps_cache[cache_key] = base_deps
+    provider.defer_extra_deps(cache_key)
+    provider.deferred_url_extras[cache_key] = deferred_url_extras
+
+
+def _handle_url_dep(
+    provider: Provider,
+    package: str,
+    req: Requirement,
+    url: str,
+    provided_extras: set[str],
+    deferred_url_extras: dict[str, list[tuple[Requirement, str]]],
+) -> None:
+    """Refuse a direct-URL requirement, or record it against its extras.
+
+    A requirement the environment excludes is dropped.  Needs the full
+    classification rather than :func:`requirement_gating`: an extra-gated URL
+    dep is refused only once one of its own extras is wanted, so the extras
+    naming it have to be known now.
+    """
+    req_extras = classify_requirement(provider, req, provided_extras)
+    if req_extras is None:
+        return
+
+    if _url_dep_is_active(provider, package, req_extras):
+        refuse_url_dep(provider, req, url)
+    else:
+        for extra_name in req_extras:
+            deferred_url_extras.setdefault(extra_name, []).append((req, url))
+
+
+class ExtraDepsMap(Mapping[tuple[str, Version], dict[str, dict[str, VersionRange]]]):
+    """Per-release ``{extra: {name: range}}``, split out on first read.
+
+    One read splits one release, so ``items()`` and ``values()`` would split
+    every parsed release at once.  A key appears as soon as
+    :func:`cache_deps_from_metadata` has classified that release, so
+    membership still tells a parsed release from an unparsed one and testing
+    it splits nothing.
+
+    A view over the provider's store rather than the store itself;
+    :attr:`Provider.extra_deps_map` builds a fresh one per read.
+    """
+
+    def __init__(
+        self,
+        provider: Provider,
+        extra_deps: dict[
+            tuple[str, Version], dict[str, dict[str, VersionRange]] | None
+        ],
+    ) -> None:
+        self._provider = provider
+        self._extra_deps = extra_deps
+
+    def __getitem__(
+        self, cache_key: tuple[str, Version]
+    ) -> dict[str, dict[str, VersionRange]]:
+        built = self._extra_deps[cache_key]
+        if built is None:
+            built = self._extra_deps[cache_key] = build_extra_deps(
+                self._provider, cache_key
+            )
+        return built
+
+    def __contains__(self, cache_key: object) -> bool:
+        return cache_key in self._extra_deps
+
+    def __iter__(self) -> Iterator[tuple[str, Version]]:
+        return iter(self._extra_deps)
+
+    def __len__(self) -> int:
+        return len(self._extra_deps)
+
+
+def build_extra_deps(
+    provider: Provider, cache_key: tuple[str, Version]
+) -> dict[str, dict[str, VersionRange]]:
+    """Split a parsed release's extra-gated requirements by the extras selecting them.
+
+    Re-reads the metadata :func:`cache_deps_from_metadata` cached.  Every
+    marker on it was evaluated there, so ``marker_base_cache`` answers
+    :func:`requirement_gating` and nothing new reaches ``consulted_markers``.
+    Direct-URL requirements stay out: :func:`_handle_url_dep` settled them at
+    parse time.
+    """
+    metadata = provider.metadata_cache[cache_key]
+    provided_extras: set[str] = {canonicalize_name(e) for e in metadata.provides_extra}
     extra_deps_map: dict[str, dict[str, VersionRange]] = {
         e: {} for e in provided_extras
     }
-    deferred_url_extras: dict[str, list[tuple[Requirement, str]]] = {}
+
     for req in metadata.requires_dist:
-        req_extras = classify_requirement(provider, req, provided_extras)
-        if req_extras is None:
+        marker = req.marker
+        if req.url is not None or marker is None:
             continue
-        if req.url is not None:
-            if _url_dep_is_active(provider, package, req_extras):
-                refuse_url_dep(provider, req, req.url)
-            else:
-                for extra_name in req_extras:
-                    deferred_url_extras.setdefault(extra_name, []).append(
-                        (req, req.url)
-                    )
+        if requirement_gating(provider, req) != "extra":
             continue
-        add_classified_dep(
-            req, req_extras, base_deps, extra_deps_map, provider.specifier_ranges
-        )
-    provider.deps_cache[cache_key] = base_deps
-    provider.extra_deps_map[cache_key] = extra_deps_map
-    provider.deferred_url_extras[cache_key] = deferred_url_extras
+
+        matched = marker_matched_extras(provider, marker, id(marker), provided_extras)
+        if matched:
+            add_extra_dep(req, matched, extra_deps_map, provider.specifier_ranges)
+
+    return extra_deps_map
 
 
 def _url_dep_is_active(provider: Provider, package: str, req_extras: set[str]) -> bool:
@@ -1266,24 +1380,53 @@ def add_classified_dep(
     extra_deps_map: dict[str, dict[str, VersionRange]],
     specifier_ranges: dict[str, VersionRange],
 ) -> None:
-    """Add a classified requirement to the appropriate dep set.
+    """Add a classified requirement to the appropriate dep set."""
+    if req_extras:
+        add_extra_dep(req, req_extras, extra_deps_map, specifier_ranges)
+    else:
+        add_base_dep(req, base_deps, specifier_ranges)
+
+
+def add_base_dep(
+    req: Requirement,
+    base_deps: dict[str, VersionRange],
+    specifier_ranges: dict[str, VersionRange],
+) -> None:
+    """Add an ungated requirement to ``base_deps``.
 
     A name appearing on several ``Requires-Dist`` lines is intersected
     into one range.
     """
     name = canonicalize_name(req.name)
     dep_range = _specifier_range(req.specifier, specifier_ranges)
-    dep_extras: set[str] = req.extras
 
-    if not req_extras:
-        existing = base_deps.get(name)
-        base_deps[name] = dep_range if existing is None else existing & dep_range
-        for re in sorted(dep_extras):
-            base_deps[join_extra(name, re)] = VersionRange.full(admit_arbitrary=False)
-    else:
-        for extra_name in req_extras:
-            edeps = extra_deps_map[extra_name]
-            existing = edeps.get(name)
-            edeps[name] = dep_range if existing is None else existing & dep_range
-            for re in sorted(dep_extras):
-                edeps[join_extra(name, re)] = VersionRange.full(admit_arbitrary=False)
+    existing = base_deps.get(name)
+    base_deps[name] = dep_range if existing is None else existing & dep_range
+    for dep_extra in sorted(req.extras):
+        base_deps[join_extra(name, dep_extra)] = VersionRange.full(
+            admit_arbitrary=False
+        )
+
+
+def add_extra_dep(
+    req: Requirement,
+    req_extras: set[str],
+    extra_deps_map: dict[str, dict[str, VersionRange]],
+    specifier_ranges: dict[str, VersionRange],
+) -> None:
+    """Add a requirement to the dep set of each extra in ``req_extras``.
+
+    A name appearing on several ``Requires-Dist`` lines of one extra is
+    intersected into one range.
+    """
+    name = canonicalize_name(req.name)
+    dep_range = _specifier_range(req.specifier, specifier_ranges)
+
+    for extra_name in req_extras:
+        edeps = extra_deps_map[extra_name]
+        existing = edeps.get(name)
+        edeps[name] = dep_range if existing is None else existing & dep_range
+        for dep_extra in sorted(req.extras):
+            edeps[join_extra(name, dep_extra)] = VersionRange.full(
+                admit_arbitrary=False
+            )

--- a/nab-provider/src/nab_provider/provider.py
+++ b/nab-provider/src/nab_provider/provider.py
@@ -567,8 +567,11 @@ class Provider:
         # which is what makes the id(marker)-keyed marker caches below safe
         # against id reuse. Do not bound it without re-keying those caches.
         self.metadata_cache: dict[tuple[str, Version], WheelMetadata] = {}
-        self.extra_deps_map: dict[
-            tuple[str, Version], dict[str, dict[str, VersionRange]]
+        # Per-extra deps, split out of the cached metadata on first read: a
+        # release whose extras nothing selects never pays for the split.  Read
+        # it through ``extra_deps_map``.
+        self._extra_deps: dict[
+            tuple[str, Version], dict[str, dict[str, VersionRange]] | None
         ] = {}
         # Direct-URL deps gated behind a provided-but-unrequested extra. The
         # refusal is deferred until the extra is selected, so a plain resolve of
@@ -719,6 +722,20 @@ class Provider:
                 ):
                     continue
                 self.coordinator.request_listing(normalized)
+
+    @property
+    def extra_deps_map(self) -> _metadata_resolver.ExtraDepsMap:
+        """Per-extra deps per parsed release, split out when first read.
+
+        A new view over ``_extra_deps`` each time it is asked for.  A stored
+        one would hold this provider in a reference cycle, and a matrix resolve
+        would then keep every finished target's caches until the collector ran.
+        """
+        return _metadata_resolver.ExtraDepsMap(self, self._extra_deps)
+
+    def defer_extra_deps(self, cache_key: tuple[str, Version]) -> None:
+        """Record a release as parsed, with its per-extra split not built yet."""
+        self._extra_deps[cache_key] = None
 
     def fetch_versions(self, package: str) -> list[tuple[Version, DistFile]]:
         """See :func:`nab_provider._provider.listing.fetch_versions`."""


### PR DESCRIPTION
Locally, about 43% off wall and about 39% off peak RSS on the `apache-airflow-universal` universal scenario, and about 31% and 18% on `airflow-providers-amazon`.

Parsing a release's metadata built a `{extra: {name: range}}` map for every extra that release provides, before anything asked for one. Airflow's universal scenarios reach thousands of provided extras the resolve never selects, and building those maps dominated both time and memory there. Each release's map is now built on first read instead.

| scenario | wall | peak RSS |
| --- | --- | --- |
| `apache-airflow-universal` | 8.8 s to 5.0 s, about 43% off | about 39% off |
| `airflow-providers-amazon` | 3.6 s to 2.5 s, about 31% off | about 18% off |
| `transformers-cpu-multi-python` | 1.47 s to 1.37 s, about 7% off | about 0.4% off |
| `max-25-tuples` | 0.77 s to 0.74 s, about 4% off | no difference, and the run could not have seen anything below 0.4% |

Those are medians of 12 paired runs per scenario on one machine, so expect different numbers on other hardware.

Two workloads do not move. `legacy-36-root-stress` sits inside what its run could resolve, about 5%. The `pip:apache-airflow-311-full` canary asks for 33 root extras, so it builds the same maps either way and additionally re-walks `Requires-Dist` once per release something reads; its run rules out a regression above about 7% and can say nothing finer.

The counts below are exact and reproduce anywhere. They come from `apache-airflow-universal` and repeated to the digit over three runs a side.

| | main | branch |
| --- | --- | --- |
| releases whose extras were split | 162 | 0 |
| per-extra dicts built | 18,018 | 0 |
| per-extra dep entries built | 163,496 | 0 |
| `marker_matched_extras` calls | 162,442 | 0 |
| iterations of its per-extra loop | 18,606,399 | 0 |
| `Marker.evaluate_prepared` calls | 34,668 | 289 |
| `marker_matches_base` calls | 163,198 | 163,198 |

Every requirement is still classified against the base environment when its metadata is parsed, so the set of markers consulted is unchanged, and so are the resolver's own counters: 165 decisions, 165 conflicts, 333 rounds, 164 backjumps, 150 metadata fetches, 21,129 distributions seen. The scenario ends in a resolution failure either way, with identical error text.

Allocation on the same scenario, traced: peak 230,973,071 bytes to 132,561,880, and 1,235,667 objects tracked by the collector at exit to 451,795.

What the change touches:

- `requirement_gating` answers `base`, `extra` or `excluded`. The parse-time pass uses it to cache base deps only, and never asks which extras a gated requirement belongs to.
- `Provider.extra_deps_map` is now a `Mapping` view. A key is present as soon as the release is parsed, so a membership test still separates a parsed release from an unparsed one and splits nothing; `__getitem__` splits and caches.
- Direct-URL deps stay eager, because whether one is refused now or deferred until its extra is selected depends on which extras name it. A release that refuses one still fails at the same point in `Requires-Dist`.
- The lock builder reads the map only for a package with an activated extra. On `max-25-tuples` that is 0 releases split rather than 260, and on `transformers-cpu-multi-python` 6 rather than 303.
- `extra_deps_map` is a property handing back a fresh view. A stored view would hold the provider in a reference cycle, and a matrix resolve would then keep every finished target's caches alive until the collector ran.
