### PR TITLE
Fix look-ahead blocker lines printing the VersionRange debug repr

### DIFF
--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -2091,6 +2091,104 @@ class TestNoVersionsReasons:
         assert "requires bar in ==2.0 but solution has it in <2.0" in reason
         assert "disjoint with current solution range" not in reason
 
+    @pytest.mark.parametrize("cache_listing", [True, False])
+    def test_range_block_rejection_spells_each_declared_range(
+        self, cache_listing: bool
+    ) -> None:
+        """Candidates that disagree on the blocker still read as requirements.
+
+        ``foo`` 2.0 requires ``bar==3.0`` and 1.0 requires ``bar==1.0``, a
+        union no specifier set spells, so the line states the two pins one by
+        one.  Neither pin names a version ``bar`` publishes, so its listing
+        cannot supply a spelling whether or not it is cached.
+        """
+        coordinator = make_coordinator(
+            listings={
+                "foo": [make_wheel("1.0"), make_wheel("2.0")],
+                "bar": [make_wheel(version) for version in ("5.0", "6.0")],
+            },
+            metadata_by_version={
+                "1.0": make_metadata("foo", "1.0", "bar==1.0"),
+                "2.0": make_metadata("foo", "2.0", "bar==3.0"),
+            },
+        )
+        provider = Provider(
+            coordinator,
+            target=_PY312,
+            root_requirements={"foo": VersionRange.full(admit_arbitrary=False)},
+        )
+        if cache_listing:
+            provider.fetch_versions("bar")
+        provider.solution_ranges["bar"] = SpecifierSet("==5.0").to_range()
+
+        assert provider.choose_version("foo", VersionRange.full()) is None
+
+        reason = provider.get_no_versions_reason("foo")
+        assert reason is not None
+        assert "<VersionRange" not in reason
+        assert "AFTER_LOCALS" not in reason
+        assert "requires bar in ==3.0 or ==1.0 but solution has it in ==5.0" in reason
+
+    def test_declared_pins_covering_the_listing_keep_their_spelling(self) -> None:
+        """Pins that between them cover every listed version stay on the line.
+
+        ``bar`` publishes only the two versions ``foo`` pins, so spelling
+        their union over that listing would name every version and leave no
+        requirement in the sentence.
+        """
+        coordinator = make_coordinator(
+            listings={
+                "foo": [make_wheel("1.0"), make_wheel("2.0")],
+                "bar": [make_wheel("1.0"), make_wheel("3.0")],
+            },
+            metadata_by_version={
+                "1.0": make_metadata("foo", "1.0", "bar==1.0"),
+                "2.0": make_metadata("foo", "2.0", "bar==3.0"),
+            },
+        )
+        provider = Provider(
+            coordinator,
+            target=_PY312,
+            root_requirements={"foo": VersionRange.full(admit_arbitrary=False)},
+        )
+        provider.fetch_versions("bar")
+        provider.solution_ranges["bar"] = SpecifierSet("==2.0").to_range()
+
+        assert provider.choose_version("foo", VersionRange.full()) is None
+
+        reason = provider.get_no_versions_reason("foo")
+        assert reason is not None
+        assert "requires bar in  but" not in reason
+        assert "requires bar in ==3.0 or ==1.0 but solution has it in ==2.0" in reason
+
+    def test_root_blocker_names_an_unconstrained_root_range(self) -> None:
+        """The root side reads as "any version" rather than as nothing.
+
+        ``foo`` 1.0 requires ``bar>=2,<1``, which no version satisfies, so it
+        is disjoint with the root's unconstrained ``bar``.  An unconstrained
+        range spells as nothing, which would end the line on a dangling
+        ``in``.
+        """
+        coordinator = make_coordinator(
+            [make_wheel("1.0")],
+            metadata_text=make_metadata("foo", "1.0", "bar>=2,<1"),
+            package="foo",
+        )
+        provider = Provider(
+            coordinator,
+            target=_PY312,
+            root_requirements={
+                "foo": VersionRange.full(admit_arbitrary=False),
+                "bar": VersionRange.full(admit_arbitrary=False),
+            },
+        )
+
+        assert provider.choose_version("foo", VersionRange.full()) is None
+
+        reason = provider.get_no_versions_reason("foo")
+        assert reason is not None
+        assert "requires bar in no version but root has it in any version" in reason
+
     def test_post_release_pin_blocker_spells_both_sides_as_specifiers(self) -> None:
         """``bar>2.0`` excludes 2.0's post releases, so it is disjoint with
         ``==2.0.post1``.  Both sides read as the specifiers a user would write,

--- a/nab-project/tests/test_resolve.py
+++ b/nab-project/tests/test_resolve.py
@@ -3637,6 +3637,50 @@ class TestAugmentResolutionError:
             " requires b in ==1.0 but root has it in >=2"
         ) in diagnostics
 
+    def test_blocker_diagnostics_spell_each_declared_range(
+        self, tmp_path: Path
+    ) -> None:
+        """A blocker line reads as requirements when the pins disagree.
+
+        ``a`` 7.0 pins ``c==1.0`` and 7.1 pins ``c==2.0``, a union no
+        specifier set spells, so the line states the two pins one by one.
+        """
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "proj"\ndependencies = ["a", "b"]\n',
+            encoding="utf-8",
+        )
+
+        coordinator = make_coordinator(
+            listings={
+                "a": _index_wheels("a", "7.0", "7.1"),
+                "b": _index_wheels("b", "8.0"),
+                "c": _index_wheels("c", "1.0", "2.0", "3.0"),
+            },
+            metadata_by_version={
+                "7.0": _metadata("a", "7.0", "c==1.0"),
+                "7.1": _metadata("a", "7.1", "c==2.0"),
+                "8.0": _metadata("b", "8.0", "c==3.0"),
+                "1.0": _metadata("c", "1.0"),
+                "2.0": _metadata("c", "2.0"),
+                "3.0": _metadata("c", "3.0"),
+            },
+        )
+
+        with patch("nab_project.resolve.FetchCoordinator") as mock_coord_cls:
+            mock_coord_cls.return_value.__enter__ = lambda _self: coordinator
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            with pytest.raises(ResolutionError) as info:
+                _resolved(pyproject, _FAKE_TRANSPORT, python_version="3.12.0")
+
+        diagnostics = str(info.value).split("Diagnostics:")[1]
+        assert "<VersionRange" not in diagnostics
+        assert "AFTER_LOCALS" not in diagnostics
+        assert (
+            "a: every version in range was rejected:"
+            " requires c in ==2.0 or ==1.0 but solution has it at 3.0"
+        ) in diagnostics
+
     def test_derivation_renders_readable_ranges(self, tmp_path: Path) -> None:
         """The derivation states ranges as requirements, like the diagnostics do.
 

