### PR TITLE
Parse upload times with the native ISO parser, 0.8% fewer instructions

### DIFF
--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -5575,6 +5575,17 @@ class TestUploadedPriorTo:
         with pytest.raises(InvalidUploadTimeError, match="2024-01-01T00:00:00"):
             provider.fetch_versions("foo")
 
+    def test_date_only_upload_time_reaches_the_rewriting_parser(self) -> None:
+        """A date-only ``Z`` time still parses, through the fallback, and is naive."""
+        wheels = [
+            make_wheel("1.0", upload_time="2024-01-01Z"),
+        ]
+        coordinator = make_coordinator(wheels, package="foo")
+        cutoff = datetime(2024, 3, 1, tzinfo=timezone.utc)
+        provider = Provider(coordinator, uploaded_prior_to=cutoff)
+        with pytest.raises(InvalidUploadTimeError, match="2024-01-01Z"):
+            provider.fetch_versions("foo")
+
     def test_naive_upload_time_not_metadata_error(self) -> None:
         """The error is not a MetadataError, so look-ahead cannot swallow it."""
         assert not issubclass(InvalidUploadTimeError, MetadataError)

--- a/nab-provider/src/nab_provider/_provider/listing.py
+++ b/nab-provider/src/nab_provider/_provider/listing.py
@@ -20,7 +20,7 @@ from ..errors import (
     IncompatiblePythonError,
     InvalidUploadTimeError,
 )
-from ..iso8601 import parse_iso_datetime
+from ..iso8601 import fast_iso_parser, parse_iso_datetime
 from ..metadata import intern_version as _intern_version
 from ..policy import DistPolicy
 from ..vcs_admission import UnsupportedVcsError
@@ -722,20 +722,27 @@ def excluded_by_time(
     if dist.local_path is not None:
         # A local file:// artifact has no upload time, so the cutoff cannot apply.
         return False
-    if dist.upload_time is None:
+    raw = dist.upload_time
+    if raw is None:
         provider.stats.excluded_by_time += 1
         return True
+
     try:
-        upload_dt = parse_iso_datetime(dist.upload_time)
+        upload_dt = fast_iso_parser(raw)
     except ValueError:
-        provider.stats.excluded_by_time += 1
-        return True
+        # The fast parser can be the stricter of the two, so what it rejects
+        # still gets the rewriting parse.
+        try:
+            upload_dt = parse_iso_datetime(raw)
+        except ValueError:
+            provider.stats.excluded_by_time += 1
+            return True
 
     # PEP 700 mandates timezone-aware UTC upload times; refuse to guess.
     if upload_dt.tzinfo is None:
         msg = (
             f"{normalized} {dist.version} has a timezone-naive upload time "
-            f"{dist.upload_time!r}; the Simple API requires "
+            f"{raw!r}; the Simple API requires "
             f"timezone-aware (UTC) upload times"
         )
         raise InvalidUploadTimeError(msg)

--- a/nab-provider/src/nab_provider/iso8601.py
+++ b/nab-provider/src/nab_provider/iso8601.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 import re
 import sys
 from datetime import datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 _FRACTIONAL_SECONDS = re.compile(r"\.(\d+)")
 
@@ -26,6 +30,14 @@ def parse_iso_datetime(raw: str) -> datetime:
             pass
 
     return datetime.fromisoformat(_to_isoformat(raw))
+
+
+# The cheapest parser for one timestamp per record: on 3.11+ the native one,
+# skipping the ``parse_iso_datetime`` wrapper. It rejects the shapes
+# ``_to_isoformat`` rewrites, so callers keep ``parse_iso_datetime`` as a fallback.
+fast_iso_parser: Callable[[str], datetime] = (
+    datetime.fromisoformat if _NATIVE_ACCEPTS_PEP_700 else parse_iso_datetime
+)
 
 
 def _to_isoformat(raw: str) -> str:


### PR DESCRIPTION
Calling `datetime.fromisoformat` directly instead of through `parse_iso_datetime` takes 91,539,477 instructions off `airflow:airflow-3-0-2-awswrangler --resolution lowest-direct`: 10,873,828,801 against 10,965,368,278, or 0.835% of the run. Counted under callgrind with `PYTHONHASHSEED=0`, so the number reproduces.

`excluded_by_time` parses one upload time per candidate record, about 101,000 of them on that scenario. From 3.11 `parse_iso_datetime` starts by trying `datetime.fromisoformat(raw)` and only rewrites what that rejects, so for the timestamps an index actually serves it is a Python frame around a call that already worked. `iso8601` now binds `fast_iso_parser` at import, to the native parser on 3.11+ and to `parse_iso_datetime` on 3.10, and the filter keeps `parse_iso_datetime` as the fallback for whatever the native parser will not read.

The answer is unchanged on every supported Python: on 3.10 `fast_iso_parser` is `parse_iso_datetime`, and on 3.11+ a shape only the rewrite reads, such as a date-only `2024-01-01Z`, still reaches it through the fallback.

Timing cannot see a change this small. Twelve runs of each side over the 19-scenario canary set rule out a wall regression above about 2.3% and a CPU regression above about 1.6%, and put peak memory inside about 0.14% either way. That set spends about 1.1 seconds of its roughly 18 in this scenario, so the effect was never going to surface there.
