### PR TITLE
Bound urllib3 fetches to 16 threads, ~11% off a cold lock's CPU

### DIFF
--- a/nab-index/src/nab_index/transport.py
+++ b/nab-index/src/nab_index/transport.py
@@ -2,7 +2,7 @@
 
 Defines minimal protocols for async HTTP GET requests.
 Implementations can use any async HTTP library (httpx, or urllib3
-wrapped in to_thread, etc.).
+on worker threads, etc.).
 """
 
 from __future__ import annotations

--- a/nab-index/src/nab_index/urllib3_async_transport.py
+++ b/nab-index/src/nab_index/urllib3_async_transport.py
@@ -1,18 +1,20 @@
 """urllib3-based async HTTP transport for nab-index.
 
 urllib3 is sync. To present an async surface we run each request
-in a worker thread via ``asyncio.to_thread``. This is useful for
-benchmarking against the natively-async backends, and for cases
-where users already have urllib3 in their environment.
+on a worker thread. This is useful for benchmarking against the
+natively-async backends, and for cases where users already have
+urllib3 in their environment.
 """
 
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import json as _json
 import ssl
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin
 
@@ -40,6 +42,11 @@ __all__ = [
 
 # urllib3's default read timeout is None, so bound it against a stalled index.
 _DEFAULT_TIMEOUT_SECONDS = 5.0
+
+# How many requests a transport runs at once. Each thread builds its own
+# PoolManager and truststore SSLContext, so a higher count buys more waiting on
+# the index at once and costs memory and CPU per thread.
+_REQUEST_THREADS = 16
 
 
 class _SSLContext(truststore.SSLContext):
@@ -125,12 +132,16 @@ class _Urllib3Response:
 
 
 class Urllib3AsyncTransport:
-    """Async HTTP transport using urllib3 (sync) wrapped in to_thread.
+    """Async HTTP transport using urllib3 (sync) on its own worker threads.
 
-    Each ``get`` runs the underlying sync request on the asyncio default
-    executor.  A separate :class:`~urllib3.PoolManager` (and truststore
-    SSLContext) is kept per worker thread: truststore toggles the
-    context's ``verify_mode`` to ``CERT_NONE`` for the duration of each
+    Each ``get`` runs the underlying sync request on this transport's own
+    executor of ``_REQUEST_THREADS`` threads.  A request holds a thread for
+    its whole duration, waits included, so that count is how many requests
+    are ever in flight, whatever a caller queues up.
+
+    A separate :class:`~urllib3.PoolManager` (and truststore SSLContext)
+    is kept per worker thread: truststore toggles the context's
+    ``verify_mode`` to ``CERT_NONE`` for the duration of each
     ``wrap_socket`` (truststore#209), so sharing one context across the
     executor threads races that toggle and trips spurious
     ``InsecureRequestWarning``s.  One context per thread means no two
@@ -152,6 +163,21 @@ class Urllib3AsyncTransport:
         self._local = threading.local()
         self._pools: list[urllib3.PoolManager] = []
         self._pools_lock = threading.Lock()
+        self._executor: ThreadPoolExecutor | None = None
+        self._executor_lock = threading.Lock()
+
+    def _request_executor(self) -> ThreadPoolExecutor:
+        """Return the executor requests run on, creating it on first use.
+
+        ``aclose`` retires it, so a transport used again after that builds a
+        fresh one here.
+        """
+        with self._executor_lock:
+            if self._executor is None:
+                self._executor = ThreadPoolExecutor(
+                    max_workers=_REQUEST_THREADS, thread_name_prefix="nab-urllib3"
+                )
+            return self._executor
 
     def _pool(self) -> urllib3.PoolManager:
         """Return this worker thread's pool, creating it on first use."""
@@ -221,8 +247,19 @@ class Urllib3AsyncTransport:
         request_headers = dict(DEFAULT_HEADERS)
         if headers is not None:
             request_headers.update(headers)
+
+        loop = asyncio.get_running_loop()
+        # A request sees the context vars its caller set, not an empty context.
+        context = contextvars.copy_context()
+
         try:
-            return await asyncio.to_thread(self._request, url, request_headers)
+            return await loop.run_in_executor(
+                self._request_executor(),
+                context.run,
+                self._request,
+                url,
+                request_headers,
+            )
         except Exception as exc:
             # A malformed IPv6 host in a redirect's Location makes urllib3's
             # urljoin re-parse raise a bare ValueError, outside its HTTPError
