### PR TITLE
Serve a 304 from the parsed blob, 67% fewer calls on a stale-cache resolve

### DIFF
--- a/docs/reference/cache.md
+++ b/docs/reference/cache.md
@@ -56,7 +56,9 @@ answered from cache, offline included.
 Turning a listing body into records means a JSON decode plus wheel and
 sdist filename parsing, which a warm resolve would otherwise repeat on
 every run. The `simple-parsed-v0/` bucket stores those records so a warm
-hit rehydrates them and never reads the large raw body.
+hit rehydrates them and never reads the large raw body. A stale entry is
+served the same way once the index answers `304 Not Modified`, since that
+confirms the body the blob is bound to.
 
 Each parsed blob is bound to the exact body it came from by a `body_digest`
 that the `.policy` also carries. On a hit the two digests are compared;

--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -77,11 +77,15 @@ class ParsedCacheStats:
     after it, so a benchmark can confirm a warm resolve serves parsed blobs
     rather than reparsing.
 
-    Each fresh-or-offline consult of ``get_files`` bumps exactly one counter:
-    ``hit`` when a present blob binds the policy's body and is served without
-    reading the raw body; ``miss`` when no blob was present; ``rebuild`` when a
-    blob was present but was not served (a stale digest, a different build,
-    corruption, or no records in it) and was rebuilt from the raw body.
+    Every consult of ``get_files`` that reaches the blob bumps exactly one
+    counter, on a cached read and on a revalidation alike: ``hit`` when a
+    present blob binds the policy's body and is served without reading the raw
+    body; ``miss`` when no blob was present; ``rebuild`` when a blob was
+    present but was not served (a stale digest, a different build, corruption,
+    or no records in it).
+
+    ``rebuild`` says the blob did not answer, not that one was written: on a
+    304 the fallback reparses the raw body and leaves the blob in place.
     """
 
     hit: int = 0
@@ -326,8 +330,9 @@ class CachedAsyncSimpleClient:
         the large raw body; on a blob miss, build/digest mismatch, corruption,
         or a blob holding no records the raw body is reparsed and the blob
         rebuilt (a WARNING self-heal on genuine corruption).
-        Cache hit + stale + online: conditional revalidation; on 304 the body
-        (and its parsed blob) are reused, on 200 both are replaced.
+        Cache hit + stale + online: conditional revalidation without reading
+        the body; on 304 the parsed blob answers and the body is read only
+        when the blob misses, on 200 body and blob are replaced.
         Cache miss + offline: raises :class:`OfflineError`.
         Cache miss + online: fetches, caches, returns.
 
@@ -354,19 +359,18 @@ class CachedAsyncSimpleClient:
                 or self._offline
                 or self._floor_keeps_fresh(policy, package, "listing")
             )
-            if serve_cached:
-                hit = self._parsed_hit(package, policy)
-                if hit is not None:
-                    return hit
-            # A parsed miss (serving cached) or a stale-online revalidation both
-            # need the raw body now, so read it once here.
+            if not serve_cached:
+                return await self._revalidate_simple(package, policy)
+
+            hit = self._parsed_hit(package, policy)
+            if hit is not None:
+                return hit
+
             cached = self._cache.get_simple(package)
             if cached is not None:
                 body, policy = cached
                 data = self._decode_cached_listing(body, package)
                 if data is not None:
-                    if not serve_cached:
-                        return await self._revalidate_simple(package, data, policy)
                     files = self._parse_body(data, package, page_url=policy.page_url)
                     self._rebuild_parsed(package, body, policy, files)
                     return files
@@ -416,10 +420,10 @@ class CachedAsyncSimpleClient:
 
         Returns the records only when a present blob decodes to at least one
         record and its header binds ``policy``'s body. An absent blob, a
-        build/digest mismatch, or a corrupt blob all return ``None`` so the
-        caller reparses the raw body; genuine corruption (garbage/truncated
-        bytes) is logged at WARNING as a self-heal, while a build/digest
-        mismatch is a silent rebuild.
+        build/digest mismatch, or a corrupt blob all return ``None``, leaving
+        the caller to answer from the raw body or the index; genuine corruption
+        (garbage/truncated bytes) is logged at WARNING, while a build/digest
+        mismatch is silent.
 
         A blob that rehydrates to no records also declines. An empty listing
         carries a second fact the blob does not hold: whether the page offered
@@ -445,8 +449,7 @@ class CachedAsyncSimpleClient:
         reason = _parsed_corruption(blob)
         if reason is not None:
             logger.warning(
-                "Corrupt parsed-listing cache blob for %r from %s: %s; "
-                "rebuilding from the raw body",
+                "Corrupt parsed-listing cache blob for %r from %s: %s; ignoring it",
                 package,
                 self._index_url,
                 reason,
@@ -571,14 +574,36 @@ class CachedAsyncSimpleClient:
         """Whether a listing for ``package`` held only files nab cannot read."""
         return package in self._unreadable_only
 
+    def _unmodified_records(
+        self, package: str, policy: CachePolicy
+    ) -> list[WheelFile | SdistFile] | None:
+        """Return the records a 304 confirms, or ``None`` when nothing holds them.
+
+        The blob answers a 304 the same way it answers a fresh read, so the raw
+        body is read only on a blob miss, and a body that is gone or will not
+        decode leaves nothing to serve.
+        """
+        hit = self._parsed_hit(package, policy)
+        if hit is not None:
+            return hit
+
+        cached = self._cache.get_simple(package)
+        if cached is None:
+            return None
+        body, _ = cached
+        data = self._decode_cached_listing(body, package)
+        if data is None:
+            return None
+        return self._parse_body(data, package, page_url=policy.page_url)
+
     async def _revalidate_simple(
-        self, package: str, data: object, policy: CachePolicy
+        self, package: str, policy: CachePolicy
     ) -> list[WheelFile | SdistFile]:
         """Revalidate a stale cached listing and return the records to serve.
 
