### PR TITLE
Read the listing's policy once instead of per file, 1.6% fewer calls

### DIFF
--- a/nab-provider/src/nab_provider/_provider/listing.py
+++ b/nab-provider/src/nab_provider/_provider/listing.py
@@ -7,6 +7,7 @@ already-cached metadata where possible.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from functools import partial
 from typing import TYPE_CHECKING
 
@@ -323,6 +324,35 @@ def base_distributions(
     )
 
 
+@dataclass(frozen=True, slots=True)
+class _ListingPolicy:
+    """The policy config one listing's files are judged under.
+
+    ``overridden`` is true when a per-package or per-index override can
+    vary an answer by version, so the per-candidate lookups have to run.
+    Without one, the defaults here answer for every file in the listing.
+    """
+
+    index_name: str | None
+    overridden: bool
+    default_dist_policy: DistPolicy
+    default_cutoff: datetime | None
+    time_filter_active: bool
+
+
+def _listing_policy(provider: Provider, normalized: str) -> _ListingPolicy:
+    """Return the policy answers for one listing, for its per-file loop to consult."""
+    return _ListingPolicy(
+        index_name=provider.serving_index(normalized),
+        overridden=provider.has_overrides,
+        default_dist_policy=provider.dist_policy,
+        default_cutoff=provider.uploaded_prior_to,
+        time_filter_active=(
+            provider.uploaded_prior_to is not None or provider.overrides_set_time
+        ),
+    )
+
+
 def _filter_base(
     provider: Provider,
     normalized: str,
@@ -343,12 +373,7 @@ def _filter_base(
     version alive.  The answer is the same for every target that shares
     the listing and the policy config, which is what the memo assumes.
     """
-    index_name = provider.serving_index(normalized)
-
-    # Fast path: skip the time-filter dispatch entirely when no cutoff applies.
-    time_filter_active = (
-        provider.uploaded_prior_to is not None or provider.overrides_set_time
-    )
+    policy = _listing_policy(provider, normalized)
 
     cache = provider.listing_filter_cache
     if cache is None or not cache.shares_pythons:
@@ -356,9 +381,8 @@ def _filter_base(
             provider,
             normalized,
             files,
-            index_name,
+            policy,
             target_drops=True,
-            time_filter_active=time_filter_active,
         )
     else:
         parsed, policy_by_version, sort_with_wheel_first = cache.prepared(
@@ -369,21 +393,15 @@ def _filter_base(
                 provider,
                 normalized,
                 files,
-                index_name,
+                policy,
                 target_drops=False,
-                time_filter_active=time_filter_active,
             ),
         )
         result = [
             pair
             for pair in parsed
             if not _excluded_by_python_or_time(
-                provider,
-                normalized,
-                pair[0],
-                pair[1],
-                index_name=index_name,
-                time_filter_active=time_filter_active,
+                provider, normalized, pair[0], pair[1], policy
             )
         ]
 
@@ -403,10 +421,9 @@ def _prepare_listing(
     provider: Provider,
     normalized: str,
     files: Sequence[WheelFile | SdistFile],
-    index_name: str | None,
+    policy: _ListingPolicy,
     *,
     target_drops: bool,
-    time_filter_active: bool,
 ) -> _PreparedListing:
     """Parse and dist-policy-filter the listing.
 
@@ -437,23 +454,23 @@ def _prepare_listing(
         except InvalidVersion:
             continue
 
-        effective_dist_policy = provider.effective_dist_policy(
-            normalized, version, index_name
-        )
+        if policy.overridden:
+            effective_dist_policy = provider.effective_dist_policy(
+                normalized, version, policy.index_name
+            )
+        else:
+            effective_dist_policy = policy.default_dist_policy
+
         if _excluded_by_dist_policy(dist, effective_dist_policy):
             provider.stats.excluded_by_dist_policy += 1
             continue
+
         policy_by_version[version] = effective_dist_policy
         if effective_dist_policy in (DistPolicy.PREFER_WHEEL, DistPolicy.SDIST_INSTALL):
             sort_with_wheel_first = True
 
         if target_drops and _excluded_by_python_or_time(
-            provider,
-            normalized,
-            version,
-            dist,
-            index_name=index_name,
-            time_filter_active=time_filter_active,
+            provider, normalized, version, dist, policy
         ):
             continue
 
@@ -500,16 +517,27 @@ def _excluded_by_python_or_time(
     normalized: str,
     version: Version,
     dist: DistFile,
-    *,
-    index_name: str | None,
-    time_filter_active: bool,
+    policy: _ListingPolicy,
 ) -> bool:
     """Return True when Requires-Python or the upload cutoff rejects ``dist``."""
-    if excluded_by_python(provider, normalized, version, dist):
+    if policy.overridden:
+        override_rp = provider.effective_requires_python(normalized, version)
+    else:
+        override_rp = None
+
+    if excluded_by_python(provider, dist, override_rp):
         return True
-    if not time_filter_active:
+
+    if not policy.time_filter_active:
         return False
-    cutoff = provider.effective_uploaded_prior_to(normalized, version, index_name)
+
+    if policy.overridden:
+        cutoff = provider.effective_uploaded_prior_to(
+            normalized, version, policy.index_name
+        )
+    else:
+        cutoff = policy.default_cutoff
+
     return excluded_by_time(provider, normalized, dist, cutoff)
 
 
@@ -649,18 +677,18 @@ def _excluded_by_dist_policy(dist: DistFile, policy: object) -> bool:
 
 
 def excluded_by_python(
-    provider: Provider, normalized: str, version: Version, dist: DistFile
+    provider: Provider, dist: DistFile, override_rp: str | None
 ) -> bool:
     """Return True when the target Python is excluded for this candidate.
 
-    A per-package ``requires-python`` override substitutes for
-    ``dist.requires_python`` and goes through the same cached comparison,
-    keyed by the specifier string; the verdict depends only on that string
-    and the fixed ``provider.target``.  The specifier is read at the language
-    minor, so a micro segment never excludes a target
-    (see :meth:`~nab_provider.target.ResolveTarget.admits_requires_python`).
+    ``override_rp`` is the candidate's per-package ``requires-python``
+    override and substitutes for ``dist.requires_python``.  Either goes
+    through the same cached comparison, keyed by the specifier string,
+    since the verdict depends only on that string and the fixed
+    ``provider.target``.  The specifier is read at the language minor, so
+    a micro segment never excludes a target (see
+    :meth:`~nab_provider.target.ResolveTarget.admits_requires_python`).
     """
-    override_rp = provider.effective_requires_python(normalized, version)
     effective = override_rp if override_rp is not None else dist.requires_python
     if not effective or provider.target is None:
         return False

--- a/nab-provider/src/nab_provider/provider.py
+++ b/nab-provider/src/nab_provider/provider.py
@@ -471,7 +471,7 @@ class Provider:
 
         self.extras_mode = extras_mode
         self.root_extras = root_extras or set()
-        self._dist_policy = dist_policy
+        self.dist_policy = dist_policy
         self.build_policy = build_policy
         # Opt-out: trust a pre-2.2 sdist's PKG-INFO deps as final instead of
         # routing through the dynamic path. Off by default (strict PEP 643).
@@ -492,7 +492,7 @@ class Provider:
         self._index_overrides: Mapping[str, IndexOverride] = index_overrides or {}
 
         # With no override on either surface, every lookup is the global default.
-        self._has_overrides = bool(self._package_overrides or self._index_overrides)
+        self.has_overrides = bool(self._package_overrides or self._index_overrides)
 
         # True when any override sets a time cutoff or disables one, so the
         # listing filter can skip the per-candidate dispatch otherwise.
@@ -810,8 +810,8 @@ class Provider:
         index_name: str | None = None,
     ) -> DistPolicy:
         """Return the dist policy for ``name==version`` served from ``index_name``."""
-        if not self._has_overrides:
-            return self._dist_policy
+        if not self.has_overrides:
+            return self.dist_policy
 
         result = self._effective_field(
             canonical_name,
@@ -821,7 +821,7 @@ class Provider:
             value=lambda o: _unset_if_none(o.dist_policy),
         )
         if result is _UNSET:
-            return self._dist_policy
+            return self.dist_policy
         assert isinstance(result, DistPolicy)
         return result
 
@@ -839,9 +839,6 @@ class Provider:
         field.  A per-package (range-matching) and a per-index override
         that both set the field are a conflict.
         """
-        if not self._has_overrides:
-            return self.uploaded_prior_to
-
         result = self._effective_field(
             canonical_name,
             version,


### PR DESCRIPTION
Resolving `pip:langchain-ml-course --resolution lowest` stops making 495,513 provider calls, about 1.6% of the 31.6 million calls the run makes. The listing filter asked for three policy answers per distribution file, and none of the three can vary within a listing unless a per-package or per-index override is configured.

Counted over that resolve (10,218 decisions and 165,441 distribution files across 215 listings, the same on both sides):

| call | before | after |
| --- | --- | --- |
| `effective_dist_policy` | 165,441 | 0 |
| `effective_requires_python` | 166,731 | 1,290 |
| `effective_uploaded_prior_to` | 164,631 | 0 |

`_filter_base` reads the answers once into a frozen `_ListingPolicy` and the per-file loop consults that. With an override configured the per-candidate lookups still run, so the answers are unchanged.

Those counts are exact. The timings are local: a run of the 19-scenario canary set uses about 1.3% less CPU, between roughly 0.8% and 2.1% over 12 runs of each, and the same runs rule out a wall regression above about 2.5%, which is the smallest change they could have seen. Peak memory is inside about 0.15% either way.

`effective_uploaded_prior_to` loses its own no-override shortcut, since the listing loop was its only caller, and `Provider._dist_policy` and `Provider._has_overrides` lose their underscore so the listing module can read them.
