### PR TITLE
Read a parsed-listing blob a batch at a time, ~6% off peak memory

### DIFF
--- a/docs/reference/cache.md
+++ b/docs/reference/cache.md
@@ -15,7 +15,7 @@ directory is harmless and `nab cache clear` reclaims it.
 | Bucket | Holds |
 | ------ | ----- |
 | `simple-v2/` | the Simple-API listing body and a `.policy` sidecar |
-| `simple-parsed-v0/` | the parsed listing, an accelerator for the body |
+| `simple-parsed-v1/` | the parsed listing, an accelerator for the body |
 | `simple-neg-v0/` | a short-lived record that a name returned a 404 |
 | `metadata-v1/` | PEP 658 metadata and recovered wheel `METADATA`, immutable |
 | `sdist-v1/` | an sdist's `PKG-INFO` and `pyproject.toml`, immutable |
@@ -55,7 +55,7 @@ answered from cache, offline included.
 
 Turning a listing body into records means a JSON decode plus wheel and
 sdist filename parsing, which a warm resolve would otherwise repeat on
-every run. The `simple-parsed-v0/` bucket stores those records so a warm
+every run. The `simple-parsed-v1/` bucket stores those records so a warm
 hit rehydrates them and never reads the large raw body. A stale entry is
 served the same way once the index answers `304 Not Modified`, since that
 confirms the body the blob is bound to.
@@ -72,17 +72,21 @@ authoritative: the accelerator is only ever a derived copy, and a rebuild
 is a reparse of whatever body is on disk.
 
 Blobs are stored as JSON, so one entry serves every interpreter sharing
-the cache. A listing nab reads no files from gets no blob, since an empty
-one could never be served: only the raw body records whether the page held
-formats nab cannot read.
+the cache. Each is a header line followed by batches of rows, so a hit
+reads the file a batch at a time instead of holding the whole document. A
+listing nab reads no files from gets no blob, since an empty one could
+never be served: only the raw body records whether the page held formats
+nab cannot read.
 
 ## Verifying and clearing
 
 `nab cache verify` walks the record buckets read-only and reports any
-entry that will not parse, including a parsed blob that is not decodable.
-It checks structure only, not freshness: a stale-but-valid parsed blob is
-not corrupt, since the digest binding retires it at read time. Clones and
-extracted archives hold no nab records, so `verify` skips them.
+entry that will not parse, including a parsed blob in the current bucket
+that is not decodable. It checks structure only, not freshness: a
+stale-but-valid parsed blob is not corrupt, since the digest binding
+retires it at read time. A retired parsed bucket is left alone, since its
+blobs are in a form this build does not read. Clones and extracted
+archives hold no nab records, so `verify` skips them.
 
 `nab cache clear` removes every bucket, clones and archives included,
 returning the cache to cold. `verify` and `clear` both refuse a root that

--- a/nab-index/src/nab_index/cache.py
+++ b/nab-index/src/nab_index/cache.py
@@ -11,7 +11,7 @@ Layout under ``root``:
     simple-v2/<index>[-<serialization>]/<package>.policy  <- {fetched_at, max_age,
                                                               etag, page_url,
                                                               body_digest}
-    simple-parsed-v0/<index>[-<serialization>]/<package>.parsed  <- parsed blob
+    simple-parsed-v1/<index>[-<serialization>]/<package>.parsed  <- parsed blob
     simple-neg-v0/<index>[-<serialization>]/<package>.neg <- {fetched_at, max_age, etag}
     metadata-v1/<index>/<package>/<url digest>.metadata
     sdist-v1/<index>/<package>/<version>.json  <- {pkg_info, pyproject}
@@ -37,6 +37,7 @@ source trees:
 from __future__ import annotations
 
 import hashlib
+import io
 import json
 import logging
 import os
@@ -55,6 +56,7 @@ from .parsed_listing import corruption_reason as _parsed_corruption
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+    from typing import BinaryIO
 
 logger = logging.getLogger(__name__)
 
@@ -71,12 +73,14 @@ __all__ = [
 
 
 CACHE_VERSION_SIMPLE = "v2"
-CACHE_VERSION_SIMPLE_PARSED = "v0"
+CACHE_VERSION_SIMPLE_PARSED = "v1"
 CACHE_VERSION_SIMPLE_NEG = "v0"
 CACHE_VERSION_METADATA = "v1"
 CACHE_VERSION_SDIST = "v1"
 CACHE_VERSION_VCS = "v1"
 CACHE_VERSION_ARCHIVE = "v1"
+
+_PARSED_BUCKET = f"simple-parsed-{CACHE_VERSION_SIMPLE_PARSED}"
 
 # Buckets of nab-written records. simple-neg-* is covered by the simple- prefix.
 ENTRY_BUCKET_PREFIXES = ("simple-", "metadata-", "sdist-")
@@ -224,9 +228,7 @@ class OnDiskCache:
             else f"{self._index}-{serialization.value}"
         )
         self._simple_dir = root / f"simple-{CACHE_VERSION_SIMPLE}" / simple_index
-        self._parsed_dir = (
-            root / f"simple-parsed-{CACHE_VERSION_SIMPLE_PARSED}" / simple_index
-        )
+        self._parsed_dir = root / _PARSED_BUCKET / simple_index
         self._neg_dir = root / f"simple-neg-{CACHE_VERSION_SIMPLE_NEG}" / simple_index
         self._metadata_dir = root / f"metadata-{CACHE_VERSION_METADATA}" / self._index
         self._sdist_dir = root / f"sdist-{CACHE_VERSION_SDIST}" / self._index
@@ -346,21 +348,23 @@ class OnDiskCache:
             )
         return policy
 
-    def get_simple_parsed(self, package: str) -> bytes | None:
-        """Return the opaque parsed-listing blob for ``package``, or ``None``.
+    def open_simple_parsed(self, package: str) -> BinaryIO | None:
+        """Open the parsed-listing blob for ``package`` for reading, or ``None``.
 
-        The blob is bytes to this layer; the record codec lives in
-        ``parsed_listing``. An absent blob is a silent miss.
+        The blob is opaque bytes to this layer; the record codec lives in
+        ``parsed_listing`` and reads it a line at a time, so the file is handed
+        over open rather than read into memory. The caller closes it. An absent
+        blob is a silent miss.
         """
         try:
-            return self._parsed_path(package).read_bytes()
+            return self._parsed_path(package).open("rb")
         except OSError:
             return None
 
     def get_simple_parsed_size(self, package: str) -> int | None:
         """Return the on-disk size of the parsed-listing blob in bytes, or ``None``.
 
-        A single ``stat`` on the same path :meth:`get_simple_parsed` reads, so a
+        A single ``stat`` on the same path :meth:`open_simple_parsed` reads, so a
         caller can size the blob before deciding whether to read and decode it.
         An absent blob is a silent miss.
         """
@@ -527,12 +531,27 @@ class OnDiskCache:
         if suffix in (".policy", ".neg"):
             return None if _decode_policy(raw) is not None else "policy not decodable"
         if suffix == ".parsed":
-            return _read_parsed_reason(raw)
+            return self._read_parsed_reason(path, raw)
         if suffix == ".metadata":
             return _read_metadata_reason(raw)
         if suffix == ".json":
             return self._read_json_reason(path, raw)
         return None
+
+    def _read_parsed_reason(self, path: Path, raw: bytes) -> str | None:
+        """Return a corruption reason for a ``.parsed`` blob, or ``None``.
+
+        A blob under a retired parsed bucket is reported clean: an earlier
+        bucket holds a wire form this codec cannot read, so parsing it there
+        would call every stale entry corrupt.
+
+        Structure only: the digest binding retires a stale-but-valid blob at
+        read time. The codec owns the check so verify and the read path agree
+        on what is corrupt.
+        """
+        if self._bucket_of(path) != _PARSED_BUCKET:
+            return None
+        return _parsed_corruption(io.BytesIO(raw))
 
     def _read_json_reason(self, path: Path, raw: bytes) -> str | None:
         try:
@@ -582,13 +601,6 @@ def _read_metadata_reason(raw: bytes) -> str | None:
     except UnicodeDecodeError:
         return "not valid UTF-8"
     return None
-
-
-def _read_parsed_reason(raw: bytes) -> str | None:
-    # Structural decodability only; the digest binding retires a stale-but-valid
-    # blob at read time, so verify does not check it. The codec owns the check so
-    # verify and the read path agree on what counts as corrupt.
-    return _parsed_corruption(raw)
 
 
 def _encode_policy(policy: CachePolicy) -> bytes:
@@ -665,8 +677,11 @@ class CacheBackend(Protocol):
         """Return a Simple entry's freshness policy without its body, or ``None``."""
         ...
 
-    def get_simple_parsed(self, package: str) -> bytes | None:
-        """Return the opaque parsed-listing blob for ``package``, or ``None``."""
+    def open_simple_parsed(self, package: str) -> BinaryIO | None:
+        """Open the parsed-listing blob for ``package``, or ``None`` on a miss.
+
+        The stream is seekable and readable, and the caller closes it.
+        """
         ...
 
     def get_simple_parsed_size(self, package: str) -> int | None:
