### PR TITLE
Pause the cyclic collector around the CLI resolve, 13% to 30% faster

### DIFF
--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -13,8 +13,10 @@ them so their ``@app.command`` decorators run before :func:`main` calls
 
 from __future__ import annotations
 
+import gc
 import os
 import sys
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -85,7 +87,7 @@ from .output import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Iterator, Mapping
 
     from nab_index.transport import AsyncHttpTransport
     from nab_project.resolve import ResolveResult
@@ -576,6 +578,21 @@ def _python_override_or_exit(
         sys.exit(1)
 
 
+@contextmanager
+def _collector_paused() -> Iterator[None]:
+    """Disable the cyclic collector for the duration of the resolve.
+
+    Only the CLI sets a collector policy, since it owns its process; the
+    library entry points leave it alone. Exit enables the collector rather
+    than restoring the state it found.
+    """
+    gc.disable()
+    try:
+        yield
+    finally:
+        gc.enable()
+
+
 def _resolve(  # noqa: PLR0913, PLR0912, C901 - one wrapper per resolve_for_targets kwarg / exit-mapped error
     path: Path,
     *,
@@ -604,18 +621,19 @@ def _resolve(  # noqa: PLR0913, PLR0912, C901 - one wrapper per resolve_for_targ
     config = _python_override_or_exit(config, python)
     try:
         try:
-            result = resolve_for_targets(
-                path,
-                transport,
-                config=config,
-                cache_dir=cache_dir,
-                offline=offline,
-                groups=groups,
-                extras=extras,
-                build_requirements=build_requirements,
-                resolution_strategy=resolution_strategy,
-                progress=progress,
-            )
+            with _collector_paused():
+                result = resolve_for_targets(
+                    path,
+                    transport,
+                    config=config,
+                    cache_dir=cache_dir,
+                    offline=offline,
+                    groups=groups,
+                    extras=extras,
+                    build_requirements=build_requirements,
+                    resolution_strategy=resolution_strategy,
+                    progress=progress,
+                )
         finally:
             if progress is not None:
                 progress.clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ suites (which need not have ``nab`` installed) do not import it.
 
 from __future__ import annotations
 
+import gc
 import os
 import stat
 from contextlib import contextmanager
@@ -45,6 +46,23 @@ def _reset_nab_output(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     yield
     cli._printer = None
     reset_log_handlers()
+
+
+@pytest.fixture
+def restored_gc_state() -> Iterator[None]:
+    """Put the cyclic collector back the way the test found it.
+
+    A test that lets the CLI switch the collector off leaks that state into
+    the rest of the session when the CLI's own restore is what broke.
+    """
+    enabled = gc.isenabled()
+    try:
+        yield
+    finally:
+        if enabled:
+            gc.enable()
+        else:
+            gc.disable()
 
 
 @pytest.fixture

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ import asyncio
 import builtins
 import contextlib
 import errno
+import gc
 import hashlib
 import importlib
 import inspect
@@ -5121,6 +5122,51 @@ class TestMain:
                 failure_prefix="cannot lock",
             )
         assert result.success
+
+    @pytest.mark.usefixtures("restored_gc_state")
+    def test_resolve_pauses_the_collector(self, tmp_path: Path) -> None:
+        """The cyclic collector is off while the resolver runs, back on after."""
+        pyproject = _make_pyproject(tmp_path)
+        config = read_pyproject_config(pyproject)
+        enabled_during: list[bool] = []
+
+        def record_gc_state(*args: object, **kwargs: object) -> ResolveResult:
+            enabled_during.append(gc.isenabled())
+            return _stub_resolve_result(pins={})
+
+        with patch("nab.cli.resolve_for_targets", side_effect=record_gc_state):
+            _resolve(
+                pyproject,
+                config=config,
+                cache_dir=None,
+                offline=False,
+                transport=MagicMock(),
+                failure_prefix="cannot lock",
+            )
+        assert enabled_during == [False]
+        assert gc.isenabled()
+
+    @pytest.mark.usefixtures("restored_gc_state")
+    def test_resolve_reenables_the_collector_on_failure(self, tmp_path: Path) -> None:
+        """A resolve that exits on an error still leaves the collector enabled."""
+        pyproject = _make_pyproject(tmp_path)
+        config = read_pyproject_config(pyproject)
+        with (
+            patch(
+                "nab.cli.resolve_for_targets",
+                side_effect=ResolutionError("no solution"),
+            ),
+            pytest.raises(SystemExit),
+        ):
+            _resolve(
+                pyproject,
+                config=config,
+                cache_dir=None,
+                offline=False,
+                transport=MagicMock(),
+                failure_prefix="cannot lock",
+            )
+        assert gc.isenabled()
 
 
 class _TtyStderr(io.StringIO):


### PR DESCRIPTION
Disabling the cyclic collector for the duration of a resolve takes 13% to 30% off wall time locally, and about the same off CPU. Peak memory rises, because objects held in reference cycles are not freed until the collector runs at the end. That is the trade.

| scenario | wall | CPU | peak RSS |
| --- | --- | --- | --- |
| `ecosystem:pandas-with-aws-s3 --resolution lowest` | -13% | -14% | +0.6 MB on 130 MB |
| `pip:google-bigquery-soda --resolution lowest` | -16% | -13% | +0.3 MB on 106 MB |
| `pip:langchain-ml-course --resolution lowest` | -22% | -22% | +2.5 MB on 317 MB |
| `uv:uv-issue-1560-airflow-all` | -30% | -29% | +4.5 MB on 261 MB |

Timings are local and rounded, over 10 to 12 alternated runs of each version with the decision order pinned so both do the same work. The runs put every scenario's wall win above 9%. The memory rise is larger than what they could resolve on all four, only just so on `pip:google-bigquery-soda`. `uv:uv-issue-1560-airflow-all` no longer resolves at this tip, so its row measures a failed search.

Each run covers interpreter startup, scenario setup and the resolve. A `nab lock` also loads config and writes the lockfile outside the bracket, so it should get the same saving over a longer total.

Counting the work instead, on `ecosystem:pandas-with-aws-s3 --resolution lowest` under callgrind with the hash seed pinned, both versions making 1383 decisions and 1081 conflicts:

- 41,502,353,455 instructions retired to 39,862,869,895, so 1,639,483,560 fewer, 3.95% of the base run
- 1308 collector passes to 1, which reclaims 2053 objects where the 1308 reclaimed 2056

Those counts reproduce anywhere; the timings do not. The wall drop is much larger than 3.95% because the collector's cost is not mostly instructions: an ordinary run of the same scenario on main spends 0.58 s collecting on a 3.9 s resolve, and 0.50 s of that goes to ten full passes over the heap.

The change is a context manager in `src/nab/cli.py` around the single `resolve_for_targets` call that `nab lock` and `nab download` share. The library entry points are untouched: `nab_project.resolve` can be imported by anything and should not set a collector policy for its host. Exit enables the collector rather than restoring what it found, which is enough for a process the CLI owns; the catch-up collection there costs about 7 ms on pandas and is already inside every number above.
