### PR TITLE
Report an unwritable temp filesystem as a build failure, not a traceback

### DIFF
--- a/nab-project/src/nab_project/_build/env.py
+++ b/nab-project/src/nab_project/_build/env.py
@@ -29,7 +29,7 @@ import subprocess
 import sys
 import tempfile
 import venv
-from contextlib import suppress
+from contextlib import contextmanager, suppress
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, TypeVar
@@ -53,7 +53,7 @@ from ..lockfile import IndexPin
 from .errors import BuildBackendError
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable, Mapping
+    from collections.abc import Callable, Iterable, Iterator, Mapping
 
     from installer.records import RecordEntry
     from installer.utils import Scheme
@@ -136,9 +136,33 @@ _SCHEME_PROBE = (
 class BuildEnvError(Exception):
     """The build env could not be set up.
 
-    Covers venv creation, the interpreter scheme probe, and the inner
-    resolve, download, and install of ``[build-system].requires``.
+    Covers the temp tree the env lives in, venv creation, the
+    interpreter scheme probe, and the inner resolve, download, and
+    install of ``[build-system].requires``.
     """
+
+
+@contextmanager
+def _as_build_env_error(action: str) -> Iterator[None]:
+    """Re-raise an ``OSError`` from the block as :class:`BuildEnvError`.
+
+    ``action`` opens the message, so it names the entry point rather
+    than the individual write that failed.
+    """
+    try:
+        yield
+    except OSError as exc:
+        msg = f"{action}: {exc}"
+        raise BuildEnvError(msg) from exc
+
+
+def _build_tempdir(prefix: str) -> tempfile.TemporaryDirectory[str]:
+    """Return a temp directory for the build, or raise :class:`BuildEnvError`."""
+    try:
+        return tempfile.TemporaryDirectory(prefix=prefix, ignore_cleanup_errors=True)
+    except OSError as exc:
+        msg = f"could not create a temporary build directory: {exc}"
+        raise BuildEnvError(msg) from exc
 
 
 BuildChain = tuple[str, ...]
@@ -224,11 +248,10 @@ class NabBuildEnv:
 
     def __enter__(self) -> Self:
         """Build the venv, run the inner resolve, install build requirements."""
-        self._tmpdir = tempfile.TemporaryDirectory(
-            prefix="nab-build-env-", ignore_cleanup_errors=True
-        )
+        self._tmpdir = _build_tempdir("nab-build-env-")
         try:
-            self._provision(Path(self._tmpdir.name))
+            with _as_build_env_error("could not populate the build env"):
+                self._provision(Path(self._tmpdir.name))
         except BaseException:
             self._tmpdir.cleanup()
             self._tmpdir = None
@@ -351,13 +374,17 @@ class NabBuildEnv:
             raise BuildEnvError(msg)
         if not requirements:
             return
-        wheel_dir = self._venv_path.parent / "wheels"
-        # Append a fresh subdir so a re-install does not re-download
-        # the same wheel into the same path under a different version.
-        sub = wheel_dir / f"_extra_{len(list(wheel_dir.iterdir()))}"
-        sub.mkdir(parents=True, exist_ok=True)
-        wheel_paths = self._resolve_and_download(sub, extra=requirements)
-        self._install_wheels(wheel_paths, _venv_scheme_paths(self._python_executable))
+
+        with _as_build_env_error("could not install extra build requirements"):
+            wheel_dir = self._venv_path.parent / "wheels"
+            # Append a fresh subdir so a re-install does not re-download
+            # the same wheel into the same path under a different version.
+            sub = wheel_dir / f"_extra_{len(list(wheel_dir.iterdir()))}"
+            sub.mkdir(parents=True, exist_ok=True)
+
+            wheel_paths = self._resolve_and_download(sub, extra=requirements)
+            scheme_paths = _venv_scheme_paths(self._python_executable)
+            self._install_wheels(wheel_paths, scheme_paths)
 
     def _resolve_and_download(
         self,
@@ -556,9 +583,7 @@ class NabBuildEnv:
             msg = f"build requirement {label} could not be read at {archive}: {exc}"
             raise BuildEnvError(msg) from exc
 
-        with tempfile.TemporaryDirectory(
-            prefix="nab-build-req-", ignore_cleanup_errors=True
-        ) as td:
+        with _build_tempdir("nab-build-req-") as td:
             try:
                 source_dir = extract_sdist_archive(data, Path(td))
             except ValueError as exc:

--- a/nab-project/src/nab_project/_build/runner.py
+++ b/nab-project/src/nab_project/_build/runner.py
@@ -82,9 +82,10 @@ def run_build_backend(
     the ``METADATA`` file the backend produces.  Raises
     :class:`BuildBackendError` on any failure: backend import
     error, a rejected ``backend-path``, hook crash, METADATA that
-    is unreadable or malformed, an unreadable built wheel, a build
-    requirement that cannot be installed or built, or build
-    requirements ``offline`` bars from being fetched.
+    is unreadable or malformed, an unreadable built wheel, scratch
+    space that cannot be created, a build requirement that cannot be
+    installed or built, or build requirements ``offline`` bars from
+    being fetched.
 
     The build runs in an isolated venv driven by
     :class:`NabBuildEnv`; nothing in the user's main environment is
@@ -100,9 +101,7 @@ def run_build_backend(
         _prepared_project(
             source_dir, data, config=config, offline=offline, chain=chain
         ) as (project, backend),
-        tempfile.TemporaryDirectory(
-            prefix="nab-build-meta-", ignore_cleanup_errors=True
-        ) as out_str,
+        _metadata_output_dir(backend) as out_str,
     ):
         metadata_dir = _extract_metadata_dir(
             project,
@@ -146,6 +145,20 @@ def build_wheel_for_install(
                 f" from build_wheel: {exc}"
             )
             raise BuildBackendError(msg) from exc
+
+
+def _metadata_output_dir(backend: str) -> tempfile.TemporaryDirectory[str]:
+    """Return the temp directory ``backend`` writes its metadata into."""
+    try:
+        return tempfile.TemporaryDirectory(
+            prefix="nab-build-meta-", ignore_cleanup_errors=True
+        )
+    except OSError as exc:
+        msg = (
+            "could not create a temporary metadata directory for build"
+            f" backend {backend!r}: {exc}"
+        )
+        raise BuildBackendError(msg) from exc
 
 
 @contextmanager

--- a/nab-project/src/nab_project/_build_remote.py
+++ b/nab-project/src/nab_project/_build_remote.py
@@ -60,9 +60,18 @@ def build_remote_sdist(
         )
         raise UnsupportedSdistError(msg)
 
-    with tempfile.TemporaryDirectory(
-        prefix="nab-build-remote-", ignore_cleanup_errors=True
-    ) as td:
+    try:
+        scratch = tempfile.TemporaryDirectory(
+            prefix="nab-build-remote-", ignore_cleanup_errors=True
+        )
+    except OSError as exc:
+        msg = (
+            f"{package}=={version} build-remote could not create a temporary"
+            f" build directory: {exc}"
+        )
+        raise UnsupportedSdistError(msg) from exc
+
+    with scratch as td:
         try:
             source_dir = extract_sdist_archive(data, Path(td))
         except ValueError as exc:

--- a/nab-project/tests/test_build_runner.py
+++ b/nab-project/tests/test_build_runner.py
@@ -21,6 +21,7 @@ import struct
 import subprocess
 import sys
 import tarfile
+import tempfile
 import zipfile
 from collections.abc import Callable
 from contextlib import AbstractContextManager
@@ -28,6 +29,7 @@ from dataclasses import fields
 from datetime import datetime, timezone
 from importlib.util import cache_from_source
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import build
@@ -377,6 +379,23 @@ def _write_fake_backend_project(
     return tmp_path
 
 
+def _tempdir_denying(denied: str) -> Callable[..., tempfile.TemporaryDirectory[str]]:
+    """Return a ``TemporaryDirectory`` stand-in that refuses one prefix.
+
+    A full temp filesystem raises ``OSError`` out of ``mkdtemp``.  Calls
+    with any other prefix are delegated, so the rest of the build still
+    gets scratch space.
+    """
+    real = tempfile.TemporaryDirectory
+
+    def factory(*args: Any, **kwargs: Any) -> tempfile.TemporaryDirectory[str]:
+        if kwargs.get("prefix") == denied:
+            raise OSError(28, "No space left on device")
+        return real(*args, **kwargs)
+
+    return factory
+
+
 @pytest.fixture
 def config() -> NabProjectConfig:
     """A minimal :class:`NabProjectConfig` for the tests."""
@@ -706,6 +725,44 @@ class TestRunBuildBackend:
 
         monkeypatch.setattr(venv_mod, "EnvBuilder", _Builder)
         with pytest.raises(BuildBackendError, match="build env setup"):
+            run_build_backend(tmp_path, config=config)
+
+    def test_temp_root_oserror_wrapped(
+        self,
+        tmp_path: Path,
+        config: NabProjectConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An OSError creating the env's temp root is wrapped as BuildBackendError."""
+        _write_fake_backend_project(tmp_path)
+        monkeypatch.setattr(
+            env_mod.tempfile,
+            "TemporaryDirectory",
+            _tempdir_denying("nab-build-env-"),
+        )
+        with pytest.raises(
+            BuildBackendError,
+            match="build env setup.*could not create a temporary build directory",
+        ):
+            run_build_backend(tmp_path, config=config)
+
+    def test_metadata_directory_oserror_wrapped(
+        self,
+        tmp_path: Path,
+        config: NabProjectConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An OSError creating the metadata directory is wrapped the same way."""
+        _write_fake_backend_project(tmp_path)
+        monkeypatch.setattr(
+            runner_mod.tempfile,
+            "TemporaryDirectory",
+            _tempdir_denying("nab-build-meta-"),
+        )
+        with pytest.raises(
+            BuildBackendError,
+            match="temporary metadata directory for build backend 'nab_test_backend'",
+        ):
             run_build_backend(tmp_path, config=config)
 
     def test_non_string_build_requirement_wrapped(
@@ -1721,6 +1778,19 @@ class TestNabBuildEnvInstall:
         )
         env.install(["pip"])
         assert len(installer_calls) == 1
+
+    def test_install_wraps_unlistable_wheel_dir(self, tmp_path: Path) -> None:
+        """An OSError listing the wheel directory surfaces as BuildEnvError."""
+        env = NabBuildEnv(requires=[], config=NabProjectConfig())
+        venv_path = tmp_path / "venv"
+        venv_path.mkdir()
+        env._venv_path = venv_path  # type: ignore[attr-defined]
+        env._python_executable = venv_path / "python"  # type: ignore[attr-defined]
+
+        with pytest.raises(
+            BuildEnvError, match="could not install extra build requirements"
+        ):
+            env.install(["pip"])
 
 
 # Every ``NabProjectConfig`` field, grouped by what the inner build-requires
@@ -2842,6 +2912,22 @@ class TestBuildRequirementBuildFailures:
         with pytest.raises(BuildEnvError, match="could not be extracted"):
             self._env()._build_requirement(self.PENDING, tmp_path)
 
+    def test_unwritable_temp_filesystem(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The directory the nested build unpacks into cannot be created."""
+        (tmp_path / self.PENDING.sdist.filename).write_bytes(b"sdist")
+        monkeypatch.setattr(
+            env_mod.tempfile,
+            "TemporaryDirectory",
+            _tempdir_denying("nab-build-req-"),
+        )
+
+        with pytest.raises(
+            BuildEnvError, match="could not create a temporary build directory"
+        ):
+            self._env()._build_requirement(self.PENDING, tmp_path)
+
     def test_backend_failure(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -3163,6 +3249,47 @@ class TestNabBuildEnvEnterInstall:
         monkeypatch.setattr(venv_mod, "EnvBuilder", _Builder)
         env = NabBuildEnv(requires=[], config=NabProjectConfig())
         with pytest.raises(BuildEnvError, match="build venv"):
+            env.__enter__()
+        assert env._tmpdir is None  # type: ignore[attr-defined]
+
+    def test_enter_wraps_inner_project_write_oserror(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An OSError writing the inner resolve's project raises BuildEnvError.
+
+        A full filesystem fails on a write, not on the ``mkdtemp`` that
+        made the empty temp root.
+        """
+
+        class _Builder:
+            def __init__(self, **_kw: object) -> None:
+                pass
+
+            def create(self, path: Path) -> None:
+                path.mkdir(parents=True, exist_ok=True)
+                (path / "bin").mkdir(exist_ok=True)
+                (path / "bin" / "python").touch()
+
+        import venv as venv_mod
+
+        monkeypatch.setattr(venv_mod, "EnvBuilder", _Builder)
+        monkeypatch.setattr(
+            env_mod, "_venv_scheme_paths", lambda _python: {"purelib": str(tmp_path)}
+        )
+
+        real_write_text = Path.write_text
+
+        def _deny_inner_project(self: Path, *args: Any, **kwargs: Any) -> int:
+            if self.parent.name == "_inner_project":
+                raise OSError(28, "No space left on device")
+            return real_write_text(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "write_text", _deny_inner_project)
+
+        env = NabBuildEnv(requires=["pip"], config=NabProjectConfig())
+        with pytest.raises(BuildEnvError, match="could not populate the build env"):
             env.__enter__()
         assert env._tmpdir is None  # type: ignore[attr-defined]
 

--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -10463,6 +10463,28 @@ class TestBuildRemoteFailureModes:
         with pytest.raises(UnsupportedSdistError, match="could not be extracted"):
             build_remote.build_remote_sdist(provider, "pkg", V("1.0"))
 
+    def test_unwritable_temp_filesystem_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A temp directory nab cannot create raises ``UnsupportedSdistError``."""
+        provider = self._provider(with_sdist=True, sdist_archive=b"data")
+        provider.versions_cache["pkg"] = [(V("1.0"), make_sdist("1.0"))]
+
+        real = _build_remote.tempfile.TemporaryDirectory
+
+        def _no_space(*args: Any, **kwargs: Any) -> object:
+            if kwargs.get("prefix") == "nab-build-remote-":
+                raise OSError(28, "No space left on device")
+            return real(*args, **kwargs)
+
+        monkeypatch.setattr(_build_remote.tempfile, "TemporaryDirectory", _no_space)
+
+        with pytest.raises(
+            UnsupportedSdistError,
+            match="could not create a temporary build directory",
+        ):
+            build_remote.build_remote_sdist(provider, "pkg", V("1.0"))
+
     def test_build_backend_failure_raises(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
A full or read-only temp filesystem crashes a build with a raw `OSError`. `run_build_backend` documents `BuildBackendError` on any failure and `build_remote_sdist` documents `UnsupportedSdistError`, but the build env's temp root was created outside every guard:

```
  File "nab-project/src/nab_project/_build/env.py", line 227, in __enter__
    self._tmpdir = tempfile.TemporaryDirectory(
OSError: [Errno 28] No space left on device
```

The same input now ends at:

```
BuildBackendError: build env setup for 'setuptools.build_meta' failed: could not create a temporary build directory: [Errno 28] No space left on device
```

Five places on the build path could let an `OSError` escape:

- the env's temp root, and everything venv creation and the inner resolve write into it
- the subdirectory `install()` adds for what `get_requires_for_build_wheel` asks for
- the tree a nested build requirement's sdist unpacks into
- the directory the backend writes its metadata into
- the scratch tree `build-remote` extracts a downloaded sdist into

Each now raises the error its own layer advertises: `BuildEnvError` inside the env, `BuildBackendError` out of the runner, `UnsupportedSdistError` out of build-remote.
