### PR TITLE
Reject a malformed [build-system].requires instead of defaulting it

### DIFF
--- a/nab-project/src/nab_project/_build/runner.py
+++ b/nab-project/src/nab_project/_build/runner.py
@@ -45,6 +45,10 @@ from nab_provider._vendor.packaging.utils import canonicalize_name, parse_wheel_
 from nab_provider._vendor.packaging.version import Version
 from nab_provider.errors import UnsupportedWheelError
 from nab_provider.metadata import WheelMetadata, validate_specifier_versions
+from nab_provider.requirements_file import (
+    InvalidProjectRequirementError,
+    require_string_list,
+)
 from nab_resolver.errors import ResolutionError
 
 from ..paths import PathState, path_state
@@ -264,6 +268,8 @@ def _read_build_system(
 
     A missing ``[build-system]`` takes the PEP 517 defaults; a
     ``build-system`` that is not a table is malformed, not absent.
+    Inside the table a default stands in only for a key the file omits,
+    never for one it declares with the wrong shape.
     """
     if "build-system" not in data:
         return _DEFAULT_BACKEND, _DEFAULT_REQUIRES, None
@@ -271,25 +277,43 @@ def _read_build_system(
     table = data["build-system"]
     if not isinstance(table, dict):
         msg = (
-            "build-system in pyproject.toml must be a table,"
+            "[build-system] in pyproject.toml must be a table,"
             f" not {type(table).__name__}"
         )
         raise BuildBackendError(msg)
 
-    backend = table.get("build-backend")
+    if "requires" not in table:
+        msg = (
+            "[build-system].requires is required by PEP 518 and"
+            " pyproject.toml does not declare it"
+        )
+        raise BuildBackendError(msg)
+
+    requires = _read_string_array(table["requires"], "requires")
+
+    backend = table.get("build-backend", _DEFAULT_BACKEND)
     if not isinstance(backend, str):
-        backend = _DEFAULT_BACKEND
-    raw_requires = table.get("requires")
-    requires: tuple[str, ...]
-    if isinstance(raw_requires, list) and all(isinstance(r, str) for r in raw_requires):
-        requires = tuple(raw_requires)
-    else:
-        requires = _DEFAULT_REQUIRES
-    raw_path = table.get("backend-path")
-    backend_path: tuple[str, ...] | None = None
-    if isinstance(raw_path, list) and all(isinstance(p, str) for p in raw_path):
-        backend_path = tuple(raw_path)
+        msg = (
+            "[build-system].build-backend in pyproject.toml must be a string,"
+            f" not {type(backend).__name__}"
+        )
+        raise BuildBackendError(msg)
+
+    backend_path = (
+        _read_string_array(table["backend-path"], "backend-path")
+        if "backend-path" in table
+        else None
+    )
+
     return backend, requires, backend_path
+
+
+def _read_string_array(value: object, key: str) -> tuple[str, ...]:
+    """Return ``[build-system].<key>``, or raise if it is not an array of strings."""
+    try:
+        return tuple(require_string_list(value, f"[build-system].{key}"))
+    except InvalidProjectRequirementError as exc:
+        raise BuildBackendError(str(exc)) from exc
 
 
 def _validate_backend_path(

--- a/nab-project/tests/test_build_runner.py
+++ b/nab-project/tests/test_build_runner.py
@@ -612,9 +612,16 @@ class TestRunBuildBackend:
     def test_build_system_table_rejected_wrapped(
         self, tmp_path: Path, config: NabProjectConfig
     ) -> None:
-        """build.BuildSystemTableValidationError from an invalid build-system table is wrapped as BuildBackendError."""
+        """build.BuildSystemTableValidationError is wrapped as BuildBackendError.
+
+        An unknown ``[build-system]`` key is build's rule rather than one
+        nab reads, so the table passes nab's own checks and fails in build.
+        """
         (tmp_path / "pyproject.toml").write_text(
-            '[build-system]\nbuild-backend = "setuptools.build_meta"\n',
+            "[build-system]\n"
+            "requires = []\n"
+            'build-backend = "setuptools.build_meta"\n'
+            "unknown-key = 1\n",
             encoding="utf-8",
         )
         env = MagicMock()
@@ -624,6 +631,35 @@ class TestRunBuildBackend:
             patch("nab_project._build.runner.NabBuildEnv", return_value=env),
             pytest.raises(BuildBackendError, match="setuptools.build_meta"),
         ):
+            run_build_backend(tmp_path, config=config)
+
+    @pytest.mark.parametrize(
+        ("table", "message"),
+        [
+            ('build-backend = "not-a-backend"\n', "requires is required by PEP 518"),
+            ('requires = "hatchling"\n', "requires.*array of strings"),
+            ('requires = ["hatchling", 42]\n', "requires.*array of strings"),
+            ('requires = {a = "b"}\n', "requires.*array of strings"),
+        ],
+    )
+    def test_bad_requires_fails_before_the_build_env(
+        self,
+        tmp_path: Path,
+        config: NabProjectConfig,
+        monkeypatch: pytest.MonkeyPatch,
+        table: str,
+        message: str,
+    ) -> None:
+        """An absent or malformed ``requires`` fails before an env is opened."""
+        (tmp_path / "pyproject.toml").write_text(
+            "[build-system]\n" + table, encoding="utf-8"
+        )
+
+        def _no_env(**_kwargs: object) -> NabBuildEnv:
+            raise AssertionError("the build env must not be opened")
+
+        monkeypatch.setattr(runner_mod, "NabBuildEnv", _no_env)
+        with pytest.raises(BuildBackendError, match=message):
             run_build_backend(tmp_path, config=config)
 
     def test_build_system_not_a_table(
@@ -838,7 +874,7 @@ class TestShouldSkipPrepare:
 
 
 class TestReadBuildSystem:
-    """Defaults for missing or wrongly-typed ``[build-system]`` fields."""
+    """Defaults for absent ``[build-system]`` fields, errors for malformed ones."""
 
     def test_no_build_system_table_returns_defaults(self) -> None:
         from nab_project._build.runner import (
@@ -857,21 +893,41 @@ class TestReadBuildSystem:
         with pytest.raises(BuildBackendError, match="must be a table"):
             _read_build_system({"build-system": value})
 
-    def test_build_backend_wrong_type_uses_default(self) -> None:
+    def test_absent_optional_keys_take_their_defaults(self) -> None:
+        """Only ``requires`` is mandatory; PEP 517 supplies the backend."""
         from nab_project._build.runner import _DEFAULT_BACKEND, _read_build_system
 
-        backend, _, _ = _read_build_system(
-            {"build-system": {"build-backend": 1234, "requires": []}}
+        assert _read_build_system({"build-system": {"requires": ["hatchling"]}}) == (
+            _DEFAULT_BACKEND,
+            ("hatchling",),
+            None,
         )
-        assert backend == _DEFAULT_BACKEND
 
-    def test_requires_wrong_type_uses_default(self) -> None:
-        from nab_project._build.runner import _DEFAULT_REQUIRES, _read_build_system
+    def test_build_backend_wrong_type_raises(self) -> None:
+        from nab_project._build.runner import _read_build_system
 
-        _, requires, _ = _read_build_system(
-            {"build-system": {"build-backend": "x", "requires": "not-a-list"}}
-        )
-        assert requires == _DEFAULT_REQUIRES
+        with pytest.raises(BuildBackendError, match="build-backend.*must be a string"):
+            _read_build_system(
+                {"build-system": {"build-backend": 1234, "requires": []}}
+            )
+
+    def test_requires_absent_raises(self) -> None:
+        """PEP 518 makes ``requires`` mandatory once the table is there."""
+        from nab_project._build.runner import _read_build_system
+
+        with pytest.raises(BuildBackendError, match="requires is required by PEP 518"):
+            _read_build_system({"build-system": {"build-backend": "x"}})
+
+    @pytest.mark.parametrize(
+        "value", ["not-a-list", ["hatchling", 42], {"a": "b"}, 1234]
+    )
+    def test_requires_wrong_type_raises(self, value: object) -> None:
+        from nab_project._build.runner import _read_build_system
+
+        with pytest.raises(BuildBackendError, match="requires.*array of strings"):
+            _read_build_system(
+                {"build-system": {"build-backend": "x", "requires": value}}
+            )
 
     def test_backend_path_returns_tuple_when_strings(self) -> None:
         from nab_project._build.runner import _read_build_system
@@ -887,19 +943,19 @@ class TestReadBuildSystem:
         )
         assert backend_path == ("src", "vendor")
 
-    def test_backend_path_wrong_type_returns_none(self) -> None:
+    def test_backend_path_wrong_type_raises(self) -> None:
         from nab_project._build.runner import _read_build_system
 
-        _, _, backend_path = _read_build_system(
-            {
-                "build-system": {
-                    "build-backend": "x",
-                    "requires": [],
-                    "backend-path": "src",
+        with pytest.raises(BuildBackendError, match="backend-path.*array of strings"):
+            _read_build_system(
+                {
+                    "build-system": {
+                        "build-backend": "x",
+                        "requires": [],
+                        "backend-path": "src",
+                    }
                 }
-            }
-        )
-        assert backend_path is None
+            )
 
 
 class TestParseMetadata:


### PR DESCRIPTION
nab defaulted a missing or wrongly typed `[build-system].requires` to the PEP 517 `setuptools >= 40.8.0`, as though the key were absent. A hatchling project that writes `requires = "hatchling"` rather than `["hatchling"]` is refused offline over a package it never mentions:

    build env setup for 'hatchling.build' failed: build requirements unavailable in offline mode: setuptools >= 40.8.0

Online nothing refuses. nab provisions a build env for the substituted `setuptools >= 40.8.0` and builds the project with it.

PEP 518 makes `requires` mandatory once `[build-system]` is there, so a value that is missing or not an array of strings is a malformed file rather than an absent key. nab now reads the table strictly:

- `requires` absent, or not an array of strings, is an error. The array check is the one `nab lock --build-requirements` already runs over the same table, so both report a bad `requires` with the same message.
- `build-backend` must be a string when present, rather than falling back to the legacy backend.
- `backend-path` must be an array of strings when present, rather than being dropped.

A default still stands in for a key the file omits: no `[build-system]` takes the PEP 517 defaults, and a table without `build-backend` takes `setuptools.build_meta:__legacy__`.
