### PR TITLE
Fix [tool.nab.environment] python "3.14rc1" resolving as 3.14.0

### DIFF
--- a/nab-project/src/nab_project/config.py
+++ b/nab-project/src/nab_project/config.py
@@ -59,6 +59,7 @@ from nab_provider.target import (
     ResolveTarget,
     check_free_threaded,
     host_environment,
+    names_a_micro,
     python_axis_environment,
 )
 from nab_provider.vcs_admission import VcsConfig, VcsPolicy, known_vcs_schemes
@@ -145,10 +146,6 @@ _PEP508_MARKER_VARIABLES = frozenset(
 
 # Marker variables whose values must parse as PEP 440 versions.
 _VERSION_MARKER_VARIABLES = frozenset({"python_version", "python_full_version"})
-
-# Release-component count of a bare ``major.minor`` python declaration; more
-# parts name a concrete patch level.
-_PYTHON_MINOR_PARTS = 2
 
 # How a ``requires-python`` declaration is named back to the user.  The
 # [tool.nab] key stays bare because the CLI's error prefix already names that
@@ -964,7 +961,9 @@ def _declared_target(environment: EnvironmentConfig) -> ResolveTarget:
     The platform is named, so the target's markers and wheel tags are
     synthesized from it rather than read off the host.  An unset ``python``
     takes the host's release, and an unset ``implementation`` is CPython,
-    matching the matrix default.
+    matching the matrix default.  A python naming a point inside its minor
+    (``"3.12.0"``, ``"3.14rc1"``) is pinned whole; a bare ``"3.12"`` resolves
+    as a micro interval.
     """
     assert environment.platform is not None  # the caller checked
     python = environment.python or host_environment()["python_full_version"]
@@ -975,16 +974,13 @@ def _declared_target(environment: EnvironmentConfig) -> ResolveTarget:
         environment, (axis["python_version"],) if environment.python else ()
     )
 
-    # More than major.minor ("3.10.5", "3.12.0", or the host's release) names a
-    # concrete micro, resolved whole.  A bare minor ("3.12") gets a synthetic
-    # .0 floor and resolves as a micro interval.
-    pinned_micro = len(Version(python).release) > _PYTHON_MINOR_PARTS
-
     return ResolveTarget.for_declared(
         python_version=axis["python_version"],
         spec=environment.platform,
         implementation=implementation,
-        python_full_version=axis["python_full_version"] if pinned_micro else None,
+        python_full_version=(
+            axis["python_full_version"] if names_a_micro(Version(python)) else None
+        ),
     )
 
 

--- a/nab-project/tests/test_config.py
+++ b/nab-project/tests/test_config.py
@@ -46,7 +46,7 @@ from nab_project.config_sources import (
 )
 from nab_project.fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL, IndexRoute
 from nab_project.workspace import WorkspaceConfig
-from nab_provider._vendor.packaging.markers import default_environment
+from nab_provider._vendor.packaging.markers import Marker, default_environment
 from nab_provider._vendor.packaging.specifiers import SpecifierSet
 from nab_provider._vendor.packaging.version import Version
 from nab_provider.provider import (
@@ -1783,6 +1783,63 @@ class TestEnvironment:
         (target,) = plan_targets(read_pyproject_config(path))
         assert target.is_minor_interval
         assert "python_full_version" not in declared_range_marker(target)
+
+    @pytest.mark.parametrize(
+        ("declared", "full"),
+        [
+            ("3.14rc1", "3.14.0rc1"),
+            ("3.14a1", "3.14.0a1"),
+            ("3.14.post1", "3.14.0.post1"),
+            ("3.14+local", "3.14.0+local"),
+        ],
+    )
+    def test_environment_tagged_python_without_a_micro_pins_whole(
+        self, tmp_path: Path, declared: str, full: str
+    ) -> None:
+        """A tagged python names one build even when written without a micro."""
+        path = write(
+            tmp_path,
+            f'[tool.nab.environment]\npython = "{declared}"\n'
+            'platform = "linux_x86_64"\n'
+            '[tool.nab]\nbuild-policy = "never"\n',
+        )
+        (target,) = plan_targets(read_pyproject_config(path))
+
+        assert target.python_full_version == full
+        assert target.marker_env["implementation_version"] == full
+        assert not target.is_minor_interval
+        assert f'python_full_version == "{full}"' in declared_range_marker(target)
+
+    def test_environment_release_candidate_is_below_its_release(
+        self, tmp_path: Path
+    ) -> None:
+        """``python_full_version >= "3.14"`` is False on a 3.14 candidate."""
+        path = write(
+            tmp_path,
+            '[tool.nab.environment]\npython = "3.14rc1"\n'
+            'platform = "linux_x86_64"\n'
+            '[tool.nab]\nbuild-policy = "never"\n',
+        )
+        (target,) = plan_targets(read_pyproject_config(path))
+
+        assert not Marker('python_full_version >= "3.14"').evaluate(target.marker_env)
+        assert Marker('python_full_version == "3.14.0rc1"').evaluate(target.marker_env)
+
+    def test_python_override_keeps_a_release_candidate_tag(
+        self, tmp_path: Path
+    ) -> None:
+        """``--python 3.14rc1`` pins the candidate on a project with a platform."""
+        path = write(
+            tmp_path,
+            '[tool.nab.environment]\npython = "3.13"\n'
+            'platform = "linux_x86_64"\n'
+            '[tool.nab]\nbuild-policy = "never"\n',
+        )
+        config = read_pyproject_config(path)
+        (target,) = plan_targets(with_python_override(config, "3.14rc1"))
+
+        assert target.python_full_version == "3.14.0rc1"
+        assert not target.is_minor_interval
 
     def test_windows_arm64_bare_id_declares_a_target(self, tmp_path: Path) -> None:
         path = write(

--- a/nab-provider/src/nab_provider/target.py
+++ b/nab-provider/src/nab_provider/target.py
@@ -66,6 +66,7 @@ __all__ = [
     "host_environment",
     "marker_variables",
     "micro_boundary_points",
+    "names_a_micro",
     "python_axis_environment",
     "slices_from_points",
     "unboundable_variables",
@@ -718,7 +719,7 @@ def _language_minor(version: Version) -> str:
     return f"{epoch}{release[0]}.{minor}"
 
 
-def _names_a_micro(version: Version) -> bool:
+def names_a_micro(version: Version) -> bool:
     """Whether ``version`` names a point inside a minor rather than the minor.
 
     ``3.13.7`` and ``3.13.0`` name one micro, ``3.13rc1`` one prerelease of
@@ -758,7 +759,7 @@ def _prefix_at_the_minor(operator: str, raw: str) -> str | None:
     prefix = Version(raw.removesuffix(".*"))
     if len(prefix.release) < _PYTHON_VERSION_PARTS:
         return f"{operator}{raw}"
-    if operator == "!=" and _names_a_micro(prefix):
+    if operator == "!=" and names_a_micro(prefix):
         return None
     return f"{operator}{_language_minor(prefix)}"
 
@@ -794,7 +795,7 @@ def _language_level_clause(clause: Specifier) -> str | None:
     if operator in {">", ">=", "<", "<="}:
         return _bound_at_the_minor(operator, version, minor)
     if operator == "!=":
-        return None if _names_a_micro(version) else f"!={minor}"
+        return None if names_a_micro(version) else f"!={minor}"
 
     # ~= "3.13.4" is >= "3.13.4", == "3.13.*": exactly the 3.13 minor.
     if operator == "~=" and len(version.release) > _PYTHON_VERSION_PARTS:


### PR DESCRIPTION
A `[tool.nab.environment]` python written as `"3.14rc1"` drops the tag, and the target's markers answer on `3.14.0`, so `python_full_version >= "3.14"` is true for an interpreter that has not reached 3.14. The same interpreter written with a micro keeps the tag, and so does `--python 3.14rc1` on a project with no platform, so the spelling decides the answer.

| `python` | `python_full_version` | resolves |
| --- | --- | --- |
| `3.14rc1` | `3.14.0` | as an interval over the whole 3.14 minor |
| `3.14.0rc1` | `3.14.0rc1` | as the one build named |

`implementation_version` follows `python_full_version` on CPython, so it reads `3.14.0` too.

`_declared_target` decided whether the declaration named a micro by counting release components, and `Version("3.14rc1").release` is `(3, 14)`. `target.py` already carries that predicate over the pre, post, dev and local cases, so the fix calls it, dropping its underscore for the import from `nab_project`. `3.14a1`, `3.14.post1` and `3.14+local` were wrong the same way.
