### PR TITLE
Reuse marker partitions and the version index, ~0.9% off universal locks

### DIFF
--- a/nab-project/src/nab_project/_lockfile/pylock.py
+++ b/nab-project/src/nab_project/_lockfile/pylock.py
@@ -275,8 +275,8 @@ def build_pylock(lock_input: LockInput, *, lock_dir: Path | None = None) -> Pylo
 
     base = (lock_dir if lock_dir is not None else Path.cwd()).resolve()
     exclusion_groups = conflict_exclusion_groups(lock_input.conflicts)
-    universe = _emission_universe(lock_input)
     store = DecisionStore()
+    universe = _emission_universe(lock_input, store)
     package_records = _build_packages(
         lock_input, base, exclusion_groups, universe, store
     )
@@ -539,7 +539,9 @@ def _sdist_to_package(sdist: SdistArtifact, *, lock_dir: Path) -> PackageSdist:
     )
 
 
-def _emission_universe(lock_input: LockInput) -> MarkerSet:
+def _emission_universe(
+    lock_input: LockInput, store: DecisionStore | None = None
+) -> MarkerSet:
     """Return the environment universe simplification must agree over.
 
     The union of the declared ``environments`` rows, or the full set when none
@@ -557,7 +559,7 @@ def _emission_universe(lock_input: LockInput) -> MarkerSet:
         return MarkerSet.full()
     rows = [MarkerSet.from_marker(m) for m in lock_input.environments]
     try:
-        uninhabited = all(row.is_empty() for row in rows)
+        uninhabited = all(row.is_empty(store=store) for row in rows)
     except IntractableMarkerSet:
         uninhabited = False
     if uninhabited:
@@ -589,7 +591,7 @@ def _finalize_marker(
         return None
     try:
         simplified = MarkerSet.from_marker(raw).simplify(within=within, store=store)
-        text = simplified.to_marker_string()
+        text = simplified.to_marker_string(store=store)
         rebuilt = None if text is None else Marker(text)
         emitted = (
             MarkerSet.full() if rebuilt is None else MarkerSet.from_marker(rebuilt)

--- a/nab-provider/src/nab_provider/_vendor/packaging/markersets.py
+++ b/nab-provider/src/nab_provider/_vendor/packaging/markersets.py
@@ -186,21 +186,25 @@ class MarkerSet:
     # ---- decision procedures
 
     @_bounded
-    def is_empty(self) -> bool:
+    def is_empty(self, *, store: DecisionStore | None = None) -> bool:
         """Whether no environment satisfies this set (the marker is a contradiction).
+
+        ``store`` shares scratch with other decisions (:class:`DecisionStore`).
 
         :raises IntractableMarkerSet: if deciding the set exceeds the internal
             cell budget, or the marker nests past the stack.
         """
-        return _markersets.is_empty(self._tree, _MAX_CELLS)
+        return _markersets.is_empty(self._tree, _MAX_CELLS, store)
 
     @_bounded
-    def is_full(self) -> bool:
+    def is_full(self, *, store: DecisionStore | None = None) -> bool:
         """Whether every environment satisfies this set (the marker is a tautology).
+
+        ``store`` shares scratch with other decisions (:class:`DecisionStore`).
 
         :raises IntractableMarkerSet: see :meth:`is_empty`.
         """
-        return _markersets.is_empty(_markersets.make_not(self._tree), _MAX_CELLS)
+        return _markersets.is_empty(_markersets.make_not(self._tree), _MAX_CELLS, store)
 
     @_bounded
     def is_disjoint(self, other: MarkerSet) -> bool:
@@ -365,17 +369,23 @@ class MarkerSet:
     # ---- serialisation
 
     @_bounded
-    def to_marker_string(self) -> str | None:
+    def to_marker_string(self, *, store: DecisionStore | None = None) -> str | None:
         """Return a marker string that re-parses to an equivalent set, or ``None``.
 
         ``None`` means the full set (no marker needed). The empty set, and any set
         whose complement structure the marker grammar cannot express, raise
         :class:`UnserializableMarkerSet` rather than emit a wrong string. The
         produced string is verified equivalent to this set before it is returned.
