### PR TITLE
Exit the CLI without freeing the resolve graph, ~5% off a `nab lock`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ Source = "https://github.com/notatallshaw/nab"
 Changelog = "https://github.com/notatallshaw/nab/releases"
 
 [project.scripts]
-nab = "nab.cli:main"
+nab = "nab.cli:console_entry"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -88,6 +88,7 @@ from .output import (
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Mapping
+    from typing import TextIO
 
     from nab_index.transport import AsyncHttpTransport
     from nab_project.resolve import ResolveResult
@@ -136,6 +137,9 @@ TUPLE_TEMPLATE_VARS = ("{python_version}", "{platform_id}", "{selection}")
 
 # Conventional KeyboardInterrupt exit code: 128 + SIGINT(2).
 _SIGINT_EXIT_CODE = 130
+
+# The status CPython exits with when it cannot flush the standard streams.
+_FLUSH_FAILED_EXIT_CODE = 120
 
 app = SubcommandApp()
 
@@ -791,7 +795,7 @@ from . import _lock as _lock_module  # noqa: E402, F401 - side-effect
 
 
 def main() -> None:
-    """Entry point for the nab command."""
+    """Parse the global flags and run the requested subcommand."""
     global _printer  # noqa: PLW0603 - the run's printer is a module singleton main() sets
     # Tyro's SubcommandApp does not surface global flags, so ``--version`` and
     # the output flags (-v/-q, --color, --no-progress) are parsed before
@@ -817,3 +821,53 @@ def main() -> None:
     except KeyboardInterrupt:
         _printer.error("interrupted")
         sys.exit(_SIGINT_EXIT_CODE)
+
+
+def _system_exit_status(code: object) -> int:
+    """Map a ``SystemExit`` code to the status the interpreter would exit with."""
+    if code is None:
+        return 0
+    if isinstance(code, int):
+        return code
+    sys.stderr.write(f"{code}\n")
+    return 1
+
+
+def _flush_stream(stream: TextIO) -> bool:
+    """Flush one stream, reporting whether its buffered output landed."""
+    try:
+        stream.flush()
+    except OSError:
+        return False
+    return True
+
+
+def _flush_std_streams() -> bool:
+    """Flush stdout and stderr, reporting whether both landed.
+
+    stderr is flushed even when stdout fails, so a command that could not
+    write its result still gets its error out.
+    """
+    out_flushed = _flush_stream(sys.stdout)
+    err_flushed = _flush_stream(sys.stderr)
+    return out_flushed and err_flushed
+
+
+def console_entry() -> NoReturn:
+    """Run the CLI, then end the process without freeing the resolve graph.
+
+    Only the installed ``nab`` command takes this path, because it owns its
+    process; :func:`main` returns normally for every other caller. No
+    ``atexit`` hook and no finalizer runs after this, so a command has to
+    finish any work it cannot lose before :func:`main` returns.
+    """
+    status = 0
+    try:
+        main()
+    except SystemExit as exc:
+        status = _system_exit_status(exc.code)
+
+    if not _flush_std_streams():
+        status = _FLUSH_FAILED_EXIT_CODE
+
+    os._exit(status)

--- a/tasks/check_dists.py
+++ b/tasks/check_dists.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import email
 import os
+import shutil
 import subprocess
 import sys
 import tarfile
@@ -136,18 +137,38 @@ def install_each_sdist(dist_root: Path, scratch: Path) -> None:
         _run([str(python), "-m", "pip", "install", *links, str(sdist)])
 
 
+def _console_script(python: Path) -> str:
+    """Return the installed ``nab`` command sitting beside a venv's interpreter."""
+    script = shutil.which("nab", path=str(python.parent))
+    if script is None:
+        msg = f"the wheel installed no nab command in {python.parent}"
+        raise SystemExit(msg)
+    return script
+
+
+def _check_version(command: list[str], version: str) -> None:
+    """Fail unless the command prints the built version and exits 0."""
+    output = _capture([*command, "--version"])
+    expected = f"nab {version}"
+    if expected not in output:
+        shown = " ".join(command)
+        msg = f"`{shown} --version` reported {output.strip()!r}, expected {expected!r}"
+        raise SystemExit(msg)
+
+
 def install_wheels(dist_root: Path, scratch: Path) -> None:
-    """Install every wheel together, then import each package and run the CLI."""
+    """Install every wheel together, then import each package and run the CLI.
+
+    ``python -m nab`` and the console script enter through different
+    functions, so both are run.
+    """
     wheels = [str(_wheel(dist_root, package)) for package in PACKAGES]
     version = _wheel_version(_wheel(dist_root, "nab"))
     python = _make_venv(scratch / "wheels")
     _run([str(python), "-m", "pip", "install", *wheels])
     _run([str(python), "-c", f"import {', '.join(MODULES)}"])
-    output = _capture([str(python), "-m", "nab", "--version"])
-    expected = f"nab {version}"
-    if expected not in output:
-        msg = f"`nab --version` reported {output.strip()!r}, expected {expected!r}"
-        raise SystemExit(msg)
+    _check_version([str(python), "-m", "nab"], version)
+    _check_version([_console_script(python)], version)
 
 
 def _wheel_version(wheel: Path) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -47,7 +47,9 @@ from nab.cli import (
     _make_transport,
     _normalize_layered_bool_flags,
     _resolve,
+    _system_exit_status,
     app,
+    console_entry,
     main,
 )
 from nab.output import Printer, Verbosity
@@ -5167,6 +5169,85 @@ class TestMain:
                 failure_prefix="cannot lock",
             )
         assert gc.isenabled()
