### PR TITLE
Fix lockfile docs claiming a lock never carries an absolute path

### DIFF
--- a/docs/reference/lockfile.md
+++ b/docs/reference/lockfile.md
@@ -234,13 +234,22 @@ installers.
 
 ### Portable paths
 
-A lockfile can reference content on disk: a `LocalPin`'s
-directory, or a wheel or sdist served from a local find-links
-directory. nab writes those paths relative to the lockfile's
-own directory, with POSIX separators, as PEP 751 requires. A
-committed lockfile therefore stays usable on another machine as
-long as the surrounding layout is preserved; it never carries an
-absolute, machine-specific path.
+A lockfile can reference content on disk. A path nab derives from a
+filesystem location is written relative to the lockfile's own directory,
+with POSIX separators: a local source or workspace member in
+`packages.directory.path`, and a wheel or sdist read from a local index or
+find-links directory in `packages.wheels.path` and `packages.sdist.path`.
+PEP 751 reads a relative path against the lockfile itself, so the lock and
+the tree it points at survive a move as long as they move together. On
+Windows a path on another drive has no relative form, and the absolute
+path is written instead. `nab lock --output -` has no lockfile to be
+relative to and writes those paths relative to the current directory.
+
+A URL declared in the configuration is written as it was declared, minus
+any embedded credentials: an archive source in `packages.archive.url`, a
+local index in `packages.index`, and a local repository in
+`packages.vcs.url`. A `file://` URL is not made relative, so a lock that
+carries one is usable only where that location exists.
 
 ### The environments the lock is for
 

--- a/nab-project/tests/test_lockfile.py
+++ b/nab-project/tests/test_lockfile.py
@@ -7,12 +7,12 @@ import logging
 import random
 import re
 import sys
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from contextlib import AbstractContextManager
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import ClassVar
+from typing import Any, ClassVar
 
 import pytest
 
@@ -4594,6 +4594,111 @@ class TestRelativeArtifactPath:
         )
         wheel = tomllib.loads(text)["packages"][0]["wheels"][0]
         assert wheel["path"] == "../../wheelhouse/foo-1.0-py3-none-any.whl"
+
+
+def _string_leaves(value: object, prefix: str = "") -> Iterator[tuple[str, str]]:
+    """Yield ``(dotted key, text)`` for every string nested under ``value``."""
+    if isinstance(value, str):
+        yield prefix, value
+    elif isinstance(value, Mapping):
+        for key, item in value.items():
+            yield from _string_leaves(item, f"{prefix}.{key}" if prefix else str(key))
+    elif isinstance(value, list):
+        for item in value:
+            yield from _string_leaves(item, prefix)
+
+
+class TestPortablePaths:
+    """Which on-disk references the lock writes relative, and what the docs say.
+
+    Every pin points into one ``store`` directory beside the lock file, so
+    a difference between the keys comes from the emitter, not the input.
+    """
+
+    def _lock(self, tmp_path: Path) -> dict[str, Any]:
+        """Return the parsed lock for one pin of every source shape."""
+        store = tmp_path / "store"
+        wheel = store / "myindex-1.0-py3-none-any.whl"
+        sdist = store / "myindex-1.0.tar.gz"
+        repo = store / "myvcs"
+        commit = "d" * 40
+
+        pins: dict[str, PinShape] = {
+            "mylocal": LocalPin(
+                name="mylocal", version="1.0", path=str(store / "mylocal")
+            ),
+            "myindex": IndexPin(
+                name="myindex",
+                version="1.0",
+                index=store.as_uri(),
+                sdist=SdistArtifact(
+                    filename=sdist.name,
+                    url=sdist.as_uri(),
+                    hashes=(("sha256", "a" * 64),),
+                    local_path=sdist,
+                ),
+                wheels=(
+                    WheelArtifact(
+                        filename=wheel.name,
+                        url=wheel.as_uri(),
+                        hashes=(("sha256", "b" * 64),),
+                        local_path=wheel,
+                    ),
+                ),
+            ),
+            "myarchive": ArchivePin(
+                name="myarchive",
+                version="1.0",
+                url=(store / "myarchive-1.0.tar.gz").as_uri(),
+                hashes=(("sha256", "c" * 64),),
+            ),
+            "myvcs": VcsPin(
+                name="myvcs",
+                version="1.0",
+                repo_url=f"git+{repo.as_uri()}@{commit}",
+                bare_repo_url=repo.as_uri(),
+                commit_id=commit,
+            ),
+        }
+
+        text = write_lock(
+            LockInput(targets=_one(pins)), output_path=tmp_path / "pylock.toml"
+        )
+        return tomllib.loads(text)
+
+    def _on_disk_keys(self, tmp_path: Path) -> tuple[set[str], set[str]]:
+        """Return the keys naming ``store``, split into relative and absolute."""
+        prefix = (tmp_path / "store").as_uri()
+        relative: set[str] = set()
+        absolute: set[str] = set()
+        for package in self._lock(tmp_path)["packages"]:
+            for key, value in _string_leaves(package):
+                if value.startswith(prefix):
+                    absolute.add(key)
+                elif value.startswith("store/"):
+                    relative.add(key)
+        return relative, absolute
+
+    def _section(self) -> str:
+        """Return the "Portable paths" section of the lockfile reference."""
+        doc = Path(__file__).resolve().parents[2] / "docs" / "reference" / "lockfile.md"
+        text = doc.read_text(encoding="utf-8")
+        start = text.index("### Portable paths")
+        return text[start : text.index("\n### ", start + 1)]
+
+    def test_configured_file_urls_stay_absolute(self, tmp_path: Path) -> None:
+        """A path nab derives is relativised; a declared URL is not."""
+        relative, absolute = self._on_disk_keys(tmp_path)
+        assert relative == {"directory.path", "sdist.path", "wheels.path"}
+        assert absolute == {"archive.url", "index", "vcs.url"}
+
+    def test_every_on_disk_key_is_documented(self, tmp_path: Path) -> None:
+        relative, absolute = self._on_disk_keys(tmp_path)
+        section = self._section()
+        undocumented = {
+            key for key in relative | absolute if f"`packages.{key}`" not in section
+        }
+        assert not undocumented, f"undocumented keys: {sorted(undocumented)}"
 
 
 class TestPathHelpers:


### PR DESCRIPTION
The lockfile reference's "Portable paths" section said a lock "never carries an absolute, machine-specific path". Three keys do: a URL that came from the configuration is written back as it was given, minus any credentials, so a `file://` source stays absolute. A lock written right beside the archive it points at still gets:

    [packages.archive]
    url = "file:///tmp/proj/vendor/myarchive-1.0.tar.gz"

The split is between a path nab derives from a filesystem location and a URL that was declared:

- relative to the lockfile's own directory: `packages.directory.path`, `packages.wheels.path`, `packages.sdist.path`
- as declared: `packages.archive.url`, `packages.index`, `packages.vcs.url`

Two more cases the old text missed. A Windows path on another drive has no relative form, so the absolute path goes in. And `nab lock --output -` has no lockfile to be relative to, so it writes those paths relative to the current directory.

The new test locks one pin of every source shape into one directory beside the lockfile, asserts which of the six keys come out relative and which absolute, and fails if the section stops naming one of them.