@@ -231,7 +268,16 @@ class Urllib3AsyncTransport:
             raise HttpError(msg) from exc
 
     async def aclose(self) -> None:
-        """Close every per-thread pool."""
+        """Retire the worker threads, then close every per-thread pool.
+
+        The threads go first: a request still running can register a pool that
+        closing in the other order would miss.
+        """
+        with self._executor_lock:
+            executor, self._executor = self._executor, None
+        if executor is not None:
+            await asyncio.to_thread(executor.shutdown)
+
         with self._pools_lock:
             pools = list(self._pools)
         for pool in pools:

--- a/nab-index/src/nab_index/urllib3_async_transport.py
+++ b/nab-index/src/nab_index/urllib3_async_transport.py
@@ -252,14 +252,12 @@ class Urllib3AsyncTransport:
         # A request sees the context vars its caller set, not an empty context.
         context = contextvars.copy_context()
 
+        def run_request() -> _Urllib3Response:
+            """Carry the request and its context into the worker thread."""
+            return context.run(self._request, url, request_headers)
+
         try:
-            return await loop.run_in_executor(
-                self._request_executor(),
-                context.run,
-                self._request,
-                url,
-                request_headers,
-            )
+            return await loop.run_in_executor(self._request_executor(), run_request)
         except Exception as exc:
             # A malformed IPv6 host in a redirect's Location makes urllib3's
             # urljoin re-parse raise a bare ValueError, outside its HTTPError

