### PR TITLE
Prefetch one sidecar per listing, 32% off airflow's cold metadata requests

### DIFF
--- a/nab-project/src/nab_project/fetch.py
+++ b/nab-project/src/nab_project/fetch.py
@@ -197,7 +197,7 @@ class FetchCoordinator:
             ...
     """
 
-    PREFETCH_METADATA_COUNT = 2
+    PREFETCH_METADATA_COUNT = 1
 
     def __init__(  # noqa: PLR0913 - the per-index knobs a coordinator wires up
         self,

--- a/nab-project/tests/test_fetch.py
+++ b/nab-project/tests/test_fetch.py
@@ -693,7 +693,7 @@ class TestFetchCoordinator:
         listing = {
             "meta": {"api-version": "1.0"},
             "name": "pkg",
-            # Oldest-first; the prefetch takes the newest wheels.
+            # Oldest-first; the prefetch takes the newest wheel.
             "files": [
                 {
                     "filename": "pkg-1.0-py3-none-any.whl",
@@ -774,33 +774,38 @@ class TestFetchCoordinator:
                 time.sleep(0.01)
             assert coord.index.has_metadata("pkg", "15.0", sidecar)
 
-        # The newest PREFETCH_METADATA_COUNT wheels, not all 15.
-        assert derived == [f"pkg-{n}.0-py3-none-any.whl" for n in range(14, 16)]
+        # Only the newest version's wheel, not all 15.
+        assert derived == ["pkg-15.0-py3-none-any.whl"]
 
-    def test_prefetch_after_listing_enqueues_newest_batch(
+    def test_prefetch_after_listing_enqueues_the_newest_version(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The extracted tail picks the newest N, one wheel per version."""
+        """The extracted tail picks the newest version's first sidecar wheel."""
 
-        def _wheel(version: str, *, has_meta: bool = True) -> WheelFile:
+        def _wheel(
+            version: str, *, build: str = "", has_meta: bool = True
+        ) -> WheelFile:
+            """A wheel for ``version``; ``build`` also varies the sidecar hash."""
+            tag = f"-{build}" if build else ""
+            name = f"pkg-{version}{tag}-py3-none-any.whl"
             return WheelFile(
-                filename=f"pkg-{version}-py3-none-any.whl",
-                url=f"https://f.com/pkg-{version}-py3-none-any.whl",
+                filename=name,
+                url=f"https://f.com/{name}",
                 version=version,
                 requires_python=None,
                 has_metadata=has_meta,
                 upload_time=None,
-                metadata_hash=("sha256", f"h{version}") if has_meta else None,
+                metadata_hash=("sha256", f"h{version}{tag}") if has_meta else None,
             )
 
-        # Oldest-first, more versions than PREFETCH_METADATA_COUNT, plus a
-        # second wheel for one version (first-with-sidecar wins), a
-        # sidecar-less wheel, and an sdist that the tail must skip.
+        # Oldest-first, with more versions than the prefetch takes.
         files: list[WheelFile | SdistFile] = []
         for n in range(1, 16):
             files.append(_wheel(f"{n}.0"))
