### PR TITLE
Decode listing rows straight to the deferred state, ~8% fewer instructions

### DIFF
--- a/nab-index/src/nab_index/parsed_listing.py
+++ b/nab-index/src/nab_index/parsed_listing.py
@@ -36,7 +36,12 @@ import json
 import sys
 from typing import TYPE_CHECKING
 
-from nab_provider.records import SdistFile, WheelFile, defer_hashes, defer_sidecar_hash
+from nab_provider.records import (
+    SdistFile,
+    WheelFile,
+    rehydrated_sdist,
+    rehydrated_wheel,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -222,17 +227,12 @@ def _decode_row(row: object) -> WheelFile | SdistFile:
     raise _BadRowError
 
 
-def _hashes_unless_deferred(cell: object) -> tuple[tuple[str, str], ...]:
-    """Return a ``hashes`` cell's pairs, or ``()`` when it is a table to defer."""
-    return () if isinstance(cell, dict) else _hashes(cell)
-
-
-def _sidecar_unless_deferred(cell: object) -> tuple[str, str] | None:
-    """Return a sidecar cell's pair, or ``None`` when it is a table to defer."""
-    return None if isinstance(cell, dict) else _pair_or_none(cell)
-
-
 def _decode_wheel(row: Sequence[object]) -> WheelFile:
+    """Rehydrate a wheel row.
+
+    An integrity cell holding the index's own table passes through unparsed,
+    for the record to parse on first read; any other form is parsed here.
+    """
     (
         _,
         filename,
@@ -245,35 +245,33 @@ def _decode_wheel(row: Sequence[object]) -> WheelFile:
         size,
         metadata_hash,
     ) = row
-    wheel = WheelFile(
-        filename=_text(filename),
-        url=_text(url),
-        version=_text(version),
-        requires_python=_interned_or_none(requires_python),
-        has_metadata=_flag(has_metadata),
-        upload_time=_text_or_none(upload_time),
-        hashes=_hashes_unless_deferred(hashes),
-        size=_count_or_none(size),
-        metadata_hash=_sidecar_unless_deferred(metadata_hash),
+    return rehydrated_wheel(
+        _text(filename),
+        _text(url),
+        _text(version),
+        _interned_or_none(requires_python),
+        _flag(has_metadata),
+        _text_or_none(upload_time),
+        hashes if isinstance(hashes, dict) else _hashes(hashes),
+        _count_or_none(size),
+        metadata_hash
+        if isinstance(metadata_hash, dict)
+        else _pair_or_none(metadata_hash),
     )
-    defer_hashes(wheel, hashes)
-    defer_sidecar_hash(wheel, metadata_hash)
-    return wheel
 
 
 def _decode_sdist(row: Sequence[object]) -> SdistFile:
+    """Rehydrate a source-distribution row; see :func:`_decode_wheel`."""
     _, filename, url, version, requires_python, upload_time, hashes, size = row
-    sdist = SdistFile(
-        filename=_text(filename),
-        url=_text(url),
-        version=_text(version),
-        requires_python=_interned_or_none(requires_python),
-        upload_time=_text_or_none(upload_time),
-        hashes=_hashes_unless_deferred(hashes),
-        size=_count_or_none(size),
+    return rehydrated_sdist(
+        _text(filename),
+        _text(url),
+        _text(version),
+        _interned_or_none(requires_python),
+        _text_or_none(upload_time),
+        hashes if isinstance(hashes, dict) else _hashes(hashes),
+        _count_or_none(size),
     )
-    defer_hashes(sdist, hashes)
-    return sdist
 
 
 # JSON hands back only its own types, so an exact type check is enough to keep a

--- a/nab-index/tests/test_parsed_listing_codec.py
+++ b/nab-index/tests/test_parsed_listing_codec.py
@@ -378,6 +378,22 @@ def test_a_rehydrated_record_defers_the_same_parse() -> None:
     assert wheel.metadata_hash == (SHA256, DIGEST)
 
 
+def test_a_rehydrated_sdist_defers_its_hashes() -> None:
+    sdist = SdistFile(
+        filename="pkg-1.0.tar.gz",
+        url="https://files.example/pkg-1.0.tar.gz",
+        version="1.0",
+        requires_python=None,
+        upload_time=None,
+    )
+    defer_hashes(sdist, {"SHA256": DIGEST.upper()})
+
+    (decoded,) = decode(encode([sdist], DIGEST), _policy()) or []
+
+    assert decoded.raw_hashes() == {"SHA256": DIGEST.upper()}
+    assert decoded.hashes == ((SHA256, DIGEST),)
+
+
 def test_a_row_is_the_same_whether_or_not_the_record_was_read() -> None:
     """A read record keeps its table, so encoding does not depend on read order."""
     unread = _deferred_wheel({"sha256": DIGEST}, sidecar={"sha256": DIGEST})

--- a/nab-provider/src/nab_provider/records.py
+++ b/nab-provider/src/nab_provider/records.py
@@ -32,6 +32,8 @@ __all__ = [
     "defer_hashes",
     "defer_sidecar_hash",
     "parse_hash_table",
+    "rehydrated_sdist",
+    "rehydrated_wheel",
     "select_artifact_hash",
     "sidecar_hash",
 ]
@@ -140,11 +142,10 @@ class _MetadataUrlMemo:
 class _DeferredIntegrity:
     """Parses a record's ``hashes`` table the first time something reads it.
 
-    :func:`defer_hashes` unsets the parsed slot and keeps the index's own table
+    A deferred record has nothing in the parsed slot and the index's own table
     beside it, so a listing pays the integrity parse only for the files a
     resolve reads.  ``__getattr__`` runs only once ordinary lookup has failed,
-    so a record built the ordinary way reads its fields straight out of their
-    slots.
+    so a record whose slot holds a parsed value reads it straight out.
 
     A read leaves the raw table in place.  The fetching and the resolving
     thread hold the same records, so both may run the parse at once, and both
@@ -253,7 +254,8 @@ class WheelFile(_WheelIntegrity):
     sidecar without a hash.
 
     A record built from a listing holds the index's own tables and parses
-    ``hashes`` and ``metadata_hash`` on first read (:func:`defer_hashes`).
+    ``hashes`` and ``metadata_hash`` on first read (:func:`defer_hashes`,
+    :func:`rehydrated_wheel`).
     """
 
     filename: str
@@ -321,6 +323,52 @@ _set_wheel_size = _slot_writer(WheelFile, "size")
 _set_wheel_local_path = _slot_writer(WheelFile, "local_path")
 _set_wheel_metadata_hash = _slot_writer(WheelFile, "metadata_hash")
 
+_set_wheel_raw_hashes = _slot_writer(_WheelIntegrity, "_raw_hashes")
+_set_wheel_raw_metadata = _slot_writer(_WheelIntegrity, "_raw_metadata")
+
+
+def rehydrated_wheel(  # noqa: PLR0913, PLR0917 - the record's fields, in its own order
+    filename: str,
+    url: str,
+    version: str,
+    requires_python: str | None,
+    has_metadata: bool,  # noqa: FBT001 - a field, not a flag
+    upload_time: str | None,
+    hashes: tuple[tuple[str, str], ...] | dict[object, object],
+    size: int | None,
+    metadata_hash: tuple[str, str] | dict[object, object] | None,
+) -> WheelFile:
+    """Return a wheel rebuilt from a cached listing row.
+
+    ``hashes`` and ``metadata_hash`` each take either a parsed value or the
+    index's own table, and a table is held raw for the field's first read to
+    parse.  Deferring a field means leaving its slot unwritten, which
+    ``__init__`` cannot do, so this writes the slots directly.
+
+    ``local_path`` is ``None``: a cached listing row carries none.
+    """
+    wheel = WheelFile.__new__(WheelFile)
+    _set_wheel_filename(wheel, filename)
+    _set_wheel_url(wheel, url)
+    _set_wheel_version(wheel, version)
+    _set_wheel_requires_python(wheel, requires_python)
+    _set_wheel_has_metadata(wheel, has_metadata)
+    _set_wheel_upload_time(wheel, upload_time)
+    _set_wheel_size(wheel, size)
+    _set_wheel_local_path(wheel, None)
+
+    if isinstance(hashes, dict):
+        _set_wheel_raw_hashes(wheel, _compact_table(hashes))
+    else:
+        _set_wheel_hashes(wheel, hashes)
+
+    if isinstance(metadata_hash, dict):
+        _set_wheel_raw_metadata(wheel, _compact_table(metadata_hash))
+    else:
+        _set_wheel_metadata_hash(wheel, metadata_hash)
+
+    return wheel
+
 
 @dataclass(frozen=True, slots=True, init=False)
 class SdistFile(_SdistIntegrity):
@@ -369,6 +417,39 @@ _set_sdist_upload_time = _slot_writer(SdistFile, "upload_time")
 _set_sdist_hashes = _slot_writer(SdistFile, "hashes")
 _set_sdist_size = _slot_writer(SdistFile, "size")
 _set_sdist_local_path = _slot_writer(SdistFile, "local_path")
+
+_set_sdist_raw_hashes = _slot_writer(_SdistIntegrity, "_raw_hashes")
+
+
+def rehydrated_sdist(
+    filename: str,
+    url: str,
+    version: str,
+    requires_python: str | None,
+    upload_time: str | None,
+    hashes: tuple[tuple[str, str], ...] | dict[object, object],
+    size: int | None,
+) -> SdistFile:
+    """Return a source distribution rebuilt from a cached listing row.
+
+    See :func:`rehydrated_wheel`; a source distribution has only ``hashes``
+    to defer.
+    """
+    sdist = SdistFile.__new__(SdistFile)
+    _set_sdist_filename(sdist, filename)
+    _set_sdist_url(sdist, url)
+    _set_sdist_version(sdist, version)
+    _set_sdist_requires_python(sdist, requires_python)
+    _set_sdist_upload_time(sdist, upload_time)
+    _set_sdist_size(sdist, size)
+    _set_sdist_local_path(sdist, None)
+
+    if isinstance(hashes, dict):
+        _set_sdist_raw_hashes(sdist, _compact_table(hashes))
+    else:
+        _set_sdist_hashes(sdist, hashes)
+
+    return sdist
 
 
 # Either distribution shape a listing can offer for one version.

--- a/nab-provider/src/nab_provider/records.py
+++ b/nab-provider/src/nab_provider/records.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import enum
 import sys
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit, urlunsplit
 
 from .digest import is_hex_digest
@@ -334,9 +334,9 @@ def rehydrated_wheel(  # noqa: PLR0913, PLR0917 - the record's fields, in its ow
     requires_python: str | None,
     has_metadata: bool,  # noqa: FBT001 - a field, not a flag
     upload_time: str | None,
-    hashes: tuple[tuple[str, str], ...] | dict[object, object],
+    hashes: tuple[tuple[str, str], ...] | dict[Any, Any],
     size: int | None,
-    metadata_hash: tuple[str, str] | dict[object, object] | None,
+    metadata_hash: tuple[str, str] | dict[Any, Any] | None,
 ) -> WheelFile:
     """Return a wheel rebuilt from a cached listing row.
 
@@ -427,7 +427,7 @@ def rehydrated_sdist(
     version: str,
     requires_python: str | None,
     upload_time: str | None,
-    hashes: tuple[tuple[str, str], ...] | dict[object, object],
+    hashes: tuple[tuple[str, str], ...] | dict[Any, Any],
     size: int | None,
 ) -> SdistFile:
     """Return a source distribution rebuilt from a cached listing row.


### PR DESCRIPTION
A resolve reading its listings from cache retires 863,870,903 fewer instructions, 8.1% of the run: 10,601,714,693 to 9,737,843,790 on `airflow:airflow-3-0-2-awswrangler --resolution lowest-direct`. A second pair of runs gives 10,596,968,199 to 9,740,206,602, also 8.1%, and the two base runs differ by 0.045%, two orders of magnitude below the change.

Stacked on #921; the diff and the numbers are against that branch.

Every row rebuilt from the parsed-listing cache is built with its integrity fields set and then unset again. `_decode_wheel` passes `hashes` and `metadata_hash` through helpers that return the empty value when the cell is still the index's own table, then calls `defer_hashes` and `defer_sidecar_hash`. Each of those runs an `object.__delattr__` and an `object.__setattr__` to reach a state the decoder knew it wanted before it built anything.

`rehydrated_wheel` and `rehydrated_sdist` allocate the record and write its slots directly: the parsed slot for a cell that already holds pairs, the raw slot for one that is still the table. That airflow resolve decodes 101,655 rows (86,999 wheels, 14,656 sdists), and four functions leave the decode path:

| function | before | after |
| --- | --- | --- |
| `_hashes_unless_deferred` | 101,655 | 0 |
| `defer_hashes` | 101,655 | 0 |
| `_sidecar_unless_deferred` | 86,999 | 0 |
| `defer_sidecar_hash` | 86,999 | 0 |

Whole-run calls drop by about 274,000 there and about 436,000 on `pip:langchain-ml-course --resolution lowest`, 3.4% and 1.4% of what each makes. `WheelFile.__init__` and `SdistFile.__init__` give way to the two builders, and the only other row to grow is the builtin `__new__`, now called outright rather than from inside `type.__call__`.

`_compact_table` is unchanged to the digit on both (188,654 and 309,598), since a deferred cell is still compacted, and `defer_hashes` and `defer_sidecar_hash` stay for `nab_index/client.py`, which builds records off the wire.

Twelve timed runs of the 19-scenario canary set, before and after, put this between about 2.6% and 6.9% faster locally, with a middle estimate near 4%; CPU time moves the same way. Peak RSS lands inside about 0.15% either way, and live bytes at exit on the airflow resolve are within 0.03%.