+
+        ``store`` shares scratch with other decisions (:class:`DecisionStore`).
+        The two emptiness decisions read the same atoms, so they share one
+        partition memo whether or not one is passed.
         """
-        if self.is_full():
+        if store is None:
+            store = _markersets.Memo()
+        if self.is_full(store=store):
             return None
-        if self.is_empty():
+        if self.is_empty(store=store):
             msg = "the empty set has no marker string"
             raise UnserializableMarkerSet(msg)
 

--- a/nab-provider/src/nab_provider/provider.py
+++ b/nab-provider/src/nab_provider/provider.py
@@ -1227,7 +1227,7 @@ class Provider:
         if preferred is None or self.wants_lowest(normalized):
             return None
 
-        all_versions = self.versions_only(normalized, self.fetch_versions(package))
+        version_list = self.fetch_versions(package)
 
         # The proxy's range is built full(), so intersect it with the base's
         # positive range, which carries the pre-release admission granted by
@@ -1239,8 +1239,9 @@ class Provider:
             if base_range is not None:
                 admit_range = version_range & base_range
 
-        in_range = admit_range.filter(all_versions, assume_sorted="descending")
-        if preferred not in in_range:
+        if not self._admits_preference(
+            normalized, version_list, admit_range, preferred
+        ):
             return None
 
         usable = (
@@ -1249,6 +1250,29 @@ class Provider:
             else self._look_ahead_ok(normalized, preferred, check_decisions=True)
         )
         return preferred if usable else None
+
+    def _admits_preference(
+        self,
+        normalized: str,
+        version_list: list[tuple[Version, DistFile]],
+        admit_range: VersionRange,
+        preferred: Version,
+    ) -> bool:
+        """Report whether ``preferred`` is one of the listing's in-range versions.
+
+        A final release is answered by ``contains`` on the range plus a lookup
+        in the listing's picked-dist view.  A pre-release needs the ``filter``
+        walk instead: ``contains`` reads only the configured pre-release policy,
+        while ``filter`` also applies the PEP 440 buffering and the range's
+        opt-in region.
+        """
+        if preferred.is_prerelease:
+            all_versions = self.versions_only(normalized, version_list)
+            in_range = admit_range.filter(all_versions, assume_sorted="descending")
+            return preferred in in_range
+        return preferred in admit_range and preferred in self._wheel_by_version(
+            normalized, version_list
+        )
 
     def has_satisfying_version(
         self, package: str, version_range: RangeProtocol[Version]

--- a/nab-provider/tests/test_markersets.py
+++ b/nab-provider/tests/test_markersets.py
@@ -768,6 +768,31 @@ def test_the_store_reaches_the_engine_from_simplify(
     assert partitions() == first
 
 
+def test_the_store_reaches_both_emptiness_decisions_under_serialisation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The store :meth:`MarkerSet.to_marker_string` is handed reaches its two decisions.
+
+    Warmed by an :meth:`MarkerSet.is_full` over the same three axes, the pair
+    partitions none of them again; the three left are the round-trip check's, which
+    keeps a memo of its own.
+    """
+    marker = ms('python_version < "3.12"' + _SPREAD)
+    text = marker.to_marker_string()
+
+    partitions = _partition_counter(monkeypatch)
+    assert marker.to_marker_string(store=DecisionStore()) == text
+    cold = partitions()
+
+    warm = DecisionStore()
+    marker.is_full(store=warm)
+    before = partitions()
+    assert marker.to_marker_string(store=warm) == text
+
+    assert cold == 6
+    assert partitions() - before == 3
+
+
 def test_a_shared_store_answers_what_fresh_stores_answer() -> None:
     """One store across a run of decisions answers as a fresh store per decision.
 

--- a/tasks/vendoring/packaging.patch
+++ b/tasks/vendoring/packaging.patch
@@ -2106,10 +2106,10 @@ index 609099c..fa29c65 100644
  def _pep440_python_full_version(python_full_version: str) -> str:
 diff --git a/nab-provider/src/nab_provider/_vendor/packaging/markersets.py b/nab-provider/src/nab_provider/_vendor/packaging/markersets.py
 new file mode 100644
-index 0000000..638bc9e
+index 0000000..3dfd597
 --- /dev/null
 +++ b/nab-provider/src/nab_provider/_vendor/packaging/markersets.py
-@@ -0,0 +1,392 @@
+@@ -0,0 +1,402 @@
 +"""The public :class:`MarkerSet`: a marker's denotation as a set of environments.
 +
 +A :class:`MarkerSet` is the denotation of a PEP 508 marker as a set of
@@ -2298,21 +2298,25 @@ index 0000000..638bc9e
 +    # ---- decision procedures
 +
 +    @_bounded
-+    def is_empty(self) -> bool:
++    def is_empty(self, *, store: DecisionStore | None = None) -> bool:
 +        """Whether no environment satisfies this set (the marker is a contradiction).
++
++        ``store`` shares scratch with other decisions (:class:`DecisionStore`).
 +
 +        :raises IntractableMarkerSet: if deciding the set exceeds the internal
 +            cell budget, or the marker nests past the stack.
 +        """
