### PR TITLE
Fix build-remote crash on an sdist whose pyproject will not parse

### DIFF
--- a/nab-project/src/nab_project/fetch.py
+++ b/nab-project/src/nab_project/fetch.py
@@ -1165,15 +1165,17 @@ class FetchCoordinator:
         self.index.store_sdist_metadata(req.package, req.version, pkg_info)
 
     def _release_archive_if_deps_are_static(
-        self, package: str, version: str, table: Mapping[str, Any]
+        self, package: str, version: str, table: Mapping[str, Any] | None
     ) -> None:
         """Release a held archive when ``table`` already declares the deps.
 
         The hold exists for a build, and the metadata ladder builds only when
         the bundled ``[project]`` table cannot supply the dependencies, so a
-        table that can means no build will ask for this archive.
+        table that can means no build will ask for this archive.  A ``None``
+        table is a pyproject that did not parse and declares nothing, so the
+        archive stays held.
         """
-        if self._sdist_archive_hold is None:
+        if self._sdist_archive_hold is None or table is None:
             return
         if static_project_from_table(table) is not None:
             self._sdist_archive_hold.take(package, version)

--- a/nab-project/tests/test_fetch.py
+++ b/nab-project/tests/test_fetch.py
@@ -3917,6 +3917,22 @@ class TestSdistArchiveHolding:
 
         assert hold.take("pkg", "1.0") == b"archive bytes"
 
+    def test_an_unparseable_pyproject_keeps_the_archive_and_the_pkg_info(self) -> None:
+        """A pyproject that will not parse reads as one the sdist never shipped.
+
+        The source here starts with a UTF-8 BOM, which tomli rejects.
+        """
+        config = NabProjectConfig(build_policy=BuildPolicy.BUILD_REMOTE)
+        coord, hold = self._fetched_with_pyproject(
+            '\ufeff[project]\nname = "pkg"\ndependencies = []\n', config
+        )
+
+        assert hold.take("pkg", "1.0") == b"archive bytes"
+        assert coord.index.get_sdist_pyproject("pkg", "1.0") is None
+        assert coord.index.get_metadata("pkg", "1.0") == (
+            "Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\n"
+        )
+
     def test_a_resolve_that_holds_nothing_still_stores_the_pyproject(self) -> None:
         """The release is skipped when there is no hold to release from."""
         coord, hold = self._fetched_with_pyproject(


### PR DESCRIPTION
A `build-policy = "build-remote"` resolve dies with a raw AttributeError as soon as it fetches an sdist bundling a pyproject.toml that TOML will not parse:

    AttributeError: 'NoneType' object has no attribute 'get'

`_fetch_sdist` passes `parse_pyproject_table`'s result straight into `_release_archive_if_deps_are_static`, which hands it to `static_project_from_table`. An unparseable pyproject makes that result `None` and `static_project_from_table` calls `.get` on it. A leading UTF-8 BOM is enough to get there.

The crash is recorded as an sdist fetch failure and re-raised, so the resolve aborts, and the PKG-INFO the same fetch had already read never reaches the index.

`_release_archive_if_deps_are_static` now returns early on a `None` table, leaving the archive held for the build that will need it. `load_static_project` already reads an unparseable pyproject the same way, as one that declares nothing.
