### PR TITLE
Read _dev and _pre in Version.is_prerelease, 0.6% fewer instructions

### DIFF
--- a/nab-provider/src/nab_provider/_vendor/packaging/PROVENANCE.md
+++ b/nab-provider/src/nab_provider/_vendor/packaging/PROVENANCE.md
@@ -41,12 +41,18 @@ most one checked-in patch.
     Upstream's opening `assert isinstance(marker, (list, tuple, str))` is
     dropped, so a value of any other type now returns unchanged instead of
     tripping the assertion.
+  - `version.py`: `Version.is_prerelease` reads the `_dev` and `_pre` slots
+    instead of the `dev` and `pre` properties over them. `pre` returns `_pre`
+    unchanged. `dev` returns `self._dev[1] if self._dev else None`, and
+    `_parse_letter_version` and `_validate_dev` only ever put `None` or a
+    2-tuple in `_dev`, so the two presence tests agree.
 
   Upstream PRs are planned for the bound ordering, the direct subset and
   disjoint walks, `filter`'s `assume_sorted` fast path,
   `from_bounds`/`snap_bounds`/`release_intervals`, the prepared marker
-  environment, and the marker-item serialisation. `relation` is not proposed
-  yet: most of its win is available from the direct walks alone.
+  environment, the marker-item serialisation, and the `is_prerelease` slot
+  reads. `relation` is not proposed yet: most of its win is available from the
+  direct walks alone.
 - `tasks/vendor-packaging.sh` fetches `pypa/packaging` at the pin, replaces this
   package with the pristine `src/packaging/` tree plus the repo-root license
   texts, and reapplies the patch. `--check` rebuilds into a temp location and

--- a/nab-provider/src/nab_provider/_vendor/packaging/version.py
+++ b/nab-provider/src/nab_provider/_vendor/packaging/version.py
@@ -1023,7 +1023,7 @@ class Version(_BaseVersion):
         >>> Version("1.2.3dev1").is_prerelease
         True
         """
-        return self.dev is not None or self.pre is not None
+        return self._dev is not None or self._pre is not None
 
     @property
     def is_postrelease(self) -> bool:

--- a/tasks/vendoring/packaging.patch
+++ b/tasks/vendoring/packaging.patch
@@ -3324,3 +3324,16 @@ index 4fbf48e..d52f359 100644
      @classmethod
      def _from_specifier_set(cls, specifier_set: SpecifierSet) -> VersionRange:
          """Build the range accepted by ``specifier_set``.
+diff --git a/nab-provider/src/nab_provider/_vendor/packaging/version.py b/nab-provider/src/nab_provider/_vendor/packaging/version.py
+index 791c8ac..bc4f908 100644
+--- a/nab-provider/src/nab_provider/_vendor/packaging/version.py
++++ b/nab-provider/src/nab_provider/_vendor/packaging/version.py
+@@ -1023,7 +1023,7 @@ class Version(_BaseVersion):
+         >>> Version("1.2.3dev1").is_prerelease
+         True
+         """
+-        return self.dev is not None or self.pre is not None
++        return self._dev is not None or self._pre is not None
+ 
+     @property
+     def is_postrelease(self) -> bool:


### PR DESCRIPTION
A `pip:langchain-ml-course --resolution lowest` resolve retires about 0.59% fewer instructions when `Version.is_prerelease` reads the `_dev` and `_pre` slots instead of going through the `dev` and `pre` properties over them. The base run costs 35,033,848,626 instructions and the two branch runs come in 208,124,312 (0.594%) and 205,158,431 (0.586%) under it, all three resolving 207 packages in 10,218 decisions.

The decision count matters here. A base run that took the scenario's other search, at 10,194 decisions, cost 381,170,219 instructions more, 1.1% of the run and nearly twice the change, so a whole-run count on this scenario only compares against a run that took the same search.

The call counts reproduce exactly, which the instruction totals do not. `Version.dev` falls from 481,518 calls to 127,198 and `Version.pre` from 370,623 to 17,944, 706,999 property calls in all, with `is_prerelease` itself unchanged at 354,320. `pre` loses 1,641 fewer than `dev` because the check short-circuits on a version that carries a dev segment.

Those calls come from prerelease filtering, so the size follows the workload: `airflow:airflow-3-0-2-awswrangler --resolution lowest-direct` makes 653 `is_prerelease` calls against langchain's 354,320.

Timing the same scenario locally, twelve runs each way, showed nothing the clock could see. Those runs rule out a wall regression above about 1.8% and a CPU regression above about 1.7%, and put peak memory inside about 0.08% either way. Nothing as small as 0.5% is visible on the clock here, so the counts are the measurement.

The slot reads are the same test: `pre` returns `_pre` unchanged, and `dev` returns `self._dev[1] if self._dev else None` over a slot that only ever holds `None` or a 2-tuple. `version.py` is vendored, so `tasks/vendoring/packaging.patch` carries the hunk and the tree's `PROVENANCE.md` records it. The same change is worth taking upstream separately.
