### PR TITLE
Parse only the METADATA header block, 1.8% off a resolve's instructions

### DIFF
--- a/nab-provider/src/nab_provider/metadata.py
+++ b/nab-provider/src/nab_provider/metadata.py
@@ -162,12 +162,28 @@ class WheelMetadata:
     dynamic: frozenset[str] = field(default_factory=frozenset)
 
 
+def _header_block(text: str) -> str:
+    """Return a prefix of ``text`` that holds all of its headers.
+
+    Cuts after the first blank line, LF or CRLF, and returns ``text``
+    unchanged when there is none.
+    """
+    end = text.find("\n\n")
+    if end != -1:
+        return text[: end + 2]
+    end = text.find("\r\n\r\n")
+    if end != -1:
+        return text[: end + 4]
+    return text
+
+
 def parse_metadata(data: str | bytes) -> WheelMetadata:
     """Parse a METADATA file and return the fields needed for resolution."""
     if isinstance(data, bytes):
         data = data.decode("utf-8")
 
-    msg = email.parser.Parser().parsestr(data)
+    # Nothing here reads the long description.
+    msg = email.parser.Parser().parsestr(_header_block(data), headersonly=True)
 
     name = msg.get("Name")
     if name is None:

--- a/nab-provider/tests/test_metadata.py
+++ b/nab-provider/tests/test_metadata.py
@@ -9,6 +9,7 @@ import pytest
 from nab_provider._vendor.packaging.specifiers import SpecifierSet
 from nab_provider._vendor.packaging.version import Version
 from nab_provider.metadata import (
+    _header_block,
     metadata_deps_are_static,
     parse_metadata,
     validate_specifier_versions,
@@ -106,6 +107,44 @@ def test_requires_dist_parsed() -> None:
     )
     md = parse_metadata(text)
     assert [str(r) for r in md.requires_dist] == ["bar>=1.0", "baz<2"]
+
+
+def test_header_block_slice_bounds() -> None:
+    """The slice ends after the blank line; text without one comes back whole."""
+    assert (
+        _header_block("Name: foo\nVersion: 1.0\n\nbody\n")
+        == "Name: foo\nVersion: 1.0\n\n"
+    )
+
+    assert (
+        _header_block("Name: foo\r\nVersion: 1.0\r\n\r\nbody\r\n")
+        == "Name: foo\r\nVersion: 1.0\r\n\r\n"
+    )
+
+    assert _header_block("Name: foo\nVersion: 1.0\n") == "Name: foo\nVersion: 1.0\n"
+
+
+def test_long_description_is_not_read() -> None:
+    """Header fields survive a description that repeats them as text."""
+    text = (
+        "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\nRequires-Dist: bar>=1.0\n"
+        "\nName: not-a-header\nRequires-Dist: nope\n"
+    )
+    md = parse_metadata(text)
+    assert md.name == "foo"
+    assert [str(r) for r in md.requires_dist] == ["bar>=1.0"]
+
+
+def test_crlf_document_with_long_description() -> None:
+    """A CRLF document ends its header block at the blank CRLF line."""
+    text = (
+        "Metadata-Version: 2.1\r\nName: foo\r\nVersion: 1.0\r\n"
+        "Requires-Dist: bar>=1.0\r\n\r\nName: not-a-header\r\n"
+    )
+    md = parse_metadata(text)
+    assert md.name == "foo"
+    assert md.version == Version("1.0")
+    assert [str(r) for r in md.requires_dist] == ["bar>=1.0"]
 
 
 def test_equal_markers_are_interned() -> None:


### PR DESCRIPTION
Slicing METADATA at the header boundary and asking for headers only takes 634,491,289 instructions out of a warm `pip:langchain-ml-course --resolution lowest` resolve, 1.811% of its 35,036,018,883. `parse_metadata` reads seven header fields and nothing from the payload, and that resolve parses 1,965 documents holding 12,779,674 characters, 5,177,813 of them after the header block.

Measured on its own over documents captured from that resolve, `parse_metadata` costs 320,577 fewer instructions per call (1,881,147,711 over 5,868 calls). Across the 1,965 documents the resolve parses, that accounts for essentially the whole saving.

A change this size is below what the clock can see here, so the end-to-end runs over the 19-scenario canary set only bound it: locally, no wall regression above about 2.5%, no CPU regression above about 1.6%, and peak memory inside about 0.12% either way.

`_header_block` cuts after the first blank line, LF or CRLF, and returns the text unchanged when there is none, which is 1,062 of those 1,965 documents. Over all 1,965, the new path returns the same `WheelMetadata`, or the same `ValueError` text, as the whole-text parse.
