### PR TITLE
Cut the METADATA long description from the store, ~16% off peak RSS

### DIFF
--- a/nab-project/tests/test_fetch.py
+++ b/nab-project/tests/test_fetch.py
@@ -152,6 +152,21 @@ class TestInMemoryIndex:
         assert idx.get_metadata("foo", "1.0") == "Metadata-Version: 2.1"
         assert idx.has_metadata("foo", "1.0")
 
+    def test_metadata_slot_keeps_only_the_header_block(self) -> None:
+        idx = InMemoryIndex()
+        idx.store_metadata(
+            "foo", "1.0", "Name: foo\nVersion: 1.0\n\nA long description.\n"
+        )
+        assert idx.get_metadata("foo", "1.0") == "Name: foo\nVersion: 1.0\n\n"
+
+    def test_sdist_metadata_slot_keeps_only_the_header_block(self) -> None:
+        idx = InMemoryIndex()
+        idx.store_sdist_metadata(
+            "foo", "1.0", "Name: foo\nVersion: 1.0\n\nA long description.\n"
+        )
+        assert idx.get_metadata("foo", "1.0") == "Name: foo\nVersion: 1.0\n\n"
+        assert idx.metadata_from_sdist("foo", "1.0")
+
     def test_store_metadata_none(self) -> None:
         idx = InMemoryIndex()
         idx.store_metadata("foo", "1.0", None)
@@ -2762,6 +2777,7 @@ class TestSiblingWheelMetadata:
 
 
 _RANGE_META = b"Metadata-Version: 2.1\nName: widget\nVersion: 1.0\n\nBody.\n"
+_RANGE_META_HEADERS = "Metadata-Version: 2.1\nName: widget\nVersion: 1.0\n\n"
 _RANGE_URL = "https://files.example.org/packages/widget-1.0-py3-none-any.whl"
 
 
@@ -2975,7 +2991,7 @@ class TestRangeMetadataCoordinator:
             assert len(submitted) == 1
             assert (
                 coord.index.get_metadata("widget", "1.0", _RANGE_URL)
-                == _RANGE_META.decode()
+                == _RANGE_META_HEADERS
             )
 
     def test_distinct_wheel_urls_enqueue_separately(self) -> None:
