### PR TITLE
Stop copying both solution maps per decision, ~0.6% off a langchain resolve

### DIFF
--- a/nab-provider/src/nab_provider/provider.py
+++ b/nab-provider/src/nab_provider/provider.py
@@ -1747,14 +1747,13 @@ class Provider:
         positive_ranges: Mapping[str, RangeProtocol[Version]],
         decisions: Mapping[str, Version],
     ) -> None:
-        """Accept a snapshot of the resolver's positive-range assignments.
+        """Accept a snapshot of the resolver's positive ranges and decisions.
 
         Decision-only forward checking is safer than reasoning over
         derivations because backjumping a decision also undoes its derivations.
 
-        The caller hands over fresh snapshots it does not retain or mutate, so
-        we store them directly. We only ever read these maps, never mutate them
-        in place; both are reassigned wholesale on the next hint.
+        Both maps are read-only and pinned to the moment the caller took them,
+        so storing the references is enough.
         """
         self.solution_ranges = positive_ranges
         self.solution_decisions = decisions

--- a/nab-resolver/src/nab_resolver/partial_solution.py
+++ b/nab-resolver/src/nab_resolver/partial_solution.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast, overload
 from weakref import ref
 
+from ._compat import override
 from .ranges import Range
 from .types import PackageType, RangeProtocol, VersionType
 
@@ -57,7 +58,9 @@ class _Snapshot(Mapping[PackageType, _ValueType]):
 
     def __init__(self, live: dict[PackageType, _ValueType]) -> None:
         self._live = live
-        self._shadow: dict[PackageType, _ValueType | object] = {}
+        # A value or _ABSENT. Any rather than that union, which no checker
+        # narrows the sentinel back out of.
+        self._shadow: dict[PackageType, Any] = {}
 
     def freeze(self, package: PackageType) -> None:
         """Keep the package's current value before the live map moves on."""
@@ -79,6 +82,7 @@ class _Snapshot(Mapping[PackageType, _ValueType]):
         self._live = frozen
         self._shadow = {}
 
+    @override
     def __getitem__(self, package: PackageType) -> _ValueType:
         frozen = self._shadow.get(package, _UNSET)
         if frozen is _UNSET:
@@ -87,14 +91,17 @@ class _Snapshot(Mapping[PackageType, _ValueType]):
             raise KeyError(package)
         return cast("_ValueType", frozen)
 
+    # ``object`` rather than ``PackageType``: narrowing the key would not
+    # substitute for ``Mapping.get``.
     @overload
-    def get(self, package: PackageType, /) -> _ValueType | None: ...
+    def get(self, package: object, /) -> _ValueType | None: ...
     @overload
     def get(
-        self, package: PackageType, /, default: _ValueType | _DefaultType
+        self, package: object, /, default: _ValueType | _DefaultType
     ) -> _ValueType | _DefaultType: ...
+    @override
     def get(
-        self, package: PackageType, /, default: _ValueType | _DefaultType | None = None
+        self, package: Any, /, default: _ValueType | _DefaultType | None = None
     ) -> _ValueType | _DefaultType | None:
         """Return the package's value as of the snapshot, else ``default``.
 
@@ -108,12 +115,14 @@ class _Snapshot(Mapping[PackageType, _ValueType]):
             return default
         return cast("_ValueType", frozen)
 
+    @override
     def __contains__(self, package: object) -> bool:
         frozen = self._shadow.get(cast("PackageType", package), _UNSET)
         if frozen is _UNSET:
             return package in self._live
         return frozen is not _ABSENT
 
+    @override
     def __iter__(self) -> Iterator[PackageType]:
         """Yield the snapshot's packages, in the order the live map holds them.
 
@@ -126,6 +135,7 @@ class _Snapshot(Mapping[PackageType, _ValueType]):
             if shadow.get(package, _UNSET) is not _ABSENT:
                 yield package
 