--- a/nab-provider/src/nab_provider/_provider/lookahead.py
+++ b/nab-provider/src/nab_provider/_provider/lookahead.py
@@ -42,10 +42,15 @@ class DepRangeUnion(NamedTuple):
     declared on the blocker; ``covered`` counts the rejections that
     contributed one.  Widening needs the whole group, so a flush declines
     when ``covered`` falls short of the group's rejection count.
+
+    ``declared`` keeps the distinct ranges in first-recorded order.  Ranges
+    that disagree can union into a disjunction no specifier set spells, so a
+    failure report states them one by one instead.
     """
 
     covered: int
     union: VersionRange
+    declared: tuple[VersionRange, ...] = ()
 
     @classmethod
     def zero(cls) -> DepRangeUnion:
@@ -54,7 +59,11 @@ class DepRangeUnion(NamedTuple):
 
     def record(self, dep_range: VersionRange) -> DepRangeUnion:
         """Return this accumulator with one more rejection's range folded in."""
-        return DepRangeUnion(self.covered + 1, self.union | dep_range)
+        if dep_range in self.declared:
+            return DepRangeUnion(self.covered + 1, self.union, self.declared)
+        return DepRangeUnion(
+            self.covered + 1, self.union | dep_range, (*self.declared, dep_range)
+        )
 
 
 def look_ahead_ok(

--- a/nab-provider/src/nab_provider/provider.py
+++ b/nab-provider/src/nab_provider/provider.py
@@ -1651,25 +1651,26 @@ class Provider:
         for cand, blocker_pkg, blocker_version in self.pending_blocks:
             if cand != normalized:
                 continue
-            dep_range = self.pending_decision_dep_ranges[
-                (cand, blocker_pkg, blocker_version)
-            ].union
+            declared = self._format_declared_ranges(
+                self.pending_decision_dep_ranges[(cand, blocker_pkg, blocker_version)]
+            )
+
             # The blocker is decided, so the line names that version rather
             # than a singleton range, which has no specifier spelling.
             out.append(
-                f"requires {blocker_pkg} in {self.format_range(dep_range)}"
+                f"requires {blocker_pkg} in {declared}"
                 f" but solution has it at {blocker_version}"
             )
 
         for cand, blocker_pkg, pos_range in self.pending_range_blocks:
             if cand != normalized:
                 continue
-            dep_range = self.pending_range_dep_ranges[
-                (cand, blocker_pkg, pos_range)
-            ].union
+            declared = self._format_declared_ranges(
+                self.pending_range_dep_ranges[(cand, blocker_pkg, pos_range)]
+            )
+            held = self._format_blocker_range(pos_range)
             out.append(
-                f"requires {blocker_pkg} in {self.format_range(dep_range)}"
-                f" but solution has it in {self.format_range(pos_range)}"
+                f"requires {blocker_pkg} in {declared} but solution has it in {held}"
             )
 
         for (
@@ -1680,9 +1681,10 @@ class Provider:
         ) in self.pending_root_blocks:
             if cand != normalized:
                 continue
+            declared = self._format_blocker_range(dep_range)
+            required = self._format_blocker_range(root_range)
             out.append(
-                f"requires {blocker_pkg} in {self.format_range(dep_range)}"
-                f" but root has it in {self.format_range(root_range)}"
+                f"requires {blocker_pkg} in {declared} but root has it in {required}"
             )
 
         meta = self.pending_metadata_blocks.get(normalized)
@@ -1977,6 +1979,23 @@ class Provider:
         if specifier_set is None:
             return str(constraint)
         return str(specifier_set)
+
+    def _format_blocker_range(self, constraint: RangeProtocol[Version]) -> str:
+        """Render one side of a blocker line, naming an unconstrained range.
+
+        :meth:`format_range` spells an unconstrained range as nothing, which
+        would end the line on a dangling ``in``.
+        """
+        return self.format_range(constraint) or "any version"
+
+    def _format_declared_ranges(self, recorded: _lookahead.DepRangeUnion) -> str:
+        """Render the ranges a blocker's rejected candidates declared on it.
+
+        Stating them one by one keeps the line spellable where their union is
+        not; a group that recorded no range falls back to its union.
+        """
+        declared = recorded.declared or (recorded.union,)
+        return " or ".join(self._format_blocker_range(part) for part in declared)
 
     def get_dependencies(
         self, package: str, version: Version


### PR DESCRIPTION
A look-ahead blocker line prints the range object's debug repr when the rejected candidates declare different ranges on the blocker:

    every version in range was rejected: requires bar in <VersionRange '[1.0, 1.0[AFTER_LOCALS]] | [3.0, 3.0[AFTER_LOCALS]]'> but solution has it in ==5.0

It now reads:

    every version in range was rejected: requires bar in ==3.0 or ==1.0 but solution has it in ==5.0

The blocker's ranges accumulate into a union, which the widening step needs. A union of disjoint ranges is a disjunction no specifier set can spell, so `format_range` falls back to `str()` and the bounds come out in their internal form: a pin as `[1.0, 1.0[AFTER_LOCALS]]`, the top of `>=1,<2` as `2.dev0`.

The accumulator now keeps the distinct declared ranges beside the union, and the line states them one at a time.

A blocker line also dropped its right-hand side when the range was unconstrained, because an unconstrained range spells as nothing:

    every version in range was rejected: requires bar in no version but root has it in

That side now says `any version`.
