### PR TITLE
Promote the resolve graph before re-enabling gc, ~2% off a 244-package lock

### DIFF
--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -589,11 +589,22 @@ def _collector_paused() -> Iterator[None]:
     Only the CLI sets a collector policy, since it owns its process; the
     library entry points leave it alone. Exit enables the collector rather
     than restoring the state it found.
+
+    Everything the resolve allocated is in generation 0 by then, so the
+    collections that follow the enable walk the whole resolve graph. Freezing
+    empties every generation into the permanent one and unfreezing returns the
+    permanent generation to generation 2, which takes the graph out of
+    generation 0 and leaves those collections less to walk. Unfreezing also
+    returns anything frozen before the resolve; the CLI owns its process.
+    PyPy has no ``gc.freeze``.
     """
     gc.disable()
     try:
         yield
     finally:
+        if hasattr(gc, "freeze"):
+            gc.freeze()
+            gc.unfreeze()
         gc.enable()
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5149,6 +5149,76 @@ class TestMain:
         assert gc.isenabled()
 
     @pytest.mark.usefixtures("restored_gc_state")
+    def test_resolve_promotes_what_it_allocated(self, tmp_path: Path) -> None:
+        """Objects the resolve allocated end in generation 2, not generation 0.
+
+        Reads generations directly, so it needs a build whose
+        ``gc.get_objects(generation=...)`` filters by generation; the
+        free-threaded builds return every tracked object for any of them.
+        """
+        pyproject = _make_pyproject(tmp_path)
+        config = read_pyproject_config(pyproject)
+        allocated: list[object] = []
+
+        def allocate_tracked(*args: object, **kwargs: object) -> ResolveResult:
+            """Stand in for the resolve, leaving one tracked object behind."""
+            allocated.append(["resolve", "graph"])
+            return _stub_resolve_result(pins={})
+
+        # Zeroed generation counters keep the collection the re-enable triggers
+        # at generation 1, so without the promotion the object cannot reach
+        # generation 2 on the session's own schedule.
+        gc.collect()
+
+        with patch("nab.cli.resolve_for_targets", side_effect=allocate_tracked):
+            _resolve(
+                pyproject,
+                config=config,
+                cache_dir=None,
+                offline=False,
+                transport=MagicMock(),
+                failure_prefix="cannot lock",
+            )
+
+        # gc.get_objects allocates, and a collection it triggers would move the
+        # object out of the generation the resolve left it in.
+        gc.disable()
+
+        graph = allocated[0]
+        assert not any(obj is graph for obj in gc.get_objects(generation=0))
+        assert any(obj is graph for obj in gc.get_objects(generation=2))
+
+    @pytest.mark.usefixtures("restored_gc_state")
+    def test_resolve_without_gc_freeze_still_reenables_the_collector(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The collector comes back on an interpreter without ``gc.freeze``.
+
+        The resolve fails here because the promotion sits in a ``finally``: an
+        ``AttributeError`` raised there would replace the ``ResolutionError``,
+        and the command would print a traceback instead of exiting 1.
+        """
+        monkeypatch.delattr(gc, "freeze")
+        pyproject = _make_pyproject(tmp_path)
+        config = read_pyproject_config(pyproject)
+        with (
+            patch(
+                "nab.cli.resolve_for_targets",
+                side_effect=ResolutionError("no solution"),
+            ),
+            pytest.raises(SystemExit),
+        ):
+            _resolve(
+                pyproject,
+                config=config,
+                cache_dir=None,
+                offline=False,
+                transport=MagicMock(),
+                failure_prefix="cannot lock",
+            )
+        assert gc.isenabled()
+
+    @pytest.mark.usefixtures("restored_gc_state")
     def test_resolve_reenables_the_collector_on_failure(self, tmp_path: Path) -> None:
         """A resolve that exits on an error still leaves the collector enabled."""
         pyproject = _make_pyproject(tmp_path)


### PR DESCRIPTION
On a 244-package `nab lock` the cyclic collector spends 36.9 ms after the resolve re-enables it, out of a 1.72 s command. Promoting the resolve graph to generation 2 first takes that to 2.1 ms, and the command runs between about 1.4% and 3.3% faster locally, with a middle estimate near 2.2%. CPU time moves with it.

The resolve runs with the collector off, so everything it allocated is in generation 0 when the collector comes back, and the collections that follow walk the whole graph. `gc.freeze()` empties every generation into the permanent one and `gc.unfreeze()` returns that to generation 2. About as many collections still run (45 instead of 51), so what drops is the cost of each one.

Instructions retired for the whole process, under callgrind with `PYTHONHASHSEED=0`:

| lock | base | promoted | removed | share of the run |
|---|---|---|---|---|
| 244 packages | 18,754,568,001 | 18,656,681,458 | 97,886,543 | 0.52% |
| 48 packages | 5,487,171,023 | 5,475,611,163 | 11,559,860 | 0.21% |

These do not repeat to the digit on a real command: the same base commit counted three times spans 2.5M instructions on the 244-package lock and 0.4M on the 48-package one, and across those three pairs the savings run 97.9M to 103.3M and 11.6M to 12.4M. The table quotes the lowest of each.

The two smaller locks gain less: 2.5 ms to 0.3 ms on a 48-package lock (a 0.57 s command), 6.8 ms to 0.2 ms on a 27-package one (3.31 s), medians over five runs each, locally. Neither timing run could have seen anything below about 1.9% and 1.0%, so they only rule out a regression larger than that. The runs put peak RSS inside about 0.26% either way on all three.

The cost is retention. The collections after the resolve reclaim 21,186 objects instead of 51,458, and blocks still allocated when `main()` returns go from 429,295 to 461,566 on the 244-package lock. The command exits through `os._exit`, so none of that is freed on the way out either way.

PyPy has no `gc.freeze`, hence the `hasattr` check. The pair sits in a `finally`, where an `AttributeError` would replace whatever the resolve was raising and print a traceback in place of `resolution failed: ...`. On CPython 3.14.4, whose collector is incremental, the pair costs about 80 microseconds instead of about 1, still far below the milliseconds it removes.
