### PR TITLE
Test the published sidecar digest on every metadata request

### DIFF
--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import errno
 import gc
+import hashlib
 import io
 import json
 import logging
@@ -119,6 +120,7 @@ def make_wheel(
     has_metadata: bool = True,
     upload_time: str | None = None,
     local_path: Path | None = None,
+    metadata_hash: tuple[str, str] | None = None,
 ) -> WheelFile:
     """Build a WheelFile for testing."""
     return WheelFile(
@@ -129,6 +131,7 @@ def make_wheel(
         has_metadata=has_metadata,
         upload_time=upload_time,
         local_path=local_path,
+        metadata_hash=metadata_hash,
     )
 
 
@@ -171,11 +174,32 @@ def make_sdist(
     )
 
 
+def _sidecar_hash(version: str) -> tuple[str, str]:
+    """A published ``core-metadata`` digest, distinct per version."""
+    return ("sha256", hashlib.sha256(version.encode()).hexdigest())
+
+
 def _prefetched_batch_versions(coordinator: FakeFetchPort) -> list[str]:
     """Versions of the one batch metadata prefetch, in submission order."""
     batches = coordinator.calls_to("request_metadata_batch")
     assert len(batches) == 1
     return [version for _package, version, _url, _hash in batches[0][0]]
+
+
+def _requested_digests(
+    coordinator: FakeFetchPort,
+) -> list[tuple[str, tuple[str, str] | None]]:
+    """``(version, digest)`` for every single metadata request, in call order."""
+    calls = coordinator.calls_to("request_metadata")
+    return [(version, digest) for _package, version, _url, digest in calls]
+
+
+def _batched_digests(
+    coordinator: FakeFetchPort,
+) -> list[tuple[str, tuple[str, str] | None]]:
+    """``(version, digest)`` for the last metadata batch, in submission order."""
+    items = coordinator.calls_to("request_metadata_batch")[-1][0]
+    return [(version, digest) for _package, version, _url, digest in items]
 
 
 def _done_event() -> threading.Event:
@@ -521,6 +545,81 @@ class TestSpeculativePrefetch:
         # v2.0 was prefetched, but we ask for v1.0
         deps = provider.get_dependencies("foo", V("1.0"))
         assert "bar" in deps
+
+
+class TestSidecarDigestForwarding:
+    """Each metadata request carries the sidecar digest its listing published.
+
+    A request that drops the listing's ``core-metadata`` value is fetched
+    without a hash check and reports nothing, so there is one test per request
+    site the provider owns.
+    """
+
+    def _coordinator(self, *versions: str) -> FakeFetchPort:
+        """A ``foo`` listing whose wheels each publish their own digest."""
+        return make_coordinator(
+            [make_wheel(v, metadata_hash=_sidecar_hash(v)) for v in versions],
+            auto_metadata=True,
+            package="foo",
+        )
+
+    def test_transitive_best_prefetch_forwards_the_digest(self) -> None:
+        """The single-candidate prefetch carries the picked wheel's digest."""
+        coordinator = self._coordinator("2.0", "1.0")
+        provider = Provider(coordinator, target=_PY312)
+
+        provider.fetch_versions("foo")
+
+        assert _requested_digests(coordinator) == [("2.0", _sidecar_hash("2.0"))]
+
+    def test_root_batch_prefetch_forwards_the_digest(self) -> None:
+        """The root-range batch carries a digest per item, not one for the batch."""
+        coordinator = self._coordinator("2.0", "1.0")
+        provider = Provider(
+            coordinator,
+            target=_PY312,
+            root_requirements={"foo": SpecifierSet(">=1.0").to_range()},
+        )
+
+        provider.fetch_versions("foo")
+
+        assert _batched_digests(coordinator) == [
+            ("2.0", _sidecar_hash("2.0")),
+            ("1.0", _sidecar_hash("1.0")),
+        ]
+
+    def test_walk_ahead_prefetch_forwards_the_digest(self) -> None:
+        """The deep walk-ahead batch carries the digest of each version it warms."""
+        coordinator = self._coordinator("2.0", "1.0")
+        provider = Provider(coordinator, target=_PY312)
+        provider.fetch_versions("foo")
+        coordinator.reset()
+
+        provider.prefetch_walk_ahead("foo")
+
+        assert _batched_digests(coordinator) == [("1.0", _sidecar_hash("1.0"))]
+
+    def test_pipelined_batch_forwards_the_digest(self) -> None:
+        """The scan's own batch carries the digest of the version it submits."""
+        coordinator = self._coordinator("2.0", "1.0")
+        provider = Provider(coordinator, target=_PY312)
+        versions = provider.fetch_versions("foo")
+        coordinator.reset()
+
+        provider._prefetch_batch(
+            "foo", [V("1.0")], provider._wheel_by_version("foo", versions)
+        )
+
+        assert _batched_digests(coordinator) == [("1.0", _sidecar_hash("1.0"))]
+
+    def test_synchronous_read_forwards_the_digest(self) -> None:
+        """The blocking read of a version no prefetch warmed carries its digest."""
+        coordinator = self._coordinator("2.0", "1.0")
+        provider = Provider(coordinator, target=_PY312)
+
+        provider.get_dependencies("foo", V("1.0"))
+
+        assert _requested_digests(coordinator)[-1] == ("1.0", _sidecar_hash("1.0"))
 
 
 class TestBatchPrefetchUrlDepRefusal:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -61,6 +61,7 @@ from nab_project._testing.coordinator_fake import make_coordinator
 from nab_project.config import ConfigError, read_pyproject_config
 from nab_project.config_sources import SourceRoots
 from nab_project.download import DownloadError
+from nab_project.fetch import FetchCoordinator
 from nab_project.lockfile import (
     ArchivePin,
     DisjointnessError,
@@ -1405,6 +1406,69 @@ class TestLockCommandSpecific:
         assert "sha256 mismatch" in err
         assert "0" * 64 in err
         assert "Traceback" not in err
+
+    def test_metadata_hash_mismatch_below_prefetch_window_exits(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A pin no prefetch covers still has its sidecar checked.
+
+        The coordinator warms the newest ``PREFETCH_METADATA_COUNT`` versions
+        as soon as a listing lands and forwards the published digest itself.
+        Pinning an older version leaves the provider's own request as the only
+        carrier of that digest.
+        """
+        monkeypatch.setattr(
+            "nab.cli._config_search_roots",
+            lambda p: SourceRoots(project_dir=p.parent, pyproject=p),
+        )
+
+        # Guards the premise: the pin has to sit outside the prefetch window.
+        versions = ("1.0", "2.0", "3.0")
+        pinned = versions[0]
+        assert len(versions) > FetchCoordinator.PREFETCH_METADATA_COUNT
+
+        pyproject = _make_pyproject(
+            tmp_path, f'[project]\ndependencies = ["foo=={pinned}"]\n'
+        )
+
+        files: list[dict[str, object]] = []
+        bodies: dict[str, bytes] = {}
+        for version in versions:
+            url = f"https://files.example.com/foo-{version}-py3-none-any.whl"
+            sidecar = f"Metadata-Version: 2.1\nName: foo\nVersion: {version}\n\n"
+            bodies[f"{url}.metadata"] = sidecar.encode()
+
+            # Only the pin advertises a digest its sidecar bytes do not match.
+            published = (
+                "0" * 64
+                if version == pinned
+                else hashlib.sha256(sidecar.encode()).hexdigest()
+            )
+            files.append(
+                {
+                    "filename": f"foo-{version}-py3-none-any.whl",
+                    "url": url,
+                    "core-metadata": {"sha256": published},
+                }
+            )
+
+        bodies["https://pypi.org/simple/foo/"] = json.dumps({"files": files}).encode()
+        transport = _SidecarTransport(bodies)
+
+        with (
+            patch("nab.cli._make_transport", return_value=transport),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, output=tmp_path / "pylock.toml", cache=False)
+
+        err = capsys.readouterr().err
+        assert "cannot lock" in err
+        assert "sha256 mismatch" in err
+        assert "0" * 64 in err
+        assert not (tmp_path / "pylock.toml").exists()
 
     def test_wheel_hash_mismatch_exits(
         self,


### PR DESCRIPTION
Nulling `dist.metadata_hash` at all five provider request sites leaves the test suite green.

The one test that puts a published `core-metadata` sha256 through a real transport, `test_metadata_hash_mismatch_exits`, locks a listing with a single version. The coordinator prefetches the newest two versions as soon as a listing lands and forwards the published digest itself, so its request registers the pending key first and whatever the provider forwards is never submitted.

The five forwards, none pinned by a test:

- `prefetch_root_batch`
- `prefetch_transitive_best`
- `prefetch_walk_ahead`
- `prefetch_batch`
- `_read_direct_wheel_metadata`, the blocking read of a version no prefetch warmed

`TestSidecarDigestForwarding` covers one each. Every wheel in the fake listing publishes a digest derived from its own version, so forwarding another version's digest fails the same way forwarding `None` does. The root-range batch goes out with two versions, which pins a digest per item rather than one for the whole batch.

The CLI test pins `foo==1.0` against a three-version listing, putting the pin outside the prefetch window so the provider's own request is the only carrier of the digest. Only the pin advertises a sha256 its sidecar bytes do not match: the lock exits 1 and writes no `pylock.toml`.