@@ -753,7 +768,7 @@ class NullCache:
     def get_simple_policy(self, package: str) -> CachePolicy | None:
         """Return ``None`` (always a miss)."""
 
-    def get_simple_parsed(self, package: str) -> bytes | None:
+    def open_simple_parsed(self, package: str) -> BinaryIO | None:
         """Return ``None`` (always a miss)."""
 
     def get_simple_parsed_size(self, package: str) -> int | None:

--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -252,10 +252,11 @@ def read_fresh_parsed_listing(
         return None
     if not (policy.is_fresh() or offline):
         return None
-    blob = cache.get_simple_parsed(package)
-    if blob is None:
+    handle = cache.open_simple_parsed(package)
+    if handle is None:
         return None
-    return _decode_parsed(blob, policy) or None
+    with handle:
+        return _decode_parsed(handle, policy) or None
 
 
 class SdistArchiveHold:
@@ -480,18 +481,20 @@ class CachedAsyncSimpleClient:
         served blob counts a ``hit``, an absent one a ``miss``, and a
         present-but-not-served one a ``rebuild``.
         """
-        blob = self._cache.get_simple_parsed(package)
-        if blob is None:
+        handle = self._cache.open_simple_parsed(package)
+        if handle is None:
             self._parsed_stats.miss += 1
             return None
-        records = _decode_parsed(blob, policy)
-        if records:
-            self._parsed_stats.hit += 1
-            return records
-        self._parsed_stats.rebuild += 1
-        if records is not None:
-            return None
-        reason = _parsed_corruption(blob)
+        with handle:
+            records = _decode_parsed(handle, policy)
+            if records:
+                self._parsed_stats.hit += 1
+                return records
+            self._parsed_stats.rebuild += 1
+            if records is not None:
+                return None
+            handle.seek(0)
+            reason = _parsed_corruption(handle)
         if reason is not None:
             logger.warning(
                 "Corrupt parsed-listing cache blob for %r from %s: %s; ignoring it",

--- a/nab-index/src/nab_index/parsed_listing.py
+++ b/nab-index/src/nab_index/parsed_listing.py
@@ -5,21 +5,27 @@ resolve skips ``json.loads`` and wheel/sdist filename parsing. This module
 owns the record<->bytes translation; :class:`~nab_index.cache.OnDiskCache`
 treats the blob as opaque and knows nothing about record shapes.
 
-Wire form (UTF-8 JSON of ``[header, rows]``):
+Wire form (UTF-8 JSON, one document per line):
 
-* header ``[format, codec, key_scheme, body_digest]`` is checked before
-  anything is trusted. A reader on a different ``format``, ``codec``, or
-  ``key_scheme`` treats the entry as a miss and rebuilds, so a cache written by
-  an older build self-heals instead of misdecoding. ``body_digest`` binds the
-  blob to the raw body it was parsed from; :func:`decode` rejects a blob whose
-  digest does not equal the policy's, so a raw-body update invalidates the
-  derived form.
-* rows hold one entry per surviving record, in the order the wire parse
-  returned them, so a downstream stable-sort tie-break stays identical. Each
-  row is a flat list tagged wheel or sdist by its first element. Every field is
-  type-checked on the way back, and ``requires_python`` and hash-algorithm
-  names are re-interned via ``sys.intern`` so the round trip reproduces the
-  dedup the wire parse builds.
+* the first line is the header
+  ``[format, codec, key_scheme, body_digest, rows]``, checked before anything
+  is trusted. A reader on a different ``format``, ``codec``, or ``key_scheme``
+  treats the entry as a miss and rebuilds, so a cache written by an older build
+  self-heals instead of misdecoding. ``body_digest`` binds the blob to the raw
+  body it was parsed from; :func:`decode` rejects a blob whose digest does not
+  equal the policy's, so a raw-body update invalidates the derived form.
+  ``rows`` is how many rows were written, and a reader that decodes a different
+  number rejects the blob, so bytes lost at a line boundary are a miss rather
+  than a silently short listing.
+* every later line is a batch of up to ``_ROWS_PER_LINE`` rows, one entry per
+  surviving record, in the order the wire parse returned them, so a downstream
+  stable-sort tie-break stays identical. Each row is a flat list tagged wheel
+  or sdist by its first element. Every field is type-checked on the way back,
+  and ``requires_python`` and hash-algorithm names are re-interned via
+  ``sys.intern`` so the round trip reproduces the dedup the wire parse builds.
+* batching lets :func:`decode` read straight from the cache file, one line at
+  a time, rather than holding the whole document and the copy ``json.loads``
+  makes of it.
 * the two integrity cells carry the index's own table, as a JSON object, when
   the record was built from one, and the parsed pairs otherwise. A rehydrated
   record defers the same way, so a listing pays the integrity parse only for
@@ -44,7 +50,7 @@ from nab_provider.records import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Iterable, Iterator, Sequence
 
     from .cache import CachePolicy
 
@@ -57,13 +63,15 @@ __all__ = ["corruption_reason", "decode", "encode"]
 FORMAT_VERSION = 3
 # Serialization variant that wrote the rows, so a future codec switch
 # self-heals rather than misdecodes.
-CODEC = 1
+CODEC = 2
 # Version sort-key scheme the rows carry; 0 == no precomputed keys. A later
 # scheme bumps this and self-heals via a reparse.
 KEY_SCHEME = 0
 
-_TOP_LEN = 2
-_HEADER_LEN = 4
+_HEADER_LEN = 5
+# Rows per wire line. A smaller batch holds fewer decoded rows at once and costs
+# more ``json.loads`` calls.
+_ROWS_PER_LINE = 1024
 _PAIR_LEN = 2
 _TAG_WHEEL = 0
 _TAG_SDIST = 1
@@ -98,118 +106,151 @@ def encode(files: list[WheelFile | SdistFile], body_digest: str) -> bytes:
     remote body) and ``metadata_url`` is a derived property, so neither rides
     the wire.
     """
-    rows: list[list[object]] = []
+    header = [FORMAT_VERSION, CODEC, KEY_SCHEME, body_digest, len(files)]
+    blob = bytearray(_line(header))
+    batch: list[list[object]] = []
     for record in files:
         if isinstance(record, WheelFile):
-            rows.append(
-                [
-                    _TAG_WHEEL,
-                    record.filename,
-                    record.url,
-                    record.version,
-                    record.requires_python,
-                    record.has_metadata,
-                    record.upload_time,
-                    _hashes_cell(record),
-                    record.size,
-                    _sidecar_cell(record),
-                ]
-            )
+            row: list[object] = [
+                _TAG_WHEEL,
+                record.filename,
+                record.url,
+                record.version,
+                record.requires_python,
+                record.has_metadata,
+                record.upload_time,
+                _hashes_cell(record),
+                record.size,
+                _sidecar_cell(record),
+            ]
         else:
-            rows.append(
-                [
-                    _TAG_SDIST,
-                    record.filename,
-                    record.url,
-                    record.version,
-                    record.requires_python,
-                    record.upload_time,
-                    _hashes_cell(record),
-                    record.size,
-                ]
-            )
-    header = [FORMAT_VERSION, CODEC, KEY_SCHEME, body_digest]
+            row = [
+                _TAG_SDIST,
+                record.filename,
+                record.url,
+                record.version,
+                record.requires_python,
+                record.upload_time,
+                _hashes_cell(record),
+                record.size,
+            ]
 
-    # Escape non-ASCII: a field kept verbatim from the listing, such as
-    # ``requires_python``, can hold a lone surrogate with no UTF-8 form.
-    return json.dumps([header, rows], separators=(",", ":")).encode()
+        batch.append(row)
+        if len(batch) == _ROWS_PER_LINE:
+            blob += _line(batch)
+            batch.clear()
+
+    if batch:
+        blob += _line(batch)
+    return bytes(blob)
 
 
-def decode(blob: bytes, policy: CachePolicy) -> list[WheelFile | SdistFile] | None:
-    """Decode a cache blob back to parsed records, or ``None`` to force a miss.
+def _line(document: object) -> bytes:
+    """Serialize one wire document as its own line.
+
+    ``json.dumps`` escapes control characters, so a serialized document carries
+    no newline of its own for the line split to trip over. Non-ASCII is escaped
+    as well, because a field kept verbatim from the listing, such as
+    ``requires_python``, can hold a lone surrogate with no UTF-8 form.
+    """
+    return json.dumps(document, separators=(",", ":")).encode() + b"\n"
+
+
+def decode(
+    lines: Iterable[bytes], policy: CachePolicy
+) -> list[WheelFile | SdistFile] | None:
+    """Decode a cache blob's ``lines`` to parsed records, or ``None`` for a miss.
+
+    ``lines`` is the blob read line by line, so an open cache file can be
+    passed straight in and the document is never held whole.
 
     Returns ``None`` (treat as a cache miss and rebuild from the raw body) when
-    the blob does not decode, is the wrong shape, was written by a different
-    build (``format`` / ``codec`` / ``key_scheme``), or is not bound to
-    ``policy``'s body (``body_digest``).  Otherwise rehydrates the records,
+    the blob does not decode, cannot be read, is the wrong shape, holds a
+    different number of rows than its header declares, was written by a
+    different build (``format`` / ``codec`` / ``key_scheme``), or is not bound
+    to ``policy``'s body (``body_digest``). Otherwise rehydrates the records,
     re-interning ``requires_python`` and hash-algorithm names so string identity
     matches a fresh parse.
     """
+    stream = iter(lines)
+    # Every failure is a miss, a read error included: this must not raise.
     try:
-        loaded = json.loads(blob)
-    except ValueError:
+        header = _read_header(stream)
+        if isinstance(header, str):
+            return None
+
+        format_, codec, key_scheme, body_digest, count = header
+        if (
+            format_ != FORMAT_VERSION
+            or codec != CODEC
+            or key_scheme != KEY_SCHEME
+            or policy.body_digest is None
+            or body_digest != policy.body_digest
+        ):
+            return None
+
+        records: list[WheelFile | SdistFile] = []
+        for batch in stream:
+            # A list rather than a generator into ``extend``: measured cheaper.
+            records.extend([_decode_row(row) for row in json.loads(batch)])
+    except (OSError, ValueError, TypeError):
         return None
-    if not (isinstance(loaded, list) and len(loaded) == _TOP_LEN):
-        return None
-    header, rows = loaded
-    if not (isinstance(header, list) and len(header) == _HEADER_LEN):
-        return None
-    format_, codec, key_scheme, body_digest = header
-    if (
-        format_ != FORMAT_VERSION
-        or codec != CODEC
-        or key_scheme != KEY_SCHEME
-        or policy.body_digest is None
-        or body_digest != policy.body_digest
-    ):
-        return None
-    # A blob whose header matches this build but whose rows are the wrong shape
-    # must rebuild, not crash the resolve; the rows are untrusted too.
-    try:
-        return _decode_rows(rows)
-    except (ValueError, TypeError):
-        return None
+    return records if len(records) == count else None
 
 
-def corruption_reason(blob: bytes) -> str | None:
-    """Return a reason if ``blob`` is structurally corrupt, else ``None``.
+def corruption_reason(lines: Iterable[bytes]) -> str | None:
+    """Return a reason if a blob's ``lines`` are structurally corrupt, else ``None``.
 
     Distinguishes genuine corruption (garbage or truncated bytes, or a
-    same-build blob whose rows are the wrong shape) from a benign miss, where
-    the header names a different build or binds a different body. The read path
-    warns only on the former. The row check runs only once the header names this
-    exact build, since a foreign build may have written a shape this one never
-    did; checking it earlier would misreport version skew as corruption. This is
-    a second pass used only to gate that warning; :func:`decode` returns ``None``
-    for every miss reason alike.
+    same-build blob whose rows are the wrong shape or the wrong number) from a
+    benign miss, where the header names a different build or binds a different
+    body. The read path warns only on the former. The row checks run only once
+    the header names this exact build, since a foreign build may have written a
+    shape this one never did; checking earlier would misreport version skew as
+    corruption. This second pass only gates that warning; :func:`decode`
+    returns ``None`` for every miss reason alike.
     """
+    stream = iter(lines)
+    seen = 0
     try:
-        loaded = json.loads(blob)
-    except ValueError:
-        return "not valid JSON"
-    if not (isinstance(loaded, list) and len(loaded) == _TOP_LEN):
-        return "unexpected top-level shape"
-    header, rows = loaded
-    if not (isinstance(header, list) and len(header) == _HEADER_LEN):
-        return "unexpected header shape"
-    format_, codec, key_scheme, _body_digest = header
-    if format_ != FORMAT_VERSION or codec != CODEC or key_scheme != KEY_SCHEME:
-        # A different-build header is benign version skew, not corruption; its
-        # rows may be a shape this build never wrote. A same-build body_digest
-        # mismatch decodes cleanly below and returns None silently.
-        return None
-    try:
-        _decode_rows(rows)
+        header = _read_header(stream)
+        if isinstance(header, str):
+            return header
+
+        format_, codec, key_scheme, _body_digest, count = header
+        if format_ != FORMAT_VERSION or codec != CODEC or key_scheme != KEY_SCHEME:
+            # Version skew: another build may write a row shape this one never did.
+            return None
+
+        for batch in stream:
+            for row in json.loads(batch):
+                _decode_row(row)
+                seen += 1
     except (ValueError, TypeError):
         return "unexpected row shape"
-    return None
+    except OSError:
+        # A blob the filesystem will not hand over is unreadable, not corrupt.
+        return None
+    return None if seen == count else "unexpected row count"
 
 
-def _decode_rows(rows: object) -> list[WheelFile | SdistFile]:
-    """Rehydrate every row, raising :class:`_BadRowError` on the first bad one."""
-    if not isinstance(rows, list):
-        raise _BadRowError
-    return [_decode_row(row) for row in rows]
+def _read_header(lines: Iterator[bytes]) -> list[object] | str:
+    """Consume the first of ``lines``, returning the header or a reason.
+
+    A ``str`` is the corruption reason for a first line that is missing, is not
+    JSON, or is not this codec's header shape. Shared so the read path and
+    :func:`corruption_reason` cannot disagree on what a header is.
+    """
+    line = next(lines, None)
+    if line is None:
+        return "not valid JSON"
+    try:
+        header = json.loads(line)
+    except ValueError:
+        return "not valid JSON"
+    if not (isinstance(header, list) and len(header) == _HEADER_LEN):
+        return "unexpected header shape"
+    return header
 
 
 def _decode_row(row: object) -> WheelFile | SdistFile:

--- a/nab-index/tests/test_index_parsed_cache.py
+++ b/nab-index/tests/test_index_parsed_cache.py
@@ -1,8 +1,8 @@
 """Tests for the parsed-listing cache storage layer and write path.
 
 Covers the ``body_digest`` policy field and its encode/decode, the
-policy-only ``get_simple_policy`` read, the opaque-bytes
-``get_simple_parsed``/``put_simple_parsed`` pair, and the ``.parsed`` branch
+policy-only ``get_simple_policy`` read, the opaque-blob
+``open_simple_parsed``/``put_simple_parsed`` pair, and the ``.parsed`` branch
 of ``read_cache_entry``, plus the write path that binds a parsed blob to
 the body just stored: :meth:`OnDiskCache.put_simple` computes the digest,
 and every :class:`CachedAsyncSimpleClient` write point emits a blob bound
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import io
 import json
 import logging
 from collections.abc import Coroutine, Mapping
@@ -33,11 +34,51 @@ from nab_index.cache import (
     is_recognized_bucket,
 )
 from nab_index.cached_client import CachedAsyncSimpleClient, ParsedCacheStats
-from nab_index.client import _parse_files
+from nab_index.client import SdistFile, WheelFile, _parse_files
 from nab_index.parsed_listing import corruption_reason, decode, encode
 
 # Derived so a bucket-version bump does not need every path updated.
 _SIMPLE_BUCKET = f"simple-{CACHE_VERSION_SIMPLE}"
+
+
+def _parsed(cache: OnDiskCache, package: str) -> bytes | None:
+    """The stored blob's bytes, read back through the handle the cache opens."""
+    handle = cache.open_simple_parsed(package)
+    if handle is None:
+        return None
+    with handle:
+        return handle.read()
+
+
+def _decode_stored(
+    cache: OnDiskCache, package: str, policy: CachePolicy
+) -> list[WheelFile | SdistFile] | None:
+    """Decode the blob the cache holds for ``package``, as the read path does."""
+    handle = cache.open_simple_parsed(package)
+    assert handle is not None
+    with handle:
+        return decode(handle, policy)
+
+
+def _decode(blob: bytes, policy: CachePolicy) -> list[WheelFile | SdistFile] | None:
+    """Decode a whole blob the way the read path decodes the open cache file."""
+    return decode(io.BytesIO(blob), policy)
+
+
+def _reason(blob: bytes) -> str | None:
+    """Report on a whole blob, as the read path does on the open cache file."""
+    return corruption_reason(io.BytesIO(blob))
+
+
+def _documents(blob: bytes) -> list:
+    """The blob's header and its row batches, one decoded document per line."""
+    return [json.loads(line) for line in blob.splitlines()]
+
+
+def _blob(header: object, rows: object) -> bytes:
+    """Write ``header`` and one batch of ``rows``, as the codec lays a blob out."""
+    return b"".join(json.dumps(doc).encode() + b"\n" for doc in (header, rows))
+
 
 _FRESH = CachePolicy(fetched_at=0, max_age=600, etag=None)
 
@@ -161,7 +202,7 @@ class TestGetSimpleParsedBucket:
     def test_round_trip(self, tmp_path: Path) -> None:
         cache = _cache(tmp_path)
         cache.put_simple_parsed("foo", b"\x00blob\x01")
-        assert cache.get_simple_parsed("foo") == b"\x00blob\x01"
+        assert _parsed(cache, "foo") == b"\x00blob\x01"
 
     def test_written_under_parsed_bucket(self, tmp_path: Path) -> None:
         cache = _cache(tmp_path)
@@ -175,13 +216,13 @@ class TestGetSimpleParsedBucket:
         assert expected.read_bytes() == b"blob"
 
     def test_miss_returns_none(self, tmp_path: Path) -> None:
-        assert _cache(tmp_path).get_simple_parsed("absent") is None
+        assert _parsed(_cache(tmp_path), "absent") is None
 
     def test_reput_replaces(self, tmp_path: Path) -> None:
         cache = _cache(tmp_path)
         cache.put_simple_parsed("foo", b"old")
         cache.put_simple_parsed("foo", b"new")
-        assert cache.get_simple_parsed("foo") == b"new"
+        assert _parsed(cache, "foo") == b"new"
 
     def test_partial_write_leaves_prior_blob(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -195,7 +236,7 @@ class TestGetSimpleParsedBucket:
         monkeypatch.setattr("nab_index.atomic.os.replace", fail_replace)
         with pytest.raises(OSError, match="disk full"):
             cache.put_simple_parsed("foo", b"partial")
-        assert cache.get_simple_parsed("foo") == b"good"
+        assert _parsed(cache, "foo") == b"good"
         parent = tmp_path / f"simple-parsed-{CACHE_VERSION_SIMPLE_PARSED}" / "pypi"
         assert [p.name for p in parent.iterdir()] == ["foo.parsed"]
 
@@ -255,13 +296,29 @@ class TestReadCacheEntryParsed:
         path.write_bytes(b"\xff\xfe not json")
         assert cache.read_cache_entry(path) is not None
 
+    def test_a_retired_bucket_blob_is_left_alone(self, tmp_path: Path) -> None:
+        """An entry a version bump retired is walked but never read as current.
+
+        A cache written before the bump keeps the old bucket until
+        ``nab cache clear`` reclaims it, and its wire form is one this codec
+        cannot read.
+        """
+        cache = _cache(tmp_path)
+        path = tmp_path / "simple-parsed-v0" / "pypi" / "foo.parsed"
+        path.parent.mkdir(parents=True)
+        # The whole-document form the v0 bucket held: header alongside rows.
+        path.write_bytes(json.dumps([[3, 1, 0, "a" * 64], []]).encode())
+
+        assert path in set(cache.iter_cache_entries())
+        assert cache.read_cache_entry(path) is None
+
 
 class TestNullCacheParsed:
     def test_get_simple_policy(self) -> None:
         assert NullCache().get_simple_policy("foo") is None
 
-    def test_get_simple_parsed(self) -> None:
-        assert NullCache().get_simple_parsed("foo") is None
+    def test_open_simple_parsed(self) -> None:
+        assert NullCache().open_simple_parsed("foo") is None
 
     def test_get_simple_parsed_size(self) -> None:
         assert NullCache().get_simple_parsed_size("foo") is None
@@ -337,14 +394,14 @@ class TestDroppedBodyWrite:
         files = _run(client.get_files("pkg"))
 
         assert files == _PARSED
-        assert cache.get_simple_parsed("pkg") is None
+        assert _parsed(cache, "pkg") is None
 
     def test_revalidation_keeps_the_blob_bound_to_the_stored_body(
         self, tmp_path: Path
     ) -> None:
         warm = _cache(tmp_path)
         _warm_bound(warm, fresh=False)
-        before = warm.get_simple_parsed("pkg")
+        before = _parsed(warm, "pkg")
         new_body = json.dumps({**_LISTING, "files": []}).encode()
         cache = _DroppingCache(tmp_path, _INDEX)
         transport = _FakeTransport([_FakeResponse(new_body, headers={"etag": "v2"})])
@@ -355,12 +412,12 @@ class TestDroppedBodyWrite:
         # The refused body never landed, so the old body, its policy, and the
         # blob bound to it stay coherent instead of being retired for a body
         # that is not there.
-        assert cache.get_simple_parsed("pkg") == before
+        assert _parsed(cache, "pkg") == before
         result = cache.get_simple("pkg")
         assert result is not None
         body, policy = result
         assert body == _LISTING_BYTES
-        assert decode(before, policy) is not None
+        assert _decode(before, policy) is not None
 
 
 _UNREADABLE_LISTING_BYTES = json.dumps(
@@ -391,14 +448,14 @@ class TestWritePathParsedBlob:
         client = CachedAsyncSimpleClient(transport, cache, _INDEX)
 
         assert _run(client.get_files("pkg")) == []
-        assert cache.get_simple_parsed("pkg") is None
+        assert _parsed(cache, "pkg") is None
 
         stats = ParsedCacheStats()
         warm = CachedAsyncSimpleClient(
             _FakeTransport([]), cache, _INDEX, parsed_stats=stats
         )
         assert _run(warm.get_files("pkg")) == []
-        assert cache.get_simple_parsed("pkg") is None
+        assert _parsed(cache, "pkg") is None
         assert (stats.hit, stats.miss, stats.rebuild) == (0, 1, 0)
 
     def test_fetch_writes_bound_parsed_blob(self, tmp_path: Path) -> None:
@@ -415,9 +472,9 @@ class TestWritePathParsedBlob:
         body, policy = result
         assert body == _LISTING_BYTES
         assert policy.body_digest == hashlib.sha256(_LISTING_BYTES).hexdigest()
-        blob = cache.get_simple_parsed("pkg")
+        blob = _parsed(cache, "pkg")
         assert blob is not None
-        decoded = decode(blob, policy)
+        decoded = _decode(blob, policy)
         assert decoded == files
         assert decoded == _parse_files(json.loads(body), _INDEX_NORM, "pkg")
 
@@ -438,9 +495,9 @@ class TestWritePathParsedBlob:
         body, policy = result
         assert body == _LISTING_BYTES
         assert policy.body_digest == hashlib.sha256(_LISTING_BYTES).hexdigest()
-        blob = cache.get_simple_parsed("pkg")
+        blob = _parsed(cache, "pkg")
         assert blob is not None
-        assert decode(blob, policy) == files
+        assert _decode(blob, policy) == files
 
     def test_revalidate_304_preserves_body_parsed_and_digest(
         self, tmp_path: Path
@@ -467,8 +524,8 @@ class TestWritePathParsedBlob:
         new_body, policy = result
         assert new_body == body
         assert policy.body_digest == digest
-        assert cache.get_simple_parsed("pkg") == old_blob
-        assert decode(old_blob, policy) == files
+        assert _parsed(cache, "pkg") == old_blob
+        assert _decode(old_blob, policy) == files
 
     def test_revalidate_304_from_a_new_page_retires_the_blob(
         self, tmp_path: Path
@@ -498,8 +555,8 @@ class TestWritePathParsedBlob:
         assert policy.body_digest is None
         # The blob is still on disk but no longer binds, so the next read
         # rebuilds it against the new page rather than serving stale URLs.
-        assert cache.get_simple_parsed("pkg") == old_blob
-        assert decode(old_blob, policy) is None
+        assert _parsed(cache, "pkg") == old_blob
+        assert _decode(old_blob, policy) is None
 
 
 _SURROGATE_REQUIRES_PYTHON = ">=3.8\ud800"
@@ -569,14 +626,14 @@ def _warm_bound(
 
 
 def _tamper_header(blob: bytes, index: int, value: object) -> bytes:
-    header, rows = json.loads(blob)
+    header, rows = _documents(blob)
     header[index] = value
-    return json.dumps([header, rows]).encode()
+    return _blob(header, rows)
 
 
-def _tamper_rows(blob: bytes, value: object) -> bytes:
-    header, _rows = json.loads(blob)
-    return json.dumps([header, value]).encode()
+def _tamper_rows(blob: bytes, rows: object) -> bytes:
+    header, _rows = _documents(blob)
+    return _blob(header, rows)
 
 
 class TestReadPathParsedHit:
@@ -596,13 +653,13 @@ class TestReadPathParsedHit:
     def test_hit_does_not_rewrite_the_blob(self, tmp_path: Path) -> None:
         cache = _cache(tmp_path)
         _warm_bound(cache)
-        before = cache.get_simple_parsed("pkg")
+        before = _parsed(cache, "pkg")
         transport = _FakeTransport([])
         client = CachedAsyncSimpleClient(transport, cache, _INDEX)
 
         _run(client.get_files("pkg"))
 
-        assert cache.get_simple_parsed("pkg") == before
+        assert _parsed(cache, "pkg") == before
 
 
 class TestReadPathRebuild:
@@ -613,7 +670,7 @@ class TestReadPathRebuild:
             _LISTING_BYTES,
             CachePolicy(fetched_at=2_000_000_000, max_age=99999, etag=None),
         )
-        assert cache.get_simple_parsed("pkg") is None
+        assert _parsed(cache, "pkg") is None
         transport = _FakeTransport([])
         client = CachedAsyncSimpleClient(transport, cache, _INDEX)
 
@@ -621,13 +678,13 @@ class TestReadPathRebuild:
 
         assert got == _PARSED
         assert transport.calls == []
-        blob = cache.get_simple_parsed("pkg")
+        blob = _parsed(cache, "pkg")
         assert blob is not None
         result = cache.get_simple("pkg")
         assert result is not None
         _, policy = result
         assert policy.body_digest == digest
-        assert decode(blob, policy) == got
+        assert _decode(blob, policy) == got
 
     def test_rebuild_on_digest_mismatch_no_warning(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
@@ -647,7 +704,7 @@ class TestReadPathRebuild:
         result = cache.get_simple("pkg")
         assert result is not None
         _, policy = result
-        assert decode(cache.get_simple_parsed("pkg"), policy) == files
+        assert _decode_stored(cache, "pkg", policy) == files
 
     @pytest.mark.parametrize(
         ("field", "value"),
@@ -681,7 +738,7 @@ class TestReadPathRebuild:
         assert result is not None
         _, policy = result
         # The rebuilt blob is now well-formed and hits.
-        assert decode(cache.get_simple_parsed("pkg"), policy) == files
+        assert _decode_stored(cache, "pkg", policy) == files
 
     @pytest.mark.parametrize("blob", [b"\xff\xfe not json", b"", b"\x00\x01\x02"])
     def test_garbage_blob_warns_and_reparses(
@@ -701,7 +758,7 @@ class TestReadPathRebuild:
         result = cache.get_simple("pkg")
         assert result is not None
         _, policy = result
-        assert decode(cache.get_simple_parsed("pkg"), policy) == files
+        assert _decode_stored(cache, "pkg", policy) == files
 
     def test_truncated_blob_warns_and_reparses(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
@@ -742,7 +799,7 @@ class TestReadPathRebuild:
         result = cache.get_simple("pkg")
         assert result is not None
         _, policy = result
-        assert decode(cache.get_simple_parsed("pkg"), policy) == files
+        assert _decode_stored(cache, "pkg", policy) == files
 
     def test_pre_c1_policy_without_digest_self_heals(self, tmp_path: Path) -> None:
         cache = _cache(tmp_path)
@@ -768,7 +825,7 @@ class TestReadPathRebuild:
         got_policy = cache.get_simple_policy("pkg")
         assert got_policy is not None
         assert got_policy.body_digest == digest
-        assert decode(cache.get_simple_parsed("pkg"), got_policy) == _PARSED
+        assert _decode_stored(cache, "pkg", got_policy) == _PARSED
 
 
 class TestReadPathCorruptBody:
@@ -870,7 +927,7 @@ class TestReadPathRevalidate:
         assert result is not None
         body, policy = result
         assert body == _LISTING_V2_BYTES
-        assert decode(cache.get_simple_parsed("pkg"), policy) == got
+        assert _decode_stored(cache, "pkg", policy) == got
 
     def test_stale_online_200_revalidates_without_reading_the_body(
         self, tmp_path: Path
@@ -897,7 +954,7 @@ class TestReadPathRevalidate:
     def test_stale_online_304_reuses_blob(self, tmp_path: Path) -> None:
         cache = _cache(tmp_path)
         files, _ = _warm_bound(cache, fresh=False)
-        before = cache.get_simple_parsed("pkg")
+        before = _parsed(cache, "pkg")
         transport = _FakeTransport(
             [_FakeResponse(b"", status=304, headers={"etag": "e"})]
         )
@@ -906,11 +963,11 @@ class TestReadPathRevalidate:
         got = _run(client.get_files("pkg"))
 
         assert got == files
-        assert cache.get_simple_parsed("pkg") == before
+        assert _parsed(cache, "pkg") == before
         result = cache.get_simple("pkg")
         assert result is not None
         _, policy = result
-        assert decode(before, policy) == files
+        assert _decode(before, policy) == files
 
     def test_stale_online_304_serves_the_blob_without_the_body(
         self, tmp_path: Path
@@ -993,17 +1050,15 @@ class TestReadPathRevalidate:
 
 class TestParsedCorruptionReason:
     def test_garbage_is_corrupt(self) -> None:
-        assert corruption_reason(b"not json") is not None
+        assert _reason(b"not json") is not None
 
     def test_truncated_is_corrupt(self) -> None:
         blob = encode(_PARSED, "a" * 64)
-        assert corruption_reason(blob[: len(blob) // 2]) is not None
+        assert _reason(blob[: len(blob) // 2]) is not None
 
-    def test_wrong_top_shape_is_corrupt(self) -> None:
-        assert corruption_reason(json.dumps([1, 2, 3]).encode()) is not None
-
-    def test_wrong_header_shape_is_corrupt(self) -> None:
-        assert corruption_reason(json.dumps(["bad", "rows"]).encode()) is not None
+    @pytest.mark.parametrize("header", [7, [1, 2, 3], ["bad", "rows"]])
+    def test_unreadable_header_is_corrupt(self, header: object) -> None:
+        assert _reason(json.dumps(header).encode()) is not None
 
     @pytest.mark.parametrize(
         "rows",
@@ -1011,21 +1066,21 @@ class TestParsedCorruptionReason:
     )
     def test_wrong_row_shape_is_corrupt(self, rows: object) -> None:
         tampered = _tamper_rows(encode(_PARSED, "a" * 64), rows)
-        assert corruption_reason(tampered) is not None
+        assert _reason(tampered) is not None
 
     def test_well_formed_blob_is_clean(self) -> None:
-        assert corruption_reason(encode(_PARSED, "a" * 64)) is None
+        assert _reason(encode(_PARSED, "a" * 64)) is None
 
     def test_header_value_mismatch_is_clean(self) -> None:
         # A build/digest mismatch is a benign self-heal, not corruption.
         tampered = _tamper_header(encode(_PARSED, "a" * 64), 0, 99)
-        assert corruption_reason(tampered) is None
+        assert _reason(tampered) is None
 
     def test_foreign_build_with_wrong_rows_is_clean(self) -> None:
         # A future build may bump the codec and write a row shape this build
         # never wrote; that is benign version skew, not on-disk corruption.
         tampered = _tamper_rows(_tamper_header(encode(_PARSED, "a" * 64), 1, 99), [])
-        assert corruption_reason(tampered) is None
+        assert _reason(tampered) is None
 
 
 class TestParsedCacheStats:

--- a/nab-index/tests/test_parsed_listing_codec.py
+++ b/nab-index/tests/test_parsed_listing_codec.py
@@ -13,6 +13,8 @@ and the field checks that keep a hand-written row from reaching a record.
 from __future__ import annotations
 
 import dataclasses
+import errno
+import io
 import json
 import sys
 
@@ -21,6 +23,7 @@ import pytest
 from nab_index.cache import CachePolicy
 from nab_index.client import SdistFile, WheelFile
 from nab_index.parsed_listing import (
+    _ROWS_PER_LINE,
     _TAG_SDIST,
     _TAG_WHEEL,
     CODEC,
@@ -42,6 +45,7 @@ RP = sys.intern(">=3.8")
 _H_FORMAT = 0
 _H_CODEC = 1
 _H_KEY_SCHEME = 2
+_H_ROWS = 4
 
 # An sdist row is tag plus seven fields; the unknown-tag case relies on keeping
 # that arity so the tag check is what rejects it, not the unpack.
@@ -116,8 +120,28 @@ SDIST_BARE = SdistFile(
 SAMPLE: list[WheelFile | SdistFile] = [WHEEL_FULL, SDIST_FULL, WHEEL_BARE, SDIST_BARE]
 
 
+def _decode(blob: bytes, policy: CachePolicy) -> list[WheelFile | SdistFile] | None:
+    """Decode a whole blob the way the read path decodes the open cache file."""
+    return decode(io.BytesIO(blob), policy)
+
+
+def _reason(blob: bytes) -> str | None:
+    """Report on a whole blob, as the read path does on the open cache file."""
+    return corruption_reason(io.BytesIO(blob))
+
+
+def _documents(blob: bytes) -> list:
+    """The blob's header and its row batches, one decoded document per line."""
+    return [json.loads(line) for line in blob.splitlines()]
+
+
+def _blob(header: object, rows: object) -> bytes:
+    """Write ``header`` and one batch of ``rows``, as the codec lays a blob out."""
+    return b"".join(json.dumps(doc).encode() + b"\n" for doc in (header, rows))
+
+
 def _roundtrip(files: list[WheelFile | SdistFile]) -> list[WheelFile | SdistFile]:
-    decoded = decode(encode(files, DIGEST), _policy())
+    decoded = _decode(encode(files, DIGEST), _policy())
     assert decoded is not None
     return decoded
 
@@ -146,6 +170,18 @@ def test_empty_listing_roundtrips() -> None:
     assert _roundtrip([]) == []
 
 
+def test_a_listing_past_one_batch_roundtrips() -> None:
+    """Records spanning several wire lines come back in one flat list, in order."""
+    files: list[WheelFile | SdistFile] = [
+        dataclasses.replace(WHEEL_FULL, filename=f"pkg-{n}-py3-none-any.whl")
+        for n in range(_ROWS_PER_LINE + 1)
+    ]
+    blob = encode(files, DIGEST)
+
+    assert len(blob.splitlines()) == 3
+    assert _roundtrip(files) == files
+
+
 def test_metadata_hash_present_and_absent() -> None:
     decoded = _roundtrip([WHEEL_FULL, WHEEL_BARE])
     full, bare = decoded[0], decoded[1]
@@ -163,64 +199,69 @@ def test_lone_surrogate_in_field_round_trips() -> None:
     """
     record = dataclasses.replace(SDIST_FULL, requires_python=f"{RP}\ud800")
 
-    assert decode(encode([record], DIGEST), _policy()) == [record]
+    assert _decode(encode([record], DIGEST), _policy()) == [record]
 
 
 def test_blob_is_portable_json() -> None:
     """The wire form carries no interpreter tag, so any reader can decode it."""
-    header, rows = json.loads(encode(SAMPLE, DIGEST))
-    assert header == [FORMAT_VERSION, CODEC, KEY_SCHEME, DIGEST]
+    header, rows = _documents(encode(SAMPLE, DIGEST))
+    assert header == [FORMAT_VERSION, CODEC, KEY_SCHEME, DIGEST, len(SAMPLE)]
     assert [row[0] for row in rows] == [_TAG_WHEEL, _TAG_SDIST, _TAG_WHEEL, _TAG_SDIST]
 
 
 def _tamper_header(index: int, value: object) -> bytes:
-    header, rows = json.loads(encode(SAMPLE, DIGEST))
+    header, rows = _documents(encode(SAMPLE, DIGEST))
     header[index] = value
-    return json.dumps([header, rows]).encode()
+    return _blob(header, rows)
 
 
 def _blob_with_rows(rows: object) -> bytes:
-    """A blob whose header names this exact build, over caller-supplied rows."""
-    header, _rows = json.loads(encode(SAMPLE, DIGEST))
-    return json.dumps([header, rows]).encode()
+    """A blob whose header names this exact build, over caller-supplied rows.
+
+    The header's row count is set to match, so the row checks are what these
+    cases exercise rather than the count.
+    """
+    header, _rows = _documents(encode(SAMPLE, DIGEST))
+    header[_H_ROWS] = len(rows) if isinstance(rows, list) else 0
+    return _blob(header, rows)
 
 
 def _wheel_row_with(index: int, value: object) -> bytes:
     """A blob holding one wheel row with a single field replaced."""
-    _header, rows = json.loads(encode([WHEEL_FULL], DIGEST))
+    _header, rows = _documents(encode([WHEEL_FULL], DIGEST))
     rows[0][index] = value
     return _blob_with_rows(rows)
 
 
 def _sdist_row_with(index: int, value: object) -> bytes:
     """A blob holding one sdist row with a single field replaced."""
-    _header, rows = json.loads(encode([SDIST_FULL], DIGEST))
+    _header, rows = _documents(encode([SDIST_FULL], DIGEST))
     rows[0][index] = value
     return _blob_with_rows(rows)
 
 
 def test_valid_blob_decodes() -> None:
-    assert decode(encode(SAMPLE, DIGEST), _policy()) is not None
+    assert _decode(encode(SAMPLE, DIGEST), _policy()) is not None
 
 
 def test_format_mismatch_is_miss() -> None:
-    assert decode(_tamper_header(_H_FORMAT, FORMAT_VERSION + 1), _policy()) is None
+    assert _decode(_tamper_header(_H_FORMAT, FORMAT_VERSION + 1), _policy()) is None
 
 
 def test_codec_mismatch_is_miss() -> None:
-    assert decode(_tamper_header(_H_CODEC, CODEC + 1), _policy()) is None
+    assert _decode(_tamper_header(_H_CODEC, CODEC + 1), _policy()) is None
 
 
 def test_key_scheme_mismatch_is_miss() -> None:
-    assert decode(_tamper_header(_H_KEY_SCHEME, KEY_SCHEME + 1), _policy()) is None
+    assert _decode(_tamper_header(_H_KEY_SCHEME, KEY_SCHEME + 1), _policy()) is None
 
 
 def test_digest_mismatch_is_miss() -> None:
-    assert decode(encode(SAMPLE, DIGEST), _policy("b" * 64)) is None
+    assert _decode(encode(SAMPLE, DIGEST), _policy("b" * 64)) is None
 
 
 def test_policy_without_digest_is_miss() -> None:
-    assert decode(encode(SAMPLE, DIGEST), _policy(None)) is None
+    assert _decode(encode(SAMPLE, DIGEST), _policy(None)) is None
 
 
 @pytest.mark.parametrize(
@@ -236,12 +277,52 @@ def test_policy_without_digest_is_miss() -> None:
     ],
 )
 def test_malformed_blob_is_miss(blob: bytes) -> None:
-    assert decode(blob, _policy()) is None
+    assert _decode(blob, _policy()) is None
 
 
 def test_truncated_blob_is_miss() -> None:
     blob = encode(SAMPLE, DIGEST)
-    assert decode(blob[: len(blob) // 2], _policy()) is None
+    assert _decode(blob[: len(blob) // 2], _policy()) is None
+
+
+def test_a_blob_short_by_a_whole_line_is_a_miss() -> None:
+    """Rows lost at a line boundary are a miss, not a silently short listing.
+
+    Every line still parses, so only the header's row count catches it.
+    """
+    files: list[WheelFile | SdistFile] = [
+        dataclasses.replace(WHEEL_FULL, filename=f"pkg-{n}-py3-none-any.whl")
+        for n in range(_ROWS_PER_LINE * 2)
+    ]
+    blob = encode(files, DIGEST)
+    short = b"".join(blob.splitlines(keepends=True)[:-1])
+
+    assert _decode(short, _policy()) is None
+    assert _reason(short) == "unexpected row count"
+
+
+class _FailingReads(io.RawIOBase):
+    """A readable stream whose every read raises, as a failing disk would."""
+
+    def readable(self) -> bool:
+        return True
+
+    def readinto(self, buffer: object) -> int:
+        raise OSError(errno.EIO, "read failed")
+
+
+def _unreadable_blob() -> io.BufferedReader:
+    """An open blob that raises on the first line the codec asks for."""
+    return io.BufferedReader(_FailingReads())
+
+
+def test_an_unreadable_blob_is_a_miss() -> None:
+    assert decode(_unreadable_blob(), _policy()) is None
+
+
+def test_an_unreadable_blob_is_not_corruption() -> None:
+    """A read that fails says nothing about the bytes, so verify stays quiet."""
+    assert corruption_reason(_unreadable_blob()) is None
 
 
 @pytest.mark.parametrize(
@@ -258,7 +339,7 @@ def test_truncated_blob_is_miss() -> None:
 )
 def test_rows_corrupt_but_header_valid_is_miss(rows: object) -> None:
     """A same-build header over wrong-shape rows self-heals to a miss, not a crash."""
-    assert decode(_blob_with_rows(rows), _policy()) is None
+    assert _decode(_blob_with_rows(rows), _policy()) is None
 
 
 @pytest.mark.parametrize("tag", [7, -1, "0", None, True])
@@ -268,10 +349,10 @@ def test_unknown_tag_on_a_well_formed_row_is_miss(tag: object) -> None:
     The row keeps sdist arity, so a codec that fell through to the sdist branch
     instead of rejecting would decode it happily. That is what this pins.
     """
-    _header, rows = json.loads(encode([SDIST_FULL], DIGEST))
+    _header, rows = _documents(encode([SDIST_FULL], DIGEST))
     assert len(rows[0]) == _SDIST_ROW_LEN
     rows[0][0] = tag
-    assert decode(_blob_with_rows(rows), _policy()) is None
+    assert _decode(_blob_with_rows(rows), _policy()) is None
 
 
 @pytest.mark.parametrize(
@@ -299,7 +380,7 @@ def test_unknown_tag_on_a_well_formed_row_is_miss(tag: object) -> None:
 )
 def test_wrong_field_type_is_miss(index: int, value: object) -> None:
     """A field JSON allows but the record does not never reaches a record."""
-    assert decode(_wheel_row_with(index, value), _policy()) is None
+    assert _decode(_wheel_row_with(index, value), _policy()) is None
 
 
 @pytest.mark.parametrize(
@@ -318,12 +399,12 @@ def test_wrong_field_type_is_miss(index: int, value: object) -> None:
 )
 def test_wrong_sdist_field_type_is_miss(index: int, value: object) -> None:
     """An sdist row is checked on its own fields, not through the wheel's."""
-    assert decode(_sdist_row_with(index, value), _policy()) is None
+    assert _decode(_sdist_row_with(index, value), _policy()) is None
 
 
 def test_absent_optional_fields_decode_as_none() -> None:
     blob = _wheel_row_with(_W_METADATA_HASH, None)
-    decoded = decode(blob, _policy())
+    decoded = _decode(blob, _policy())
     assert decoded is not None
     wheel = decoded[0]
     assert isinstance(wheel, WheelFile)
@@ -334,29 +415,29 @@ def test_absent_optional_fields_decode_as_none() -> None:
     ("blob", "reason"),
     [
         (b"not json", "not valid JSON"),
-        (json.dumps(7).encode(), "unexpected top-level shape"),
+        (json.dumps(7).encode(), "unexpected header shape"),
         (json.dumps(["bad-header", []]).encode(), "unexpected header shape"),
     ],
 )
 def test_corruption_reason_names_the_structural_fault(blob: bytes, reason: str) -> None:
-    assert corruption_reason(blob) == reason
+    assert _reason(blob) == reason
 
 
 def test_corruption_reason_flags_same_build_bad_rows() -> None:
-    assert corruption_reason(_blob_with_rows([[7]])) == "unexpected row shape"
+    assert _reason(_blob_with_rows([[7]])) == "unexpected row shape"
 
 
 def test_corruption_reason_passes_a_valid_blob() -> None:
-    assert corruption_reason(encode(SAMPLE, DIGEST)) is None
+    assert _reason(encode(SAMPLE, DIGEST)) is None
 
 
 def test_foreign_build_header_is_not_corruption() -> None:
     """Version skew is a benign miss, so the read path rebuilds without warning."""
-    assert corruption_reason(_tamper_header(_H_CODEC, CODEC + 1)) is None
+    assert _reason(_tamper_header(_H_CODEC, CODEC + 1)) is None
 
 
 def test_digest_mismatch_is_not_corruption() -> None:
-    assert corruption_reason(encode(SAMPLE, "b" * 64)) is None
+    assert _reason(encode(SAMPLE, "b" * 64)) is None
 
 
 def _deferred_wheel(hashes: object, *, sidecar: object) -> WheelFile:
@@ -377,7 +458,7 @@ def _deferred_wheel(hashes: object, *, sidecar: object) -> WheelFile:
 def test_unparsed_tables_ride_the_wire_as_the_index_served_them() -> None:
     wheel = _deferred_wheel({"SHA256": DIGEST.upper()}, sidecar={"sha256": DIGEST})
 
-    rows = json.loads(encode([wheel], DIGEST))[1]
+    rows = _documents(encode([wheel], DIGEST))[1]
 
     assert rows[0][_W_HASHES] == {"SHA256": DIGEST.upper()}
     assert rows[0][_W_METADATA_HASH] == {"sha256": DIGEST}
@@ -387,7 +468,7 @@ def test_a_value_that_is_not_an_object_rides_as_its_parse() -> None:
     """Only a table defers, so any other value writes what the record parsed."""
     wheel = _deferred_wheel(["sha256", DIGEST], sidecar=True)
 
-    rows = json.loads(encode([wheel], DIGEST))[1]
+    rows = _documents(encode([wheel], DIGEST))[1]
 
     assert rows[0][_W_HASHES] == []
     assert rows[0][_W_METADATA_HASH] is None
@@ -396,7 +477,7 @@ def test_a_value_that_is_not_an_object_rides_as_its_parse() -> None:
 def test_a_many_algorithm_table_defers_as_the_index_served_it() -> None:
     wheel = _deferred_wheel({"sha256": DIGEST, "sha512": "f" * 128}, sidecar=True)
 
-    rows = json.loads(encode([wheel], DIGEST))[1]
+    rows = _documents(encode([wheel], DIGEST))[1]
 
     assert rows[0][_W_HASHES] == {"sha256": DIGEST, "sha512": "f" * 128}
     assert wheel.hashes == ((SHA256, DIGEST), (SHA512, "f" * 128))
@@ -408,7 +489,7 @@ def test_a_rehydrated_record_defers_the_same_parse() -> None:
         DIGEST,
     )
 
-    (wheel,) = decode(blob, _policy()) or []
+    (wheel,) = _decode(blob, _policy()) or []
 
     assert wheel.raw_hashes() == {"SHA256": DIGEST.upper()}
     assert wheel.raw_sidecar() == {"sha256": DIGEST}
@@ -426,7 +507,7 @@ def test_a_rehydrated_sdist_defers_its_hashes() -> None:
     )
     defer_hashes(sdist, {"SHA256": DIGEST.upper()})
 
-    (decoded,) = decode(encode([sdist], DIGEST), _policy()) or []
+    (decoded,) = _decode(encode([sdist], DIGEST), _policy()) or []
 
     assert decoded.raw_hashes() == {"SHA256": DIGEST.upper()}
     assert decoded.hashes == ((SHA256, DIGEST),)

--- a/nab-index/tests/test_read_fresh_parsed_listing.py
+++ b/nab-index/tests/test_read_fresh_parsed_listing.py
@@ -11,10 +11,12 @@ to ``get_files`` so a future edit to either cannot drift them.
 from __future__ import annotations
 
 import asyncio
+import errno
+import io
 import json
 from collections.abc import Coroutine, Mapping
 from pathlib import Path
-from typing import Any, TypeVar
+from typing import Any, BinaryIO, TypeVar
 
 import pytest
 
@@ -117,6 +119,32 @@ def _cache(root: Path) -> OnDiskCache:
     return OnDiskCache(root, _INDEX)
 
 
+def _parsed(cache: OnDiskCache, package: str) -> bytes | None:
+    """The stored blob's bytes, read back through the handle the cache opens."""
+    handle = cache.open_simple_parsed(package)
+    if handle is None:
+        return None
+    with handle:
+        return handle.read()
+
+
+class _FailingReads(io.RawIOBase):
+    """A readable stream whose every read raises, as a failing disk would."""
+
+    def readable(self) -> bool:
+        return True
+
+    def readinto(self, buffer: object) -> int:
+        raise OSError(errno.EIO, "read failed")
+
+
+class _UnreadableBlobCache(OnDiskCache):
+    """A cache whose parsed blob opens but fails once the codec reads it."""
+
+    def open_simple_parsed(self, package: str) -> BinaryIO | None:
+        return io.BufferedReader(_FailingReads())
+
+
 def _warm_bound(
     cache: OnDiskCache, *, fresh: bool = True, body: bytes = _LISTING_BYTES
 ) -> tuple[list, str]:
@@ -136,7 +164,7 @@ class TestParsedBlobSize:
     def test_size_matches_written_blob(self, tmp_path: Path) -> None:
         cache = _cache(tmp_path)
         _warm_bound(cache)
-        blob = cache.get_simple_parsed("pkg")
+        blob = _parsed(cache, "pkg")
         assert blob is not None
         assert cache.get_simple_parsed_size("pkg") == len(blob)
 
@@ -189,7 +217,7 @@ class TestReadFreshParsedListing:
             _LISTING_BYTES,
             CachePolicy(fetched_at=2_000_000_000, max_age=99999, etag=None),
         )
-        assert cache.get_simple_parsed("pkg") is None
+        assert _parsed(cache, "pkg") is None
         assert read_fresh_parsed_listing(cache, "pkg", offline=False) is None
 
     def test_digest_mismatch_returns_none(self, tmp_path: Path) -> None:
@@ -216,9 +244,16 @@ class TestReadFreshParsedListing:
     def test_hit_does_not_write(self, tmp_path: Path) -> None:
         cache = _cache(tmp_path)
         _warm_bound(cache)
-        before = cache.get_simple_parsed("pkg")
+        before = _parsed(cache, "pkg")
         read_fresh_parsed_listing(cache, "pkg", offline=False)
-        assert cache.get_simple_parsed("pkg") == before
+        assert _parsed(cache, "pkg") == before
+
+    def test_unreadable_blob_declines_instead_of_raising(self, tmp_path: Path) -> None:
+        """A failed read is a decline, so the caller's pending is not stranded."""
+        cache = _UnreadableBlobCache(tmp_path, _INDEX)
+        _warm_bound(cache)
+
+        assert read_fresh_parsed_listing(cache, "pkg", offline=False) is None
 
     def test_decline_does_not_write(self, tmp_path: Path) -> None:
         cache = _cache(tmp_path)
@@ -227,7 +262,7 @@ class TestReadFreshParsedListing:
         cache.put_simple_parsed("pkg", mismatched)
         read_fresh_parsed_listing(cache, "pkg", offline=False)
         # No rebuild: the mismatched blob is left exactly as it was.
-        assert cache.get_simple_parsed("pkg") == mismatched
+        assert _parsed(cache, "pkg") == mismatched
 
 
 class TestIdenticalByConstruction:

--- a/nab-project/tests/property_python/test_cached_client_equiv.py
+++ b/nab-project/tests/property_python/test_cached_client_equiv.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import io
 import json
 from dataclasses import replace
 from typing import TYPE_CHECKING, TypeVar
@@ -35,7 +36,7 @@ from .strategies import PROPERTY_SETTINGS
 
 if TYPE_CHECKING:
     from collections.abc import Coroutine
-    from typing import Any
+    from typing import Any, BinaryIO
 
 pytestmark = pytest.mark.property
 
@@ -115,8 +116,9 @@ class DictCache:
         entry = self.simple.get(package)
         return None if entry is None else entry[1]
 
-    def get_simple_parsed(self, package: str) -> bytes | None:
-        return self.parsed.get(package)
+    def open_simple_parsed(self, package: str) -> BinaryIO | None:
+        blob = self.parsed.get(package)
+        return None if blob is None else io.BytesIO(blob)
 
     def put_simple_parsed(self, package: str, blob: bytes) -> None:
         self.parsed[package] = blob

--- a/nab-project/tests/property_python/test_parsed_listing_equiv.py
+++ b/nab-project/tests/property_python/test_parsed_listing_equiv.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import dataclasses
 import hashlib
+import io
 import json
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -63,6 +64,16 @@ hex_digests = st.text(alphabet="0123456789abcdefABCDEF", min_size=0, max_size=16
 
 def _digest_of(body: bytes) -> str:
     return hashlib.sha256(body).hexdigest()
+
+
+def _decode(blob: bytes, policy: CachePolicy) -> list[WheelFile | SdistFile] | None:
+    """Decode a whole blob the way the read path decodes the open cache file."""
+    return decode(io.BytesIO(blob), policy)
+
+
+def _documents(blob: bytes) -> list[Any]:
+    """The blob's header and its row batches, one decoded document per line."""
+    return [json.loads(line) for line in blob.splitlines()]
 
 
 def _policy_for(body: bytes) -> CachePolicy:
@@ -199,7 +210,7 @@ def _assert_roundtrip(package: str, body: bytes) -> None:
     parsed = _parse_files(json.loads(body), INDEX, package)
     policy = CachePolicy(fetched_at=0, max_age=0, etag=None, body_digest=digest)
     blob = encode(parsed, digest)
-    decoded = decode(blob, policy)
+    decoded = _decode(blob, policy)
     assert decoded is not None
     assert len(decoded) == len(parsed)
     for got, want in zip(decoded, parsed, strict=True):
@@ -238,46 +249,47 @@ def _sample_blob() -> tuple[bytes, CachePolicy]:
 def _retamper(header_index: int, value: object) -> tuple[bytes, CachePolicy]:
     """Re-encode a valid blob with one header field replaced."""
     blob, policy = _sample_blob()
-    header, rows = json.loads(blob)
-    header[header_index] = value
-    return json.dumps([header, rows]).encode(), policy
+    documents = _documents(blob)
+    documents[0][header_index] = value
+    rewritten = b"".join(json.dumps(doc).encode() + b"\n" for doc in documents)
+    return rewritten, policy
 
 
 def test_digest_mismatch_decodes_to_none() -> None:
     """A parsed blob whose header digest differs from the policy is a miss."""
     blob, _ = _sample_blob()
     other = CachePolicy(fetched_at=0, max_age=0, etag=None, body_digest="0" * 64)
-    assert decode(blob, other) is None
+    assert _decode(blob, other) is None
 
 
 def test_policy_without_digest_decodes_to_none() -> None:
     """An older policy carrying no digest can never bind a parsed blob."""
     blob, _ = _sample_blob()
     policy = CachePolicy(fetched_at=0, max_age=0, etag=None, body_digest=None)
-    assert decode(blob, policy) is None
+    assert _decode(blob, policy) is None
 
 
 def test_format_mismatch_decodes_to_none() -> None:
     blob, policy = _retamper(0, 99)
-    assert decode(blob, policy) is None
+    assert _decode(blob, policy) is None
 
 
 def test_codec_mismatch_decodes_to_none() -> None:
     blob, policy = _retamper(1, 99)
-    assert decode(blob, policy) is None
+    assert _decode(blob, policy) is None
 
 
 def test_key_scheme_mismatch_decodes_to_none() -> None:
     blob, policy = _retamper(2, 7)
-    assert decode(blob, policy) is None
+    assert _decode(blob, policy) is None
 
 
 def test_blob_carries_no_interpreter_tag() -> None:
     """The wire form is portable, so a blob written anywhere decodes here."""
     blob, policy = _sample_blob()
-    header, _rows = json.loads(blob)
+    header, *_batches = _documents(blob)
     assert not any(isinstance(field, list) for field in header)
-    assert decode(blob, policy) is not None
+    assert _decode(blob, policy) is not None
 
 
 @pytest.mark.parametrize(
@@ -294,13 +306,13 @@ def test_blob_carries_no_interpreter_tag() -> None:
 def test_garbage_blob_decodes_to_none(blob: bytes) -> None:
     """Truncated, non-JSON, or wrong-shaped blobs are misses, not crashes."""
     _, policy = _sample_blob()
-    assert decode(blob, policy) is None
+    assert _decode(blob, policy) is None
 
 
 def test_truncated_blob_decodes_to_none() -> None:
     """A valid blob cut short raises inside json and is treated as a miss."""
     blob, policy = _sample_blob()
-    assert decode(blob[: len(blob) // 2], policy) is None
+    assert _decode(blob[: len(blob) // 2], policy) is None
 
 
 def test_malformed_body_never_reaches_encode() -> None:

--- a/tests/test_cache_cmd.py
+++ b/tests/test_cache_cmd.py
@@ -8,12 +8,18 @@ import pytest
 
 from nab import cli as nab_cli
 from nab.cli import app
-from nab_index.cache import CACHE_VERSION_SIMPLE, CachePolicy, OnDiskCache
+from nab_index.cache import (
+    CACHE_VERSION_SIMPLE,
+    CACHE_VERSION_SIMPLE_PARSED,
+    CachePolicy,
+    OnDiskCache,
+)
 from nab_index.parsed_listing import encode as _encode_parsed
 from nab_project.config_sources import SourceRoots
 
 # Derived so a bucket-version bump does not need every path updated.
 SIMPLE_BUCKET = f"simple-{CACHE_VERSION_SIMPLE}"
+PARSED_BUCKET = f"simple-parsed-{CACHE_VERSION_SIMPLE_PARSED}"
 
 _FRESH = CachePolicy(fetched_at=0, max_age=600, etag=None)
 
@@ -284,7 +290,7 @@ class TestCacheVerify:
     ) -> None:
         root = tmp_path / "cache"
         _populate(root)
-        parsed_path = root / "simple-parsed-v0" / "pypi" / "foo.parsed"
+        parsed_path = root / PARSED_BUCKET / "pypi" / "foo.parsed"
         parsed_path.write_bytes(b"not json data")
         _run_cache(["verify", "--cache-dir", str(root)])
         err = capsys.readouterr().err


### PR DESCRIPTION
Peak memory on a warm `airflow:airflow-3-0-2-awswrangler --resolution lowest-direct` resolve comes down about 6.4% locally, median 173,560 KB to 162,506 KB over 12 runs on each side, with the interval between about 6.3% and 6.5% off.

The decode pays for it: 249,497,612 more instructions, 3,582,098,794 to 3,831,596,406, over a harness that reads the 140 parsed-listing blobs that same resolve decodes and nothing else. That is 7% more work in the decode; the resolve's own instruction total was never counted, so it is not 7% of a resolve.

Stacked on #926; the diff and the numbers are against that branch.

The same runs rule out a wall slowdown worse than about 3.6% and a CPU slowdown worse than about 2.9%, and neither moved enough for the clock to say more. The instruction counts reproduce on any machine; the memory and timing figures are off mine.

`decode` took the whole blob as `bytes` and handed it to `json.loads`, which builds its own `str` copy before the scanner runs and then the entire row structure before a single record exists. Three full representations of one listing were alive at the same moment, and the largest listing in the benchmark cache is 6.3 MB.

What changed:

- the blob is a header line followed by batches of 1024 rows, and `decode` reads it straight from the open cache file, so a hit holds one batch
- `OnDiskCache.get_simple_parsed` becomes `open_simple_parsed` and hands the handle over
- `CODEC` goes to 2 and the bucket to `simple-parsed-v1`, so a blob written by an older build is a miss and a rebuild
- the header carries the row count, so a blob truncated at a line boundary is a miss rather than a silently short listing
- `nab cache verify` leaves a retired parsed bucket alone, having no way to read a wire form it did not write

Rows are batched rather than written one per line because one per line runs `json.loads` for every row instead of once per batch: 101,667 calls over the same 140 blobs, and +1,403,554,610 instructions (+39.2%).