--- a/nab-project/tests/test_async_transports.py
+++ b/nab-project/tests/test_async_transports.py
@@ -58,6 +58,7 @@ from nab_index.transport import (
     raise_for_error_status,
 )
 from nab_index.urllib3_async_transport import (
+    _REQUEST_THREADS,
     Urllib3AsyncTransport,
     _SSLContext,
     _Urllib3Response,
@@ -1140,6 +1141,57 @@ def _redirected_response(status: int, hops: list[tuple[str, str]]) -> MagicMock:
     return response
 
 
+_BLOCKED_SECONDS = 5.0
+"""How long a blocked request waits before the test gives up on it.
+
+The transport either reaches its thread count in a moment or never will, so a
+regression fails in seconds rather than hanging.
+"""
+
+
+class _BlockingPool:
+    """A PoolManager stand-in whose requests block until they are released.
+
+    ``high_water`` is the most requests that ran at once, which is the
+    concurrency the transport's executor delivered.
+    """
+
+    def __init__(self, response: MagicMock) -> None:
+        response.data = b"body"
+        response.headers = urllib3.HTTPHeaderDict()
+        self._response = response
+        self._lock = threading.Lock()
+        self._started = threading.Semaphore(0)
+        self._released = threading.Event()
+        self._in_flight = 0
+        self.high_water = 0
+
+    def request(self, *_args: Any, **_kwargs: Any) -> MagicMock:
+        with self._lock:
+            self._in_flight += 1
+            self.high_water = max(self.high_water, self._in_flight)
+
+        self._started.release()
+        assert self._released.wait(_BLOCKED_SECONDS), "requests were never released"
+
+        with self._lock:
+            self._in_flight -= 1
+        return self._response
+
+    def wait_for_starts(self, count: int) -> None:
+        """Block until ``count`` requests have entered ``request``."""
+        for _ in range(count):
+            assert self._started.acquire(timeout=_BLOCKED_SECONDS), (
+                f"fewer than {count} ran at once"
+            )
+
+    def release(self) -> None:
+        self._released.set()
+
+    def clear(self) -> None:
+        """Stand in for the ``clear`` that ``aclose`` calls on each pool."""
+
+
 class TestUrllib3AsyncTransport:
     def _fake_pool(self, body: bytes, status: int = 200) -> MagicMock:
         fake_response = _unredirected_response(status)
@@ -1643,6 +1695,62 @@ class TestUrllib3AsyncTransport:
         # Distinct worker threads -> distinct pools; all tracked for aclose.
         assert pools[0] is not pools[1]
         assert set(map(id, pools)) <= set(map(id, transport._pools))
+
+    def test_concurrent_gets_stop_at_the_request_thread_count(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """More gets than threads run ``_REQUEST_THREADS`` at a time.
+
+        The bound is a constant rather than a function of the CPU count, so
+        the high-water mark is the same number on every machine.
+        """
+        pool = _BlockingPool(_unredirected_response(200))
+        monkeypatch.setattr(
+            "nab_index.urllib3_async_transport.urllib3.PoolManager",
+            lambda **kw: pool,
+        )
+
+        async def go() -> None:
+            transport = Urllib3AsyncTransport()
+            gets = [
+                asyncio.create_task(transport.get(f"https://example.com/{i}/"))
+                for i in range(_REQUEST_THREADS + 4)
+            ]
+            try:
+                await asyncio.to_thread(pool.wait_for_starts, _REQUEST_THREADS)
+            finally:
+                pool.release()
+                await asyncio.gather(*gets)
+                await transport.aclose()
+
+        asyncio.run(go())
+        assert pool.high_water == _REQUEST_THREADS
+
+    def test_a_reused_transport_builds_a_second_executor(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``aclose`` retires the executor, so a later get builds a fresh one."""
+        pool = self._fake_pool(b"body")
+        monkeypatch.setattr(
+            "nab_index.urllib3_async_transport.urllib3.PoolManager",
+            lambda **kw: pool,
+        )
+
+        async def go() -> list[bytes]:
+            transport = Urllib3AsyncTransport()
+            bodies = []
+            for url in ("https://example.com/a/", "https://example.com/b/"):
+                bodies.append((await transport.get(url)).content)
+                await transport.aclose()
+            return bodies
+
+        assert asyncio.run(go()) == [b"body", b"body"]
+
+    def test_aclose_before_any_get_retires_nothing(self) -> None:
+        """A transport that never ran a request has no executor to shut down."""
+        transport = Urllib3AsyncTransport()
+        asyncio.run(transport.aclose())
+        assert transport._executor is None
 
     def test_ssl_context_satisfies_urllib3_cert_check(self) -> None:
         """``_SSLContext`` returns a non-empty CA count for urllib3-future.


### PR DESCRIPTION
On a cold `nab lock` of 43 direct requirements, running urllib3's fetches on a fixed pool of 16 threads takes 9% to 14% off process CPU and 2% to 6% off wall, locally. On `apache-airflow` it is 7% to 11% off CPU and 2% to 9% off peak memory. The one case it makes worse is a throttled index, about 50% slower.

The fetch coordinator admits 50 concurrent gets, and the default transport hands each one to `asyncio.to_thread`, so the asyncio default executor delivers `min(32, cpu_count + 4)` of them, 28 on this 24-core machine. Giving the transport its own executor of 16 puts 16 requests in flight and builds 16 `PoolManager`s and 16 truststore SSLContexts per resolve instead of 28. Demand stays at 50, and every run issues the same 251 and 508 gets either way.

Counts are exact; timings are local and rounded, off that 24-core machine.

| cold `nab lock` | wall | CPU | peak memory |
| --- | --- | --- | --- |
| 43 direct requirements, 251 gets, 16 runs each way | 2% to 6% faster | 9% to 14% lower | 7% lower to no change |
| `apache-airflow`, 508 gets, 20 runs each way | not resolved, rules out a slowdown above ~13% | 7% to 11% lower | 2% to 9% lower |

The airflow run's own wall varies 26% to 28% run to run, which is why it resolves memory but not time.

Sizing the executor up instead is worse. An executor sized to the coordinator's 50 raises delivered concurrency to 43 on the same 251-fetch lock, and costs about 18% more CPU with it. No wall win came back: that run could only have seen one above about 7%. Each thread costs a `PoolManager`, an OS trust store load, and one more TLS handshake to the index.

What 16 costs is a throttled index, where a lower ceiling means more rounds of waiting. Against a local server answering 503 to everything, so each of 50 concurrent gets sits in urllib3's retry backoff holding its thread, the branch is about 50% slower: a median 4.8 s against 7.4 s over 10 runs each way, with the run putting it between 39% and 58%. CPU falls about 6% and peak memory about 5% on that same workload, so both improve while the time a user waits gets worse.

Medians of three runs at each thread count on that workload:

| threads | 8 | 12 | 16 | 20 | 24 | 28 | 50 |
| --- | --- | --- | --- | --- | --- | --- | --- |
| wall | 12.4 s | 8.8 s | 7.1 s | 5.5 s | 5.3 s | 4.6 s | 3.1 s |

So 16 is not an optimum either measurement found. It sits between two curves that run in opposite directions, and it is the number to argue with.

It also changes how the ceiling tracks the host. The shipped count follows the CPU count, so a fixed 16 lowers it above 12 cores and raises it below: 28 to 16 here, 8 to 16 on a 4-core runner.

`run_in_executor` does not carry the caller's contextvars the way `asyncio.to_thread` does, so `get` copies the context itself.
