### PR TITLE
Read METADATA headers without email.parser, 4.4% off a resolve's instructions

### DIFF
--- a/nab-provider/src/nab_provider/metadata.py
+++ b/nab-provider/src/nab_provider/metadata.py
@@ -9,10 +9,10 @@ LRU cache so repeated dep strings parse once.
 
 from __future__ import annotations
 
-import email.parser
 from contextlib import suppress
 from dataclasses import dataclass, field
 from functools import lru_cache
+from io import StringIO
 from typing import TYPE_CHECKING, Any
 
 from nab_provider._vendor.packaging.requirements import Requirement
@@ -163,13 +163,27 @@ class WheelMetadata:
     dynamic: frozenset[str] = field(default_factory=frozenset)
 
 
+# The header names parse_metadata reads, lowercased.
+_READ_FIELDS = frozenset(
+    {
+        "dynamic",
+        "metadata-version",
+        "name",
+        "provides-extra",
+        "requires-dist",
+        "requires-python",
+        "version",
+    }
+)
+
+
 def metadata_header_block(text: str) -> str:
     r"""Return ``text`` cut after the earlier of its first ``\n\n`` and ``\r\n\r\n``.
 
-    ``email.parser`` closes the RFC 822 headers at the first blank line at the
-    latest, so the prefix holds every field :func:`parse_metadata` reads and
-    parses to the same :class:`WheelMetadata` as the whole document.  A
-    document with neither sequence comes back whole.
+    RFC 822 closes the headers at the first blank line at the latest, so the
+    prefix holds every field :func:`parse_metadata` reads and parses to the
+    same :class:`WheelMetadata` as the whole document.  A document with
+    neither sequence comes back whole.
 
     ``lf + 3`` bounds the second search: it is as far as a ``\r\n\r\n``
     starting before the ``\n\n`` hit can reach.
@@ -183,27 +197,88 @@ def metadata_header_block(text: str) -> str:
     return text
 
 
+def _first(fields: Mapping[str, list[str]], name: str) -> str | None:
+    """Return the first value of ``name``, or ``None`` when it is absent."""
+    values = fields.get(name)
+    return values[0] if values else None
+
+
+def _is_field_name(raw: str) -> bool:
+    """Report whether ``raw`` uses only the characters a field name may hold."""
+    return raw.isascii() and raw.isprintable() and " " not in raw
+
+
+def _read_header_fields(text: str) -> dict[str, list[str]]:
+    """Map each name in ``_READ_FIELDS`` that ``text`` carries to its values.
+
+    Reads ``text`` as RFC 822 headers. A line starting with whitespace continues
+    the value above it and keeps its own line ending, and a value loses the
+    whitespace in front of it and its trailing line ending. A ``From `` envelope
+    line carries no field. The headers stop at the first line that is neither a
+    continuation nor ``name:``. Repeats of a name stay in file order.
+
+    A value that begins on its continuation line loses that fold's leading
+    whitespace. Older ``email`` keeps it and newer ``email`` does not; taking the
+    newer reading parses such a value the same way on every supported
+    interpreter.
+    """
+    fields: dict[str, list[str]] = {}
+    name = ""
+    value: list[str] = []
+    # newline="" leaves a bare \r ending a line, which is what email splits on.
+    for line in StringIO(text, newline=""):
+        first = line[0]
+        if first in {" ", "\t"}:
+            if name:
+                value.append(line)
+            continue
+
+        if name:
+            joined = "".join(value).lstrip(" \t\r\n")
+            fields.setdefault(name, []).append(joined.rstrip("\r\n"))
+            name = ""
+
+        if first == "F" and line.startswith("From "):
+            continue
+
+        colon = line.find(":")
+        if colon < 0:
+            break
+        raw_name = line[:colon]
+        if not _is_field_name(raw_name):
+            break
+        candidate = raw_name.lower()
+        if candidate in _READ_FIELDS:
+            name = candidate
+            value = [line[colon + 1 :]]
+
+    if name:
+        joined = "".join(value).lstrip(" \t\r\n")
+        fields.setdefault(name, []).append(joined.rstrip("\r\n"))
+    return fields
+
+
 def parse_metadata(data: str | bytes) -> WheelMetadata:
     """Parse a METADATA file and return the fields needed for resolution."""
     if isinstance(data, bytes):
         data = data.decode("utf-8")
 
     # Nothing here reads the long description.
-    msg = email.parser.Parser().parsestr(metadata_header_block(data), headersonly=True)
+    fields = _read_header_fields(metadata_header_block(data))
 
-    name = msg.get("Name")
+    name = _first(fields, "name")
     if name is None:
         err = "METADATA missing required Name field"
         raise ValueError(err)
     # RFC 822 makes the whitespace around a header value insignificant.
     name = name.strip()
 
-    version_str = msg.get("Version")
+    version_str = _first(fields, "version")
     if version_str is None:
         err = "METADATA missing required Version field"
         raise ValueError(err)
 
-    requires_python_str = msg.get("Requires-Python")
+    requires_python_str = _first(fields, "requires-python")
     requires_python = None
     if requires_python_str:
         try:
@@ -219,15 +294,15 @@ def parse_metadata(data: str | bytes) -> WheelMetadata:
             raise ValueError(err) from exc
 
     requires_dist = [
-        _parse_requirement_cached(r) for r in msg.get_all("Requires-Dist") or []
+        _parse_requirement_cached(r) for r in fields.get("requires-dist", ())
     ]
 
-    provides_extra = [e.strip() for e in msg.get_all("Provides-Extra") or []]
+    provides_extra = [e.strip() for e in fields.get("provides-extra", ())]
 
-    metadata_version = msg.get("Metadata-Version")
+    metadata_version = _first(fields, "metadata-version")
     # PEP 643 field names are case-insensitive, and RFC 822 makes surrounding
     # whitespace insignificant.
-    dynamic = frozenset(d.strip().lower() for d in msg.get_all("Dynamic") or [])
+    dynamic = frozenset(d.strip().lower() for d in fields.get("dynamic", ()))
 
     return WheelMetadata(
         name=name,

--- a/nab-provider/tests/test_metadata.py
+++ b/nab-provider/tests/test_metadata.py
@@ -10,6 +10,7 @@ import pytest
 from nab_provider._vendor.packaging.specifiers import SpecifierSet
 from nab_provider._vendor.packaging.version import Version
 from nab_provider.metadata import (
+    _read_header_fields,
     metadata_deps_are_static,
     metadata_header_block,
     parse_metadata,
@@ -357,3 +358,81 @@ class TestOversizedClauseVersions:
         )
         with pytest.raises(ValueError, match="Exceeds the limit"):
             parse_metadata(text)
+
+
+class TestReadHeaderFields:
+    """``_read_header_fields``: folding, envelope lines, and where headers stop."""
+
+    def test_repeated_fields_keep_file_order(self) -> None:
+        """Repeats stack in order, and a re-declared single field keeps the first."""
+        fields = _read_header_fields(
+            "Name: foo\nRequires-Dist: a\nProvides-Extra: dev\n"
+            "Requires-Dist: b\nName: bar\nProvides-Extra: test\n"
+        )
+        assert fields["requires-dist"] == ["a", "b"]
+        assert fields["provides-extra"] == ["dev", "test"]
+        assert fields["name"] == ["foo", "bar"]
+
+        assert parse_metadata("Name: foo\nVersion: 1.0\nName: bar\n").name == "foo"
+
+    def test_continuation_line_keeps_its_line_ending(self) -> None:
+        """A folded value joins its lines verbatim, minus the last line ending."""
+        assert _read_header_fields("Requires-Dist: bar;\n extra == 'dev'\n") == {
+            "requires-dist": ["bar;\n extra == 'dev'"]
+        }
+        assert _read_header_fields("Requires-Dist: bar;\r\n\textra == 'dev'\r\n") == {
+            "requires-dist": ["bar;\r\n\textra == 'dev'"]
+        }
+
+    def test_value_may_start_on_a_continuation_line(self) -> None:
+        """A blank first line leaves the value starting at the fold's own text."""
+        assert _read_header_fields("Requires-Dist:\n  bar\n") == {
+            "requires-dist": ["bar"]
+        }
+
+    def test_continuation_with_nothing_to_continue_is_dropped(self) -> None:
+        """A fold before any field, or under one that is not read, adds nothing."""
+        assert _read_header_fields(" orphan\nName: foo\n") == {"name": ["foo"]}
+        assert _read_header_fields("Summary: s\n more of it\nName: foo\n") == {
+            "name": ["foo"]
+        }
+
+    def test_field_values_are_stripped_of_leading_blanks_only(self) -> None:
+        """The value starts after the colon's spaces and keeps its trailing ones."""
+        assert _read_header_fields("Name:\t  foo  \n") == {"name": ["foo  "]}
+
+    def test_envelope_from_line_is_not_a_field(self) -> None:
+        """``From `` lines are mbox envelope headers and carry no field."""
+        assert _read_header_fields(
+            "From nobody Wed Aug 20 03:00:00 2026\nName: foo\nFrom someone else\n"
+        ) == {"name": ["foo"]}
+
+    def test_bare_carriage_return_ends_a_line(self) -> None:
+        """A lone ``\\r`` ends a line, as it does in :mod:`email`'s own reader."""
+        assert _read_header_fields("Name: foo\rVersion: 1.0\r") == {
+            "name": ["foo"],
+            "version": ["1.0"],
+        }
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Name: foo\nnot a header at all\nVersion: 1.0\n",
+            "Name: foo\nBad Name: x\nVersion: 1.0\n",
+            "Name: foo\nNo\x7fnprintable: x\nVersion: 1.0\n",
+            "Name: foo\nnon-ascii-é: x\nVersion: 1.0\n",
+        ],
+    )
+    def test_headers_end_at_the_first_non_field_line(self, text: str) -> None:
+        """Anything but a continuation or ``name:`` ends the headers."""
+        assert _read_header_fields(text) == {"name": ["foo"]}
+
+    def test_field_name_is_checked_before_it_is_lowercased(self) -> None:
+        """U+212A lowercases to ASCII ``k``, which does not make it a field name."""
+        assert _read_header_fields("Name: foo\n\u212a: x\nVersion: 1.0\n") == {
+            "name": ["foo"]
+        }
+
+    def test_field_with_an_empty_name_is_skipped(self) -> None:
+        """A line starting with a colon has no name, and the headers continue."""
+        assert _read_header_fields(": stray\nName: foo\n") == {"name": ["foo"]}


