### PR TITLE
Parse mode, resolution and conflict policy through _parse_enum

### DIFF
--- a/nab-project/src/nab_project/config.py
+++ b/nab-project/src/nab_project/config.py
@@ -1213,18 +1213,6 @@ def _check_requires_python_admits_target(
     raise ConfigError(msg)
 
 
-def _parse_mode(value: object) -> ResolveMode:
-    if not isinstance(value, str):
-        msg = f"mode must be a string, got {type(value).__name__}"
-        raise ConfigError(msg)
-    try:
-        return ResolveMode(value)
-    except ValueError as exc:
-        valid = sorted(m.value for m in ResolveMode)
-        msg = f"mode must be one of {valid!r}, got {value!r}"
-        raise ConfigError(msg) from exc
-
-
 def _parse_string_list(key: str, value: object) -> tuple[str, ...]:
     if not isinstance(value, list):
         msg = f"{key} must be a list of strings, got {type(value).__name__}"
@@ -3091,17 +3079,9 @@ def _parse_conflict_set(item: object, index: int) -> ConflictSet:
 
 def _parse_conflict_policy(value: object, where: str) -> ConflictPolicy:
     """Parse the ``policy`` value of a conflict-set table; default at-most-one."""
-    if value is None:
-        return ConflictPolicy.AT_MOST_ONE
-    if not isinstance(value, str):
-        msg = f"{where}.policy must be a string, got {type(value).__name__}"
-        raise ConfigError(msg)
-    policy = _CONFLICT_POLICY_VALUES.get(value)
-    if policy is None:
-        valid = sorted(_CONFLICT_POLICY_VALUES)
-        msg = f"{where}.policy must be one of {valid!r}, got {value!r}"
-        raise ConfigError(msg)
-    return policy
+    return _parse_enum(
+        f"{where}.policy", value, ConflictPolicy, ConflictPolicy.AT_MOST_ONE
+    )
 
 
 def _parse_conflict_members(value: object, where: str) -> tuple[ConflictMember, ...]:

--- a/nab-project/src/nab_project/config_sources.py
+++ b/nab-project/src/nab_project/config_sources.py
@@ -310,16 +310,12 @@ def _parse_path(value: Any, where: str) -> Path:
 
 
 def _parse_resolution(value: Any, where: str) -> ResolutionStrategy:
-    # TOML/env supply a string; the CLI layer also passes the string spelling.
-    if not isinstance(value, str):
-        msg = f"{where} must be a string, got {type(value).__name__}"
-        raise SourceConfigError(msg)
-    try:
-        return ResolutionStrategy(value)
-    except ValueError as exc:
-        valid = sorted(s.value for s in ResolutionStrategy)
-        msg = f"{where} must be one of {valid!r}, got {value!r}"
-        raise SourceConfigError(msg) from exc
+    from .config import _parse_enum as _impl  # noqa: PLC0415 (config import cycle)
+
+    # Unlike the other enum rows, this message names the source location, not the key.
+    return _delegate(
+        lambda: _impl(where, value, ResolutionStrategy, ResolutionStrategy.HIGHEST)
+    )
 
 
 _HTTP_BACKENDS = ("httpx", "urllib3")
@@ -362,13 +358,10 @@ def _parse_max_concurrency(value: Any, where: str) -> int:
 def _delegate(call: Callable[[], Any]) -> Any:
     """Run a ``config.py`` parse helper, re-typing its error for the registry.
 
-    The registry rows reuse the single-environment parsers in
-    :mod:`nab_project.config` verbatim, so the value and every validation
-    message are identical to the pyproject parse path.  Those helpers raise
-    :class:`config.ConfigError`; the registry contract is
-    :class:`SourceConfigError`, and the CLI and loader catch only the latter.
-    Re-raise with the same message so behaviour is preserved and the error is
-    caught by the ladder.
+    The rows reuse the parse helpers in :mod:`nab_project.config`, so a value
+    and its validation wording match the pyproject parse path where there is
+    one.  Those helpers raise :class:`config.ConfigError` and the registry
+    contract is :class:`SourceConfigError`, so re-raise with the same message.
     """
     try:
         return call()
@@ -376,14 +369,11 @@ def _delegate(call: Callable[[], Any]) -> Any:
         raise SourceConfigError(str(exc)) from exc
 
 
-def _parse_mode(value: Any, where: str) -> Any:
-    # Delegates to config._parse_mode (enum specific|universal).  ``where``
-    # is unused: the helper owns the (config-keyed) message wording, kept
-    # identical to the pyproject path.
+def _parse_mode(value: Any, where: str) -> ResolveMode:
     del where
-    from .config import _parse_mode as _impl  # noqa: PLC0415 (config import cycle)
+    from .config import _parse_enum as _impl  # noqa: PLC0415 (config import cycle)
 
-    return _delegate(lambda: _impl(value))
+    return _delegate(lambda: _impl("mode", value, ResolveMode, ResolveMode.SPECIFIC))
 
 
 def _parse_requires_python(value: Any, where: str) -> str | None:


### PR DESCRIPTION
Routing `mode`, `resolution` and a conflict set's `policy` through `config._parse_enum` takes 46 lines out and puts 16 back, across two source files and no test. Each of the three carried its own isinstance check, its own `sorted(...)` list of valid values and its own two message strings. Ten other sites in `config.py` and `config_sources.py` already call the helper.

The messages and exception types are unchanged. Two differences are intended:

- `None` now returns the default on the `mode` and `resolution` rows instead of raising "mode must be a string, got NoneType". Nothing can deliver one: neither row has an env var, `build_cli_overrides` omits a CLI param left unset, and TOML has no null. `decision-order` and `build-policy`, the two registry rows that already delegated, return the default there too.
- `_parse_conflict_policy` chains the underlying `ValueError` as `__cause__`, which is what the shared helper does.

`_parse_resolution` passes `where` as the key where its neighbours drop it, because its message names the source location rather than the config key. `_CONFLICT_POLICY_VALUES` stays: the unknown-key message for a conflict-set table still reads it.
