### PR TITLE
Intern the sdist filename parse, ~1% off a cold resolve's instructions

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -395,11 +395,10 @@ def _parse_files(
     ``package`` is the package the index was queried for; files whose
     parsed canonical name does not match are dropped.  PyPI hosts a
     handful of legacy sdists with embedded build tags
-    (``cffi-1.0.2-2.tar.gz`` and similar) that
-    :func:`_parse_sdist_filename` interprets as a
-    different project (``cffi-1-0-2`` at version ``2``).  Without the
-    name check those leak into the listing as a phantom version, and
-    show up in the resolved lockfile as ``cffi==2``.
+    (``cffi-1.0.2-2.tar.gz`` and similar) that :func:`_parse_sdist_filename`
+    interprets as a different project (``cffi-1-0-2`` at version ``2``).
+    Without the name check those leak into the listing as a phantom
+    version, and show up in the resolved lockfile as ``cffi==2``.
 
     ``page_url`` is the URL the project page was retrieved from, the base a
     relative entry resolves against. ``None`` falls back to the page URL

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -20,7 +20,7 @@ from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin, urlsplit, urlunsplit
 
-from packaging.utils import canonicalize_name, parse_sdist_filename
+from packaging.utils import canonicalize_name
 from packaging.version import Version
 
 from nab_provider.digest import is_hex_digest
@@ -165,25 +165,34 @@ def _parse_wheel_filename(filename: str) -> tuple[NormalizedName, str] | None:
 def _parse_sdist_filename(filename: str) -> tuple[NormalizedName, str] | None:
     """Parse a ``.tar.gz`` sdist filename to ``(canonical_name, version)``.
 
-    Returns ``None`` for anything packaging rejects, for a version digit
-    run past CPython's int-from-string limit, and for ``.zip`` sdists,
-    which nab does not support (gzip-tar only, and not part of the PEP 625
-    standard).  Never raises.
+    Accepts what nab-provider's vendored ``parse_sdist_filename`` accepts,
+    except ``.zip`` sdists, which nab does not support (gzip-tar only, and
+    not part of the PEP 625 standard).  Returns ``None`` for everything
+    else, including a version digit run past CPython's int-from-string
+    limit, and never raises.  The vendored copy is the one to match, not
+    the released ``packaging`` this package depends on; the two can differ
+    on an empty project name, which releases before 26.3 accept.
 
     Legacy filenames with embedded build tags (e.g. ``cffi-1.0.2-2.tar.gz``)
     parse to a surprising ``(name="cffi-1-0-2", version="2")``, so callers
     MUST drop files whose canonical name does not match the queried
     package.  See :func:`_parse_files`.
     """
-    if filename.endswith(".zip"):
+    if not filename.endswith(".tar.gz"):
+        return None
+
+    stem = filename[: -len(".tar.gz")]
+    name_part, sep, version_part = stem.rpartition("-")
+    if not sep or not name_part:
         return None
 
     try:
-        name, version = parse_sdist_filename(filename)
+        version = _canonical_version(version_part)
     except ValueError:
-        # InvalidSdistFilename, or int() refusing a digit run past CPython's limit.
+        # InvalidVersion, or int() refusing a digit run past CPython's limit.
         return None
-    return (name, str(version))
+
+    return (_intern_name(name_part), version)
 
 
 def holds_unreadable_format(data: object) -> bool:
@@ -387,7 +396,7 @@ def _parse_files(
     parsed canonical name does not match are dropped.  PyPI hosts a
     handful of legacy sdists with embedded build tags
     (``cffi-1.0.2-2.tar.gz`` and similar) that
-    :func:`packaging.utils.parse_sdist_filename` interprets as a
+    :func:`_parse_sdist_filename` interprets as a
     different project (``cffi-1-0-2`` at version ``2``).  Without the
     name check those leak into the listing as a phantom version, and
     show up in the resolved lockfile as ``cffi==2``.

--- a/nab-index/tests/test_index_client.py
+++ b/nab-index/tests/test_index_client.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import sys
 
 import pytest
+from packaging.utils import parse_sdist_filename
 
 from nab_index.client import (
+    _parse_sdist_filename,
     _sdist_member_top_level,
     holds_unreadable_format,
     is_readable_filename,
@@ -76,6 +78,46 @@ def test_holds_unreadable_format_finds_oversized_version() -> None:
 )
 def test_holds_unreadable_format_false(data: object) -> None:
     assert not holds_unreadable_format(data)
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "foo-1.0.tar.gz",
+        "Foo_Bar.baz-1.0rc1.tar.gz",
+        "foo-1.0.post1.dev2+local.tag.tar.gz",
+        "foo-1!2.0.tar.gz",
+        "cffi-1.0.2-2.tar.gz",
+        "foo-1.0.zip",
+        "foo-1.0.tar.bz2",
+        "foo-1.5.win32.exe",
+        "foo.tar.gz",
+        "-1.0.tar.gz",
+        "foo-.tar.gz",
+        "foo-v1.0.tar.gz",
+        "foo--1.0.tar.gz",
+        "foo-1.0.TAR.GZ",
+        f"foo-{OVERSIZED}.tar.gz",
+    ],
+)
+def test_parse_sdist_filename_parity(filename: str) -> None:
+    """The inline parse matches the vendored parser on everything but ``.zip``.
+
+    Released ``parse_sdist_filename`` is the oracle, corrected on the two
+    known divergences: ``.zip`` sdists, which nab rejects, and an empty
+    project name, which packaging releases before 26.3 accept.
+    """
+    if filename.endswith(".zip"):
+        expected = None
+    else:
+        try:
+            name, version = parse_sdist_filename(filename)
+        except ValueError:
+            expected = None
+        else:
+            expected = (name, str(version)) if name else None
+
+    assert _parse_sdist_filename(filename) == expected
 
 
 def test_sdist_member_top_level_normal() -> None:


### PR DESCRIPTION
Between about 0.9% and 1.1% of a cold-cache resolve's instructions go away, counted under callgrind with `PYTHONHASHSEED=0`:

| scenario | base | branch | change |
| --- | --- | --- | --- |
| `pip:google-bigquery-soda@lowest` | 10,074,535,633 | 9,984,646,339 | 89,889,294 fewer (0.89%) |
| `uv:boto3-urllib3-transient@lowest` | 7,699,394,688 | 7,615,931,689 | 83,462,999 fewer (1.08%) |

Repeats on this workload do not agree to the digit: a second bigquery-soda pair measured 87,601,674 fewer (0.87%).

Stacked on #908; the diff and the numbers are against that branch.

`_parse_sdist_filename` is now the mirror of `_parse_wheel_filename`: an inline `.tar.gz` check, an `rpartition` on the last hyphen, and the raw substrings routed through the `_canonical_version` and `_intern_name` caches the wheel parser already fills. That replaces a call into packaging's `parse_sdist_filename` and, on each successful parse, a fresh `Version()` to `str()` round trip.

A cold bigquery-soda resolve hands the parser 6,145 distinct filenames. Of the 4,326 distinct (name, version) pairs that parse, about 84% of the version substrings and 99% of the names are already in the caches.

The inline parse accepts, rejects, and produces exactly what the packaging-based formula did: a differential check over the 934,848 distinct filenames in the 3,006-listing benchmark corpus, plus malformed and edge-case shapes, found no differences. A unit test pins the parity.

The clock cannot see a change this small: paired timing runs on the cold bigquery-soda resolve rule out a wall regression above about 1.3% and put peak memory inside about 0.5% either way.
