### PR TITLE
Decode a prefetched candidate only when the solver reads it

### DIFF
--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -8577,7 +8577,7 @@ class TestAwaitMetadataBatchEdgeCases:
         Pre-empting the walk-ahead deep prefetch can land metadata for a
         version that the next pipelined batch also submits; by the time
         ``_await_metadata_batch`` runs, that version's deps are cached
-        already and re-parsing is wasted work.
+        already and queuing it for another parse is wasted work.
         """
         wheels = [make_wheel("1.0")]
         coordinator = make_coordinator(wheels, package="foo")
@@ -8587,6 +8587,8 @@ class TestAwaitMetadataBatchEdgeCases:
             "foo",
             [(V("1.0"), "1.0", _SIDECAR_URL, _done_event())],
         )
+
+        assert ("foo", V("1.0")) not in provider.pending_metadata_parses
         assert provider.deps_cache[("foo", V("1.0"))] == {"bar": VersionRange.full()}
 
     def test_batch_invalid_metadata_refuses_version(self) -> None:
@@ -8662,6 +8664,8 @@ class TestAwaitMetadataBatchEdgeCases:
             "foo",
             [(V("1.0"), "1.0", _SIDECAR_URL, _done_event())],
         )
+        listing_mod.parse_prefetched_metadata(provider, ("foo", V("1.0")))
+
         assert ("foo", V("1.0")) not in provider.deps_cache
         with pytest.raises(MetadataHashMismatchError):
             provider.get_dependencies("foo", V("1.0"))
@@ -8717,6 +8721,7 @@ class TestAwaitMetadataBatchEdgeCases:
         wheel_map = provider._wheel_by_version("pkg", version_list)
         submitted = provider._prefetch_batch("pkg", [V("1.0")], wheel_map)
         provider._await_metadata_batch("pkg", submitted)
+        listing_mod.parse_prefetched_metadata(provider, ("pkg", V("1.0")))
 
         assert ("pkg", V("1.0")) not in provider.deps_cache
         with pytest.raises(UnsupportedSdistError):
@@ -8744,8 +8749,65 @@ class TestAwaitMetadataBatchEdgeCases:
         wheel_map = provider._wheel_by_version("pkg", version_list)
         submitted = provider._prefetch_batch("pkg", [V("1.0")], wheel_map)
         provider._await_metadata_batch("pkg", submitted)
+        listing_mod.parse_prefetched_metadata(provider, ("pkg", V("1.0")))
 
         assert ("pkg", V("1.0")) not in provider.deps_cache
+
+
+class TestPipelinedScanDefersUnreadMetadata:
+    """The scan decodes what it reads and leaves the rest of the batch queued."""
+
+    @staticmethod
+    def _provider_over_twelve_versions() -> Provider:
+        """A provider whose scan rejects foo>=10.0 and settles on 9.0.
+
+        ``bar`` is decided at 1.0, which the top three versions exclude.  With
+        twelve versions the first prefetch batch reaches below 9.0, so it holds
+        candidates no read ever asks about.
+        """
+        versions = [f"{n}.0" for n in range(1, 13)]
+        metadata = {
+            v: (
+                "Metadata-Version: 2.1\nName: foo\n"
+                f"Version: {v}\n"
+                f"Requires-Dist: bar{'>=2' if V(v) >= V('10.0') else '<2'}\n"
+            )
+            for v in versions
+        }
+        coordinator = make_coordinator(
+            [make_wheel(v) for v in versions],
+            package="foo",
+            metadata_by_version=metadata,
+        )
+        provider = Provider(
+            coordinator,
+            target=_PY312,
+            root_requirements={"foo": VersionRange.full(admit_arbitrary=False)},
+        )
+        provider.solution_decisions["bar"] = V("1.0")
+        return provider
+
+    def test_batch_below_the_pick_stays_undecoded(self) -> None:
+        """Versions the scan never reaches are queued, not parsed."""
+        provider = self._provider_over_twelve_versions()
+
+        assert provider.choose_version("foo", VersionRange.full()) == V("9.0")
+
+        assert ("foo", V("5.0")) in provider.pending_metadata_parses
+        assert ("foo", V("5.0")) not in provider.deps_cache
+        assert ("foo", V("9.0")) in provider.deps_cache
+
+    def test_later_read_serves_the_queued_metadata(self) -> None:
+        """A read of a queued version decodes it without a metadata fetch."""
+        provider = self._provider_over_twelve_versions()
+        provider.choose_version("foo", VersionRange.full())
+        fetched = provider.stats.metadata_fetched
+
+        deps = provider.get_dependencies("foo", V("5.0"))
+
+        assert deps == {"bar": SpecifierSet("<2").to_range()}
+        assert provider.stats.metadata_fetched == fetched
+        assert ("foo", V("5.0")) not in provider.pending_metadata_parses
 
 
 class TestIsReady:

--- a/nab-provider/src/nab_provider/_provider/listing.py
+++ b/nab-provider/src/nab_provider/_provider/listing.py
@@ -815,50 +815,68 @@ def await_metadata_batch(
     package: str,
     submitted: list[tuple[Version, str, str, Waitable]],
 ) -> None:
-    """Wait for all submitted metadata to arrive, then parse into cache."""
+    """Wait for all submitted metadata to arrive and queue it for decoding.
+
+    A batch is scanned only until look-ahead accepts a candidate, so the rest
+    of it is often never read.  :func:`parse_prefetched_metadata` decodes an
+    entry when a caller asks for that candidate's dependencies.
+
+    The integrity check stays at await time: it also reads the version-level
+    error slot, which a later sdist failure can write, so a deferred check
+    would see a failure this sidecar fetch never had.
+    """
+    index = provider.coordinator.index
+    pending = provider.pending_metadata_parses
     for version, ver_str, metadata_url, event in submitted:
         cache_key = (package, version)
         if cache_key in provider.deps_cache:
             continue
         event.wait()
-        integrity_error = provider.coordinator.index.get_metadata_error(
-            package, ver_str, metadata_url
-        )
-        if integrity_error is not None:
-            # Leave the version un-cached instead of aborting the batch.
-            # The error stays recorded, so get_dependencies re-raises it
-            # only if the scan actually selects this version.
+        if index.get_metadata_error(package, ver_str, metadata_url) is not None:
             continue
-        text, from_sdist = provider.coordinator.index.get_metadata_with_origin(
-            package, ver_str, metadata_url
-        )
-        if text is None:
-            # No PEP 658 text arrived: leave the version un-cached so
-            # look-ahead's get_dependencies runs the sdist fallback (or
-            # refuses it) rather than pinning it as dependency-free.
-            continue
-        if from_sdist:
-            # The sidecar served nothing and the read fell back to sdist
-            # PKG-INFO; caching it here would skip the PEP 643 gate that
-            # get_dependencies applies on the from_sdist path.
-            continue
-        try:
-            provider.parse_and_cache_metadata(cache_key, text)
-        except (
-            ValueError,
-            InvalidVersion,
-            InvalidSpecifier,
-            ForeignMetadataError,
-            IncompatiblePythonError,
-            UnsupportedVcsError,
-            NotImplementedError,
-        ):
-            # Malformed metadata, metadata declaring another release, a
-            # Python-incompatible Requires-Python, or a refused base
-            # direct-URL/VCS dep: leave the version un-cached so
-            # get_dependencies re-raises at selection time instead of aborting
-            # the speculative prefetch of a candidate the scan may never pick.
-            continue
+        pending[cache_key] = (ver_str, metadata_url)
+
+
+def parse_prefetched_metadata(
+    provider: Provider, cache_key: tuple[str, Version]
+) -> None:
+    """Decode this version's queued prefetch into ``deps_cache``, if it has one.
+
+    Every rejection below returns without caching, leaving ``get_dependencies``
+    to read the metadata itself and decide what the failure means.
+    """
+    queued = provider.pending_metadata_parses.pop(cache_key, None)
+    if queued is None:
+        return
+
+    package, _version = cache_key
+    ver_str, metadata_url = queued
+    text, from_sdist = provider.coordinator.index.get_metadata_with_origin(
+        package, ver_str, metadata_url
+    )
+    if text is None:
+        # No PEP 658 text arrived, and caching nothing would pin the version
+        # as dependency-free.
+        return
+    if from_sdist:
+        # sdist PKG-INFO: caching it here would skip the PEP 643 gate.
+        return
+
+    try:
+        provider.parse_and_cache_metadata(cache_key, text)
+    except (
+        ValueError,
+        InvalidVersion,
+        InvalidSpecifier,
+        ForeignMetadataError,
+        IncompatiblePythonError,
+        UnsupportedVcsError,
+        NotImplementedError,
+    ):
+        # Malformed metadata, metadata declaring another release, a
+        # Python-incompatible Requires-Python, or a refused base
+        # direct-URL/VCS dep.
+        return
 
 
 def prefetch_new_deps(provider: Provider, deps: Mapping[str, VersionRange]) -> None:

--- a/nab-provider/src/nab_provider/provider.py
+++ b/nab-provider/src/nab_provider/provider.py
@@ -559,6 +559,10 @@ class Provider:
         self.constraints: Mapping[str, VersionRange] = constraints or {}
         self.versions_cache: dict[str, list[tuple[Version, DistFile]]] = {}
         self.deps_cache: dict[tuple[str, Version], dict[str, VersionRange]] = {}
+        # Metadata the pipelined scan prefetched, as ``(version string, sidecar
+        # URL)``, decoded on the first read of that candidate.  A candidate the
+        # solver never reads is never decoded.
+        self.pending_metadata_parses: dict[tuple[str, Version], tuple[str, str]] = {}
         # One range per distinct dependency specifier text, shared by every
         # parent that names it.
         self.specifier_ranges: dict[str, VersionRange] = {}
@@ -1988,6 +1992,11 @@ class Provider:
             return _extras.get_extra_dependencies(self, base, extra, version)
 
         cache_key = (normalized, version)
+
+        # Before the cache check: a queued prefetch lands in deps_cache only
+        # when this decodes it.
+        _listing.parse_prefetched_metadata(self, cache_key)
+
         if cache_key in self.deps_cache:
             return self.deps_cache[cache_key]
         cached_unsupported = self._unsupported_sdists.get(cache_key)

--- a/nab-provider/tests/test_provider_declared_target.py
+++ b/nab-provider/tests/test_provider_declared_target.py
@@ -1353,6 +1353,7 @@ class TestSiblingWheelDependencies:
         submitted = linux._prefetch_batch("pkg", [Version("1.0")], linux_wheels)
         windows._prefetch_batch("pkg", [Version("1.0")], win_wheels)
         linux._await_metadata_batch("pkg", submitted)
+        listing_mod.parse_prefetched_metadata(linux, ("pkg", Version("1.0")))
 
         assert set(linux.deps_cache[("pkg", Version("1.0"))]) == {"linuxdep"}
 
@@ -1446,6 +1447,7 @@ class TestTwoInstallableSiblingWheels:
 
         submitted = provider._prefetch_batch("pkg", [Version("1.0")], mapping)
         provider._await_metadata_batch("pkg", submitted)
+        listing_mod.parse_prefetched_metadata(provider, ("pkg", Version("1.0")))
 
         assert set(provider.deps_cache[("pkg", Version("1.0"))]) == {"linuxdep"}
 


### PR DESCRIPTION
`pip:google-bigquery-soda --resolution lowest` makes 67,921 fewer calls, 1.7% of the 4,072,991 it made before, because 49 of the 228 candidate records it used to decode are no longer decoded. Counts come from cProfile under `PYTHONHASHSEED=0` and reproduce; the timings below are from this machine.

Stacked on #913, so the diff and every number here are against that branch.

Instruction counts fell on both scenarios measured, three runs each against the same base: `pip:google-bigquery-soda@lowest` by 0.5% to 1.2% off about 5.5 billion, `uv:boto3-urllib3-transient@lowest` by 2.1% to 2.9% off about 4.9 billion.

CPU time over five scenarios from the 19-scenario canary set, 40 runs each way, is between about 0.3% and 1.6% lower locally, with a middle estimate near 1%. Those runs cannot resolve the wall or the memory effect: they rule out a wall regression above about 2% and put peak memory inside about 2.4% either way.

The pipelined scan prefetches candidates 8 at a time, waits for the whole batch, then returns at the first one look-ahead accepts. Everything below that candidate was decoded on arrival and often never looked at again: a probe on the same scenario counted 51 of the 230 records a run decodes as never read.

`await_metadata_batch` now queues the version and sidecar URL instead of parsing, and `get_dependencies` decodes the one candidate it is about to answer for, applying every rejection rule the await path did.

Search behaviour moves slightly: `_span_identical_deps` reads a candidate's neighbours out of `deps_cache` without draining the queue, so a neighbour the scan skipped now fences a span it used to extend.

Over 14 scenarios from the canary set forced to `--resolution highest`, the 12 that produce comparable data keep the same packages, distributions seen, metadata fetched and look-ahead rejections, and decisions move from 17,537 to 17,557. The whole difference is `pip:promptflow-vectordb`, 11,154 to 11,174 with four more conflicts, and it is deterministic on both sides.