+
+
+class TestConsoleEntry:
+    """Tests for the installed ``nab`` command's entry point.
+
+    ``os._exit`` ends the process outright, so every test here patches it.
+    """
+
+    def test_exits_zero_when_main_returns(self) -> None:
+        """A command that returns normally exits 0 through ``os._exit``."""
+        with (
+            patch("nab.cli.main") as mock_main,
+            patch("nab.cli.os._exit") as mock_exit,
+        ):
+            console_entry()
+        mock_main.assert_called_once()
+        mock_exit.assert_called_once_with(0)
+
+    def test_carries_the_exit_code_through(self) -> None:
+        """``sys.exit(2)`` inside the command becomes exit status 2."""
+        with (
+            patch("nab.cli.main", side_effect=SystemExit(2)),
+            patch("nab.cli.os._exit") as mock_exit,
+        ):
+            console_entry()
+        mock_exit.assert_called_once_with(2)
+
+    def test_flushes_the_streams_before_exiting(self) -> None:
+        """Output written by the command is flushed, since ``os._exit`` will not."""
+        flushed: list[str] = []
+        with (
+            patch("nab.cli.main"),
+            patch.object(sys.stdout, "flush", lambda: flushed.append("out")),
+            patch.object(sys.stderr, "flush", lambda: flushed.append("err")),
+            patch("nab.cli.os._exit"),
+        ):
+            console_entry()
+        assert flushed == ["out", "err"]
+
+    def test_unflushed_output_exits_120(self) -> None:
+        """A stdout flush that fails still flushes stderr and exits 120."""
+        with (
+            patch("nab.cli.main"),
+            patch.object(sys.stdout, "flush", side_effect=OSError(28, "No space")),
+            patch.object(sys.stderr, "flush") as mock_stderr_flush,
+            patch("nab.cli.os._exit") as mock_exit,
+        ):
+            console_entry()
+        mock_stderr_flush.assert_called_once()
+        mock_exit.assert_called_once_with(120)
+
+    def test_a_crash_is_left_to_the_interpreter(self) -> None:
+        """Only ``SystemExit`` takes the fast exit; anything else propagates."""
+        with (
+            patch("nab.cli.main", side_effect=ValueError("boom")),
+            patch("nab.cli.os._exit") as mock_exit,
+            pytest.raises(ValueError, match="boom"),
+        ):
+            console_entry()
+        mock_exit.assert_not_called()
+
+
+class TestSystemExitStatus:
+    """Tests for mapping a ``SystemExit`` code to a process status."""
+
+    def test_bare_exit_is_zero(self) -> None:
+        """``sys.exit()`` raises ``SystemExit(None)``, which means success."""
+        assert _system_exit_status(None) == 0
+
+    def test_integer_passes_through(self) -> None:
+        """``sys.exit(3)`` becomes exit status 3."""
+        assert _system_exit_status(3) == 3
+
+    def test_message_prints_and_exits_one(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A string code is the message, printed to stderr as CPython does."""
+        assert _system_exit_status("boom") == 1
+        assert capsys.readouterr().err == "boom\n"
 
 
 class _TtyStderr(io.StringIO):


### PR DESCRIPTION
Locally, `nab lock` runs about 5.5% faster on `pip:google-bigquery-soda` under `--project-resolution lowest` and about 4.2% faster on `pip:langchain-ml-course`. Twelve paired runs each put the first between about 4% and 7% and the second between about 3% and 5.5%, and CPU moves with wall, about 5.6% and 4.3%. The runs put peak memory inside about 0.2% either way on google-bigquery-soda and about 0.11% either way on langchain.

That is 35 ms off a 0.62 s command and 77 ms off a 1.81 s one, a fixed cost whose share falls as the resolve grows. Both workloads are the scenario written out as a nab project and resolved by the CLI against a warm cache, so they are smaller than the benchmark suite's runs of the same names.

The process retires 116,054,898 fewer instructions on google-bigquery-soda, 2.082% of the 5,574,747,625 it ran there, and 201,771,697 fewer on langchain, 1.076% of 18,759,548,168. Wall falls by more than the counts do, which they cannot explain on their own: instructions do not price cache misses or allocator work.

The command was freeing the resolve graph before it exited. 73,570 tracked objects and 431,088 allocated blocks are still live when `main()` returns on the langchain workload, and CPython walks all of that on the way out. The installed `nab` script now flushes stdout and stderr and calls `os._exit` instead of returning into teardown.

Only the console script takes this path. `main()` still returns normally, so `python -m nab` and every in-process caller keep the usual teardown.

What makes the hard exit safe here:

- No `atexit` handler, `__del__` or `weakref` under `src/` in any of the five packages, the vendored packaging tree included, and no `atexit` handler in tyro, urllib3, truststore, build, installer, pyproject_hooks or tomli_w.
- The lockfile is written and renamed into place before `main()` returns, and `--output -` goes to stdout, which the new code flushes. A flush that raises `OSError` exits 120, the status CPython uses when it cannot flush the streams.
- `NabBuildEnv._tmpdir` is the one `TemporaryDirectory` held on an instance attribute, and its single caller uses `with`, so the finalizer was never what removed it. The one background thread is already `daemon=True`.

`tasks/check_dists.py` now runs the installed `nab --version` as well as `python -m nab --version`, since the console script is the path that changed.

The instruction counts are callgrind with the hash seed pinned, one run per side. They do not repeat to the digit here, because a real `nab lock` reads a warm disk cache and runs a fetch thread: the same base code counted twice landed 311,859 apart on google-bigquery-soda and 8,652,032 apart on langchain, far below either saving.
