### PR TITLE
Prefetch 2 wheel sidecars per listing, not 10: ~40% fewer metadata fetches

### DIFF
--- a/nab-project/src/nab_project/fetch.py
+++ b/nab-project/src/nab_project/fetch.py
@@ -179,7 +179,7 @@ class FetchCoordinator:
             ...
     """
 
-    PREFETCH_METADATA_COUNT = 10
+    PREFETCH_METADATA_COUNT = 2
 
     def __init__(  # noqa: PLR0913 - the per-index knobs a coordinator wires up
         self,

--- a/nab-project/tests/test_fetch.py
+++ b/nab-project/tests/test_fetch.py
@@ -689,10 +689,11 @@ class TestFetchCoordinator:
         listing = {
             "meta": {"api-version": "1.0"},
             "name": "pkg",
+            # Oldest-first; the prefetch takes the newest wheels.
             "files": [
                 {
-                    "filename": "pkg-3.0-py3-none-any.whl",
-                    "url": "https://f.com/pkg-3.0-py3-none-any.whl",
+                    "filename": "pkg-1.0-py3-none-any.whl",
+                    "url": "https://f.com/pkg-1.0-py3-none-any.whl",
                     "dist-info-metadata": {"sha256": digest},
                 },
                 {
@@ -701,8 +702,8 @@ class TestFetchCoordinator:
                     "dist-info-metadata": {"sha256": digest},
                 },
                 {
-                    "filename": "pkg-1.0-py3-none-any.whl",
-                    "url": "https://f.com/pkg-1.0-py3-none-any.whl",
+                    "filename": "pkg-3.0-py3-none-any.whl",
+                    "url": "https://f.com/pkg-3.0-py3-none-any.whl",
                     "dist-info-metadata": {"sha256": digest},
                 },
             ],
@@ -716,10 +717,7 @@ class TestFetchCoordinator:
         with _coord() as coord:
             event = coord.request_listing("pkg")
             event.wait(timeout=5)
-            # Auto-prefetch should have fired for the newest 3 wheels
-            # Give them a moment to complete
-            import time
-
+            # Wait for the async prefetch of the newest wheel's sidecar.
             sidecar = "https://f.com/pkg-3.0-py3-none-any.whl.metadata"
             deadline = time.monotonic() + 5
             while time.monotonic() < deadline:
@@ -773,7 +771,7 @@ class TestFetchCoordinator:
             assert coord.index.has_metadata("pkg", "15.0", sidecar)
 
         # The newest PREFETCH_METADATA_COUNT wheels, not all 15.
-        assert derived == [f"pkg-{n}.0-py3-none-any.whl" for n in range(6, 16)]
+        assert derived == [f"pkg-{n}.0-py3-none-any.whl" for n in range(14, 16)]
 
     def test_prefetch_after_listing_enqueues_newest_batch(
         self, monkeypatch: pytest.MonkeyPatch
@@ -828,7 +826,7 @@ class TestFetchCoordinator:
                 f"https://f.com/pkg-{n}.0-py3-none-any.whl.metadata",
                 ("sha256", f"h{n}.0"),
             )
-            for n in range(6, 16)
+            for n in range(14, 16)
         ]
         assert calls == expected
 


### PR DESCRIPTION
Lowering `FetchCoordinator.PREFETCH_METADATA_COUNT` from 10 to 2 cuts metadata fetches on a warm run of a 5-scenario canary subset from 9,314 to 5,622: 3,692 fewer, which is 39.6% of the base run's metadata fetches and 32.2% of its 11,454 requests of all kinds. Fetches issued but never read drop from 7,553 to 3,888, and every scenario pins the same versions at both widths.

When a listing arrives, the coordinator prefetches metadata sidecars for its newest versions. At a width of 10, that one path issued 5,580 of the base run's 9,314 metadata fetches, and 5,191 of those were never read.

The risk in narrowing a prefetch is the cold cache, where a sidecar that was never prefetched turns into a fetch the resolver waits on. Against real PyPI with a cold HTTP cache, google-bigquery-soda issues 564 metadata fetches instead of 928 and airflow-3-0-2-awswrangler 410 instead of 1,437, with listing counts identical at both widths (49 and 141) and identical pins. Of the fetches the narrower prefetch stops issuing, only a trickle comes back through other fetch paths: 18 of 382 on google-bigquery-soda, 45 of 1,072 on airflow.

The clock agrees, locally, 12 runs at each width:

- Cold airflow-3-0-2-awswrangler: wall about 38% faster, CPU about 33% lower, peak RSS about 7% lower.
- Cold google-bigquery-soda: wall between about 9% and 35% faster with a middle estimate near 31%, CPU between about 6% and 18% lower. That run puts peak RSS inside about 9% either way, the smallest change it could have seen.
- Warm, on a 3-scenario canary subset (google-bigquery-soda, boto3-urllib3-transient, airflow-3-0-2-awswrangler): wall between about 2% and 8% faster with a middle estimate near 5.5%, CPU between about 3% and 7% lower, peak RSS about 8% lower.

Nothing moved the wrong way in any of the three timing runs. Each fetch count comes from one counted run with the hash seed pinned; repeat cold runs land within about 4% of the quoted counts, and all timings are local.

Three tests encoded the old width. Two expectation ranges move to the newest 2, and one fixture listed its files newest-first where listings arrive oldest-first, which a width of 10 masked; it now lists them oldest-first and still asserts the newest wheel's sidecar lands.
