### PR TITLE
Check a cached listing row's fields in one pass, ~2.7% fewer instructions

### DIFF
--- a/nab-index/src/nab_index/parsed_listing.py
+++ b/nab-index/src/nab_index/parsed_listing.py
@@ -245,15 +245,29 @@ def _decode_wheel(row: Sequence[object]) -> WheelFile:
         size,
         metadata_hash,
     ) = row
+
+    # ``type() is`` rather than ``isinstance``: bool is a subclass of int, so
+    # ``True`` would pass as a size.
+    if (
+        type(filename) is not str
+        or type(url) is not str
+        or type(version) is not str
+        or type(has_metadata) is not bool
+        or (requires_python is not None and type(requires_python) is not str)
+        or (upload_time is not None and type(upload_time) is not str)
+        or (size is not None and type(size) is not int)
+    ):
+        raise _BadRowError
+
     return rehydrated_wheel(
-        _text(filename),
-        _text(url),
-        _text(version),
-        _interned_or_none(requires_python),
-        _flag(has_metadata),
-        _text_or_none(upload_time),
+        filename,
+        url,
+        version,
+        None if requires_python is None else sys.intern(requires_python),
+        has_metadata,
+        upload_time,
         hashes if isinstance(hashes, dict) else _hashes(hashes),
-        _count_or_none(size),
+        size,
         metadata_hash
         if isinstance(metadata_hash, dict)
         else _pair_or_none(metadata_hash),
@@ -263,47 +277,32 @@ def _decode_wheel(row: Sequence[object]) -> WheelFile:
 def _decode_sdist(row: Sequence[object]) -> SdistFile:
     """Rehydrate a source-distribution row; see :func:`_decode_wheel`."""
     _, filename, url, version, requires_python, upload_time, hashes, size = row
+
+    if (
+        type(filename) is not str
+        or type(url) is not str
+        or type(version) is not str
+        or (requires_python is not None and type(requires_python) is not str)
+        or (upload_time is not None and type(upload_time) is not str)
+        or (size is not None and type(size) is not int)
+    ):
+        raise _BadRowError
+
     return rehydrated_sdist(
-        _text(filename),
-        _text(url),
-        _text(version),
-        _interned_or_none(requires_python),
-        _text_or_none(upload_time),
+        filename,
+        url,
+        version,
+        None if requires_python is None else sys.intern(requires_python),
+        upload_time,
         hashes if isinstance(hashes, dict) else _hashes(hashes),
-        _count_or_none(size),
+        size,
     )
 
 
 # JSON hands back only its own types, so an exact type check is enough to keep a
-# hand-written or corrupt blob from reaching a record's fields. ``type() is``
-# rather than ``isinstance`` because ``bool`` is a subclass of ``int`` and the
-# two are not interchangeable in a record.
+# hand-written or corrupt blob from reaching a record's fields.
 def _text(value: object) -> str:
     if type(value) is not str:
-        raise _BadRowError
-    return value
-
-
-def _text_or_none(value: object) -> str | None:
-    return None if value is None else _text(value)
-
-
-def _interned_or_none(value: object) -> str | None:
-    # JSON builds a fresh string per occurrence, so interning here is what
-    # reproduces the dedup the wire parse leaves behind.
-    return None if value is None else sys.intern(_text(value))
-
-
-def _flag(value: object) -> bool:
-    if type(value) is not bool:
-        raise _BadRowError
-    return value
-
-
-def _count_or_none(value: object) -> int | None:
-    if value is None:
-        return None
-    if type(value) is not int:
         raise _BadRowError
     return value
 

--- a/nab-index/tests/test_parsed_listing_codec.py
+++ b/nab-index/tests/test_parsed_listing_codec.py
@@ -50,11 +50,21 @@ _SDIST_ROW_LEN = 8
 # Wheel row positions after the tag, for the field-check cases below.
 _W_FILENAME = 1
 _W_URL = 2
+_W_VERSION = 3
 _W_REQUIRES_PYTHON = 4
 _W_HAS_METADATA = 5
+_W_UPLOAD_TIME = 6
 _W_HASHES = 7
 _W_SIZE = 8
 _W_METADATA_HASH = 9
+
+# The same for an sdist row, which carries neither flag nor sidecar hash.
+_S_FILENAME = 1
+_S_URL = 2
+_S_VERSION = 3
+_S_REQUIRES_PYTHON = 4
+_S_UPLOAD_TIME = 5
+_S_SIZE = 7
 
 
 def _policy(digest: str | None = DIGEST) -> CachePolicy:
@@ -182,6 +192,13 @@ def _wheel_row_with(index: int, value: object) -> bytes:
     return _blob_with_rows(rows)
 
 
+def _sdist_row_with(index: int, value: object) -> bytes:
+    """A blob holding one sdist row with a single field replaced."""
+    _header, rows = json.loads(encode([SDIST_FULL], DIGEST))
+    rows[0][index] = value
+    return _blob_with_rows(rows)
+
+
 def test_valid_blob_decodes() -> None:
     assert decode(encode(SAMPLE, DIGEST), _policy()) is not None
 
@@ -263,10 +280,12 @@ def test_unknown_tag_on_a_well_formed_row_is_miss(tag: object) -> None:
         (_W_FILENAME, 12345),
         (_W_FILENAME, None),
         (_W_URL, None),
+        (_W_VERSION, 1.0),
         (_W_REQUIRES_PYTHON, 3),
         (_W_HAS_METADATA, "yes"),
         # bool is a subclass of int, so an int must not pass as a flag.
         (_W_HAS_METADATA, 1),
+        (_W_UPLOAD_TIME, 20230101),
         (_W_SIZE, "1024"),
         # ... nor a bool as a count.
         (_W_SIZE, True),
@@ -281,6 +300,25 @@ def test_unknown_tag_on_a_well_formed_row_is_miss(tag: object) -> None:
 def test_wrong_field_type_is_miss(index: int, value: object) -> None:
     """A field JSON allows but the record does not never reaches a record."""
     assert decode(_wheel_row_with(index, value), _policy()) is None
+
+
+@pytest.mark.parametrize(
+    ("index", "value"),
+    [
+        (_S_FILENAME, 12345),
+        (_S_URL, None),
+        (_S_VERSION, None),
+        (_S_REQUIRES_PYTHON, 3),
+        (_S_UPLOAD_TIME, 20230101),
+        (_S_SIZE, "10"),
+        # bool is a subclass of int here too.
+        (_S_SIZE, True),
+        (_S_SIZE, 1.5),
+    ],
+)
+def test_wrong_sdist_field_type_is_miss(index: int, value: object) -> None:
+    """An sdist row is checked on its own fields, not through the wheel's."""
+    assert decode(_sdist_row_with(index, value), _policy()) is None
 
 
 def test_absent_optional_fields_decode_as_none() -> None:


### PR DESCRIPTION
Checking a cached listing row's scalar fields in one expression, rather than calling a type-guard helper for each one, takes 269,656,727 instructions off `airflow:airflow-3-0-2-awswrangler --resolution lowest-direct`, 2.77% of that run's 9,744,948,371 (callgrind, `PYTHONHASHSEED=0`). A repeat of the same pair put it at 2.71%.

Stacked on #922, so the diff and the numbers here are against `opt/macro-decode-defer-slot-dance`.

That workload decodes 101,655 rows. A call count over it puts the guards at 881,922 of the run's 7,887,043 calls, 11.18%:

| function | before | after |
| --- | --- | --- |
| `_text` | 489,958 | 0 |
| `_text_or_none` | 101,655 | 0 |
| `_interned_or_none` | 101,655 | 0 |
| `_count_or_none` | 101,655 | 0 |
| `_flag` | 86,999 | 0 |

`_decode_row` (101,655), `_decode_wheel` (86,999), `_decode_sdist` (14,656) and `_decode_rows` (140) are called the same number of times either way, so nothing absorbed the removed calls.

Across the 19-scenario canary set the wall time is between about 0.5% and 5.8% lower locally, with a middle estimate near 1.2%, and CPU between about 0.6% and 2.3% lower. Peak memory sits inside about 0.14% either way, the smallest difference those runs could have seen.

Behaviour is the same: `sys.intern` still runs on `requires_python`, and a corrupt blob still misses, with `decode` returning `None` and `corruption_reason` naming the row shape. `_text` stays because `_pair` uses it.

The counts are exact and reproduce anywhere; the timings are off my machine.