+    @override
     def __len__(self) -> int:
         return sum(1 for _ in self)
 

--- a/nab-resolver/src/nab_resolver/partial_solution.py
+++ b/nab-resolver/src/nab_resolver/partial_solution.py
@@ -15,14 +15,16 @@ Reference: https://github.com/dart-lang/pub/blob/master/doc/solver.md#partial-so
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Generic, cast
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast, overload
+from weakref import ref
 
 from .ranges import Range
 from .types import PackageType, RangeProtocol, VersionType
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Iterator, Sequence
 
     from .types import Incompatibility, Term
 
@@ -33,8 +35,123 @@ __all__ = [
 ]
 
 
-# Distinguishes "cached miss" from a legitimate cached None.
+# Marks a missing map entry, where None can itself be the stored value.
 _UNSET = object()
+
+# Marks a package that the live map did not hold when a snapshot was taken.
+_ABSENT = object()
+
+_ValueType = TypeVar("_ValueType")
+_DefaultType = TypeVar("_DefaultType")
+
+
+class _Snapshot(Mapping[PackageType, _ValueType]):
+    """A read-only view of one of the solution's maps, pinned to one moment.
+
+    Reads fall through to the live map, so nothing is copied up front.
+    Before the solution changes a package's entry it calls :meth:`freeze`,
+    which records the value this view has to keep.
+    """
+
+    __slots__ = ("__weakref__", "_live", "_shadow")
+
+    def __init__(self, live: dict[PackageType, _ValueType]) -> None:
+        self._live = live
+        self._shadow: dict[PackageType, _ValueType | object] = {}
+
+    def freeze(self, package: PackageType) -> None:
+        """Keep the package's current value before the live map moves on."""
+        if package not in self._shadow:
+            self._shadow[package] = self._live.get(package, _ABSENT)
+
+    def detach(self) -> None:
+        """Take a copy of the live map, so later changes need no freezing.
+
+        Backtracking rewrites most of the map at once, where one copy beats
+        recording each package on its way out.
+        """
+        frozen = dict(self._live)
+        for package, value in self._shadow.items():
+            if value is _ABSENT:
+                frozen.pop(package, None)
+            else:
+                frozen[package] = value
+        self._live = frozen
+        self._shadow = {}
+
+    def __getitem__(self, package: PackageType) -> _ValueType:
+        frozen = self._shadow.get(package, _UNSET)
+        if frozen is _UNSET:
+            return self._live[package]
+        if frozen is _ABSENT:
+            raise KeyError(package)
+        return cast("_ValueType", frozen)
+
+    @overload
+    def get(self, package: PackageType, /) -> _ValueType | None: ...
+    @overload
+    def get(
+        self, package: PackageType, /, default: _ValueType | _DefaultType
+    ) -> _ValueType | _DefaultType: ...
+    def get(
+        self, package: PackageType, /, default: _ValueType | _DefaultType | None = None
+    ) -> _ValueType | _DefaultType | None:
+        """Return the package's value as of the snapshot, else ``default``.
+
+        Defined rather than inherited: ``Mapping.get`` routes every read
+        through ``__getitem__``, and every miss through a raised ``KeyError``.
+        """
+        frozen = self._shadow.get(package, _UNSET)
+        if frozen is _UNSET:
+            return self._live.get(package, default)
+        if frozen is _ABSENT:
+            return default
+        return cast("_ValueType", frozen)
+
+    def __contains__(self, package: object) -> bool:
+        frozen = self._shadow.get(cast("PackageType", package), _UNSET)
+        if frozen is _UNSET:
+            return package in self._live
+        return frozen is not _ABSENT
+
+    def __iter__(self) -> Iterator[PackageType]:
+        """Yield the snapshot's packages, in the order the live map holds them.
+
+        Freezing leaves a package where it is, and the only path that removes
+        one is ``backtrack``, which detaches first, so the live map still holds
+        every key of the snapshot in the order it arrived.
+        """
+        shadow = self._shadow
+        for package in self._live:
+            if shadow.get(package, _UNSET) is not _ABSENT:
+                yield package
+
+    def __len__(self) -> int:
+        return sum(1 for _ in self)
+
+
+def _take_snapshot(
+    live: dict[PackageType, _ValueType],
+    holders: list[ref[_Snapshot[PackageType, _ValueType]]],
+) -> _Snapshot[PackageType, _ValueType]:
+    """Snapshot ``live`` and hold a weak reference to it in ``holders``.
+
+    Entries whose snapshot the caller has since released are dropped on the way.
+    """
+    snapshot = _Snapshot(live)
+    holders[:] = [holder for holder in holders if holder() is not None]
+    holders.append(ref(snapshot))
+    return snapshot
+
+
+def _detach_snapshots(
+    holders: list[ref[_Snapshot[PackageType, _ValueType]]],
+) -> None:
+    """Detach every outstanding snapshot from the map it reads through."""
+    for holder in holders:
+        snapshot = holder()
+        if snapshot is not None:
+            snapshot.detach()
 
 
 @dataclass(slots=True)