@@ -3008,7 +3024,7 @@ class TestRangeMetadataCoordinator:
             assert event.wait(timeout=5)
             assert (
                 coord.index.get_metadata("widget", "1.0", _RANGE_URL)
-                == _RANGE_META.decode()
+                == _RANGE_META_HEADERS
             )
             assert not coord.index.metadata_from_sdist("widget", "1.0")
             assert coord.index.get_range_outcome("widget", "1.0", _RANGE_URL) in (

--- a/nab-provider/src/nab_provider/metadata.py
+++ b/nab-provider/src/nab_provider/metadata.py
@@ -29,6 +29,7 @@ __all__ = [
     "WheelMetadata",
     "intern_version",
     "metadata_deps_are_static",
+    "metadata_header_block",
     "parse_metadata",
     "static_project_from_table",
     "validate_specifier_versions",
@@ -162,18 +163,23 @@ class WheelMetadata:
     dynamic: frozenset[str] = field(default_factory=frozenset)
 
 
-def _header_block(text: str) -> str:
-    """Return a prefix of ``text`` that holds all of its headers.
+def metadata_header_block(text: str) -> str:
+    r"""Return ``text`` cut after the earlier of its first ``\n\n`` and ``\r\n\r\n``.
 
-    Cuts after the first blank line, LF or CRLF, and returns ``text``
-    unchanged when there is none.
+    ``email.parser`` closes the RFC 822 headers at the first blank line at the
+    latest, so the prefix holds every field :func:`parse_metadata` reads and
+    parses to the same :class:`WheelMetadata` as the whole document.  A
+    document with neither sequence comes back whole.
+
+    ``lf + 3`` bounds the second search: it is as far as a ``\r\n\r\n``
+    starting before the ``\n\n`` hit can reach.
     """
-    end = text.find("\n\n")
-    if end != -1:
-        return text[: end + 2]
-    end = text.find("\r\n\r\n")
-    if end != -1:
-        return text[: end + 4]
+    lf = text.find("\n\n")
+    crlf = text.find("\r\n\r\n", 0, None if lf == -1 else lf + 3)
+    if crlf != -1:
+        return text[: crlf + 4]
+    if lf != -1:
+        return text[: lf + 2]
     return text
 
 
@@ -183,7 +189,7 @@ def parse_metadata(data: str | bytes) -> WheelMetadata:
         data = data.decode("utf-8")
 
     # Nothing here reads the long description.
-    msg = email.parser.Parser().parsestr(_header_block(data), headersonly=True)
+    msg = email.parser.Parser().parsestr(metadata_header_block(data), headersonly=True)
 
     name = msg.get("Name")
     if name is None:

--- a/nab-provider/src/nab_provider/store.py
+++ b/nab-provider/src/nab_provider/store.py
@@ -1,7 +1,6 @@
 """Shared store for fetched package data.
 
-Stdlib-only: no network, no filesystem, no import of the index client at
-runtime.
+No network, no filesystem, no import of the index client at runtime.
 """
 
 from __future__ import annotations
@@ -10,6 +9,8 @@ import threading
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
+
+from nab_provider.metadata import metadata_header_block
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Mapping, Sequence
@@ -68,7 +69,8 @@ class InMemoryIndex:
 
         # Metadata text is keyed by the artifact it came from: the sidecar URL
         # for a wheel's METADATA, or None for text that stands for the version
-        # itself, such as an sdist's PKG-INFO.
+        # itself, such as an sdist's PKG-INFO.  Each is cut to its header block
+        # on the way in.
         self._metadata: dict[tuple[str, str, str | None], str | None] = {}
         self._metadata_errors: dict[tuple[str, str, str | None], BaseException] = {}
         # Versions whose version-level slot was written from an sdist PKG-INFO;
@@ -204,7 +206,7 @@ class InMemoryIndex:
     def get_metadata(
         self, package: str, version: str, metadata_url: str | None = None
     ) -> str | None:
-        """Return cached metadata text, or ``None`` if not yet stored."""
+        """Return the cached header block, or ``None`` if not yet stored."""
         with self._lock:
             return self._read_metadata(package, version, metadata_url)[0]
 
@@ -244,20 +246,21 @@ class InMemoryIndex:
         *,
         from_sdist: bool,
     ) -> None:
-        """Write one metadata slot. Caller holds the lock.
+        """Write one metadata slot, cut to its header block. Caller holds the lock.
 
         Reconciled sdist metadata is derived from the version-level text, so
         replacing that text drops it.
         """
         package, version, metadata_url = slot
+        text = None if data is None else metadata_header_block(data)
         if metadata_url is None:
-            if self._metadata.get(slot) != data:
+            if self._metadata.get(slot) != text:
                 self._resolved_sdist_metadata.pop((package, version), None)
             if from_sdist:
                 self._metadata_from_sdist.add((package, version))
             else:
                 self._metadata_from_sdist.discard((package, version))
-        self._metadata[slot] = data
+        self._metadata[slot] = text
 
     def store_metadata(
         self,
@@ -267,7 +270,7 @@ class InMemoryIndex:
         *,
         metadata_url: str | None = None,
     ) -> None:
-        """Cache metadata text, or ``None`` when no sidecar was served.
+        """Cache the header block of ``data``, or ``None`` when no sidecar was served.
 
         ``metadata_url`` is the sidecar the text came from; ``None`` stores it
         as standing for the version rather than one artifact.  It is

--- a/nab-provider/tests/test_metadata.py
+++ b/nab-provider/tests/test_metadata.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import email.parser
 import sys
 
 import pytest
@@ -9,8 +10,8 @@ import pytest
 from nab_provider._vendor.packaging.specifiers import SpecifierSet
 from nab_provider._vendor.packaging.version import Version
 from nab_provider.metadata import (
-    _header_block,
     metadata_deps_are_static,
+    metadata_header_block,
     parse_metadata,
     validate_specifier_versions,
 )
@@ -109,21 +110,6 @@ def test_requires_dist_parsed() -> None:
     assert [str(r) for r in md.requires_dist] == ["bar>=1.0", "baz<2"]
 
 
-def test_header_block_slice_bounds() -> None:
-    """The slice ends after the blank line; text without one comes back whole."""
-    assert (
-        _header_block("Name: foo\nVersion: 1.0\n\nbody\n")
-        == "Name: foo\nVersion: 1.0\n\n"
-    )
-
-    assert (
-        _header_block("Name: foo\r\nVersion: 1.0\r\n\r\nbody\r\n")
-        == "Name: foo\r\nVersion: 1.0\r\n\r\n"
-    )
-
-    assert _header_block("Name: foo\nVersion: 1.0\n") == "Name: foo\nVersion: 1.0\n"
-
-
 def test_long_description_is_not_read() -> None:
     """Header fields survive a description that repeats them as text."""
     text = (
@@ -187,6 +173,67 @@ def test_provides_extra_whitespace_stripped() -> None:
     )
     md = parse_metadata(text)
     assert md.provides_extra == ["dev", "docs"]
+
+
+_HEADER_BLOCK_DOCUMENTS = [
+    pytest.param(
+        "Metadata-Version: 2.1\nName: foo\nVersion: 1.2.3\n"
+        "Requires-Python: >=3.9\nRequires-Dist: bar>=2\n"
+        "Provides-Extra: docs\n\nName: not-a-header\nA description.\n",
+        id="lf",
+    ),
+    pytest.param(
+        "Metadata-Version: 2.1\r\nName: foo\r\nVersion: 1.2.3\r\n"
+        "Requires-Dist: bar>=2\r\n\r\nA description.\r\n",
+        id="crlf",
+    ),
+    pytest.param(
+        "Metadata-Version: 2.1\r\nName: foo\r\nVersion: 1.2.3\r\n"
+        "Requires-Dist: bar>=2\r\n\r\nFirst para.\n\nSecond para.\n",
+        id="crlf-headers-lf-description",
+    ),
+    pytest.param(
+        "Metadata-Version: 2.1\nName: foo\nVersion: 1.2.3\n"
+        "Summary: line one\nline two unfolded\nRequires-Dist: bar>=2\n"
+        "\nA description.\n",
+        id="unfolded-field-ends-the-headers-early",
+    ),
+    pytest.param("Metadata-Version: 2.1\nName: foo\nVersion: 1.2.3\n", id="no-body"),
+]
+
+
+class TestMetadataHeaderBlock:
+    """Cutting a document at its header boundary."""
+
+    def test_description_after_the_blank_line_is_dropped(self) -> None:
+        text = "Name: foo\nVersion: 1.0\n\nA long description.\n"
+        assert metadata_header_block(text) == "Name: foo\nVersion: 1.0\n\n"
+
+    def test_crlf_blank_line_ends_the_headers(self) -> None:
+        text = "Name: foo\r\nVersion: 1.0\r\n\r\nA long description.\r\n"
+        assert metadata_header_block(text) == "Name: foo\r\nVersion: 1.0\r\n\r\n"
+
+    def test_crlf_headers_cut_before_an_lf_description(self) -> None:
+        text = "Name: foo\r\nVersion: 1.0\r\n\r\nFirst para.\n\nSecond para.\n"
+        assert metadata_header_block(text) == "Name: foo\r\nVersion: 1.0\r\n\r\n"
+
+    def test_document_without_a_blank_line_comes_back_whole(self) -> None:
+        text = "Name: foo\nVersion: 1.0\n"
+        assert metadata_header_block(text) is text
+
+    def test_cuts_at_the_first_blank_line(self) -> None:
+        text = "Name: foo\nVersion: 1.0\n\nFirst para.\n\nSecond para.\n"
+        assert metadata_header_block(text) == "Name: foo\nVersion: 1.0\n\n"
+
+    @pytest.mark.parametrize("text", _HEADER_BLOCK_DOCUMENTS)
+    def test_the_cut_keeps_the_whole_header_block(self, text: str) -> None:
+        """The prefix ends at or after where ``email.parser`` ends the headers."""
+        cut = metadata_header_block(text)
+        assert text.startswith(cut)
+
+        parser = email.parser.Parser()
+        assert parser.parsestr(cut).items() == parser.parsestr(text).items()
+        assert parse_metadata(cut) == parse_metadata(text)
 
 
 class TestMetadataDepsAreStatic:


### PR DESCRIPTION
Peak RSS on a warm `pip:langchain-ml-course --resolution lowest` resolve drops about 16%, from about 315 MB to about 264 MB locally. That resolve ends holding 66,619,156 bytes of METADATA text in `InMemoryIndex`, and 52,038,948 of those are the description that follows the RFC 822 header block. Nothing reads the description, so each document is now cut at its header boundary on the way into the store.

Text the store still holds when the resolve returns, `sys.getsizeof` over the slot values:

| Scenario | Retained store text | Removed | Share of that run's traced peak |
| --- | --- | --- | --- |
| `pip:langchain-ml-course` lowest | 66,619,156 -> 14,580,208 | 52,038,948 | 20.3% |
| `airflow:airflow-3-0-2-awswrangler` lowest-direct | 6,503,311 -> 1,111,623 | 5,391,688 | 4.6% |
| `ai-stack:vllm-transformers-floor` | 14,422,930 -> 1,550,880 | 12,872,050 | 11.1% |

Those shares are taken over each run's own traced peak: about 256 MB for langchain, about 116 MB for the other two. All three scenarios are bistable, so each pair is matched on decisions (10,218, 145 and 693) and on slot count, and the branch's retained bytes come out equal to the base run's header bytes to the byte. The byte counts are exact and repeat; the RSS and timing figures are off my machine.

`tracemalloc` over the whole langchain run agrees: peak 272,512,417 and 272,497,885 bytes before, 222,564,125 and 222,560,717 after, 18.3% in both pairs, with the two repeats on each side inside 0.006%. Live bytes at exit sit at about 42.71 MB on all four runs, within 14 kB of each other, so the store is freed before the process ends and the win is in the peak rather than in what survives.

Over 20 interleaved runs each way of that scenario the RSS win is between about 15.9% and 16.1%. The machine was busy throughout, so the clock rules out a wall regression above about 10% and a CPU regression above about 6%, and cannot see anything smaller.

The change:

- `metadata_header_block` cuts a document after the earlier of its first `\n\n` and its first `\r\n\r\n`, and returns it whole when it has neither (1,073 of the 4,502 langchain slots).
- `InMemoryIndex._write_metadata_slot` calls it, so the sidecar, range-recovered wheel and sdist PKG-INFO paths all store the header block and every reader sees the same text.
- `parse_metadata` calls it too, in place of the private `_header_block` it was using, so one helper cuts for both the store and the parse.

Nothing downstream needs the body: `parse_metadata` reads Name, Version, Requires-Python, Requires-Dist, Provides-Extra, Metadata-Version and Dynamic, all header fields. `get_parsed_metadata` only asks whether a parse came from this text, and both sides of that comparison are cut on the way in. `check_sibling_metadata_divergence` compares `TargetDepSignature` values built from the parsed fields rather than raw text.

Two consequences:

- `store.py` now imports `nab_provider.metadata`, which pulls in the vendored `Requirement`, `SpecifierSet` and `Version`, so its module docstring no longer claims stdlib-only.
- The slot-equality guard in `_write_metadata_slot` compares header blocks, so rewriting a version-level slot with a document whose headers match but whose description differs no longer drops the reconciled sdist metadata. That value is derived from the parse, which is identical in that case.

The helper costs about 4.1 microseconds per call over the 4,502 calls that langchain resolve makes, so about 18 ms of a resolve that runs in roughly 5 s here, measured on the real function over inputs captured from the run.