### PR DESCRIPTION
Reading the METADATA header block directly, instead of handing it to `email.parser.Parser().parsestr(..., headersonly=True)`, takes 4.389% of the instructions off a warm `pip:langchain-ml-course --resolution lowest` resolve: 34,406,223,088 down to 32,896,278,533, or 1,509,944,555 fewer. That count is callgrind under `PYTHONHASHSEED=0` and reproduces anywhere; the timings below came off my machine.

Stacked on #938, so the diff and the numbers are against that branch.

`parse_metadata` reads seven header names. The stdlib builds a whole `Message` out of every header, a line at a time, then answers each of the seven with a linear scan that lowercases every name it stored. `_read_header_fields` walks the block once, keeps the seven, and returns a `dict[str, list[str]]`. That is 81,409 ns to 25,409 ns per call over 1,956 documents captured from that resolve (the ones that parse without raising), against the 1,965 calls the resolve makes, so about 0.11 s comes off it.

The 19-scenario canary set sees it on the clock too: locally between about 1% and 5% faster, with a middle estimate near 4%, and CPU between about 2% and 5% lower. Peak memory sits inside about 0.34% either way.

Matching `email` is the risk here:

- `StringIO(text, newline="")` is what `email` splits with. `str.splitlines` is faster and wrong, because it also breaks on `\x0b`, `\x0c`, `\x1c` to `\x1e`, `\x85`, `\u2028` and `\u2029`, so a form feed inside a header value would truncate the read.
- Compared against `email` over 500,000 generated documents and the 64,182 METADATA files in my local cache: no differences.
- One deliberate divergence. CPython changed `Compat32.header_source_parse` in 3.12.8 and 3.13.1, so `Requires-Dist:\n  bar` reads as `"bar"` from those releases on and as `"\n  bar"` on 3.10, 3.11 and the earlier 3.12 and 3.13 patches. The reader takes the newer reading everywhere, which is the one `Requirement` accepts.
