### PR TITLE
Skip listing URL rebuild when nothing changes, ~1.8% off a cold resolve

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -441,6 +441,31 @@ def _parse_files(
     return files
 
 
+def _normalized_url(url: str) -> str:
+    """Return ``urlunsplit(urlsplit(url))``, skipping a rebuild that returns ``url``.
+
+    The parse still runs on every URL, so a malformed authority raises the
+    same ``ValueError`` as the round trip.  A nonempty netloc reassembles
+    as ``[scheme:]//netloc`` plus the remaining parts; when those parts and
+    their separators add back up to ``len(url)``, the parse stripped no
+    character and dropped no empty ``?``/``#`` marker, leaving an
+    upper-cased scheme as the one length-preserving rewrite to rule out.
+    """
+    parts = urlsplit(url)
+    scheme, netloc, path, query, fragment = parts
+    if netloc:
+        rebuilt_len = len(scheme) + len(netloc) + len(path) + 2
+        if scheme:
+            rebuilt_len += 1
+        if query:
+            rebuilt_len += 1 + len(query)
+        if fragment:
+            rebuilt_len += 1 + len(fragment)
+        if rebuilt_len == len(url) and url.startswith(scheme):
+            return url
+    return urlunsplit(parts)
+
+
 def _resolve_file_url(raw_url: str, base_url: str) -> str | None:
     """Return the entry's absolute URL, or None when it is not usable.
 
@@ -461,7 +486,7 @@ def _resolve_file_url(raw_url: str, base_url: str) -> str | None:
             if raw_url.startswith(("https://", "http://"))
             else urljoin(base_url, raw_url)
         )
-        file_url = urlunsplit(urlsplit(absolute))
+        file_url = _normalized_url(absolute)
 
         # Encode only to reject a string with no UTF-8 form.
         file_url.encode()

--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -31,7 +31,7 @@ import zlib
 from email.parser import BytesParser, Parser
 from pathlib import Path
 from typing import TYPE_CHECKING
-from urllib.parse import unquote, urljoin, urlparse, urlsplit, urlunsplit
+from urllib.parse import unquote, urljoin, urlparse, urlsplit
 from urllib.request import url2pathname
 
 from packaging.utils import canonicalize_name as _canonical
@@ -44,6 +44,7 @@ from .client import (
     SdistFile,
     WheelFile,
     _extract_sdist_files,
+    _normalized_url,
     _parse_sdist_filename,
     _parse_wheel_filename,
     is_readable_filename,
@@ -310,7 +311,7 @@ def _resolve_local_link(
     # below.  urljoin leaves an href alone when its scheme differs from the
     # page's, so the split round trip is what drops a tab, CR or LF.
     try:
-        url = urlunsplit(urlsplit(urljoin(base_url, href_no_frag)))
+        url = _normalized_url(urljoin(base_url, href_no_frag))
         parsed = urlparse(url)
     except ValueError:
         return (None, href_no_frag, None, hashes)

--- a/nab-project/tests/test_cached_client.py
+++ b/nab-project/tests/test_cached_client.py
@@ -18,7 +18,7 @@ from dataclasses import replace
 from email.utils import formatdate
 from pathlib import Path
 from typing import Any
-from urllib.parse import urljoin, urlsplit
+from urllib.parse import urljoin, urlsplit, urlunsplit
 
 import pytest
 from packaging.utils import canonicalize_name
@@ -41,6 +41,7 @@ from nab_index.client import (
     SdistHashMismatchError,
     WheelFile,
     WheelHashMismatchError,
+    _normalized_url,
     _parse_files,
     _parse_sdist_filename,
     _select_artifact_hash,
@@ -654,6 +655,38 @@ class TestControlCharacterUrl:
         )
 
         assert from_json.url == from_html.url == self._STRIPPED
+
+
+class TestNormalizedUrl:
+    """_normalized_url returns the same string as the split round trip."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://files.example.com/ab/foo-1.0-py3-none-any.whl",
+            "https://files.example.com/foo-1.0-py3-none-any.whl?token=x",
+            "https://files.example.com/foo-1.0-py3-none-any.whl#sha256=abc",
+            "//files.example.com/foo-1.0-py3-none-any.whl",
+            "file:///mirror/foo-1.0-py3-none-any.whl",
+            "file:/mirror/foo-1.0-py3-none-any.whl",
+            "https://files.example.com/a\tb/foo-1.0-py3-none-any.whl",
+            "https://files.example.com/foo-1.0-py3-none-any.whl?",
+            "https://files.example.com/foo-1.0-py3-none-any.whl#",
+            "HTTPS://files.example.com/foo-1.0-py3-none-any.whl",
+            "https://Files.Example.com/foo-1.0-py3-none-any.whl",
+            "https:foo-1.0-py3-none-any.whl",
+        ],
+    )
+    def test_matches_round_trip(self, url: str) -> None:
+        assert _normalized_url(url) == urlunsplit(urlsplit(url))
+
+    def test_clean_url_is_not_rebuilt(self) -> None:
+        url = "https://files.example.com/ab/foo-1.0-py3-none-any.whl"
+        assert _normalized_url(url) is url
+
+    def test_malformed_authority_raises(self) -> None:
+        with pytest.raises(ValueError, match="IPv6"):
+            _normalized_url("https://[::1/foo-1.0-py3-none-any.whl")
 
 
 class TestMetadataUrl:


### PR DESCRIPTION
A cold `pip:google-bigquery-soda@lowest` resolve retires 181,079,860 fewer instructions, 1.77% of the whole run (10,254,296,215 to 10,073,216,355, callgrind, `PYTHONHASHSEED=0`). Counting calls on the same command, `urlunsplit` drops from 43,214 to 1,702, one skipped rebuild per ingested listing URL.

Stacked on #861; the diff and the numbers here are against that branch.

Both ingest sites normalize each listing file URL with `urlunsplit(urlsplit(url))`, and on real PyPI listings the rebuild changes nothing: 0 of 1,033,992 URLs across 3,494 cached listings come back different. `_normalized_url` keeps the `urlsplit` parse, so a malformed authority raises the same `ValueError`, and skips the rebuild only when the parsed parts prove it would return the input unchanged:

- nonempty netloc, so the parts reassemble as `[scheme:]//netloc` plus the rest
- part lengths plus separators adding back up to `len(url)`, so the parse stripped nothing and dropped no empty `?`/`#` marker
- the scheme already lowercase

Anything else still rebuilds, and on this workload nothing did: all 41,512 ingested URLs took the skip. Stored `url` and `metadata_url` values are byte-identical to the base across all 903,819 entries in a second corpus of 3,006 cached listings.

A warm resolve reads listings from the parsed cache and never reaches this code. On the same cold resolve, timed locally: CPU comes down between about 0.7% and 2.7%, middle estimate near 1.7%, and peak memory about 0.7%. The wall runs could not resolve anything below about 2.4%, so they only rule out a slowdown above that.
