### PR TITLE
Fix --locked calling a fresh lock stale with base-group in default-groups

### DIFF
--- a/nab-project/src/nab_project/_lockfile/validate.py
+++ b/nab-project/src/nab_project/_lockfile/validate.py
@@ -104,8 +104,10 @@ def check_envelope(
 
     ``base_group`` and ``build_group`` are the names this run would give
     the project's own dependencies and its build requirements. No run
-    selects either, so both are checked before the arrays are compared and
-    then dropped from them: a reason names only groups the caller asked for.
+    selects either, so both are checked on their own and then dropped
+    before the arrays are compared: a reason names only groups the caller
+    asked for. ``base_group`` leaves ``default-groups`` only when this run
+    declares none, since the writer appends it only then.
     """
     requires_python_result = _check_requires_python(
         committed.requires_python, requires_python
@@ -130,7 +132,7 @@ def check_envelope(
         ),
         (
             "default-groups",
-            _without(committed.default_groups, base_group),
+            _without(committed.default_groups, None if default_groups else base_group),
             default_groups,
         ),
     ):

--- a/nab-project/tests/test_lockfile_validate.py
+++ b/nab-project/tests/test_lockfile_validate.py
@@ -191,19 +191,55 @@ def test_default_groups_reordered_does_not_fire() -> None:
 
 
 def test_the_named_base_group_does_not_fire() -> None:
-    """The writer adds it to both arrays and no run selects it."""
+    """With no declared default-groups the writer puts it in both arrays."""
     committed = make_pylock(
         dependency_groups=("dev", "default"),
-        default_groups=("main", "default"),
+        default_groups=("default",),
     )
     assert (
         envelope(
             committed,
             dependency_groups=("dev",),
-            default_groups=("main",),
+            default_groups=(),
             base_group="default",
         )
         is None
+    )
+
+
+def test_the_base_group_declared_in_default_groups_does_not_fire() -> None:
+    """The run declares it, so it is not dropped from the committed array."""
+    committed = make_pylock(
+        dependency_groups=("default",),
+        default_groups=("main", "default"),
+    )
+    assert (
+        envelope(
+            committed,
+            dependency_groups=(),
+            default_groups=("main", "default"),
+            base_group="default",
+        )
+        is None
+    )
+
+
+def test_a_run_declaring_default_groups_fires_on_the_appended_base_group() -> None:
+    """The lock was written for a run that declared none, so it is stale."""
+    committed = make_pylock(
+        dependency_groups=("dev", "default"),
+        default_groups=("default",),
+    )
+    result = envelope(
+        committed,
+        dependency_groups=("dev",),
+        default_groups=("dev",),
+        base_group="default",
+    )
+    assert result is not None
+    assert result.reason == (
+        "the lockfile was built with default-groups {default} "
+        "but this run selects {dev}"
     )
 
 

--- a/tests/test_lock_locked.py
+++ b/tests/test_lock_locked.py
@@ -538,6 +538,31 @@ def test_satisfiable_and_reproducible_falls_through_up_to_date(
     assert out.read_bytes() == before
 
 
+def test_the_base_group_named_in_default_groups_falls_through(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A declared default-groups keeps the name, so the tier must not fire."""
+    pyproject = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "proj"\nversion = "0.1"\ndependencies = ["foo"]\n'
+        "[dependency-groups]\n"
+        'dev = ["bb"]\n'
+        "[tool.nab]\n"
+        'base-group = "base"\n'
+        'default-groups = ["dev", "base"]\n',
+    )
+    out = tmp_path / "pylock.toml"
+    _write_lock(pyproject, out, _result({"foo": "1.0", "bb": "1.0"}))
+    capsys.readouterr()
+    assert tomli.loads(out.read_text())["default-groups"] == ["dev", "base"]
+
+    mock = _locked_mock(_result({"foo": "1.0", "bb": "1.0"}))
+    _run_locked(pyproject, out, mock)
+
+    assert f"Lockfile {out} is up to date." in capsys.readouterr().err
+    mock.assert_called_once()
+
+
 def test_non_sticky_stale_falls_through_out_of_date(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
Set `base-group` and list that name in `default-groups`, as the configuration reference recommends, and `nab lock --locked` calls the file `nab lock` just wrote out of date. Re-running `nab lock` writes the same file back, so the next `--locked` fails the same way.

```toml
[tool.nab]
base-group = "base"
default-groups = ["dev", "base"]
```

```
error: --locked: lockfile pylock.toml is out of date: the lockfile was built with default-groups {dev} but this run selects {base, dev}; re-run `nab lock` to update it.
```

The lock's own `default-groups` is `["dev", "base"]`, so the message misstates the file it just read.

The writer appends `base-group` to `default-groups` only when the project declares none of its own, because a declared `default-groups` replaces the default selection instead of extending it. The check dropped the name from the committed array either way, and now drops it only when this run declares no `default-groups`.

The message was wrong in the other direction too. A lock written with `default-groups` unset, then checked by a run that declares `["dev"]`, is genuinely stale, but it was reported as built with `{}` where the file holds `["base"]`. It now says `{base}`.