-        ``data`` is the decoded cached body. Only a 304 serves it, parsing it
-        against the response's URL; a 200 serves the replacement body and a
-        404 serves nothing.
+        A 304 is answered from the parsed blob, falling back to the cached body
+        and then to a full fetch; a 200 serves the replacement body and a 404
+        serves nothing.
         """
         url = f"{self._index_url}{package}/"
         headers = {"Accept": simple_accept_header(self._serialization)}
@@ -587,10 +612,6 @@ class CachedAsyncSimpleClient:
             headers["If-None-Match"] = policy.etag
         response = await self._transport.get(url, headers=headers)
         if response.status_code == _HTTP_NOT_MODIFIED:
-            # Parse before refreshing the policy, so a body that will not parse
-            # keeps its stale window.
-            files = self._parse_body(data, package, page_url=response.url)
-
             # A 304 stating no freshness of its own keeps the stored max-age.
             new_policy = CachePolicy(
                 fetched_at=_freshness_start(response),
@@ -603,8 +624,16 @@ class CachedAsyncSimpleClient:
                 page_url=response.url,
                 body_digest=_carried_digest(policy, response.url),
             )
+
+            # Find the records before refreshing the policy, so a body that
+            # will not parse keeps its stale window.
+            unmodified = self._unmodified_records(package, new_policy)
+            if unmodified is None:
+                # The 304 confirmed a body the cache can no longer read.
+                return await self._fetch_simple(package)
+
             self._cache.refresh_simple_policy(package, new_policy)
-            return files
+            return unmodified
 
         if response.status_code == _HTTP_NOT_FOUND:
             self._cache.put_negative(package, self._negative_policy(response))

--- a/nab-index/tests/test_index_parsed_cache.py
+++ b/nab-index/tests/test_index_parsed_cache.py
@@ -2,7 +2,7 @@
 
 Covers the ``body_digest`` policy field and its encode/decode, the
 policy-only ``get_simple_policy`` read, the opaque-bytes
-``get_simple_parsed``/``put_simple_parsed`` pair, and the ``.parsed`` arm
+``get_simple_parsed``/``put_simple_parsed`` pair, and the ``.parsed`` branch
 of ``read_cache_entry``, plus the write path that binds a parsed blob to
 the body just stored: :meth:`OnDiskCache.put_simple` computes the digest,
 and every :class:`CachedAsyncSimpleClient` write point emits a blob bound
@@ -69,6 +69,21 @@ _LISTING = {
     ],
 }
 _LISTING_BYTES = json.dumps(_LISTING).encode()
+
+# A replacement listing at a new version, so a swapped body shows in the records.
+_LISTING_V2_BYTES = json.dumps(
+    {
+        "meta": {"api-version": "1.0"},
+        "name": "pkg",
+        "files": [
+            {
+                "filename": "pkg-2.0-py3-none-any.whl",
+                "url": "https://files.example.com/pkg-2.0-py3-none-any.whl",
+                "hashes": {"sha256": "beef"},
+            }
+        ],
+    }
+).encode()
 
 
 def _run(coro: Coroutine[Any, Any, _T]) -> _T:
@@ -843,21 +858,8 @@ class TestReadPathRevalidate:
     def test_stale_online_200_replaces_body_and_blob(self, tmp_path: Path) -> None:
         cache = _cache(tmp_path)
         _warm_bound(cache, fresh=False)
-        new_listing = json.dumps(
-            {
-                "meta": {"api-version": "1.0"},
-                "name": "pkg",
-                "files": [
-                    {
-                        "filename": "pkg-2.0-py3-none-any.whl",
-                        "url": "https://files.example.com/pkg-2.0-py3-none-any.whl",
-                        "hashes": {"sha256": "beef"},
-                    }
-                ],
-            }
-        ).encode()
         transport = _FakeTransport(
-            [_FakeResponse(new_listing, status=200, headers={"etag": "v2"})]
+            [_FakeResponse(_LISTING_V2_BYTES, status=200, headers={"etag": "v2"})]
         )
         client = CachedAsyncSimpleClient(transport, cache, _INDEX)
 
@@ -867,8 +869,30 @@ class TestReadPathRevalidate:
         result = cache.get_simple("pkg")
         assert result is not None
         body, policy = result
-        assert body == new_listing
+        assert body == _LISTING_V2_BYTES
         assert decode(cache.get_simple_parsed("pkg"), policy) == got
+
+    def test_stale_online_200_revalidates_without_reading_the_body(
+        self, tmp_path: Path
+    ) -> None:
+        cache = _cache(tmp_path)
+        _warm_bound(cache, fresh=False)
+        # The body is gone, so a read of it before revalidating would fetch
+        # unconditionally instead of sending the ETag.
+        tmp_path.joinpath(*_JSON_PATH_PARTS).unlink()
+        transport = _FakeTransport(
+            [_FakeResponse(_LISTING_V2_BYTES, status=200, headers={"etag": "v2"})]
+        )
+        client = CachedAsyncSimpleClient(transport, cache, _INDEX)
+
+        got = _run(client.get_files("pkg"))
+
+        assert [f.version for f in got] == ["2.0"]
+
+        assert len(transport.calls) == 1
+        _, headers = transport.calls[0]
+        assert headers is not None
+        assert headers["If-None-Match"] == "e"
 
     def test_stale_online_304_reuses_blob(self, tmp_path: Path) -> None:
         cache = _cache(tmp_path)
@@ -887,6 +911,84 @@ class TestReadPathRevalidate:
         assert result is not None
         _, policy = result
         assert decode(before, policy) == files
+
+    def test_stale_online_304_serves_the_blob_without_the_body(
+        self, tmp_path: Path
+    ) -> None:
+        cache = _cache(tmp_path)
+        files, _ = _warm_bound(cache, fresh=False)
+        # The body is gone: a 304 must be answered from the blob alone.
+        tmp_path.joinpath(*_JSON_PATH_PARTS).unlink()
+        transport = _FakeTransport(
+            [_FakeResponse(b"", status=304, headers={"etag": "e"})]
+        )
+        client = CachedAsyncSimpleClient(transport, cache, _INDEX)
+
+        got = _run(client.get_files("pkg"))
+
+        assert got == files
+        assert len(transport.calls) == 1
+
+    def test_stale_online_304_without_body_or_blob_refetches(
+        self, tmp_path: Path
+    ) -> None:
+        cache = _cache(tmp_path)
+        cache.put_simple(
+            "pkg",
+            _LISTING_BYTES,
+            CachePolicy(fetched_at=0, max_age=0, etag="e", page_url=_PAGE_URL),
+        )
+        tmp_path.joinpath(*_JSON_PATH_PARTS).unlink()
+        transport = _FakeTransport(
+            [
+                _FakeResponse(b"", status=304, headers={"etag": "e"}),
+                _FakeResponse(_LISTING_BYTES, headers={"etag": "e2"}),
+            ]
+        )
+        client = CachedAsyncSimpleClient(transport, cache, _INDEX)
+
+        got = _run(client.get_files("pkg"))
+
+        assert [f.filename for f in got] == [f.filename for f in _PARSED]
+
+        assert len(transport.calls) == 2
+
+        # The second request is a full copy, not another conditional one.
+        _, headers = transport.calls[1]
+        assert headers is not None
+        assert "If-None-Match" not in headers
+
+        result = cache.get_simple("pkg")
+        assert result is not None
+        assert result[0] == _LISTING_BYTES
+
+    def test_stale_online_304_with_corrupt_body_refetches(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        cache = _cache(tmp_path)
+        cache.put_simple(
+            "pkg",
+            b"<html>not json",
+            CachePolicy(fetched_at=0, max_age=0, etag="e", page_url=_PAGE_URL),
+        )
+        transport = _FakeTransport(
+            [
+                _FakeResponse(b"", status=304, headers={"etag": "e"}),
+                _FakeResponse(_LISTING_BYTES, headers={"etag": "e2"}),
+            ]
+        )
+        client = CachedAsyncSimpleClient(transport, cache, _INDEX)
+
+        with caplog.at_level(logging.WARNING):
+            got = _run(client.get_files("pkg"))
+
+        assert [f.filename for f in got] == [f.filename for f in _PARSED]
+        assert len(transport.calls) == 2
+        assert "Corrupt cached Simple-API body" in caplog.text
+
+        result = cache.get_simple("pkg")
+        assert result is not None
+        assert result[0] == _LISTING_BYTES
 
 
 class TestParsedCorruptionReason:


### PR DESCRIPTION
A warm `uv:uv-issue-2700-pydantic-rebuild@highest` resolve whose 29 cached listings have all gone stale makes about 3.37 million function calls instead of about 10.12 million, and locally takes about half the wall time and half the peak memory.

Stacked on #861, so the diff and the numbers are against that branch.

`get_files` read and decoded the cached body before sending the conditional request, so a stale entry paid a JSON decode and a full listing parse before the index had been asked anything, then parsed the body again to answer the 304. The stale path now goes straight to the conditional request, and a 304 is served from the parsed blob the way a fresh read already is. The body is read only when the blob does not bind, and when it is gone or will not decode the client fetches a full copy.

| | base | branch |
| --- | ---: | ---: |
| function calls | 10,117,174 | 3,371,792 |
| `json.loads` | 132 | 83 |
| `_parse_files` | 58 | 3 |
| `_parse_file_entry` | 80,496 | 421 |

The per-function rows reproduce exactly; the totals are one run of each side and move by about 1,400 calls between repeats. `_parse_files` on the base is two parses for each of the 29 revalidations; on the branch 26 of them bind their blob and 3 fall back to reading the body.

Peak allocations under `tracemalloc` drop from about 157 MB to about 70 MB, with two runs of each side putting the saving at 87.0 MB and 86.8 MB. Over 8 runs of each, the process goes from about 1.7 s to about 0.9 s, between roughly 43% and 50% faster locally, and its peak resident memory is about 47% lower.

Fresh and offline warm reads come from the blob already and this does not touch them: 12 runs of each over the 19-scenario canary set rule out a wall regression there above about 6% and a peak-memory regression above about 0.13%. PyPI serves listings with `max-age=600`, so the path that does change is the one a warm resolve takes whenever it runs more than ten minutes after the last.
