### PR TITLE
Defer the listing integrity parse to first read, ~2% off a cold ingest

### DIFF
--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -19,6 +19,7 @@ from datetime import timezone
 from email.utils import parsedate_to_datetime
 from typing import TYPE_CHECKING
 
+from nab_provider.records import select_artifact_hash
 from nab_provider.serialization import SimpleSerialization, simple_accept_header
 
 from .cache import CacheBackend, CachePolicy, OfflineError
@@ -32,7 +33,6 @@ from .client import (
     _header,
     _listing_body,
     _parse_files,
-    _select_artifact_hash,
     _verify_metadata_hash,
     holds_unreadable_format,
     verify_sdist_hash,
@@ -767,7 +767,7 @@ class CachedAsyncSimpleClient:
             wheel_url,
             canonical_name,
             self._range_memo,
-            wheel_hash=_select_artifact_hash(wheel_hashes),
+            wheel_hash=select_artifact_hash(wheel_hashes),
         )
         if result.text is not None:
             self._cache.put_metadata(package, wheel_url, result.text)
@@ -802,7 +802,7 @@ class CachedAsyncSimpleClient:
 
         response = await self._transport.get(sdist_url, headers=IDENTITY_HEADERS)
         raise_unless_ok(response, sdist_url)
-        selected = _select_artifact_hash(sdist_hashes)
+        selected = select_artifact_hash(sdist_hashes)
         if selected is not None:
             verify_sdist_hash(response.content, selected)
         pkg_info, pyproject_toml = _extract_sdist_files(response.content)
@@ -837,7 +837,7 @@ class CachedAsyncSimpleClient:
             raise OfflineError(msg)
         response = await self._transport.get(sdist_url, headers=IDENTITY_HEADERS)
         raise_unless_ok(response, sdist_url)
-        selected = _select_artifact_hash(sdist_hashes)
+        selected = select_artifact_hash(sdist_hashes)
         if selected is not None:
             verify_sdist_hash(response.content, selected)
         return response.content

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -23,14 +23,19 @@ from urllib.parse import urljoin, urlsplit, urlunsplit
 from packaging.utils import canonicalize_name
 from packaging.version import Version
 
-from nab_provider.digest import is_hex_digest
 from nab_provider.errors import (
     MalformedSimpleResponseError,
     MetadataHashMismatchError,
     SdistHashMismatchError,
     WheelHashMismatchError,
 )
-from nab_provider.records import ACCEPTED_HASH_ALGORITHMS, SdistFile, WheelFile
+from nab_provider.records import (
+    ACCEPTED_HASH_ALGORITHMS,
+    SdistFile,
+    WheelFile,
+    defer_hashes,
+    defer_sidecar_hash,
+)
 from nab_provider.serialization import SimpleSerialization, simple_accept_header
 
 from ._pep503 import json_listing
