### PR TITLE
Build listing records without object.__setattr__, 5% fewer instructions

### DIFF
--- a/nab-provider/src/nab_provider/records.py
+++ b/nab-provider/src/nab_provider/records.py
@@ -16,6 +16,7 @@ from .digest import is_hex_digest
 from .serialization import SimpleSerialization
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
 __all__ = [
@@ -223,7 +224,18 @@ def defer_sidecar_hash(wheel: WheelFile, table: object) -> None:
     object.__setattr__(wheel, "_raw_metadata", _compact_table(table))
 
 
-@dataclass(frozen=True, slots=True)
+def _slot_writer(cls: type, name: str) -> Callable[[object, object], None]:
+    """Return the setter for one of ``cls``'s slots.
+
+    A frozen dataclass refuses ``self.field = value``, so its generated
+    ``__init__`` writes every field through ``object.__setattr__``. A record
+    fills its slots through these instead, leaving ``__setattr__`` frozen for
+    callers.
+    """
+    return cls.__dict__[name].__set__
+
+
+@dataclass(frozen=True, slots=True, init=False)
 class WheelFile(_WheelIntegrity):
     """Wheel file record returned by the Simple-API client.
 
@@ -255,6 +267,31 @@ class WheelFile(_WheelIntegrity):
     local_path: Path | None = None
     metadata_hash: tuple[str, str] | None = None
 
+    def __init__(  # noqa: PLR0913, PLR0917 - the dataclass's own fields, in its own order
+        self,
+        filename: str,
+        url: str,
+        version: str,
+        requires_python: str | None,
+        has_metadata: bool,  # noqa: FBT001 - a field, not a flag
+        upload_time: str | None,
+        hashes: tuple[tuple[str, str], ...] = (),
+        size: int | None = None,
+        local_path: Path | None = None,
+        metadata_hash: tuple[str, str] | None = None,
+    ) -> None:
+        """Write each field's slot directly, not through the frozen ``__setattr__``."""
+        _set_wheel_filename(self, filename)
+        _set_wheel_url(self, url)
+        _set_wheel_version(self, version)
+        _set_wheel_requires_python(self, requires_python)
+        _set_wheel_has_metadata(self, has_metadata)
+        _set_wheel_upload_time(self, upload_time)
+        _set_wheel_hashes(self, hashes)
+        _set_wheel_size(self, size)
+        _set_wheel_local_path(self, local_path)
+        _set_wheel_metadata_hash(self, metadata_hash)
+
     @property
     def metadata_url(self) -> str | None:
         """Return the PEP 658/714 metadata URL, or None when unsupported.
@@ -273,7 +310,19 @@ class WheelFile(_WheelIntegrity):
             return url
 
 
-@dataclass(frozen=True, slots=True)
+_set_wheel_filename = _slot_writer(WheelFile, "filename")
+_set_wheel_url = _slot_writer(WheelFile, "url")
+_set_wheel_version = _slot_writer(WheelFile, "version")
+_set_wheel_requires_python = _slot_writer(WheelFile, "requires_python")
+_set_wheel_has_metadata = _slot_writer(WheelFile, "has_metadata")
+_set_wheel_upload_time = _slot_writer(WheelFile, "upload_time")
+_set_wheel_hashes = _slot_writer(WheelFile, "hashes")
+_set_wheel_size = _slot_writer(WheelFile, "size")
+_set_wheel_local_path = _slot_writer(WheelFile, "local_path")
+_set_wheel_metadata_hash = _slot_writer(WheelFile, "metadata_hash")
+
+
+@dataclass(frozen=True, slots=True, init=False)
 class SdistFile(_SdistIntegrity):
     """A source distribution from the Simple API.
 
@@ -289,6 +338,37 @@ class SdistFile(_SdistIntegrity):
     hashes: tuple[tuple[str, str], ...] = ()
     size: int | None = None
     local_path: Path | None = None
+
+    def __init__(
+        self,
+        filename: str,
+        url: str,
+        version: str,
+        requires_python: str | None,
+        upload_time: str | None,
+        hashes: tuple[tuple[str, str], ...] = (),
+        size: int | None = None,
+        local_path: Path | None = None,
+    ) -> None:
+        """Write each field's slot directly, not through the frozen ``__setattr__``."""
+        _set_sdist_filename(self, filename)
+        _set_sdist_url(self, url)
+        _set_sdist_version(self, version)
+        _set_sdist_requires_python(self, requires_python)
+        _set_sdist_upload_time(self, upload_time)
+        _set_sdist_hashes(self, hashes)
+        _set_sdist_size(self, size)
+        _set_sdist_local_path(self, local_path)
+
+
+_set_sdist_filename = _slot_writer(SdistFile, "filename")
+_set_sdist_url = _slot_writer(SdistFile, "url")
+_set_sdist_version = _slot_writer(SdistFile, "version")
+_set_sdist_requires_python = _slot_writer(SdistFile, "requires_python")
+_set_sdist_upload_time = _slot_writer(SdistFile, "upload_time")
+_set_sdist_hashes = _slot_writer(SdistFile, "hashes")
+_set_sdist_size = _slot_writer(SdistFile, "size")
+_set_sdist_local_path = _slot_writer(SdistFile, "local_path")
 
 
 # Either distribution shape a listing can offer for one version.

--- a/nab-provider/tests/test_records.py
+++ b/nab-provider/tests/test_records.py
@@ -3,14 +3,18 @@
 from __future__ import annotations
 
 import copy
+import inspect
 import pickle
 from collections.abc import Callable
+from dataclasses import MISSING, fields
 
 import pytest
 
-from nab_provider.records import WheelFile
+from nab_provider.records import SdistFile, WheelFile
 
 WHEEL_URL = "https://pypi.example/pkg-1.0-py3-none-any.whl"
+
+HAND_WRITTEN_INIT_RECORDS = [WheelFile, SdistFile]
 
 
 def make_wheel(*, has_metadata: bool = True) -> WheelFile:
@@ -75,3 +79,34 @@ def test_wheel_round_trips_either_side_of_first_read(
 
     read = make_wheel()
     assert read.metadata_url == clone(read).metadata_url
+
+
+@pytest.mark.parametrize("record", HAND_WRITTEN_INIT_RECORDS)
+def test_init_takes_the_fields_in_order(record: type[WheelFile | SdistFile]) -> None:
+    """``__match_args__`` comes off the field list, not off this signature.
+
+    So a parameter reordered here alone would change what a positional call
+    means without changing what a pattern binds.
+    """
+    parameters = list(inspect.signature(record.__init__).parameters)
+
+    assert parameters[0] == "self"
+    assert parameters[1:] == [field.name for field in fields(record)]
+
+
+@pytest.mark.parametrize("record", HAND_WRITTEN_INIT_RECORDS)
+def test_init_defaults_match_the_fields(record: type[WheelFile | SdistFile]) -> None:
+    """Each field's default is declared twice, and both have to say the same thing."""
+    field_defaults = {
+        field.name: (
+            inspect.Parameter.empty if field.default is MISSING else field.default
+        )
+        for field in fields(record)
+    }
+    parameter_defaults = {
+        name: parameter.default
+        for name, parameter in inspect.signature(record.__init__).parameters.items()
+        if name != "self"
+    }
+
+    assert parameter_defaults == field_defaults


### PR DESCRIPTION
A warm `airflow:airflow-3-0-2-awswrangler --resolution lowest-direct` resolve retires 10,586,530,897 instructions instead of 11,155,360,457, a drop of 568,829,560, or 5.1% of the run. Two more callgrind runs of the same comparison, all with `PYTHONHASHSEED=0`, gave 5.10% and 5.05%.

`WheelFile` and `SdistFile` are frozen slotted dataclasses. A frozen dataclass cannot write `self.field = value`, so the generated `__init__` puts all ten wheel fields (eight for sdists) through `object.__setattr__`, which looks the name up on the type every time. Both records now define an `__init__` that writes each field through that slot's own descriptor, and `__setattr__` and `__delattr__` stay frozen for callers.

- Locally, decoding one listing row into a record takes about 1,750 ns rather than about 2,140 ns, over 2,000 rows captured from a canary run. A warm resolve of the airflow scenario above decodes 101,479 rows.
- Over 12 runs of the 19-scenario canary set on each side, wall time is between about 0.8% and 3% lower locally, with a middle estimate near 1.9% (medians 18.9 s against 18.6 s), and CPU time between about 1.4% and 3.3% lower. Peak memory sits inside about 0.3% either way.

Dropping the generated `__init__` also drops the guarantee that the constructor signature tracks the field list, and `__match_args__` still comes off that list, so two tests pin the parameter order and the defaults against it.
