### PR TITLE
Fix nab download crashing on an index filename with no UTF-8 form

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -111,32 +111,49 @@ def _tag_triple_is_parseable(tag_str: str) -> bool:
     return all("" not in field.split(".") for field in (abis, platforms))
 
 
+def _is_usable_filename(filename: str) -> bool:
+    """Whether ``filename`` has a UTF-8 form and holds no NUL.
+
+    nab records the name in a UTF-8 lockfile and writes the artefact
+    under it, so a name failing either is unusable however well it
+    parses.  A lone surrogate has no UTF-8 form, including the
+    ``U+DC80``..``U+DCFF`` range POSIX carries through ``surrogateescape``.
+    """
+    if "\x00" in filename:
+        return False
+    try:
+        filename.encode()
+    except UnicodeEncodeError:
+        return False
+    return True
+
+
 def _parse_wheel_filename(filename: str) -> tuple[NormalizedName, str] | None:
     """Parse a wheel filename per PEP 427.
 
     Returns ``(canonical_name, version_string)`` or ``None`` for any
-    filename packaging rejects (wrong extension, malformed, etc.) and
-    for a version digit run past CPython's int-from-string limit.
-    Never raises.
+    filename packaging rejects (wrong extension, malformed, etc.), for a
+    version digit run past CPython's int-from-string limit, and for a name
+    :func:`_is_usable_filename` refuses.  Never raises.
     The version string is the canonical form produced by
     :class:`packaging.version.Version`, so trailing-zero handling
     matches what packaging records on the file; e.g. a wheel
     declaring ``2.0.0`` in its filename comes back as ``"2.0.0"``,
     not ``"2"``.
 
-    This accepts what nab-provider's vendored ``parse_wheel_filename`` accepts,
-    but discards the ``frozenset[Tag]`` the tag parser builds and nab does not
-    use. The vendored copy is the one to match, not the released ``packaging``
-    this package depends on, because the vendored tag parser ranks whatever is
-    admitted here; the two can differ on an empty project name, which releases
-    before 26.3 accept.
+    Unusable names aside, this accepts what nab-provider's vendored
+    ``parse_wheel_filename`` accepts, but discards the ``frozenset[Tag]`` the
+    tag parser builds and nab does not use. The vendored copy is the one to
+    match, not the released ``packaging`` this package depends on, because the
+    vendored tag parser ranks whatever is admitted here; the two can differ on
+    an empty project name, which releases before 26.3 accept.
 
     A build tag past that same digit limit is admitted rather than rejected:
     ``parse_wheel_filename`` raises ``ValueError`` out of ``int()`` on one, but
     nab reads a build tag only to sort by it and sorts an unconvertible run
     lowest.
     """
-    if not filename.endswith(".whl"):
+    if not filename.endswith(".whl") or not _is_usable_filename(filename):
         return None
 
     stem = filename[:-4]