@@ -523,7 +528,6 @@ def _parse_file_entry(
     if file_url is None:
         return None
 
-    hashes = _parse_hashes(file_info.get("hashes"))
     size = _parse_size(file_info.get("size"))
     # ``requires-python`` has only a few dozen distinct values across
     # all of PyPI (``>=3.7``, ``>=3.8`` etc.) but appears once per
@@ -543,22 +547,26 @@ def _parse_file_entry(
     upload_time_raw = file_info.get("upload-time")
     upload_time = upload_time_raw if isinstance(upload_time_raw, str) else None
 
+    raw_hashes = file_info.get("hashes")
+
     wheel_parsed = _parse_wheel_filename(filename)
     if wheel_parsed is not None:
         parsed_name, version = wheel_parsed
         if parsed_name != expected:
             return None
-        return WheelFile(
+        sidecar = _metadata_value(file_info)
+        wheel = WheelFile(
             filename=filename,
             url=file_url,
             version=version,
             requires_python=requires_python,
-            has_metadata=_has_metadata(file_info),
+            has_metadata=_advertises_sidecar(sidecar),
             upload_time=upload_time,
-            hashes=hashes,
             size=size,
-            metadata_hash=_metadata_hash(file_info),
         )
+        defer_hashes(wheel, raw_hashes)
+        defer_sidecar_hash(wheel, sidecar)
+        return wheel
 
     sdist_parsed = _parse_sdist_filename(filename)
     if sdist_parsed is None:
@@ -566,39 +574,16 @@ def _parse_file_entry(
     parsed_name, version = sdist_parsed
     if parsed_name != expected:
         return None
-    return SdistFile(
+    sdist = SdistFile(
         filename=filename,
         url=file_url,
         version=version,
         requires_python=requires_python,
         upload_time=upload_time,
-        hashes=hashes,
         size=size,
     )
-
-
-def _parse_hashes(value: object) -> tuple[tuple[str, str], ...]:
-    # Algo names are a tiny fixed vocabulary, so interning dedups them.
-    # Both halves are lowercased: PEP 503/691 don't mandate a case, pip
-    # treats them case-insensitively, and the acceptable-algorithm filter
-    # and hashlib.hexdigest() both expect the lowercase form.
-    # A digest that is not hex can never match a file's bytes, so it is dropped.
-    if not isinstance(value, dict):
-        return ()
-
-    # The common case is a single hash; skip the list build.
-    if len(value) == 1:
-        ((algo, digest),) = value.items()
-        if isinstance(algo, str) and isinstance(digest, str) and is_hex_digest(digest):
-            return ((sys.intern(algo.lower()), digest.lower()),)
-        return ()
-
-    out: list[tuple[str, str]] = []
-    for algo, digest in value.items():
-        if isinstance(algo, str) and isinstance(digest, str) and is_hex_digest(digest):
-            out.append((sys.intern(algo.lower()), digest.lower()))
-
-    return tuple(out)
+    defer_hashes(sdist, raw_hashes)
+    return sdist
 
 
 def _parse_size(value: object) -> int | None:
@@ -625,33 +610,14 @@ def _metadata_value(file_info: _FileEntry) -> object:
     return file_info.get(_LEGACY_METADATA_KEY)
 
 
-def _has_metadata(file_info: _FileEntry) -> bool:
-    """Return True when the file entry advertises a PEP 658/714 sidecar.
+def _advertises_sidecar(value: object) -> bool:
+    """Return True when a metadata value promises a PEP 658/714 sidecar.
 
-    PEP 691 allows either a ``true`` boolean (sidecar exists but no
-    hashes published) or a mapping carrying the digest table.  Either
-    flavour means the index will serve ``<file>.metadata``.
+    The value is either ``true`` (the sidecar exists, with no digest
+    published) or the digest table itself; both mean the index will serve
+    ``<file>.metadata``.
     """
-    value = _metadata_value(file_info)
     return value is True or isinstance(value, dict)
-
-
-def _metadata_hash(file_info: _FileEntry) -> tuple[str, str] | None:
-    """Return the sidecar's published ``(algo, hex)`` to verify, or None.
-
-    A bare ``true`` (sidecar exists, no hash), a digest that is not hex, or a
-    table with no accepted algorithm yields None, so no check runs.
-    """
-    value = _metadata_value(file_info)
-    if not isinstance(value, dict):
-        return None
-
-    published = tuple(
-        (algo, digest)
-        for algo, digest in value.items()
-        if isinstance(algo, str) and isinstance(digest, str) and is_hex_digest(digest)
-    )
-    return _select_artifact_hash(published)
 
 
 def _verify_metadata_hash(content: bytes, metadata_hash: tuple[str, str]) -> None:
@@ -661,23 +627,6 @@ def _verify_metadata_hash(content: bytes, metadata_hash: tuple[str, str]) -> Non
     if actual != expected:
         msg = f"metadata {algo} mismatch: expected {expected}, got {actual}"
         raise MetadataHashMismatchError(msg)
-
-
-def _select_artifact_hash(
-    hashes: tuple[tuple[str, str], ...],
-) -> tuple[str, str] | None:
-    """Pick the preferred ``(algo, hex)`` to verify, or ``None`` if none qualify.
-
-    Walks :data:`ACCEPTED_HASH_ALGORITHMS` in order, so sha256 is preferred,
-    then sha384, then sha512. An empty set, an empty digest, or only unaccepted
-    algorithms (md5) yields ``None``.
-    """
-    by_algo = {algo.lower(): digest.lower() for algo, digest in hashes}
-    for algo in ACCEPTED_HASH_ALGORITHMS:
-        digest = by_algo.get(algo)
-        if digest:
-            return (algo, digest)
-    return None
 
 
 def verify_sdist_hash(content: bytes, sdist_hash: tuple[str, str]) -> None:

--- a/nab-index/src/nab_index/parsed_listing.py
+++ b/nab-index/src/nab_index/parsed_listing.py
@@ -20,6 +20,10 @@ Wire form (UTF-8 JSON of ``[header, rows]``):
   type-checked on the way back, and ``requires_python`` and hash-algorithm
   names are re-interned via ``sys.intern`` so the round trip reproduces the
   dedup the wire parse builds.
+* the two integrity cells carry the index's own table, as a JSON object, when
+  the record was built from one, and the parsed pairs otherwise. A rehydrated
+  record defers the same way, so a listing pays the integrity parse only for
+  the files a resolve reads.
 
 The blob is portable: one entry serves every interpreter that shares the cache,
 and a body this module will not parse is a miss, never an exception reaching
@@ -32,7 +36,7 @@ import json
 import sys
 from typing import TYPE_CHECKING
 
-from .client import SdistFile, WheelFile
+from nab_provider.records import SdistFile, WheelFile, defer_hashes, defer_sidecar_hash
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -45,7 +49,7 @@ __all__ = ["corruption_reason", "decode", "encode"]
 # blob surfacing under the current bucket. Bump it when the row shape changes
 # or when the same body parses to different records: ``body_digest`` pins only
 # the input.
-FORMAT_VERSION = 2
+FORMAT_VERSION = 3
 # Serialization variant that wrote the rows, so a future codec switch
 # self-heals rather than misdecodes.
 CODEC = 1
@@ -62,6 +66,22 @@ _TAG_SDIST = 1
 
 class _BadRowError(ValueError):
     """A row whose tag, arity, or field types are not what this codec wrote."""
+
+
+def _hashes_cell(record: WheelFile | SdistFile) -> object:
+    """Return the row cell for ``hashes``: the raw table, or the parsed pairs.
+
+    A record built from the index's own table writes that table, so encoding a
+    fresh listing does not force the parse it deferred.
+    """
+    raw = record.raw_hashes()
+    return record.hashes if raw is None else raw
+
+
+def _sidecar_cell(wheel: WheelFile) -> object:
+    """Return the row cell for ``metadata_hash``, raw table or parsed pair."""
+    raw = wheel.raw_sidecar()
+    return wheel.metadata_hash if raw is None else raw
 
 
 def encode(files: list[WheelFile | SdistFile], body_digest: str) -> bytes:
@@ -85,9 +105,9 @@ def encode(files: list[WheelFile | SdistFile], body_digest: str) -> bytes:
                     record.requires_python,
                     record.has_metadata,
                     record.upload_time,
-                    record.hashes,
+                    _hashes_cell(record),
                     record.size,
-                    record.metadata_hash,
+                    _sidecar_cell(record),
                 ]
             )
         else:
@@ -99,7 +119,7 @@ def encode(files: list[WheelFile | SdistFile], body_digest: str) -> bytes:
                     record.version,
                     record.requires_python,
                     record.upload_time,
-                    record.hashes,
+                    _hashes_cell(record),
                     record.size,
                 ]
             )
@@ -202,6 +222,16 @@ def _decode_row(row: object) -> WheelFile | SdistFile:
     raise _BadRowError
 
 
+def _hashes_unless_deferred(cell: object) -> tuple[tuple[str, str], ...]:
+    """Return a ``hashes`` cell's pairs, or ``()`` when it is a table to defer."""
+    return () if isinstance(cell, dict) else _hashes(cell)
+
+
+def _sidecar_unless_deferred(cell: object) -> tuple[str, str] | None:
+    """Return a sidecar cell's pair, or ``None`` when it is a table to defer."""
+    return None if isinstance(cell, dict) else _pair_or_none(cell)
+
+
 def _decode_wheel(row: Sequence[object]) -> WheelFile:
     (
         _,
@@ -215,30 +245,35 @@ def _decode_wheel(row: Sequence[object]) -> WheelFile:
         size,
         metadata_hash,
     ) = row
-    return WheelFile(
+    wheel = WheelFile(
         filename=_text(filename),
         url=_text(url),
         version=_text(version),
         requires_python=_interned_or_none(requires_python),
         has_metadata=_flag(has_metadata),
         upload_time=_text_or_none(upload_time),
-        hashes=_hashes(hashes),
+        hashes=_hashes_unless_deferred(hashes),
         size=_count_or_none(size),
-        metadata_hash=_pair_or_none(metadata_hash),
+        metadata_hash=_sidecar_unless_deferred(metadata_hash),
     )
+    defer_hashes(wheel, hashes)
+    defer_sidecar_hash(wheel, metadata_hash)
+    return wheel
 
 
 def _decode_sdist(row: Sequence[object]) -> SdistFile:
     _, filename, url, version, requires_python, upload_time, hashes, size = row
-    return SdistFile(
+    sdist = SdistFile(
         filename=_text(filename),
         url=_text(url),
         version=_text(version),
         requires_python=_interned_or_none(requires_python),
         upload_time=_text_or_none(upload_time),
-        hashes=_hashes(hashes),
+        hashes=_hashes_unless_deferred(hashes),
         size=_count_or_none(size),
     )
+    defer_hashes(sdist, hashes)
+    return sdist
 
 
 # JSON hands back only its own types, so an exact type check is enough to keep a

--- a/nab-index/tests/test_parsed_listing_codec.py
+++ b/nab-index/tests/test_parsed_listing_codec.py
@@ -5,9 +5,9 @@ The exact-equivalence contract is proved by the Hypothesis harness in
 is opt-in (``-m property``) and does not run under the coverage gate, so these
 plain unit tests drive every branch of the codec: the wheel/sdist tag split,
 present and absent ``requires_python``, present and absent ``metadata_hash``,
-each header / digest gate that turns a stale or foreign blob into a
-decode-to-``None`` miss, and the field checks that keep a hand-written row from
-reaching a record.
+the integrity cells in both their raw and their parsed form, each header /
+digest gate that turns a stale or foreign blob into a decode-to-``None`` miss,
+and the field checks that keep a hand-written row from reaching a record.
 """
 
 from __future__ import annotations
@@ -30,6 +30,7 @@ from nab_index.parsed_listing import (
     decode,
     encode,
 )
+from nab_provider.records import defer_hashes, defer_sidecar_hash
 
 DIGEST = "a" * 64
 
@@ -318,3 +319,70 @@ def test_foreign_build_header_is_not_corruption() -> None:
 
 def test_digest_mismatch_is_not_corruption() -> None:
     assert corruption_reason(encode(SAMPLE, "b" * 64)) is None
+
+
+def _deferred_wheel(hashes: object, *, sidecar: object) -> WheelFile:
+    """A wheel holding ``hashes`` and ``sidecar`` as the index served them."""
+    wheel = WheelFile(
+        filename="pkg-1.0-py3-none-any.whl",
+        url="https://files.example/pkg-1.0-py3-none-any.whl",
+        version="1.0",
+        requires_python=None,
+        has_metadata=True,
+        upload_time=None,
+    )
+    defer_hashes(wheel, hashes)
+    defer_sidecar_hash(wheel, sidecar)
+    return wheel
+
+
+def test_unparsed_tables_ride_the_wire_as_the_index_served_them() -> None:
+    wheel = _deferred_wheel({"SHA256": DIGEST.upper()}, sidecar={"sha256": DIGEST})
+
+    rows = json.loads(encode([wheel], DIGEST))[1]
+
+    assert rows[0][_W_HASHES] == {"SHA256": DIGEST.upper()}
+    assert rows[0][_W_METADATA_HASH] == {"sha256": DIGEST}
+
+
+def test_a_value_that_is_not_an_object_rides_as_its_parse() -> None:
+    """Only a table defers, so any other value writes what the record parsed."""
+    wheel = _deferred_wheel(["sha256", DIGEST], sidecar=True)
+
+    rows = json.loads(encode([wheel], DIGEST))[1]
+
+    assert rows[0][_W_HASHES] == []
+    assert rows[0][_W_METADATA_HASH] is None
+
+
+def test_a_many_algorithm_table_defers_as_the_index_served_it() -> None:
+    wheel = _deferred_wheel({"sha256": DIGEST, "sha512": "f" * 128}, sidecar=True)
+
+    rows = json.loads(encode([wheel], DIGEST))[1]
+
+    assert rows[0][_W_HASHES] == {"sha256": DIGEST, "sha512": "f" * 128}
+    assert wheel.hashes == ((SHA256, DIGEST), (SHA512, "f" * 128))
+
+
+def test_a_rehydrated_record_defers_the_same_parse() -> None:
+    blob = encode(
+        [_deferred_wheel({"SHA256": DIGEST.upper()}, sidecar={"sha256": DIGEST})],
+        DIGEST,
+    )
+
+    (wheel,) = decode(blob, _policy()) or []
+
+    assert wheel.raw_hashes() == {"SHA256": DIGEST.upper()}
+    assert wheel.raw_sidecar() == {"sha256": DIGEST}
+    assert wheel.hashes == ((SHA256, DIGEST),)
+    assert wheel.metadata_hash == (SHA256, DIGEST)
+
+
+def test_a_row_is_the_same_whether_or_not_the_record_was_read() -> None:
+    """A read record keeps its table, so encoding does not depend on read order."""
+    unread = _deferred_wheel({"sha256": DIGEST}, sidecar={"sha256": DIGEST})
+    read = _deferred_wheel({"sha256": DIGEST}, sidecar={"sha256": DIGEST})
+    assert read.hashes == ((SHA256, DIGEST),)
+    assert read.metadata_hash == (SHA256, DIGEST)
+
+    assert encode([read], DIGEST) == encode([unread], DIGEST)

--- a/nab-project/tests/property_python/test_parsed_listing_equiv.py
+++ b/nab-project/tests/property_python/test_parsed_listing_equiv.py
@@ -85,7 +85,7 @@ def _hash_table(draw: st.DrawFn) -> Any:
             "md5": draw(hex_digests),
         }
     if kind == 3:
-        # Non-string digest is dropped by _parse_hashes; exercise that path.
+        # Non-string digest is dropped by parse_hash_table; exercise that path.
         return {"sha256": draw(st.integers())}
     return draw(st.sampled_from([[], "notadict", 5]))
 

--- a/nab-project/tests/test_cached_client.py
+++ b/nab-project/tests/test_cached_client.py
@@ -41,14 +41,20 @@ from nab_index.client import (
     SdistHashMismatchError,
     WheelFile,
     WheelHashMismatchError,
+    _advertises_sidecar,
+    _metadata_value,
     _normalized_url,
     _parse_files,
     _parse_sdist_filename,
-    _select_artifact_hash,
 )
 from nab_index.lazy_wheel import RangeMetadataResult, RangeOutcome
 from nab_index.transport import HttpError
 from nab_provider.metadata import parse_metadata
+from nab_provider.records import (
+    parse_hash_table,
+    select_artifact_hash,
+    sidecar_hash,
+)
 from nab_provider.serialization import SimpleSerialization
 
 LISTING = {
@@ -195,44 +201,40 @@ def _build_tarball(members: list[tuple[str, bytes]]) -> bytes:
     return buf.getvalue()
 
 
+def _has_metadata(file_info: Mapping[Any, object]) -> bool:
+    """Whether ``file_info`` advertises a sidecar, read the way ingest reads it."""
+    return _advertises_sidecar(_metadata_value(file_info))
+
+
+def _metadata_hash(file_info: Mapping[Any, object]) -> tuple[str, str] | None:
+    """The sidecar hash ``file_info`` publishes, read the way ingest reads it."""
+    return sidecar_hash(_metadata_value(file_info))
+
+
 class TestHasMetadataFlag:
     """PEP 691 boolean variants of ``core-metadata`` / ``dist-info-metadata``."""
 
     def test_dict_value_advertises_metadata(self) -> None:
-        from nab_index.client import _has_metadata
-
         assert _has_metadata({"core-metadata": {"sha256": "abc"}})
 
     def test_true_value_advertises_metadata(self) -> None:
-        from nab_index.client import _has_metadata
-
         assert _has_metadata({"core-metadata": True})
 
     def test_legacy_json_key_true(self) -> None:
-        from nab_index.client import _has_metadata
-
         assert _has_metadata({"dist-info-metadata": True})
 
     def test_false_value_does_not_advertise(self) -> None:
-        from nab_index.client import _has_metadata
-
         assert not _has_metadata({"core-metadata": False})
 
     def test_missing_field(self) -> None:
-        from nab_index.client import _has_metadata
-
         assert not _has_metadata({})
 
     def test_core_metadata_false_suppresses_legacy_key(self) -> None:
-        from nab_index.client import _has_metadata
-
         assert not _has_metadata(
             {"core-metadata": False, "dist-info-metadata": {"sha256": "deadbeef"}}
         )
 
     def test_core_metadata_true_ignores_legacy_key(self) -> None:
-        from nab_index.client import _has_metadata
-
         assert _has_metadata({"core-metadata": True, "dist-info-metadata": False})
 
 
@@ -240,84 +242,60 @@ class TestMetadataHashParsing:
     """``_metadata_hash`` carries the published hash to verify, or None."""
 
     def test_sha256_lowercased(self) -> None:
-        from nab_index.client import _metadata_hash
-
         assert _metadata_hash({"core-metadata": {"sha256": "ABCD"}}) == (
             "sha256",
             "abcd",
         )
 
     def test_uppercase_algo_name(self) -> None:
-        from nab_index.client import _metadata_hash
-
         assert _metadata_hash({"core-metadata": {"SHA256": "ABCD"}}) == (
             "sha256",
             "abcd",
         )
 
     def test_legacy_key_used(self) -> None:
-        from nab_index.client import _metadata_hash
-
         assert _metadata_hash({"dist-info-metadata": {"sha256": "ab"}}) == (
             "sha256",
             "ab",
         )
 
     def test_true_value_yields_none(self) -> None:
-        from nab_index.client import _metadata_hash
-
         assert _metadata_hash({"core-metadata": True}) is None
 
     def test_other_algo_only_yields_none(self) -> None:
-        from nab_index.client import _metadata_hash
-
         assert _metadata_hash({"core-metadata": {"blake2b": "ab"}}) is None
 
     def test_sha512_only_verified(self) -> None:
-        from nab_index.client import _metadata_hash
-
         assert _metadata_hash({"core-metadata": {"sha512": "ABCD"}}) == (
             "sha512",
             "abcd",
         )
 
     def test_sha384_only_verified(self) -> None:
-        from nab_index.client import _metadata_hash
-
         assert _metadata_hash({"core-metadata": {"sha384": "ABCD"}}) == (
             "sha384",
             "abcd",
         )
 
     def test_sha256_preferred_over_sha512(self) -> None:
-        from nab_index.client import _metadata_hash
-
         assert _metadata_hash(
             {"core-metadata": {"sha512": "aaaa", "sha256": "bbbb"}}
         ) == ("sha256", "bbbb")
 
     def test_sha384_preferred_over_sha512(self) -> None:
-        from nab_index.client import _metadata_hash
-
         assert _metadata_hash(
             {"core-metadata": {"sha512": "aaaa", "sha384": "bbbb"}}
         ) == ("sha384", "bbbb")
 
     def test_unsupported_with_supported_skips_unsupported(self) -> None:
-        from nab_index.client import _metadata_hash
-
         assert _metadata_hash(
             {"core-metadata": {"blake2b": "aaaa", "sha512": "bbbb"}}
         ) == ("sha512", "bbbb")
 
     def test_missing_field_yields_none(self) -> None:
-        from nab_index.client import _metadata_hash
-
         assert _metadata_hash({}) is None
 
     def test_core_metadata_false_ignores_legacy_hash(self) -> None:
-        from nab_index.client import _metadata_hash
-
         assert (
             _metadata_hash(
                 {"core-metadata": False, "dist-info-metadata": {"sha256": "deadbeef"}}
@@ -326,8 +304,6 @@ class TestMetadataHashParsing:
         )
 
     def test_core_metadata_true_ignores_legacy_hash(self) -> None:
-        from nab_index.client import _metadata_hash
-
         assert (
             _metadata_hash(
                 {"core-metadata": True, "dist-info-metadata": {"sha256": "cafef00d"}}
@@ -336,8 +312,6 @@ class TestMetadataHashParsing:
         )
 
     def test_core_metadata_hash_preferred_over_legacy(self) -> None:
-        from nab_index.client import _metadata_hash
-
         assert _metadata_hash(
             {
                 "core-metadata": {"sha256": "AAAA"},
@@ -345,9 +319,34 @@ class TestMetadataHashParsing:
             }
         ) == ("sha256", "aaaa")
 
-    def test_parse_files_populates_metadata_hash(self) -> None:
-        from nab_index.client import WheelFile, _parse_files
+    def test_ingest_holds_the_tables_until_a_reader_asks(self) -> None:
+        data = {
+            "files": [
+                {
+                    "filename": "foo-1.0-py3-none-any.whl",
+                    "url": "https://example.com/foo-1.0-py3-none-any.whl",
+                    "hashes": {"SHA256": "A" * 64},
+                    "core-metadata": {"sha256": "b" * 64},
+                },
+                {
+                    "filename": "foo-1.0.tar.gz",
+                    "url": "https://example.com/foo-1.0.tar.gz",
+                    "hashes": {"sha256": "c" * 64},
+                },
+            ],
+        }
 
+        wheel, sdist = _parse_files(data, "https://example.com/simple/", "foo")
+
+        assert wheel.raw_hashes() == {"SHA256": "A" * 64}
+        assert wheel.raw_sidecar() == {"sha256": "b" * 64}
+        assert sdist.raw_hashes() == {"sha256": "c" * 64}
+
+        assert wheel.hashes == (("sha256", "a" * 64),)
+        assert wheel.metadata_hash == ("sha256", "b" * 64)
+        assert sdist.hashes == (("sha256", "c" * 64),)
+
+    def test_parse_files_populates_metadata_hash(self) -> None:
         data = {
             "files": [
                 {
@@ -362,18 +361,12 @@ class TestMetadataHashParsing:
         assert wheel.metadata_hash == ("sha256", "dead")
 
     def test_empty_digest_yields_none(self) -> None:
-        from nab_index.client import _metadata_hash
-
         assert _metadata_hash({"core-metadata": {"sha256": ""}}) is None
 
     def test_non_hex_digest_yields_none(self) -> None:
-        from nab_index.client import _metadata_hash
-
         assert _metadata_hash({"core-metadata": {"sha256": "not-a-digest"}}) is None
 
     def test_empty_digest_falls_through_to_valid_algo(self) -> None:
-        from nab_index.client import _metadata_hash
-
         assert _metadata_hash(
             {"core-metadata": {"sha256": "", "sha512": "a" * 128}}
         ) == ("sha512", "a" * 128)
@@ -800,104 +793,78 @@ class TestFragmentedUrlSidecarFetch:
 
 class TestParseHashes:
     def test_single_entry(self) -> None:
-        from nab_index.client import _parse_hashes
-
-        assert _parse_hashes({"sha256": "a" * 64}) == (("sha256", "a" * 64),)
+        assert parse_hash_table({"sha256": "a" * 64}) == (("sha256", "a" * 64),)
 
     def test_single_entry_malformed(self) -> None:
-        from nab_index.client import _parse_hashes
-
-        assert _parse_hashes({"sha256": 123}) == ()
+        assert parse_hash_table({"sha256": 123}) == ()
 
     def test_multiple_entries(self) -> None:
-        from nab_index.client import _parse_hashes
-
-        result = _parse_hashes({"sha256": "a" * 64, "md5": "b" * 32})
+        result = parse_hash_table({"sha256": "a" * 64, "md5": "b" * 32})
         assert result == (("sha256", "a" * 64), ("md5", "b" * 32))
 
     def test_multiple_entries_skips_malformed(self) -> None:
-        from nab_index.client import _parse_hashes
-
-        result = _parse_hashes({"sha256": "a" * 64, "md5": 123})
+        result = parse_hash_table({"sha256": "a" * 64, "md5": 123})
         assert result == (("sha256", "a" * 64),)
 
     def test_non_dict(self) -> None:
-        from nab_index.client import _parse_hashes
-
-        assert _parse_hashes("sha256:abc") == ()
+        assert parse_hash_table("sha256:abc") == ()
 
     def test_empty_dict(self) -> None:
-        from nab_index.client import _parse_hashes
-
-        assert _parse_hashes({}) == ()
+        assert parse_hash_table({}) == ()
 
     def test_single_empty_digest_dropped(self) -> None:
-        from nab_index.client import _parse_hashes
-
-        assert _parse_hashes({"sha256": ""}) == ()
+        assert parse_hash_table({"sha256": ""}) == ()
 
     def test_empty_digest_falls_through_to_valid(self) -> None:
-        from nab_index.client import _parse_hashes
-
-        assert _parse_hashes({"sha256": "", "sha512": "f" * 128}) == (
+        assert parse_hash_table({"sha256": "", "sha512": "f" * 128}) == (
             ("sha512", "f" * 128),
         )
 
     def test_empty_digest_yields_no_sdist_check(self) -> None:
-        from nab_index.client import _parse_hashes, _select_artifact_hash
-
-        assert _select_artifact_hash(_parse_hashes({"sha256": ""})) is None
+        assert select_artifact_hash(parse_hash_table({"sha256": ""})) is None
 
     def test_single_non_hex_digest_dropped(self) -> None:
-        from nab_index.client import _parse_hashes
-
-        assert _parse_hashes({"sha256": "not-a-digest"}) == ()
+        assert parse_hash_table({"sha256": "not-a-digest"}) == ()
 
     def test_hex_digest_split_by_whitespace_dropped(self) -> None:
-        from nab_index.client import _parse_hashes
-
-        assert _parse_hashes({"sha256": "0123abcd\nbeef"}) == ()
+        assert parse_hash_table({"sha256": "0123abcd\nbeef"}) == ()
 
     def test_non_hex_digest_falls_through_to_valid(self) -> None:
-        from nab_index.client import _parse_hashes
-
-        assert _parse_hashes({"sha256": "deadbeef ", "sha512": "f" * 128}) == (
+        assert parse_hash_table({"sha256": "deadbeef ", "sha512": "f" * 128}) == (
             ("sha512", "f" * 128),
         )
 
     def test_uppercase_digest_kept_lowercased(self) -> None:
-        from nab_index.client import _parse_hashes
-
-        assert _parse_hashes({"sha256": "A" * 64}) == (("sha256", "a" * 64),)
+        assert parse_hash_table({"sha256": "A" * 64}) == (("sha256", "a" * 64),)
 
 
 class TestSelectArtifactHash:
     def test_prefers_sha256(self) -> None:
         hashes = (("sha512", "f" * 128), ("sha256", "a" * 64))
-        assert _select_artifact_hash(hashes) == ("sha256", "a" * 64)
+        assert select_artifact_hash(hashes) == ("sha256", "a" * 64)
 
     def test_falls_through_to_sha384(self) -> None:
         hashes = (("sha512", "f" * 128), ("sha384", "b" * 96))
-        assert _select_artifact_hash(hashes) == ("sha384", "b" * 96)
+        assert select_artifact_hash(hashes) == ("sha384", "b" * 96)
 
     def test_falls_through_to_sha512(self) -> None:
-        assert _select_artifact_hash((("sha512", "f" * 128),)) == (
+        assert select_artifact_hash((("sha512", "f" * 128),)) == (
             "sha512",
             "f" * 128,
         )
 
     def test_empty_returns_none(self) -> None:
-        assert _select_artifact_hash(()) is None
+        assert select_artifact_hash(()) is None
 
     def test_only_unacceptable_returns_none(self) -> None:
-        assert _select_artifact_hash((("md5", "d" * 32),)) is None
+        assert select_artifact_hash((("md5", "d" * 32),)) is None
 
     def test_empty_digest_returns_none(self) -> None:
-        assert _select_artifact_hash((("sha256", ""),)) is None
+        assert select_artifact_hash((("sha256", ""),)) is None
 
     def test_empty_digest_falls_through_to_valid_algo(self) -> None:
         hashes = (("sha256", ""), ("sha512", "f" * 128))
-        assert _select_artifact_hash(hashes) == ("sha512", "f" * 128)
+        assert select_artifact_hash(hashes) == ("sha512", "f" * 128)
 
 
 class TestMaxAgeDirective:

--- a/nab-provider/src/nab_provider/records.py
+++ b/nab-provider/src/nab_provider/records.py
@@ -7,10 +7,12 @@ class, so the fetching side and the resolving side can both name them.
 from __future__ import annotations
 
 import enum
+import sys
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from urllib.parse import urlsplit, urlunsplit
 
+from .digest import is_hex_digest
 from .serialization import SimpleSerialization
 
 if TYPE_CHECKING:
@@ -26,10 +28,98 @@ __all__ = [
     "RangeOutcome",
     "SdistFile",
     "WheelFile",
+    "defer_hashes",
+    "defer_sidecar_hash",
+    "parse_hash_table",
+    "select_artifact_hash",
+    "sidecar_hash",
 ]
 
 # Verification order; sha256 is pip's hash-checking baseline.
 ACCEPTED_HASH_ALGORITHMS: tuple[str, ...] = ("sha256", "sha384", "sha512")
+
+
+def parse_hash_table(value: object) -> tuple[tuple[str, str], ...]:
+    """Return a PEP 691 ``hashes`` table as ``(algorithm, hex_digest)`` pairs.
+
+    PEP 503/691 mandate no case for either half, so both are lowercased here
+    and no later comparison has to.  A digest that is not hex can never match a
+    file's bytes, so it is dropped.  Algorithm names are interned: they come
+    from a tiny fixed vocabulary and repeat once per file.
+    """
+    if not isinstance(value, dict):
+        return ()
+
+    # The common case is a single hash; skip the list build.
+    if len(value) == 1:
+        ((algo, digest),) = value.items()
+        if isinstance(algo, str) and isinstance(digest, str) and is_hex_digest(digest):
+            return ((sys.intern(algo.lower()), digest.lower()),)
+        return ()
+
+    out: list[tuple[str, str]] = []
+    for algo, digest in value.items():
+        if isinstance(algo, str) and isinstance(digest, str) and is_hex_digest(digest):
+            out.append((sys.intern(algo.lower()), digest.lower()))
+
+    return tuple(out)
+
+
+def select_artifact_hash(
+    hashes: tuple[tuple[str, str], ...],
+) -> tuple[str, str] | None:
+    """Pick the preferred ``(algo, hex)`` to verify, or ``None`` if none qualify.
+
+    Walks :data:`ACCEPTED_HASH_ALGORITHMS` in order, so sha256 is preferred,
+    then sha384, then sha512. An empty set, an empty digest, or only unaccepted
+    algorithms (md5) yields ``None``.
+    """
+    by_algo = {algo.lower(): digest.lower() for algo, digest in hashes}
+    for algo in ACCEPTED_HASH_ALGORITHMS:
+        digest = by_algo.get(algo)
+        if digest:
+            return (algo, digest)
+    return None
+
+
+def sidecar_hash(value: object) -> tuple[str, str] | None:
+    """Return the ``(algo, hex)`` to verify a PEP 714 metadata value against.
+
+    ``value`` is the entry's ``core-metadata`` / ``dist-info-metadata`` field.
+    A bare ``true`` (sidecar exists, no hash), a digest that is not hex, or a
+    table with no accepted algorithm yields ``None``.
+    """
+    if not isinstance(value, dict):
+        return None
+
+    published = tuple(
+        (algo, digest)
+        for algo, digest in value.items()
+        if isinstance(algo, str) and isinstance(digest, str) and is_hex_digest(digest)
+    )
+    return select_artifact_hash(published)
+
+
+def _compact_table(table: dict[object, object]) -> object:
+    """Return the form of ``table`` a record holds until something reads it.
+
+    An index almost always publishes one algorithm, and holding that as an
+    interned ``(algo, digest)`` pair retains less than the dict it was served
+    as.  Anything else is held as it stands.
+    """
+    if len(table) == 1:
+        ((algo, digest),) = table.items()
+        if type(algo) is str:
+            return (sys.intern(algo), digest)
+    return table
+
+
+def _expand_table(held: object) -> object:
+    """Return ``held`` as the index served it, undoing :func:`_compact_table`."""
+    if isinstance(held, tuple):
+        algo, digest = held
+        return {algo: digest}
+    return held
 
 
 class _MetadataUrlMemo:
@@ -46,8 +136,95 @@ class _MetadataUrlMemo:
     _metadata_url: str
 
 
+class _DeferredIntegrity:
+    """Parses a record's ``hashes`` table the first time something reads it.
+
+    :func:`defer_hashes` unsets the parsed slot and keeps the index's own table
+    beside it, so a listing pays the integrity parse only for the files a
+    resolve reads.  ``__getattr__`` runs only once ordinary lookup has failed,
+    so a record built the ordinary way reads its fields straight out of their
+    slots.
+
+    A read leaves the raw table in place.  The fetching and the resolving
+    thread hold the same records, so both may run the parse at once, and both
+    then store the same value.
+    """
+
+    __slots__ = ()
+
+    _raw_hashes: object
+
+    def __getattr__(self, name: str) -> object:
+        if name != "hashes":
+            raise AttributeError(name)
+
+        value = parse_hash_table(_expand_table(self._raw_hashes))
+        object.__setattr__(self, "hashes", value)
+        return value
+
+    def raw_hashes(self) -> object:
+        """Return the ``hashes`` table this record was built from, else ``None``."""
+        try:
+            return _expand_table(self._raw_hashes)
+        except AttributeError:
+            return None
+
+
+class _WheelIntegrity(_DeferredIntegrity, _MetadataUrlMemo):
+    """Carries a wheel's raw tables in slots of its own."""
+
+    __slots__ = ("_raw_hashes", "_raw_metadata")
+
+    _raw_metadata: object
+
+    def __getattr__(self, name: str) -> object:
+        if name != "metadata_hash":
+            return super().__getattr__(name)
+
+        value = sidecar_hash(_expand_table(self._raw_metadata))
+        object.__setattr__(self, "metadata_hash", value)
+        return value
+
+    def raw_sidecar(self) -> object:
+        """Return the sidecar value this wheel was built from, else ``None``."""
+        try:
+            return _expand_table(self._raw_metadata)
+        except AttributeError:
+            return None
+
+
+class _SdistIntegrity(_DeferredIntegrity):
+    """Carries a source distribution's raw ``hashes`` table in a slot of its own."""
+
+    __slots__ = ("_raw_hashes",)
+
+
+def defer_hashes(record: WheelFile | SdistFile, table: object) -> None:
+    """Hold ``table`` unparsed, so ``record.hashes`` parses it on first read.
+
+    Only a PEP 691 table has pairs to defer; any other value leaves
+    ``record.hashes`` as the caller built it.
+    """
+    if not isinstance(table, dict):
+        return
+    object.__delattr__(record, "hashes")
+    object.__setattr__(record, "_raw_hashes", _compact_table(table))
+
+
+def defer_sidecar_hash(wheel: WheelFile, table: object) -> None:
+    """Hold ``table`` unparsed, so ``wheel.metadata_hash`` parses it on first read.
+
+    PEP 714's bare ``true`` promises a sidecar without publishing a digest, so
+    only a table defers.
+    """
+    if not isinstance(table, dict):
+        return
+    object.__delattr__(wheel, "metadata_hash")
+    object.__setattr__(wheel, "_raw_metadata", _compact_table(table))
+
+
 @dataclass(frozen=True, slots=True)
-class WheelFile(_MetadataUrlMemo):
+class WheelFile(_WheelIntegrity):
     """Wheel file record returned by the Simple-API client.
 
     ``hashes`` is a tuple of ``(algorithm, hex_digest)`` pairs in the
@@ -62,6 +239,9 @@ class WheelFile(_MetadataUrlMemo):
     ``metadata_hash`` is the published ``(algorithm, hex_digest)`` for
     the PEP 658/714 sidecar, or ``None`` when the index advertised the
     sidecar without a hash.
+
+    A record built from a listing holds the index's own tables and parses
+    ``hashes`` and ``metadata_hash`` on first read (:func:`defer_hashes`).
     """
 
     filename: str
@@ -94,7 +274,7 @@ class WheelFile(_MetadataUrlMemo):
 
 
 @dataclass(frozen=True, slots=True)
-class SdistFile:
+class SdistFile(_SdistIntegrity):
     """A source distribution from the Simple API.
 
     See :class:`WheelFile` for the meaning of ``hashes``, ``size`` and

--- a/nab-provider/tests/test_record_deferral.py
+++ b/nab-provider/tests/test_record_deferral.py
@@ -1,0 +1,158 @@
+"""Deferred integrity parsing on the Simple-API records."""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from nab_provider import records
+from nab_provider.records import SdistFile, WheelFile, defer_hashes, defer_sidecar_hash
+
+DIGEST = "a" * 64
+SHA256 = "sha256"
+_TIMEOUT = 10.0
+
+
+def _deferred_wheel(hashes: object, *, sidecar: object) -> WheelFile:
+    """A wheel holding ``hashes`` and ``sidecar`` as the index served them."""
+    wheel = WheelFile(
+        filename="pkg-1.0-py3-none-any.whl",
+        url="https://files.example/pkg-1.0-py3-none-any.whl",
+        version="1.0",
+        requires_python=None,
+        has_metadata=True,
+        upload_time=None,
+    )
+    defer_hashes(wheel, hashes)
+    defer_sidecar_hash(wheel, sidecar)
+    return wheel
+
+
+def _deferred_sdist(hashes: object) -> SdistFile:
+    """A source distribution holding ``hashes`` as the index served them."""
+    sdist = SdistFile(
+        filename="pkg-1.0.tar.gz",
+        url="https://files.example/pkg-1.0.tar.gz",
+        version="1.0",
+        requires_python=None,
+        upload_time=None,
+    )
+    defer_hashes(sdist, hashes)
+    return sdist
+
+
+def test_a_first_read_parses_the_table_the_index_served() -> None:
+    wheel = _deferred_wheel({"SHA256": DIGEST.upper()}, sidecar={"sha256": DIGEST})
+
+    assert wheel.hashes == ((SHA256, DIGEST),)
+    assert wheel.metadata_hash == (SHA256, DIGEST)
+
+
+def test_a_second_read_returns_the_value_the_first_stored() -> None:
+    wheel = _deferred_wheel({"sha256": DIGEST}, sidecar={"sha256": DIGEST})
+    hashes = wheel.hashes
+    metadata_hash = wheel.metadata_hash
+
+    assert wheel.hashes is hashes
+    assert wheel.metadata_hash is metadata_hash
+
+
+def test_a_one_algorithm_table_is_held_as_a_pair() -> None:
+    """The compact form is why a deferred record costs less than the served dict."""
+    wheel = _deferred_wheel({"sha256": DIGEST}, sidecar={"sha256": DIGEST})
+
+    assert wheel._raw_hashes == (SHA256, DIGEST)
+    assert wheel._raw_metadata == (SHA256, DIGEST)
+
+
+def test_a_many_algorithm_table_is_held_as_it_stands() -> None:
+    table = {"sha256": DIGEST, "sha512": "f" * 128}
+
+    wheel = _deferred_wheel(table, sidecar=table)
+
+    assert wheel._raw_hashes == table
+    assert wheel._raw_metadata == table
+
+
+def test_a_read_keeps_the_table_it_parsed() -> None:
+    wheel = _deferred_wheel({"sha256": DIGEST}, sidecar={"sha256": DIGEST})
+
+    assert wheel.hashes == ((SHA256, DIGEST),)
+    assert wheel.raw_hashes() == {"sha256": DIGEST}
+
+    assert wheel.metadata_hash == (SHA256, DIGEST)
+    assert wheel.raw_sidecar() == {"sha256": DIGEST}
+
+
+@pytest.mark.parametrize(
+    ("field", "parser", "expected"),
+    [
+        ("hashes", "parse_hash_table", ((SHA256, DIGEST),)),
+        ("metadata_hash", "sidecar_hash", (SHA256, DIGEST)),
+    ],
+)
+def test_two_threads_reading_one_deferred_field_both_get_it(
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+    parser: str,
+    expected: object,
+) -> None:
+    """A listing's records are read by the fetching and the resolving thread."""
+    wheel = _deferred_wheel({"sha256": DIGEST}, sidecar={"sha256": DIGEST})
+    parse = getattr(records, parser)
+    both_reading = threading.Barrier(2, timeout=_TIMEOUT)
+
+    def wait_then_parse(value: object) -> object:
+        both_reading.wait()
+        return parse(value)
+
+    monkeypatch.setattr(records, parser, wait_then_parse)
+
+    seen: list[object] = []
+    failures: list[AttributeError] = []
+
+    def read() -> None:
+        try:
+            seen.append(getattr(wheel, field))
+        except AttributeError as exc:
+            failures.append(exc)
+
+    readers = [threading.Thread(target=read) for _ in range(2)]
+    for reader in readers:
+        reader.start()
+    for reader in readers:
+        reader.join(_TIMEOUT)
+
+    assert failures == []
+    assert seen == [expected, expected]
+
+
+def test_a_value_that_is_not_a_table_defers_nothing() -> None:
+    wheel = _deferred_wheel(["sha256", DIGEST], sidecar=True)
+
+    assert wheel.raw_hashes() is None
+    assert wheel.raw_sidecar() is None
+    assert wheel.hashes == ()
+    assert wheel.metadata_hash is None
+
+
+def test_a_table_keyed_by_a_non_string_defers_as_it_stands() -> None:
+    wheel = _deferred_wheel({7: DIGEST}, sidecar=True)
+
+    assert wheel.raw_hashes() == {7: DIGEST}
+    assert wheel.hashes == ()
+
+
+def test_a_source_distribution_has_no_sidecar_hash_to_defer() -> None:
+    sdist = _deferred_sdist({"sha256": DIGEST})
+
+    with pytest.raises(AttributeError, match="metadata_hash"):
+        sdist.metadata_hash  # noqa: B018
+
+
+def test_deferral_does_not_answer_for_an_unknown_attribute() -> None:
+    wheel = _deferred_wheel({"sha256": DIGEST}, sidecar={"sha256": DIGEST})
+
+    with pytest.raises(AttributeError, match="no_such_field"):
+        wheel.no_such_field  # noqa: B018


### PR DESCRIPTION
A cold ingest of `airflow:airflow-3-0-2-awswrangler --resolution lowest-direct`, with the parsed-listing cache cleared so every file entry goes through the ingest parse, retires 472,255,436 fewer instructions: 21,565,672,140 against 22,037,927,576, or 2.1% of the whole run. Peak RSS drops about 2.9% locally, roughly 6 MB off a peak near 200 MB.

Three counts of that workload, on this branch and two earlier revisions of it, gave -2.051%, -2.112% and -2.143%, and their base counts differ by up to 18.4M instructions, so read the instruction win as 2.05% to 2.14% rather than to the digit. The RSS win sits between about 2.7% and 3.1%. Wall and CPU came back with no difference on runs that could not have seen anything below about 1%, so all they establish is that there is no wall regression above that.

What changes:

- `WheelFile` and `SdistFile` keep the entry's `hashes` and `core-metadata` values in slots of their own and parse them in `__getattr__` on the first read of `hashes` or `metadata_hash`. The record is still a frozen slotted dataclass, so it stays hashable, and only the files a resolve looks at pay the parse.
- The table parsers move from `nab_index.client` to `nab_provider.records`, beside the records that now defer them.
- The parsed-listing codec writes whichever form a record holds, so writing the blob after an ingest does not force the parse, and a rehydrated record defers the same way.
- `FORMAT_VERSION` goes to 3, so an existing cache rebuilds itself under the codec's own skew rule.

Holding the JSON objects the index served is the obvious version, and it trades the wrong way: it counted -7.7% instructions and ran about 12% faster locally, but peak RSS went up between 7.4% and 7.7%, because two one-key dicts per wheel retain more than the pairs they replace. Holding a single-algorithm table as an interned `(algo, digest)` pair fixes the memory, and building those pairs is why this counts -2.1% instead of -7.7%. Anything chasing the rest of that gap has to beat the pair form on memory as well.

The warm path is not measured here. Rehydrated records defer too, so a warm resolve should skip the same parse, but the format bump makes both sides start cold.

The instruction counts reproduce anywhere; the timings are off my machine.
