### PR TITLE
Fix crash when an index upload-time overflows the datetime range in UTC

### DIFF
--- a/nab-project/src/nab_project/_lockfile/builder.py
+++ b/nab-project/src/nab_project/_lockfile/builder.py
@@ -604,18 +604,19 @@ def _parse_upload_time(raw: str | None) -> datetime | None:
     Accepts the RFC 3339 form the Simple/JSON API serves (``Z`` or an
     explicit offset) and normalizes it to UTC (PEP 751 requires UTC for
     the emitted field). Returns ``None`` when the field is absent,
-    unparseable, or has no timezone; the timestamp is informational, so
-    a bad value is dropped rather than fatal.
+    unparseable, has no timezone, or lands outside the ``datetime``
+    range once shifted to UTC; the timestamp is informational, so a bad
+    value is dropped rather than fatal.
     """
     if raw is None:
         return None
     try:
         parsed = parse_iso_datetime(raw)
-    except ValueError:
+        if parsed.tzinfo is None:
+            return None
+        return parsed.astimezone(timezone.utc)
+    except (OverflowError, ValueError):
         return None
-    if parsed.tzinfo is None:
-        return None
-    return parsed.astimezone(timezone.utc)
 
 
 def _filter_acceptable_hashes(

--- a/nab-project/tests/test_lockfile.py
+++ b/nab-project/tests/test_lockfile.py
@@ -4045,6 +4045,30 @@ class TestBuildTargetLock:
         assert isinstance(pin, IndexPin)
         assert pin.wheels[0].upload_time is None
 
+    @pytest.mark.parametrize(
+        "upload_time",
+        ["9999-12-31T23:59:59-23:59", "0001-01-01T00:00:00+01:00"],
+    )
+    def test_upload_time_outside_datetime_range_in_utc_is_dropped(
+        self, upload_time: str
+    ) -> None:
+        """An offset can move a parseable timestamp out of range once in UTC."""
+        wheel = WheelFile(
+            filename="foo-1.0-py3-none-any.whl",
+            url="https://pypi.org/simple/foo/foo-1.0-py3-none-any.whl",
+            version="1.0",
+            requires_python=">=3.10",
+            has_metadata=False,
+            upload_time=upload_time,
+            hashes=(("sha256", "a" * 64),),
+            size=1234,
+        )
+        provider = _FakeProvider(listings={"foo": [(Version("1.0"), wheel)]})
+        lock = build_target_lock(provider, _HOST, {"foo": Version("1.0")})
+        pin = lock.pins["foo"]
+        assert isinstance(pin, IndexPin)
+        assert pin.wheels[0].upload_time is None
+
     def test_missing_acceptable_hash_raises(self) -> None:
         wheel = _wheel_file(sha256=None)
         provider = _FakeProvider(listings={"foo": [(Version("1.0"), wheel)]})


### PR DESCRIPTION
`nab lock` and `nab download` crash with an uncaught `OverflowError: date value out of range` when an index reports an `upload-time` that parses fine but falls outside the `datetime` range once shifted to UTC. Two values that do it:

- `9999-12-31T23:59:59-23:59`, which lands past `datetime.max`
- `0001-01-01T00:00:00+01:00`, which lands before `datetime.min`

`_parse_upload_time` guards `parse_iso_datetime` with `except ValueError` and calls `astimezone` outside that guard, so nothing catches the `OverflowError` it raises and the traceback reaches the user.

The timestamp is informational and every other unusable value is already dropped, so this one is too: the guard now covers the conversion and catches `OverflowError` alongside `ValueError`.