@@ -172,18 +189,19 @@ def _parse_sdist_filename(filename: str) -> tuple[NormalizedName, str] | None:
 
     Accepts what nab-provider's vendored ``parse_sdist_filename`` accepts,
     except ``.zip`` sdists, which nab does not support (gzip-tar only, and
-    not part of the PEP 625 standard).  Returns ``None`` for everything
-    else, including a version digit run past CPython's int-from-string
-    limit, and never raises.  The vendored copy is the one to match, not
-    the released ``packaging`` this package depends on; the two can differ
-    on an empty project name, which releases before 26.3 accept.
+    not part of the PEP 625 standard), and names :func:`_is_usable_filename`
+    refuses.  Returns ``None`` for everything else, including a version digit
+    run past CPython's int-from-string limit, and never raises.  The vendored
+    copy is the one to match, not the released ``packaging`` this package
+    depends on; the two can differ on an empty project name, which releases
+    before 26.3 accept.
 
     Legacy filenames with embedded build tags (e.g. ``cffi-1.0.2-2.tar.gz``)
     parse to a surprising ``(name="cffi-1-0-2", version="2")``, so callers
     MUST drop files whose canonical name does not match the queried
     package.  See :func:`_parse_files`.
     """
-    if not filename.endswith(".tar.gz"):
+    if not filename.endswith(".tar.gz") or not _is_usable_filename(filename):
         return None
 
     stem = filename[: -len(".tar.gz")]
@@ -223,7 +241,7 @@ def holds_unreadable_format(data: object) -> bool:
 
 
 def is_readable_filename(filename: str) -> bool:
-    """Whether ``filename`` names a wheel or a ``.tar.gz`` sdist."""
+    """Whether ``filename`` names a wheel or ``.tar.gz`` sdist that nab can use."""
     return (
         _parse_wheel_filename(filename) is not None
         or _parse_sdist_filename(filename) is not None

--- a/nab-index/tests/test_index_client.py
+++ b/nab-index/tests/test_index_client.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import json
 import sys
 
 import pytest
 from packaging.utils import parse_sdist_filename
 
 from nab_index.client import (
+    _parse_files,
     _parse_sdist_filename,
     _sdist_member_top_level,
     holds_unreadable_format,
@@ -45,6 +47,56 @@ def test_unreadable_filenames(filename: str) -> None:
 )
 def test_oversized_version_is_unreadable(filename: str) -> None:
     assert not is_readable_filename(filename)
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        pytest.param("foo-1.0-1\ud800-py3-none-any.whl", id="wheel-build-tag"),
+        pytest.param("foo-1.0-py3-\ud800-any.whl", id="wheel-abi"),
+        pytest.param("foo-1.0-py3-none-\ud800.whl", id="wheel-platform"),
+        pytest.param("foo\ud800-1.0.tar.gz", id="sdist-name"),
+        # POSIX carries this range through surrogateescape, so a file on
+        # disk can be named that; a UTF-8 lockfile cannot record it.
+        pytest.param("foo-1.0-1\udc80-py3-none-any.whl", id="wheel-surrogateescape"),
+    ],
+)
+def test_filename_with_no_utf8_form_is_unreadable(filename: str) -> None:
+    assert not is_readable_filename(filename)
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        pytest.param("foo-1.0-1\x00-py3-none-any.whl", id="wheel"),
+        pytest.param("foo\x00-1.0.tar.gz", id="sdist"),
+    ],
+)
+def test_filename_with_an_embedded_nul_is_unreadable(filename: str) -> None:
+    assert not is_readable_filename(filename)
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        pytest.param("foo-1.0-1é-py3-none-any.whl", id="wheel"),
+        pytest.param("fooé-1.0.tar.gz", id="sdist"),
+    ],
+)
+def test_non_ascii_filename_stays_readable(filename: str) -> None:
+    assert is_readable_filename(filename)
+
+
+def test_listing_drops_a_file_with_no_utf8_form() -> None:
+    # An ASCII PEP 691 body still carries this name: json.loads turns the
+    # \ud800 escape into a lone surrogate.
+    body = json.loads(
+        '{"files": [{"filename": "foo-1.0-1\\ud800-py3-none-any.whl",'
+        ' "url": "https://e.example/foo-1.0.whl"}]}'
+    )
+
+    assert _parse_files(body, "https://e.example/simple/", "foo") == []
+    assert holds_unreadable_format(body)
 
 
 def test_holds_unreadable_format_finds_zip_sdist() -> None:


### PR DESCRIPTION
`nab download` crashes with a raw `UnicodeEncodeError` when a PEP 691 listing offers a file whose name holds a lone surrogate, such as `foo-1.0-1\ud800-py3-none-any.whl`:

```
UnicodeEncodeError: 'utf-8' codec can't encode character '\ud800' in position 26: surrogates not allowed
```

It comes out of `atomic_write` with the artefact's bytes already fetched, and `download_lock` reports its failures as `DownloadError`, so nothing above it is looking for an encoding error.

The name arrives in a response that is pure ASCII on the wire: `json.loads` turns a `\ud800` escape into a lone surrogate. The wheel grammar constrains only the project name and the version, so a surrogate in a build tag, an ABI, a platform, or anywhere in an sdist name parses as a real file.

`download_lock`'s basename guard then passes it, because `Path(name).name` is still the name. An embedded NUL takes the same route and lands on `ValueError: embedded null byte`.

`_parse_wheel_filename` and `_parse_sdist_filename` now refuse a name with no UTF-8 form or a NUL, so the entry never enters the listing, which is the treatment the entry's `url` already gets. A package left with no other file reports what a `.zip`-only page reports: "found on index but no file is a wheel or a .tar.gz sdist".

The check is on the UTF-8 form rather than on what the filesystem takes. `U+DC80` through `U+DCFF` survives a POSIX write via `surrogateescape`, so `foo-1.0-1\udc80-py3-none-any.whl` would land on disk and break the UTF-8 lockfile write instead. A merely non-ASCII name still resolves, `fooé-1.0.tar.gz` included.