-+        return _markersets.is_empty(self._tree, _MAX_CELLS)
++        return _markersets.is_empty(self._tree, _MAX_CELLS, store)
 +
 +    @_bounded
-+    def is_full(self) -> bool:
++    def is_full(self, *, store: DecisionStore | None = None) -> bool:
 +        """Whether every environment satisfies this set (the marker is a tautology).
++
++        ``store`` shares scratch with other decisions (:class:`DecisionStore`).
 +
 +        :raises IntractableMarkerSet: see :meth:`is_empty`.
 +        """
-+        return _markersets.is_empty(_markersets.make_not(self._tree), _MAX_CELLS)
++        return _markersets.is_empty(_markersets.make_not(self._tree), _MAX_CELLS, store)
 +
 +    @_bounded
 +    def is_disjoint(self, other: MarkerSet) -> bool:
@@ -2477,17 +2481,23 @@ index 0000000..638bc9e
 +    # ---- serialisation
 +
 +    @_bounded
-+    def to_marker_string(self) -> str | None:
++    def to_marker_string(self, *, store: DecisionStore | None = None) -> str | None:
 +        """Return a marker string that re-parses to an equivalent set, or ``None``.
 +
 +        ``None`` means the full set (no marker needed). The empty set, and any set
 +        whose complement structure the marker grammar cannot express, raise
 +        :class:`UnserializableMarkerSet` rather than emit a wrong string. The
 +        produced string is verified equivalent to this set before it is returned.
++
++        ``store`` shares scratch with other decisions (:class:`DecisionStore`).
++        The two emptiness decisions read the same atoms, so they share one
++        partition memo whether or not one is passed.
 +        """
-+        if self.is_full():
++        if store is None:
++            store = _markersets.Memo()
++        if self.is_full(store=store):
 +            return None
-+        if self.is_empty():
++        if self.is_empty(store=store):
 +            msg = "the empty set has no marker string"
 +            raise UnserializableMarkerSet(msg)
 +


### PR DESCRIPTION
The three universal lock scenarios below retire 0.93% fewer instructions, counted under callgrind with the hash seed pinned: about 1.0% off `universal:max-25-tuples` (roughly 69 million of 6.75 billion), about 1.0% off `universal:scientific-python-multi`, and about 0.25% off `universal:marker-heavy`. Repeat runs of a scenario vary, so read those as ranges: 0.94% to 1.2%, 0.5% to 1.3%, and 0.16% to 0.31%.

Counted on the #906 branch, where the marker algebra sits in `nab-markersets`. This diff is against main, where the same code sits in the vendored `markersets.py`.

The call counts are exact, one run per side of `universal_scenarios.py --scenario max-25-tuples`:

| call | before | after |
| --- | ---: | ---: |
| total calls | 6,340,432 | 6,262,611 |
| `listing.py(versions_only)` | 330 | 82 |
| `packaging/ranges.py(VersionRange.filter)` | 517 | 269 |
| `_markersets.py(_partition_axis)` | 120 | 104 |
| `metadata_resolver.py(version_dists)` | 532 | 780 |
| `provider.py(_admits_preference)` | 0 | 248 |
| `packaging/version.py(Version.__hash__)` | 150,978 | 129,892 |

Two independent changes:

- `build_pylock` already builds a `DecisionStore` for the per-package simplification. `_emission_universe` and `to_marker_string` now take it as well, so the environment rows and the serialiser's two emptiness decisions share that memo instead of each building their own. The 1,948 partition requests are unchanged, and 16 of the 120 that used to compute one now find it already there.
- `_admits_preference` answers a final-release preference from the range bounds plus the memoised `version_dists` index, instead of materialising the package's whole de-duplicated version view. All 248 preference checks on `max-25-tuples` are final releases, which is where both 248-call drops in the table come from. A pre-release still needs the `filter` walk: `contains` reads only the configured pre-release policy, while `filter` also applies PEP 440's buffering and the range's opt-in region.

The timing runs on `universal:max-25-tuples` rule out a wall regression above about 1.7% and put peak memory inside about 0.24% either way; the clock cannot see anything smaller here. The memory bound is the one that matters, because the shared store now holds the serialiser's partitions until the emission finishes. Both sides resolve the scenario the same way: 25 tuples, 12 packages, 285 decisions.

One case these three scenarios do not cover: `_admits_preference` asks for the picked-dist index on a path that never did, so a package whose preference always hits, and that nothing else indexes, now pays for a first index build. The table's 248 extra `version_dists` calls are that lookup, and how many of them build an index rather than hit the memo was not counted. On all three scenarios the share still comes out negative, so the added calls cost less than the version views they replace.

