### PR TITLE
Fix raw traceback when an archive cache entry cannot be written

### DIFF
--- a/nab-project/src/nab_project/_sources.py
+++ b/nab-project/src/nab_project/_sources.py
@@ -413,8 +413,13 @@ def _extract_archive(
     target = cache_dir / digest
 
     if not _is_published(target):
-        cache_dir.mkdir(parents=True, exist_ok=True)
-        tmp = Path(tempfile.mkdtemp(dir=cache_dir, prefix=f"{digest}.", suffix=".tmp"))
+        try:
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            tmp = Path(
+                tempfile.mkdtemp(dir=cache_dir, prefix=f"{digest}.", suffix=".tmp")
+            )
+        except OSError as exc:
+            raise _cache_write_error(exc) from exc
 
         try:
             unpacked = tmp / "unpacked"
@@ -451,12 +456,19 @@ def _extract_archive(
                 if not _is_published(target):
                     msg = f"extracted archive could not be moved into place: {exc}"
                     raise UnsupportedSdistError(msg) from exc
+        except OSError as exc:
+            raise _cache_write_error(exc) from exc
         finally:
             # A successful rename leaves nothing here; any other exit, an
             # interrupt included, would leak the temp tree.
             shutil.rmtree(tmp, ignore_errors=True)
 
     return _extracted_root(target)
+
+
+def _cache_write_error(exc: OSError) -> UnsupportedSdistError:
+    """Return the error for an archive-cache write that failed with ``exc``."""
+    return UnsupportedSdistError(f"archive cache entry could not be written: {exc}")
 
 
 def _extracted_root(target: Path) -> Path:

--- a/nab-project/tests/test_archive.py
+++ b/nab-project/tests/test_archive.py
@@ -214,6 +214,22 @@ def _deny_access(monkeypatch: pytest.MonkeyPatch, method: str, target: Path) -> 
     monkeypatch.setattr(Path, method, failing)
 
 
+def _deny_disk_space(monkeypatch: pytest.MonkeyPatch, method: str, name: str) -> None:
+    """Make every ``Path`` call on a path named ``name`` fail with ENOSPC.
+
+    ``mkdtemp`` picks the entry's directory name, so paths beneath it cannot
+    be named up front and the denial matches on the basename instead.
+    """
+    original = getattr(Path, method)
+
+    def failing(self: Path, *args: Any, **kwargs: Any) -> Any:
+        if self.name == name:
+            raise OSError(errno.ENOSPC, "No space left on device", str(self))
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, method, failing)
+
+
 def _lock_input(pins: Mapping[str, PinShape]) -> LockInput:
     """Wrap ``pins`` as the one-target lock input the downloader reads."""
     target = ResolveTarget.for_host()
@@ -501,6 +517,41 @@ class TestArchiveMaterialize:
         with pytest.raises(UnsupportedSdistError, match="could not be extracted"):
             provider.fetch_versions("foo")
         assert list((tmp_path / "arch").iterdir()) == []
+
+    def test_unwritable_cache_dir_reports_the_os_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A cache directory this process cannot write fails the resolve the
+        # way an unextractable archive does.
+        data = _make_sdist("foo", "1.0.0", _PYPROJECT)
+        cache = tmp_path / "arch"
+        _deny_access(monkeypatch, "mkdir", cache)
+        provider = _archive_provider(data, cache)
+
+        with pytest.raises(
+            UnsupportedSdistError, match="could not be written"
+        ) as excinfo:
+            provider.fetch_versions("foo")
+
+        assert "Permission denied" in str(excinfo.value)
+
+    def test_full_cache_filesystem_reports_the_os_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # "unpacked" is the first write inside the entry's temporary directory,
+        # so this failure lands after ``mkdtemp`` succeeded.
+        data = _make_sdist("foo", "1.0.0", _PYPROJECT)
+        cache = tmp_path / "arch"
+        _deny_disk_space(monkeypatch, "mkdir", "unpacked")
+        provider = _archive_provider(data, cache)
+
+        with pytest.raises(
+            UnsupportedSdistError, match="could not be written"
+        ) as excinfo:
+            provider.fetch_versions("foo")
+
+        assert "No space left on device" in str(excinfo.value)
+        assert list(cache.iterdir()) == []
 
     @requires_data_filter
     def test_reextraction_replaces_stale_partial_tree(self, tmp_path: Path) -> None:


### PR DESCRIPTION
`nab lock` and `nab download` end in a raw traceback when the archive cache cannot be written: a read-only cache directory gives `PermissionError`, a full filesystem gives `ENOSPC`. Extraction and rename failures a few lines away in the same function already exit 1 with one line.

The writes that build a cache entry were unguarded. Two groups of them now raise `UnsupportedSdistError`, which the CLI already prints as a single `error:` line:

- creating the bucket and the entry's temporary directory (`mkdir`, `mkdtemp`)
- everything written into that temporary directory before it is renamed into place: the extracted tree, the hash record, the completion marker

A `file://` archive source against a read-only cache bucket now says

    error: cannot lock: archive cache entry could not be written: [Errno 13] Permission denied: '<cache>/archive-v1/<digest>.<random>.tmp'

instead of a traceback out of `tempfile.mkdtemp`. The temporary tree is still removed on the way out, so a failed write leaves nothing in the cache.
