### PR TITLE
Read a build-remote sdist once instead of twice, half the bytes per build

### DIFF
--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -63,6 +63,7 @@ if TYPE_CHECKING:
 __all__ = [
     "CachedAsyncSimpleClient",
     "ParsedCacheStats",
+    "SdistArchiveHold",
     "read_fresh_parsed_listing",
 ]
 
@@ -100,6 +101,7 @@ _MAX_AGE_RE = re.compile(r'max-age\s*=\s*"?(\d+)', re.IGNORECASE)
 _AGE_RE = re.compile(r"\A\s*(\d+)\s*\Z")
 _SECONDS_CEILING = 2**31
 _SECONDS_CEILING_DIGITS = len(str(_SECONDS_CEILING))
+_DEFAULT_HELD_ARCHIVES = 50
 
 
 def _parse_seconds(digits: str) -> int:
@@ -256,6 +258,43 @@ def read_fresh_parsed_listing(
     return _decode_parsed(blob, policy) or None
 
 
+class SdistArchiveHold:
+    """Archive bytes read for a PKG-INFO, kept for a build of the same version.
+
+    A version taken down the ``BUILD_REMOTE`` path reads its sdist twice, once
+    for the PKG-INFO the metadata ladder reads and again for the whole archive
+    the backend builds. Holding what the first read downloaded lets the second
+    take those bytes rather than the URL.
+
+    At most ``max_entries`` archives are held, the oldest evicted first, so a
+    resolve whose sdists are read but never built has a ceiling rather than a
+    growing hold. A build whose archive was evicted, or never held, downloads
+    it.
+
+    Touched only on the fetcher loop's single thread, so its state needs no
+    lock.
+    """
+
+    def __init__(self, max_entries: int = _DEFAULT_HELD_ARCHIVES) -> None:
+        """Create a hold with room for ``max_entries`` archives."""
+        self._held: dict[tuple[str, str], bytes] = {}
+        self._max_entries = max_entries
+
+    def put(self, package: str, version: str, data: bytes) -> None:
+        """Hold ``data`` as the archive of ``package==version``."""
+        self._held[(package, version)] = data
+        while len(self._held) > self._max_entries:
+            del self._held[next(iter(self._held))]
+
+    def take(self, package: str, version: str) -> bytes | None:
+        """Release and return the archive held for ``package==version``."""
+        return self._held.pop((package, version), None)
+
+    def clear(self) -> None:
+        """Drop every archive still held."""
+        self._held.clear()
+
+
 class CachedAsyncSimpleClient:
     """Async PyPI Simple API client with on-disk caching.
 
@@ -263,7 +302,7 @@ class CachedAsyncSimpleClient:
     :class:`FetchCoordinator` actually needs rather than the Simple API.
     """
 
-    def __init__(
+    def __init__(  # noqa: PLR0913 - the index's settings plus the run's shared state
         self,
         transport: AsyncHttpTransport,
         cache: CacheBackend,
@@ -274,6 +313,7 @@ class CachedAsyncSimpleClient:
         serialization: SimpleSerialization = SimpleSerialization.NEGOTIATE,
         min_fresh_seconds: int | None = None,
         parsed_stats: ParsedCacheStats | None = None,
+        sdist_archive_hold: SdistArchiveHold | None = None,
     ) -> None:
         """Create a cached client wrapping ``transport``.
 
@@ -294,6 +334,10 @@ class CachedAsyncSimpleClient:
         same way so hit/miss/rebuild counts total across every index client. A
         private sink is created when none is passed, so a stand-alone client
         still counts its own outcomes.
+
+        ``sdist_archive_hold`` is the run's :class:`SdistArchiveHold`; ``None``
+        holds nothing, which is what a resolve that never builds a remote sdist
+        wants.
         """
         self._transport = transport
         self._cache = cache
@@ -309,6 +353,7 @@ class CachedAsyncSimpleClient:
             parsed_stats if parsed_stats is not None else ParsedCacheStats()
         )
         self._parsed_store_failed = False
+        self._sdist_archive_hold = sdist_archive_hold
 
     async def aclose(self) -> None:
         """Close the underlying transport."""
@@ -791,6 +836,10 @@ class CachedAsyncSimpleClient:
         downloaded archive is verified against it before extraction. A
         mismatch raises :class:`SdistHashMismatchError` and nothing is
         cached.
+
+        A downloaded archive is handed to the client's
+        :class:`SdistArchiveHold`, when it has one, for a build of the same
+        version to take.
         """
         cached = self._cache.get_sdist_files(package, version)
         if cached is not None:
@@ -807,6 +856,9 @@ class CachedAsyncSimpleClient:
             verify_sdist_hash(response.content, selected)
         pkg_info, pyproject_toml = _extract_sdist_files(response.content)
 
+        if self._sdist_archive_hold is not None:
+            self._sdist_archive_hold.put(package, version, response.content)
+
         if pkg_info is not None or pyproject_toml is not None:
             self._cache.put_sdist_files(package, version, pkg_info, pyproject_toml)
 
@@ -822,22 +874,33 @@ class CachedAsyncSimpleClient:
         """Return the raw bytes of an sdist archive.
 
         Used by the ``BUILD_REMOTE`` path when a real backend invocation
-        is required.  No on-disk caching is performed: archives are
-        large, builds are rare, and the in-memory index already
-        deduplicates within a single resolve.  Offline mode raises
-        :class:`OfflineError` because there is no slot to read from.
+        is required.  A :class:`SdistArchiveHold` answers when this version's
+        PKG-INFO read already downloaded the archive.  No on-disk caching is
+        performed: archives are large, builds are rare, and the in-memory
+        index already deduplicates within a single resolve.  Offline mode
+        raises :class:`OfflineError` because there is no slot to read from.
 
         When ``sdist_hashes`` carries an acceptable published digest, the
-        downloaded archive is verified before its bytes are returned. A
-        mismatch raises :class:`SdistHashMismatchError`.
+        archive is verified before its bytes are returned, whether it was
+        downloaded here or held. A mismatch raises
+        :class:`SdistHashMismatchError`.
         """
-        del package, version  # offline check below is the only use
-        if self._offline:
-            msg = f"sdist archive fetch unavailable in offline mode ({sdist_url})"
-            raise OfflineError(msg)
-        response = await self._transport.get(sdist_url, headers=IDENTITY_HEADERS)
-        raise_unless_ok(response, sdist_url)
+        content = self._held_archive(package, version)
+        if content is None:
+            if self._offline:
+                msg = f"sdist archive fetch unavailable in offline mode ({sdist_url})"
+                raise OfflineError(msg)
+            response = await self._transport.get(sdist_url, headers=IDENTITY_HEADERS)
+            raise_unless_ok(response, sdist_url)
+            content = response.content
+
         selected = select_artifact_hash(sdist_hashes)
         if selected is not None:
-            verify_sdist_hash(response.content, selected)
-        return response.content
+            verify_sdist_hash(content, selected)
+        return content
+
+    def _held_archive(self, package: str, version: str) -> bytes | None:
+        """Take this version's archive out of the hold, when there is one."""
+        if self._sdist_archive_hold is None:
+            return None
+        return self._sdist_archive_hold.take(package, version)

--- a/nab-project/src/nab_project/fetch.py
+++ b/nab-project/src/nab_project/fetch.py
@@ -16,7 +16,7 @@ import enum
 import logging
 import threading
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit
 
 from packaging.utils import canonicalize_name as canonicalize_name_boundary
@@ -25,6 +25,7 @@ from nab_index.cache import CacheBackend, NullCache, OfflineError, OnDiskCache
 from nab_index.cached_client import (
     CachedAsyncSimpleClient,
     ParsedCacheStats,
+    SdistArchiveHold,
     read_fresh_parsed_listing,
 )
 from nab_index.lazy_wheel import RangeCapabilityMemo
@@ -32,6 +33,8 @@ from nab_index.local_index import LocalIndexClient, is_file_url, parse_file_url
 from nab_index.multi_index import MultiIndexClient
 from nab_index.transport import IDENTITY_HEADERS, raise_unless_ok
 from nab_provider._vendor.packaging.utils import canonicalize_name
+from nab_provider.metadata import static_project_from_table
+from nab_provider.policy import BuildPolicy
 from nab_provider.records import (
     DEFAULT_INDEX_NAME,
     DEFAULT_INDEX_URL,
@@ -126,6 +129,21 @@ def _resolve_routes(routes: list[IndexRoute]) -> dict[str, str]:
     routes for one name at parse time), so this is a straight projection.
     """
     return {canonicalize_name(entry.name): entry.index for entry in routes}
+
+
+def _builds_remote_sdists(config: NabProjectConfig | None) -> bool:
+    """Whether ``config`` names ``build-remote`` anywhere.
+
+    Coarser than :meth:`~nab_provider.provider.Provider.effective_build_policy`,
+    which decides per version. Holding sdist archives is a whole-run decision,
+    so an upper bound on what could reach a build is enough.
+    """
+    if config is None:
+        return False
+    if config.build_policy is BuildPolicy.BUILD_REMOTE:
+        return True
+    overrides = (*config.package_overrides, *config.index_overrides.values())
+    return any(o.build_policy is BuildPolicy.BUILD_REMOTE for o in overrides)
 
 
 @dataclass(frozen=True, slots=True)
@@ -288,6 +306,10 @@ class FetchCoordinator:
         # index client the same way; rebuilt on the fetcher loop so each run
         # starts at zero.
         self._parsed_cache_stats = ParsedCacheStats()
+        # Only a resolve that can build a remote sdist holds archives, so
+        # nothing else pays the memory.
+        self._holds_sdist_archives = _builds_remote_sdists(build_config)
+        self._sdist_archive_hold: SdistArchiveHold | None = None
         self._warm_sync_stats = WarmSyncStats()
         self._warm_sync_min_blob_bytes = _WARM_SYNC_MIN_BLOB_BYTES
         self._thread: threading.Thread | None = None
@@ -785,6 +807,7 @@ class FetchCoordinator:
             serialization=cfg.serialization,
             min_fresh_seconds=self._index_cache_floors.get(cfg.name),
             parsed_stats=self._parsed_cache_stats,
+            sdist_archive_hold=self._sdist_archive_hold,
         )
 
     async def _async_fetcher(self) -> None:
@@ -794,6 +817,13 @@ class FetchCoordinator:
         # Fresh per-run parsed-listing counters, injected the same way, so a
         # reused coordinator starts each run at zero.
         self._parsed_cache_stats = ParsedCacheStats()
+        # Held archives are capped at the fetcher's in-flight width; a build
+        # past that downloads its own archive.
+        self._sdist_archive_hold = (
+            SdistArchiveHold(self._max_concurrency)
+            if self._holds_sdist_archives
+            else None
+        )
 
         queue: asyncio.Queue[_QueueItem] = asyncio.Queue()
         sem = asyncio.Semaphore(self._max_concurrency)
@@ -842,6 +872,10 @@ class FetchCoordinator:
             # A file:// index client owns no transport, but a direct archive
             # fetch can still have opened one.  aclose is idempotent.
             await self._transport.aclose()
+
+            # Nothing can take from the hold once the loop is gone.
+            if self._sdist_archive_hold is not None:
+                self._sdist_archive_hold.clear()
 
     def _dispatch(
         self,
@@ -1125,10 +1159,24 @@ class FetchCoordinator:
         # pending event, and a released waiter reads the pyproject slot
         # with no further synchronisation.
         if pyproject is not None:
-            self.index.store_sdist_pyproject(
-                req.package, req.version, parse_pyproject_table(pyproject)
-            )
+            table = parse_pyproject_table(pyproject)
+            self.index.store_sdist_pyproject(req.package, req.version, table)
+            self._release_archive_if_deps_are_static(req.package, req.version, table)
         self.index.store_sdist_metadata(req.package, req.version, pkg_info)
+
+    def _release_archive_if_deps_are_static(
+        self, package: str, version: str, table: Mapping[str, Any]
+    ) -> None:
+        """Release a held archive when ``table`` already declares the deps.
+
+        The hold exists for a build, and the metadata ladder builds only when
+        the bundled ``[project]`` table cannot supply the dependencies, so a
+        table that can means no build will ask for this archive.
+        """
+        if self._sdist_archive_hold is None:
+            return
+        if static_project_from_table(table) is not None:
+            self._sdist_archive_hold.take(package, version)
 
     async def _fetch_sdist_archive(
         self,

--- a/nab-project/tests/test_cached_client.py
+++ b/nab-project/tests/test_cached_client.py
@@ -29,6 +29,7 @@ from nab_index._pep503 import json_listing
 from nab_index.cache import CachePolicy, NullCache, OfflineError, OnDiskCache
 from nab_index.cached_client import (
     CachedAsyncSimpleClient,
+    SdistArchiveHold,
     _freshness_lifetime,
     _header,
     _max_age_directive,
@@ -3413,6 +3414,26 @@ class TestGetSdistFiles:
         assert "Name: pkg" in pkg_info
 
 
+class TestSdistArchiveHold:
+    def test_the_oldest_archive_goes_when_the_hold_is_full(self) -> None:
+        """A full hold evicts the oldest rather than growing."""
+        hold = SdistArchiveHold(2)
+        hold.put("pkg", "1.0", b"one")
+        hold.put("pkg", "2.0", b"two")
+        hold.put("pkg", "3.0", b"three")
+
+        assert hold.take("pkg", "1.0") is None
+        assert hold.take("pkg", "2.0") == b"two"
+        assert hold.take("pkg", "3.0") == b"three"
+
+    def test_clear_drops_every_archive(self) -> None:
+        hold = SdistArchiveHold()
+        hold.put("pkg", "1.0", b"one")
+        hold.clear()
+
+        assert hold.take("pkg", "1.0") is None
+
+
 class TestGetSdistArchive:
     def test_matching_hash_returns_bytes(self, tmp_path: Path) -> None:
         cache = _make_cache(tmp_path)
@@ -3481,6 +3502,77 @@ class TestGetSdistArchive:
 
         with pytest.raises(OfflineError):
             asyncio.run(go())
+
+    def test_a_held_archive_answers_without_a_second_request(
+        self, tmp_path: Path
+    ) -> None:
+        """The PKG-INFO read's own download serves the build that follows."""
+        cache = _make_cache(tmp_path)
+        body = _build_tarball([("pkg-1.0/PKG-INFO", b"Name: pkg\n")])
+        transport = _FakeTransport([_FakeResponse(body)])
+        hold = SdistArchiveHold()
+
+        async def go() -> bytes:
+            client = CachedAsyncSimpleClient(transport, cache, sdist_archive_hold=hold)
+            try:
+                await client.get_sdist_files("pkg", "1.0", "https://x/pkg.tar.gz")
+                return await client.get_sdist_archive(
+                    "pkg", "1.0", "https://x/pkg.tar.gz"
+                )
+            finally:
+                await client.aclose()
+
+        assert asyncio.run(go()) == body
+        assert len(transport.calls) == 1
+
+    def test_a_held_archive_is_verified_against_the_published_hash(
+        self, tmp_path: Path
+    ) -> None:
+        """Held bytes go through the same digest check a downloaded body does."""
+        cache = _make_cache(tmp_path)
+        published = _build_tarball([("pkg-1.0/PKG-INFO", b"Name: pkg\n")])
+        tampered = _build_tarball([("pkg-1.0/PKG-INFO", b"Name: evil\n")])
+        transport = _FakeTransport([])
+        hold = SdistArchiveHold()
+        hold.put("pkg", "1.0", tampered)
+
+        async def go() -> bytes:
+            client = CachedAsyncSimpleClient(transport, cache, sdist_archive_hold=hold)
+            try:
+                return await client.get_sdist_archive(
+                    "pkg",
+                    "1.0",
+                    "https://x/pkg.tar.gz",
+                    (("sha256", hashlib.sha256(published).hexdigest()),),
+                )
+            finally:
+                await client.aclose()
+
+        with pytest.raises(SdistHashMismatchError):
+            asyncio.run(go())
+        assert transport.calls == []
+
+    def test_a_hold_holding_another_version_is_not_consulted(
+        self, tmp_path: Path
+    ) -> None:
+        """The hold is keyed by version, so a sibling's archive is not served."""
+        cache = _make_cache(tmp_path)
+        body = _build_tarball([("pkg-2.0/PKG-INFO", b"Name: pkg\n")])
+        transport = _FakeTransport([_FakeResponse(body)])
+        hold = SdistArchiveHold()
+        hold.put("pkg", "1.0", b"the other version")
+
+        async def go() -> bytes:
+            client = CachedAsyncSimpleClient(transport, cache, sdist_archive_hold=hold)
+            try:
+                return await client.get_sdist_archive(
+                    "pkg", "2.0", "https://x/pkg-2.0.tar.gz"
+                )
+            finally:
+                await client.aclose()
+
+        assert asyncio.run(go()) == body
+        assert hold.take("pkg", "1.0") == b"the other version"
 
 
 class TestContextManager:

--- a/nab-project/tests/test_fetch.py
+++ b/nab-project/tests/test_fetch.py
@@ -22,7 +22,7 @@ import pytest
 import respx
 
 from nab_index.cache import CachePolicy, NullCache, OfflineError, OnDiskCache
-from nab_index.cached_client import CachedAsyncSimpleClient
+from nab_index.cached_client import CachedAsyncSimpleClient, SdistArchiveHold
 from nab_index.client import (
     MalformedSimpleResponseError,
     MetadataHashMismatchError,
@@ -45,11 +45,15 @@ from nab_project.fetch import (
     IndexRoute,
     InMemoryIndex,
     WarmSyncStats,
+    _builds_remote_sdists,
     _resolve_routes,
 )
 from nab_provider._vendor.packaging.version import Version
 from nab_provider.metadata import WheelMetadata
+from nab_provider.overrides import IndexOverride
+from nab_provider.policy import BuildPolicy
 from nab_provider.serialization import SimpleSerialization
+from nab_provider.testing import pkg_override
 
 
 @pytest.fixture
@@ -3803,3 +3807,175 @@ class TestWarmSyncTailOffload:
             "listing prefetch tail failed" in record.getMessage()
             for record in caplog.records
         )
+
+
+class _SdistFilesClient:
+    """A client whose PKG-INFO read returns a fixed pair of files."""
+
+    def __init__(self, pyproject: str | None) -> None:
+        self._pyproject = pyproject
+
+    async def get_sdist_files(
+        self,
+        package: str,
+        version: str,
+        sdist_url: str,
+        sdist_hashes: tuple[tuple[str, str], ...] = (),
+    ) -> tuple[str | None, str | None]:
+        return ("Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\n", self._pyproject)
+
+
+class TestSdistArchiveHolding:
+    """Which resolves hold an sdist archive after reading its PKG-INFO."""
+
+    @pytest.mark.parametrize(
+        ("config", "holds"),
+        [
+            (None, False),
+            (NabProjectConfig(), False),
+            (NabProjectConfig(build_policy=BuildPolicy.BUILD_REMOTE), True),
+            (
+                NabProjectConfig(
+                    package_overrides=(
+                        pkg_override("foo", build_policy=BuildPolicy.BUILD_REMOTE),
+                    )
+                ),
+                True,
+            ),
+            (
+                NabProjectConfig(
+                    index_overrides={
+                        "pypi": IndexOverride(build_policy=BuildPolicy.BUILD_REMOTE)
+                    }
+                ),
+                True,
+            ),
+            (
+                NabProjectConfig(
+                    package_overrides=(
+                        pkg_override("foo", build_policy=BuildPolicy.NEVER),
+                    )
+                ),
+                False,
+            ),
+        ],
+    )
+    def test_build_remote_anywhere_in_the_config_holds(
+        self, config: NabProjectConfig | None, holds: bool
+    ) -> None:
+        assert _builds_remote_sdists(config) is holds
+
+    def _fetched_with_pyproject(
+        self, pyproject: str | None, config: NabProjectConfig | None
+    ) -> tuple[FetchCoordinator, SdistArchiveHold]:
+        """Fetch one version's sdist files with its archive already held.
+
+        The hold is attached to the coordinator only when ``config`` would give
+        it one, so it comes back untouched for a resolve that holds nothing.
+        Returns the coordinator and the hold.
+        """
+        coord = _coord(build_config=config)
+        hold = SdistArchiveHold()
+        hold.put("pkg", "1.0", b"archive bytes")
+        coord._sdist_archive_hold = hold if coord._holds_sdist_archives else None
+
+        asyncio.run(
+            coord._fetch_sdist(
+                client=_SdistFilesClient(pyproject),  # type: ignore[arg-type]
+                req=FetchRequest(
+                    kind=FetchKind.SDIST,
+                    package="pkg",
+                    version="1.0",
+                    url="https://f.example/pkg-1.0.tar.gz",
+                ),
+            )
+        )
+        return coord, hold
+
+    def test_a_static_pyproject_releases_the_archive(self) -> None:
+        """A pyproject that declares the deps means the version never builds."""
+        config = NabProjectConfig(build_policy=BuildPolicy.BUILD_REMOTE)
+        coord, hold = self._fetched_with_pyproject(
+            '[project]\nname = "pkg"\ndependencies = []\n', config
+        )
+
+        assert hold.take("pkg", "1.0") is None
+        assert coord.index.get_sdist_pyproject("pkg", "1.0") is not None
+
+    def test_a_dynamic_pyproject_keeps_the_archive(self) -> None:
+        """A table that defers its deps leaves the build's bytes in place."""
+        config = NabProjectConfig(build_policy=BuildPolicy.BUILD_REMOTE)
+        _, hold = self._fetched_with_pyproject(
+            '[project]\nname = "pkg"\ndynamic = ["dependencies"]\n', config
+        )
+
+        assert hold.take("pkg", "1.0") == b"archive bytes"
+
+    def test_an_sdist_without_a_pyproject_keeps_the_archive(self) -> None:
+        config = NabProjectConfig(build_policy=BuildPolicy.BUILD_REMOTE)
+        _, hold = self._fetched_with_pyproject(None, config)
+
+        assert hold.take("pkg", "1.0") == b"archive bytes"
+
+    def test_a_resolve_that_holds_nothing_still_stores_the_pyproject(self) -> None:
+        """The release is skipped when there is no hold to release from."""
+        coord, hold = self._fetched_with_pyproject(
+            '[project]\nname = "pkg"\ndependencies = []\n', None
+        )
+
+        assert coord._sdist_archive_hold is None
+        assert hold.take("pkg", "1.0") == b"archive bytes"
+        assert coord.index.get_sdist_pyproject("pkg", "1.0") is not None
+
+    def _sdist_bytes(self) -> bytes:
+        """A gzipped sdist carrying a PKG-INFO and no pyproject.toml."""
+        body = b"Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\n"
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            info = tarfile.TarInfo(name="pkg-1.0/PKG-INFO")
+            info.size = len(body)
+            tar.addfile(info, io.BytesIO(body))
+        return buf.getvalue()
+
+    @respx.mock
+    def test_a_build_remote_run_reads_the_archive_once(self) -> None:
+        """The build's archive is the PKG-INFO read's own download."""
+        archive = self._sdist_bytes()
+        url = "https://files.example.com/pkg-1.0.tar.gz"
+        route = respx.get(url).mock(return_value=httpx.Response(200, content=archive))
+        config = NabProjectConfig(build_policy=BuildPolicy.BUILD_REMOTE)
+
+        with _coord(build_config=config) as coord:
+            coord.request_sdist("pkg", "1.0", url).wait(timeout=5)
+            coord.request_sdist_archive("pkg", "1.0", url).wait(timeout=5)
+
+            assert coord.index.get_sdist_archive("pkg", "1.0") == archive
+            assert route.call_count == 1
+
+    @respx.mock
+    def test_a_run_that_cannot_build_reads_the_archive_twice(self) -> None:
+        """A config without build-remote holds nothing, so the build downloads."""
+        archive = self._sdist_bytes()
+        url = "https://files.example.com/pkg-1.0.tar.gz"
+        route = respx.get(url).mock(return_value=httpx.Response(200, content=archive))
+
+        with _coord() as coord:
+            coord.request_sdist("pkg", "1.0", url).wait(timeout=5)
+            coord.request_sdist_archive("pkg", "1.0", url).wait(timeout=5)
+
+            assert coord.index.get_sdist_archive("pkg", "1.0") == archive
+            assert route.call_count == 2
+
+    def test_the_fetcher_loop_drops_what_it_still_holds(self) -> None:
+        """Nothing takes from the hold once the loop is gone."""
+        config = NabProjectConfig(build_policy=BuildPolicy.BUILD_REMOTE)
+        coord = _coord(build_config=config)
+        coord.start()
+
+        hold = coord._sdist_archive_hold
+        assert hold is not None
+        hold.put("pkg", "1.0", b"archive bytes")
+
+        coord.shutdown()
+
+        assert hold.take("pkg", "1.0") is None


### PR DESCRIPTION
A 30-package fixture resolving sdist-only packages under `build-remote`, 3 of which fall through to a build, transfers 3,089,845 bytes over 60 requests against 3,398,039 over 63 on the base: 3 requests and 308,194 bytes gone, 9.07% of everything the resolve transferred. Cut to one package and one build, it goes from 3 requests / 205,636 bytes to 2 / 102,904, a saving of just under half. Both counts come off a recording transport and are exact.

A version on the `build-remote` path downloaded its sdist twice: once for the PKG-INFO the metadata ladder reads, then again for the archive the backend builds. `SdistArchiveHold` keeps what the first read downloaded and `get_sdist_archive` takes it, re-verifying the published digest exactly as it verifies a downloaded body.

Three things keep the hold from trading transfer for memory:

- the coordinator builds a hold only when the config names `build-remote` somewhere, so every other resolve holds nothing
- a version's archive is released as soon as its bundled `[project]` table can answer the dependencies, the same predicate the ladder's pyproject fallback uses
- the hold is capped at the fetcher's concurrency width, 50 by default, evicting the oldest first, and the fetch loop empties it on its way out

That costs about 16,000 bytes of peak traced memory on the 30-package fixture, +0.08%. Small, but a real increase rather than noise.

The release is what keeps it small. With it removed at 120 packages, holding to the end of the resolve costs about 5 MB over the same base, and about 12 MB with the cap removed as well. The cap gives up nothing here: a 60-package run still makes 60 archive requests over 60 distinct URLs.

Nothing in the 19-scenario canary set builds a remote sdist, so none of this reaches it. The timing runs there only rule out a slowdown: no regression above about 1.9% wall, 0.8% CPU or 0.1% peak memory, locally.

One case still holds to the end: an sdist whose dependencies come from a static PKG-INFO rather than its `pyproject.toml`, or that ships no `pyproject.toml` at all, and is never built. Its archive stays until the cap evicts it or the fetch loop closes. Cutting that needs the PKG-INFO parsed at the fetch layer, which duplicates work the provider already does.