-        files.append(_wheel("15.0"))  # duplicate version, must not re-enqueue
-        files.append(_wheel("16.0", has_meta=False))  # no sidecar, skipped
+
+        # The three the tail must pass over.
+        files.append(_wheel("15.0", build="1"))  # second wheel of 15.0
+        files.append(_wheel("16.0", has_meta=False))  # no sidecar
         files.append(
             SdistFile(
                 filename="pkg-17.0.tar.gz",
@@ -823,16 +828,14 @@ class TestFetchCoordinator:
         monkeypatch.setattr(coord, "request_metadata", _spy)
         coord._prefetch_metadata_after_listing("pkg", files)
 
-        expected = [
+        assert calls == [
             (
                 "pkg",
-                f"{n}.0",
-                f"https://f.com/pkg-{n}.0-py3-none-any.whl.metadata",
-                ("sha256", f"h{n}.0"),
+                "15.0",
+                "https://f.com/pkg-15.0-py3-none-any.whl.metadata",
+                ("sha256", "h15.0"),
             )
-            for n in range(14, 16)
         ]
-        assert calls == expected
 
     @respx.mock
     def test_listing_entry_with_unsplittable_url_is_dropped(self) -> None:
@@ -874,12 +877,17 @@ class TestFetchCoordinator:
         assert [f.version for f in files] == ["2.0", "3.0"]
         assert coord.index.get_listing_error("pkg") is None
 
-        for version in ("2.0", "3.0"):
-            sidecar = f"https://f.com/pkg-{version}-py3-none-any.whl.metadata"
-            _, prefetched = coord.index.get_or_create_pending(
-                f"metadata:pkg:{version}:{sidecar}"
-            )
-            assert prefetched
+        newest = "https://f.com/pkg-3.0-py3-none-any.whl.metadata"
+        _, newest_prefetched = coord.index.get_or_create_pending(
+            f"metadata:pkg:3.0:{newest}"
+        )
+        assert newest_prefetched
+
+        older = "https://f.com/pkg-2.0-py3-none-any.whl.metadata"
+        _, older_prefetched = coord.index.get_or_create_pending(
+            f"metadata:pkg:2.0:{older}"
+        )
+        assert not older_prefetched
 
     @respx.mock
     def test_fetch_error_logged_not_raised(self) -> None:
@@ -3654,7 +3662,7 @@ class TestWarmSyncTailOffload:
 
     @respx.mock
     def test_sync_hit_runs_tail_off_the_caller_thread(self, tmp_path: Path) -> None:
-        """The newest-N selection walk executes on the fetcher thread only."""
+        """The newest-version selection walk executes on the fetcher thread only."""
         cache = OnDiskCache(tmp_path, _PYPI)
         files: list[WheelFile | SdistFile] = [_sync_wheel("1.0"), _sync_wheel("2.0")]
         _warm_parsed(cache, "pkg", files)
@@ -3700,7 +3708,7 @@ class TestWarmSyncTailOffload:
 
     @respx.mock
     def test_offloaded_tail_prefetches_metadata(self, tmp_path: Path) -> None:
-        """The offloaded tail enqueues the newest-N metadata and it lands."""
+        """The offloaded tail enqueues the newest version's metadata and it lands."""
         respx.get(url__regex=r".*\.whl\.metadata$").mock(
             return_value=httpx.Response(200, text="Metadata-Version: 2.1\n")
         )
@@ -3727,19 +3735,15 @@ class TestWarmSyncTailOffload:
                 for item in calls
                 if isinstance(item, FetchRequest) and item.kind is FetchKind.METADATA
             }
-            assert meta_submits == {
-                ("pkg", "1.0", "https://f.example/pkg-1.0-py3-none-any.whl.metadata"),
-                ("pkg", "2.0", "https://f.example/pkg-2.0-py3-none-any.whl.metadata"),
-            }
+            sidecar = "https://f.example/pkg-2.0-py3-none-any.whl.metadata"
+            assert meta_submits == {("pkg", "2.0", sidecar)}
 
-            for version in ("1.0", "2.0"):
-                sidecar = f"https://f.example/pkg-{version}-py3-none-any.whl.metadata"
-                deadline = time.monotonic() + 5
-                while time.monotonic() < deadline and not coord.index.has_metadata(
-                    "pkg", version, sidecar
-                ):
-                    time.sleep(0.01)
-                assert coord.index.has_metadata("pkg", version, sidecar)
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline and not coord.index.has_metadata(
+                "pkg", "2.0", sidecar
+            ):
+                time.sleep(0.01)
+            assert coord.index.has_metadata("pkg", "2.0", sidecar)
 
     @respx.mock
     def test_dead_loop_runs_tail_inline(self, tmp_path: Path) -> None:


### PR DESCRIPTION
On a cold cache against real PyPI, `airflow:airflow-3-0-2-awswrangler --resolution lowest-direct` issues 268 metadata requests where main issues 395, and the number never read falls from 249 to 128. Listing requests stay at 140 and the pins are identical on all 25 runs of the scenario, so the requests are dropped rather than deferred.

Cold CPU on that scenario is about 7% lower locally, between about 4.5% and 8%, medians 3.69s to 3.43s. Peak RSS over the 19-scenario canary set is about 1.3% lower, between about 1.2% and 1.4%.

The change is one constant. When a listing arrives, the fetch coordinator now asks for the sidecar METADATA of the newest version only, not the two newest.

Most of what that prefetch asks for is never read. Counting which requester filled each stored metadata slot on a warm `airflow-3-0-2-awswrangler --resolution highest` resolve, it filled 280 slots and 32 of them were read, while `prefetch_transitive_best`, which does see the resolution strategy, had 99 of its 105 read. The same 280 and 32 appear under `lowest-direct`, and `ai-stack:vllm-transformers-floor --resolution highest` reads 17 of 265, so the miss rate is the code and not one strategy.

Cold-cache counts from the airflow scenario's 145-decision runs, its most common outcome, identical on every one of them:

| | main | branch |
| --- | --- | --- |
| Metadata requests issued | 395 | 268 |
| ... from the listing prefetch | 280 | 140 |
| ... from `prefetch_transitive_best` | 105 | 118 |
| ... from `prefetch_root_batch` | 3 | 3 |
| ... issued on demand | 7 | 7 |
| Of those, never read | 249 | 128 |
| Listing requests | 140 | 140 |

`prefetch_transitive_best` picks up 13 of the 140 the listing prefetch stops asking for, so 127 go away and the demand path does not move. `pip:google-bigquery-soda --resolution lowest` is a smaller version of the same: 518 requests against 563 or 564, none of its 98 post-listing prefetches read at either value, `prefetch_walk_ahead` up by 3, and 49 listings and the same pins on both.

Peak traced bytes, over four runs of each version: 2.1 MB off 132.6 MB on airflow (1.6%), and 2.6 MB off 132.3 MB on `vllm-transformers-floor` (2.0%), where repeats of one version differ by at most 0.16%.

The rest of the timing runs cannot resolve an effect this size and only rule out a regression: above about 6% wall and 1.6% CPU on the canary set, above about 14% wall on cold airflow, and above about 4% CPU and 40% wall on cold google-bigquery-soda, where network variance dominates.

`check_sibling_metadata_divergence` compares only the sidecar texts already in memory and never fetches, so with one fewer version prefetched it has fewer siblings to compare and can raise on fewer versions, never on more.