@@ -116,6 +233,12 @@ class PartialSolution(Generic[PackageType, VersionType]):
             PackageType, list[Assignment[PackageType, VersionType]]
         ] = defaultdict(list)
 
+        # Weak references to the snapshots still outstanding.
+        self._range_snapshots: list[
+            ref[_Snapshot[PackageType, RangeProtocol[VersionType]]]
+        ] = []
+        self._decision_snapshots: list[ref[_Snapshot[PackageType, VersionType]]] = []
+
     @property
     def decision_level(self) -> int:
         """Return the current decision depth."""
@@ -190,6 +313,8 @@ class PartialSolution(Generic[PackageType, VersionType]):
         self._decision_level += 1
         exact_range = self._range_type.singleton(version)
 
+        self._freeze_ranges(package)
+        self._freeze_decisions(package)
         self._positive_ranges[package] = exact_range
         self._decided_versions[package] = version
         self._refresh_effective_range(package)
@@ -227,6 +352,7 @@ class PartialSolution(Generic[PackageType, VersionType]):
                 new_range = self._positive_ranges[package] & constraint
             else:
                 new_range = self._range_type.full() & constraint
+            self._freeze_ranges(package)
             self._positive_ranges[package] = new_range
             if package not in self._decided_versions:
                 self._undecided.add(package)
@@ -264,6 +390,8 @@ class PartialSolution(Generic[PackageType, VersionType]):
         See: https://github.com/dart-lang/pub/blob/master/doc/solver.md#conflict-resolution
         """
         self._contradiction_epoch += 1
+        _detach_snapshots(self._range_snapshots)
+        _detach_snapshots(self._decision_snapshots)
 
         # Trail levels never decrease, so this pops exactly the assignments above
         # target_level; every other package keeps the positive and negative ranges
@@ -337,9 +465,26 @@ class PartialSolution(Generic[PackageType, VersionType]):
         else:
             self._undecided.discard(package)
 
-    def decisions(self) -> dict[PackageType, VersionType]:
-        """Return the current decision map: ``{package: version}``."""
-        return dict(self._decided_versions)
+    def decisions(self) -> Mapping[PackageType, VersionType]:
+        """Return the decision map ``{package: version}``.
+
+        Read-only, and pinned: later decisions and backtracking do not reach it.
+        """
+        return _take_snapshot(self._decided_versions, self._decision_snapshots)
+
+    def _freeze_decisions(self, package: PackageType) -> None:
+        """Preserve the package's decided version in outstanding snapshots."""
+        for holder in self._decision_snapshots:
+            snapshot = holder()
+            if snapshot is not None:
+                snapshot.freeze(package)
+
+    def _freeze_ranges(self, package: PackageType) -> None:
+        """Preserve the package's positive range in outstanding snapshots."""
+        for holder in self._range_snapshots:
+            snapshot = holder()
+            if snapshot is not None:
+                snapshot.freeze(package)
 
     def take_changed_packages(self) -> set[PackageType]:
         """Return the packages whose state moved since the last call, and reset.
@@ -364,9 +509,12 @@ class PartialSolution(Generic[PackageType, VersionType]):
         """Return True if the package has a positive constraint or decision."""
         return package in self._positive_ranges or package in self._decided_versions
 
-    def positive_ranges(self) -> dict[PackageType, RangeProtocol[VersionType]]:
-        """Return a copy of the positive-range map for each package."""
-        return dict(self._positive_ranges)
+    def positive_ranges(self) -> Mapping[PackageType, RangeProtocol[VersionType]]:
+        """Return each package's positive range.
+
+        Read-only, and pinned: later derivations and backtracking do not reach it.
+        """
+        return _take_snapshot(self._positive_ranges, self._range_snapshots)
 
     def positive_range(self, package: PackageType) -> RangeProtocol[VersionType] | None:
         """Return the package's accumulated positive range, or None if unset."""

