### PR TITLE
Keep urllib3 and truststore out of CLI startup, ~7.6% off `nab cache dir`

### DIFF
--- a/nab-index/src/nab_index/httpx_async_transport.py
+++ b/nab-index/src/nab_index/httpx_async_transport.py
@@ -10,7 +10,8 @@ from typing import TYPE_CHECKING, Any
 import httpx
 import truststore
 
-from .retry import MAX_REDIRECTS, MAX_RETRIES, RETRY_STATUSES, next_delay
+from .retry import next_delay
+from .retry_limits import MAX_REDIRECTS, MAX_RETRIES, RETRY_STATUSES
 from .transport import (
     DEFAULT_HEADERS,
     ContentDecodingError,

--- a/nab-index/src/nab_index/retry.py
+++ b/nab-index/src/nab_index/retry.py
@@ -16,25 +16,12 @@ import urllib3
 from typing_extensions import override
 from urllib3.exceptions import InvalidHeader
 
+from .retry_limits import MAX_REDIRECTS, MAX_RETRIES, RETRY_STATUSES
+
 __all__ = [
     "GET_RETRY",
-    "MAX_REDIRECTS",
-    "MAX_RETRIES",
-    "RETRY_STATUSES",
     "next_delay",
 ]
-
-MAX_RETRIES = 3
-"""Retries after the first attempt: ``GET_RETRY`` counts them per failure class;
-the transports' own retry loops count them across all failures."""
-
-MAX_REDIRECTS = 20
-"""Redirects followed per GET, matching httpx's default."""
-
-# A 408 says the server gave up waiting for the request (RFC 9110 15.5.9).
-# 520-524 and 527 are Cloudflare's transient origin errors, not the index's answer.
-RETRY_STATUSES = frozenset({408, 429, 500, 502, 503, 504, 520, 521, 522, 523, 524, 527})
-"""Statuses that are retried; any other status is served to the caller."""
 
 _BACKOFF_FACTOR = 0.25
 

--- a/nab-index/src/nab_index/retry_limits.py
+++ b/nab-index/src/nab_index/retry_limits.py
@@ -1,0 +1,25 @@
+"""Retry budgets and the statuses that are retried.
+
+Separate from :mod:`.retry` so :mod:`.transport` can classify a status without
+importing urllib3.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "MAX_REDIRECTS",
+    "MAX_RETRIES",
+    "RETRY_STATUSES",
+]
+
+MAX_RETRIES = 3
+"""Retries after the first attempt: :data:`~.retry.GET_RETRY` counts them per
+failure class; the transports' own retry loops count them across all failures."""
+
+MAX_REDIRECTS = 20
+"""Redirects followed per GET, matching httpx's default."""
+
+# A 408 says the server gave up waiting for the request (RFC 9110 15.5.9).
+# 520-524 and 527 are Cloudflare's transient origin errors, not the index's answer.
+RETRY_STATUSES = frozenset({408, 429, 500, 502, 503, 504, 520, 521, 522, 523, 524, 527})
+"""Statuses that are retried; any other status is served to the caller."""

--- a/nab-index/src/nab_index/transport.py
+++ b/nab-index/src/nab_index/transport.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any, Final, Protocol
 
 from nab_provider.errors import HttpError, UnserveableUrlError
 
-from .retry import RETRY_STATUSES
+from .retry_limits import RETRY_STATUSES
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -195,9 +195,10 @@ class AsyncHttpTransport(Protocol):
 def raise_for_error_status(status: int, url: str) -> None:
     """Raise :class:`HttpError` for a 4xx/5xx ``status``.
 
-    A client error outside :data:`~nab_index.retry.RETRY_STATUSES` raises the
-    :class:`UnserveableUrlError` subclass: the retry policy calls those the
-    index's answer rather than a blip, so they name the URL, not the moment.
+    A client error outside :data:`~nab_index.retry_limits.RETRY_STATUSES`
+    raises the :class:`UnserveableUrlError` subclass: the retry policy calls
+    those the index's answer rather than a blip, so they name the URL, not the
+    moment.
     """
     if status < _HTTP_BAD_REQUEST:
         return

--- a/nab-index/src/nab_index/urllib3_async_transport.py
+++ b/nab-index/src/nab_index/urllib3_async_transport.py
@@ -20,7 +20,8 @@ import truststore
 import urllib3
 from typing_extensions import override
 
-from .retry import GET_RETRY, MAX_RETRIES, next_delay
+from .retry import GET_RETRY, next_delay
+from .retry_limits import MAX_RETRIES
 from .transport import (
     DEFAULT_HEADERS,
     ContentDecodingError,

--- a/nab-index/tests/test_lazy_wheel.py
+++ b/nab-index/tests/test_lazy_wheel.py
@@ -1188,7 +1188,7 @@ def test_reject_416_does_not_latch_netloc() -> None:
 def test_reject_statuses_disjoint_from_transport_retries() -> None:
     """A refused range must come back on the first answer, never retried."""
     from nab_index.lazy_wheel import _RANGE_REJECT_STATUSES
-    from nab_index.retry import RETRY_STATUSES
+    from nab_index.retry_limits import RETRY_STATUSES
 
     assert _RANGE_REJECT_STATUSES.isdisjoint(RETRY_STATUSES)
 

--- a/nab-project/tests/test_async_transports.py
+++ b/nab-project/tests/test_async_transports.py
@@ -37,13 +37,8 @@ from nab_index.client import (
     _extract_sdist_files,
 )
 from nab_index.httpx_async_transport import HttpxAsyncTransport, _HttpxResponse
-from nab_index.retry import (
-    GET_RETRY,
-    MAX_REDIRECTS,
-    MAX_RETRIES,
-    RETRY_STATUSES,
-    next_delay,
-)
+from nab_index.retry import GET_RETRY, next_delay
+from nab_index.retry_limits import MAX_REDIRECTS, MAX_RETRIES, RETRY_STATUSES
 from nab_index.transport import (
     DEFAULT_HEADERS,
     IDENTITY_HEADERS,

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -27,7 +27,6 @@ import tyro
 from tyro.extras import SubcommandApp
 
 from nab._version import __version__
-from nab_index.urllib3_async_transport import Urllib3AsyncTransport
 from nab_project.config import (
     ConfigError,
     NabProjectConfig,
@@ -157,8 +156,12 @@ def printer() -> Printer:
 
 
 def _make_transport(backend: HttpBackend) -> AsyncHttpTransport:
-    # httpx is an optional extra; import lazily so a urllib3-only
-    # install doesn't need it.
+    """Return the transport for ``backend``.
+
+    Importing either transport module loads its HTTP library and truststore,
+    so both imports stay local: the CLI itself needs neither, and httpx is an
+    optional extra a urllib3-only install will not have.
+    """
     if backend == "httpx":
         try:
             from nab_index.httpx_async_transport import (  # noqa: PLC0415
@@ -177,6 +180,10 @@ def _make_transport(backend: HttpBackend) -> AsyncHttpTransport:
                 "run `pip install nab[httpx]`"
             )
             sys.exit(1)
+
+    from nab_index.urllib3_async_transport import (  # noqa: PLC0415
+        Urllib3AsyncTransport,
+    )
 
     return Urllib3AsyncTransport()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,6 +16,7 @@ import logging
 import re
 import runpy
 import stat
+import subprocess
 import sys
 import tarfile
 import zipfile
@@ -5579,6 +5580,27 @@ class TestMakeTransport:
         assert "nab[httpx]" in err
         assert "HTTP/2" in err
         assert "httpx is not installed" not in err
+
+
+_HTTP_LIBRARY_PROBE = """
+import sys
+
+import nab.cli
+
+roots = {name.partition(".")[0] for name in sys.modules}
+leaked = sorted(roots & {"truststore", "urllib3"})
+assert not leaked, f"importing nab.cli loaded {leaked}"
+"""
+
+
+class TestCliImportPath:
+    """What importing :mod:`nab.cli` is allowed to pull in."""
+
+    def test_urllib3_and_truststore_stay_unimported(self) -> None:
+        """Neither library belongs on the path of a command that never fetches."""
+        subprocess.run(  # noqa: S603 - the probe is this file's own source
+            [sys.executable, "-c", _HTTP_LIBRARY_PROBE], check=True
+        )
 
 
 class TestDownloadCommand:


### PR DESCRIPTION
`nab cache dir` runs 82,037,457 fewer instructions, 7.6% of the 1,083,734,663 it costs on main (callgrind, `PYTHONHASHSEED=0`, base c7e5c979). Repeat counts of that command put the saving between 82,023,835 and 82,037,457, so it reproduces to about 0.003% rather than to the digit.

Every command paid for the HTTP stack, including the ones that never open a socket:

- `nab.cli` imported `Urllib3AsyncTransport` at module scope, which pulls in urllib3 and truststore. That import now sits in `_make_transport`, beside the httpx import that was already local.
- `transport.py` needs `RETRY_STATUSES` only to classify a status, so `MAX_RETRIES`, `MAX_REDIRECTS` and `RETRY_STATUSES` move to a new `nab_index.retry_limits` that pulls in no libraries. `retry.py` keeps `GET_RETRY` and the backoff and still owns the urllib3 import.

`sys.modules` after `nab cache dir` holds 429 entries instead of 465: main loaded 27 urllib3 modules and 4 truststore modules, and now loads neither. A subprocess check imports `nab.cli` and fails if either turns up.

The counts above reproduce anywhere; the timings are off my machine. The same command runs between about 3% and 9% faster over 12 paired runs, with a middle estimate near 7%, and peak memory drops about 1.4 MB from roughly 37 MB.

A command that fetches still pays for both libraries, just later. `nab lock` of a one-dependency project against a warm cache runs 452,743 fewer instructions, 0.036% of its 1,273,858,949.
