### PR TITLE
Share Tag instances across universal targets, 12% off a 25-target resolve

### DIFF
--- a/nab-provider/src/nab_provider/tags.py
+++ b/nab-provider/src/nab_provider/tags.py
@@ -426,6 +426,14 @@ _TAG_RULE_IMPLEMENTATIONS = frozenset(_IMPLEMENTATION_FOR_PREFIX.values())
 # machine, so it never seeds the platform axis of another target.
 _ANY_PLATFORM = "any"
 
+# Stands in for the platform axis while a target's tag order is derived.  No
+# platform tag can contain a NUL, so it never collides with a real one.
+_PLATFORM_PLACEHOLDER = "\x00platform"
+
+# The shared Tag instances every target's tag order draws from, keyed by
+# (interpreter, abi) and then by platform.
+_TARGET_TAGS: dict[tuple[str, str], dict[str, Tag]] = {}
+
 
 @lru_cache(maxsize=4096)
 def _intern_tag(tag: Tag) -> Tag:
@@ -731,6 +739,66 @@ def _tags_in_order(
     free_threaded: bool,
 ) -> Iterable[Tag]:
     """Yield the tags a target accepts in install preference order.
+
+    The order comes from :func:`_tag_order_template`, and each tag is built
+    once and then shared across targets: the Python minors of one platform
+    spec re-derive most of each other's tags, and ``Tag.__init__`` lowercases
+    all three fields and precomputes a hash on every call.
+    """
+    for interpreter, abi, fixed_platform in _tag_order_template(
+        python_version, implementation, free_threaded=free_threaded
+    ):
+        instances = _TARGET_TAGS.setdefault((interpreter, abi), {})
+        axis_platforms = platforms if fixed_platform is None else (fixed_platform,)
+        for platform_ in axis_platforms:
+            tag = instances.get(platform_)
+            if tag is None:
+                tag = instances[platform_] = ptags.Tag(interpreter, abi, platform_)
+            yield tag
+
+
+@cache
+def _tag_order_template(
+    python_version: str, implementation: str, *, free_threaded: bool
+) -> tuple[tuple[str, str, str | None], ...]:
+    """Return a target's tag order with the platform axis projected out.
+
+    ``cpython_tags`` and ``compatible_tags`` pair each (interpreter, abi) with
+    the whole platform list before moving to the next, so deriving the order
+    against a single placeholder platform and expanding each placeholder entry
+    back over the real list reproduces the sequence tag for tag.  A ``None``
+    platform marks an entry the platform axis multiplies; the rest
+    (``cpXY-none-any``, ``py3-none-any``) name a platform of their own.
+
+    That pairing is not guaranteed by construction: ``cpython_tags`` loops the
+    platforms outside the abi choice in its abi3 backfill, and holds the
+    pairing there only because ``abi3`` and ``abi3t`` never apply to the same
+    build.  ``TestSharedTagInstances`` pins the expansion against packaging's
+    own output rather than trusting it.
+    """
+    return tuple(
+        (
+            tag.interpreter,
+            tag.abi,
+            None if tag.platform == _PLATFORM_PLACEHOLDER else tag.platform,
+        )
+        for tag in _packaging_tags(
+            python_version,
+            (_PLATFORM_PLACEHOLDER,),
+            implementation,
+            free_threaded=free_threaded,
+        )
+    )
+
+
+def _packaging_tags(
+    python_version: str,
+    platforms: Sequence[str],
+    implementation: str,
+    *,
+    free_threaded: bool,
+) -> Iterable[Tag]:
+    """Yield a target's tags as packaging derives them.
 
     CPython targets use ``packaging.tags.cpython_tags`` (cpXY-cpXY,
     cpXY-abi3 forward-compat, cpXY-none), with the abi named from the

--- a/nab-provider/tests/test_tags.py
+++ b/nab-provider/tests/test_tags.py
@@ -26,8 +26,10 @@ from nab_provider.tags import (
     PlatformSpec,
     TagSet,
     _ordered_tags_for_spec,
+    _packaging_tags,
     _parse_tag_str,
     _platform_tags_for_spec,
+    _tags_in_order,
     python_axis_accepts,
     wheel_tag_set,
 )
@@ -1340,3 +1342,62 @@ class TestLinuxPlatformOrderMatchesSysTags:
         many = Tag("cp311", "cp311", "manylinux_2_28_x86_64")
         assert host.rank[plain] < host.rank[many]
         assert declared.rank[plain] < declared.rank[many]
+
+
+# The platform lists production hands ``_tags_in_order``: one per declared
+# platform id, the bare ``any`` axis ``_python_axis_tags`` projects over, and
+# the empty list ``TagSet.for_host_python`` builds when the host advertises no
+# platform but ``any``.
+_ORDER_PLATFORM_LISTS = [
+    *(
+        pytest.param(_platform_tags_for_spec(PlatformSpec(platform_id)), id=platform_id)
+        for platform_id in sorted(_PLATFORM_KIND)
+    ),
+    pytest.param(["any"], id="any-axis"),
+    pytest.param([], id="no-platforms"),
+]
+
+
+class TestSharedTagInstances:
+    """A target's platform axis is expanded from a template, over shared tags.
+
+    ``_tags_in_order`` derives the order once per (python, implementation,
+    build) against a placeholder platform, then expands each placeholder entry
+    over the real platform list.  That reproduces packaging's sequence only
+    while packaging pairs an (interpreter, abi) with every platform before
+    moving to the next, so the expansion is pinned against packaging's own
+    output: a reordering would silently change which wheel a target picks.
+    """
+
+    @pytest.mark.parametrize("platforms", _ORDER_PLATFORM_LISTS)
+    @pytest.mark.parametrize("python_version", ["3.10", "3.13"])
+    @pytest.mark.parametrize("implementation", ["cpython", "pypy"])
+    def test_order_matches_packaging(
+        self, platforms: list[str], python_version: str, implementation: str
+    ) -> None:
+        assert tuple(
+            _tags_in_order(
+                python_version, platforms, implementation, free_threaded=False
+            )
+        ) == tuple(
+            _packaging_tags(
+                python_version, platforms, implementation, free_threaded=False
+            )
+        )
+
+    def test_order_matches_packaging_free_threaded(self) -> None:
+        platforms = _platform_tags_for_spec(PlatformSpec("linux_x86_64"))
+        assert tuple(
+            _tags_in_order("3.13", platforms, "cpython", free_threaded=True)
+        ) == tuple(_packaging_tags("3.13", platforms, "cpython", free_threaded=True))
+
+    def test_two_pythons_reuse_one_instance_per_tag(self) -> None:
+        spec = PlatformSpec("linux_x86_64")
+        older = _ordered_tags_for_spec("3.12", spec, "cpython")
+        newer = _ordered_tags_for_spec("3.13", spec, "cpython")
+
+        shared = set(older) & set(newer)
+        assert shared
+
+        instances = {id(tag) for tag in older}
+        assert all(id(tag) in instances for tag in newer if tag in shared)


### PR DESCRIPTION
Building each wheel tag once instead of once per target takes `universal:max-25-tuples` from 6,378,307,612 instructions to 5,607,672,591, a saving of 770,635,021 or 12.08% of the whole scenario process, interpreter startup and imports included. Locally the same scenario runs between about 10% and 15% faster, with a middle estimate near 13%, and its peak RSS is between about 25.5% and 26% lower.

| scenario | tuples | base | branch | delta | share |
| --- | --- | --- | --- | --- | --- |
| `universal:max-25-tuples` | 25 | 6,378,307,612 | 5,607,672,591 | -770,635,021 | -12.08% |
| `universal:scientific-python-multi` | 12 | 7,530,684,930 | 7,367,955,175 | -162,729,755 | -2.16% |
| `universal:transformers-cpu-multi-python` | 6 | 11,783,293,217 | 11,632,780,365 | -150,512,852 | -1.28% |

Counts are callgrind under `PYTHONHASHSEED=0`, one run per side. Only the top row reproduces to the digit: repeats of the other two moved by up to half a point, and three base runs of `transformers-cpu-multi-python` on identical code spanned 0.68%, so read those two rows as the quoted run rather than as exact figures. A wide matrix wins most, because the duplication is across targets.

A 25-tuple matrix is five Python minors across five platform specs, and every target derives its accepted tags on its own: 123,850 `Tag` objects for 32,802 distinct triples. The platform strings do not depend on the Python version, and `compatible_tags` emits `pyXY-none-<platform>` for every minor at or below the target's, so minors sharing a platform spec re-derive most of each other's tags. `Tag.__init__` lowercases all three fields and precomputes a hash every time.

`_tags_in_order` now derives the order once per (python, implementation, build) against a placeholder platform, expands each placeholder entry back over the real platform list, and draws every tag from a module-level table keyed by (interpreter, abi) and then by platform. packaging still decides the order and the abi rules; nab decides only which instance carries a triple.

That order is what `TagSet.rank` reads, so a reordering would quietly change which wheel a target picks. `TestSharedTagInstances` pins the expansion against packaging's own output tag for tag, over every platform id and both implementations, plus a free-threaded build and the two lists production also passes: `any` alone, and no platforms at all.

Peak traced bytes on `max-25-tuples` go from 65,042,016 to 43,566,282, and live blocks at exit from 797,494 to 347,573.

The table lives for the process, so a workload with few targets pays for it without collecting much of the saving. Across the 19-scenario canary set it holds 1,464 tags, against 32,802 for the 25-tuple matrix, and the timing runs there found no difference: they rule out a wall change above about 3.6% and put peak RSS inside about 0.4% either way.