--- a/nab-resolver/tests/test_partial_solution.py
+++ b/nab-resolver/tests/test_partial_solution.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import gc
+
+import pytest
+
 from nab_resolver.partial_solution import PartialSolution
 from nab_resolver.ranges import Range
 from nab_resolver.types import Incompatibility, IncompatibilityCause, Term
@@ -386,3 +390,137 @@ class TestContradictionEpoch:
         assert effective is not None
         assert effective.is_empty
         assert ps.contradiction_epoch == 1
+
+
+class TestSnapshots:
+    """A map handed out keeps reading as it did when it was taken."""
+
+    def test_a_snapshot_does_not_show_a_later_decision(self) -> None:
+        ps = PartialSolution()
+        ps.decide("foo", 3)
+        snapshot = ps.decisions()
+
+        ps.decide("bar", 1)
+
+        assert dict(snapshot) == {"foo": 3}
+        assert len(snapshot) == 1
+        assert "bar" not in snapshot
+        assert snapshot.get("bar") is None
+        assert snapshot.get("bar", 9) == 9
+
+        assert "foo" in snapshot
+        assert snapshot.get("foo") == 3
+        assert snapshot["foo"] == 3
+
+    def test_reading_a_package_the_snapshot_never_held(self) -> None:
+        ps = PartialSolution()
+        snapshot = ps.decisions()
+
+        ps.decide("foo", 3)
+
+        assert dict(snapshot) == {}
+        assert len(snapshot) == 0
+        with pytest.raises(KeyError):
+            snapshot["foo"]
+
+    def test_positive_ranges_keep_the_range_they_were_taken_with(self) -> None:
+        ps = PartialSolution()
+        inc = Incompatibility([], cause=IncompatibilityCause.ROOT)
+        ps.derive("foo", Range.at_least(1), positive=True, cause=inc)
+        snapshot = ps.positive_ranges()
+        taken_with = snapshot["foo"]
+
+        ps.derive("foo", Range.at_most(5), positive=True, cause=inc)
+        ps.derive("foo", Range.at_most(4), positive=True, cause=inc)
+
+        assert snapshot["foo"] is taken_with
+        assert snapshot.get("foo") is taken_with
+        assert list(snapshot) == ["foo"]
+        assert ps.positive_ranges()["foo"] != taken_with
+
+        ps.backtrack(0)
+
+        assert snapshot.get("foo") is taken_with
+
+    def test_backtracking_leaves_the_snapshot_alone(self) -> None:
+        ps = PartialSolution()
+        ps.decide("foo", 3)
+        ps.decide("bar", 1)
+        snapshot = ps.decisions()
+
+        ps.backtrack(1)
+        ps.decide("baz", 7)
+
+        assert dict(snapshot) == {"foo": 3, "bar": 1}
+        assert snapshot["bar"] == 1
+        assert "baz" not in snapshot
+
+    def test_backtracking_does_not_resurrect_a_package(self) -> None:
+        """A package absent when the snapshot was taken stays absent."""
+        ps = PartialSolution()
+        snapshot = ps.decisions()
+        ps.decide("foo", 3)
+
+        ps.backtrack(0)
+        ps.decide("foo", 4)
+
+        assert dict(snapshot) == {}
+        assert "foo" not in snapshot
+
+    def test_two_outstanding_snapshots_hold_their_own_state(self) -> None:
+        ps = PartialSolution()
+        ps.decide("foo", 3)
+        first = ps.decisions()
+        ps.decide("bar", 1)
+        second = ps.decisions()
+
+        ps.decide("baz", 7)
+
+        assert dict(first) == {"foo": 3}
+        assert dict(second) == {"foo": 3, "bar": 1}
+
+    def test_a_frozen_package_keeps_its_place_in_the_order(self) -> None:
+        ps = PartialSolution()
+        ps.decide("foo", 3)
+        ps.decide("bar", 1)
+        snapshot = ps.decisions()
+
+        assert list(snapshot) == ["foo", "bar"]
+
+        ps.decide("foo", 4)
+
+        assert list(snapshot) == ["foo", "bar"]
+        assert list(dict(snapshot)) == ["foo", "bar"]
+
+    def test_a_detached_snapshot_reads_as_of_its_own_moment(self) -> None:
+        ps = PartialSolution()
+        ps.decide("foo", 3)
+        ps.decide("bar", 1)
+        snapshot = ps.decisions()
+
+        ps.backtrack(1)
+        ps.decide("baz", 7)
+        ps.decide("foo", 4)
+
+        assert dict(snapshot) == {"foo": 3, "bar": 1}
+        assert list(snapshot) == ["foo", "bar"]
+        assert len(snapshot) == 2
+        assert snapshot["foo"] == 3
+        assert "baz" not in snapshot
+
+    def test_a_released_snapshot_drops_out_of_the_register(self) -> None:
+        """Freezing, detaching and taking all step over a dead reference."""
+        ps = PartialSolution()
+        ps.decide("foo", 3)
+        dropped = ps.decisions()
+        kept = ps.positive_ranges()
+        del dropped
+        gc.collect()
+
+        ps.decide("bar", 1)
+        ps.backtrack(1)
+        latest = ps.decisions()
+
+        assert len(ps._decision_snapshots) == 1
+        assert dict(latest) == {"foo": 3}
+        assert list(kept) == ["foo"]


### PR DESCRIPTION
198,779,457 instructions off `pip:langchain-ml-course --resolution lowest`, 35,018,701,585 down to 34,819,922,128, or 0.57% of the run. That is callgrind with the hash seed pinned, and both counted runs made the same 10,218 decisions, 156 conflicts and 16,946 derivations. Repeat counts of the base commit spread about 0.045% on this scenario, so read the size as roughly 0.6% rather than to the third digit.

Choosing a version hands the provider a hint, and building that hint copied both whole solution maps. Over one run of the same scenario:

- 2,038,041 entries copied, across 20,149 calls
- 43,638 reads back out, almost all `get` on a single key

`positive_ranges()` and `decisions()` now return a read-only view that reads through to the live map. The solution keeps a weak reference to each view it has handed out and names the package about to change, so the view keeps that entry's current value and goes on reading as it did when it was taken. Backtracking rewrites most of the map at once, so it copies into each outstanding view once instead of recording package by package.

The clock cannot see a change this size. Twelve runs of the scenario on each side, alternating between them, rule out a wall regression above about 4% and a CPU regression above about 1%, and put peak resident memory inside about 0.13% either way. Those bounds are off my machine.
