### PR TITLE
Fix README claiming commit-pinned git URLs are allowed by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,31 @@ so that the lockfile will be stable, even if mirrors are used
 
 ## VCS policy
 
-By default nab only allows git URLs that point to a specific
-commit. Using a floating branch as a dependency must be
-enabled in the configuration.
+By default nab refuses every git URL, pinned or not:
+
+```toml
+[tool.nab.vcs]
+policy = "block"
+allowed-schemes = []
+allowed-repos = []
+require-pin = true
+```
+
+Each of the first three refuses everything until you set it:
+
+ * `policy`: set to `allow` to consider git URLs at all
+ * `allowed-schemes`: the schemes you accept, e.g. `git+https`
+ * `allowed-repos`: the repository prefixes you accept, e.g.
+   `https://github.com/myorg/`
+
+`require-pin` is on by default, so a URL has to carry a
+40-character commit hash and a floating branch or tag is
+refused.
+
+A package is then taken from a repository through a
+`[[tool.nab.vcs-sources]]` entry. A `pkg @ git+...` requirement
+under `[project].dependencies` gets the same admission checks,
+but nab cannot resolve that form yet, so use a source entry.
 
 # Standards first behavior
 

--- a/tests/test_readme_docs.py
+++ b/tests/test_readme_docs.py
@@ -1,0 +1,61 @@
+"""Check the README's VCS policy section against the admission code.
+
+The README is the ``nab`` distribution's PyPI description, so it states the
+default posture to readers who never open the documentation site.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import tomli
+
+from nab_project.config_sources import OPTIONS
+from nab_provider.vcs_admission import UnsupportedVcsError, VcsConfig, admit_vcs_url
+
+README = Path(__file__).resolve().parents[1] / "README.md"
+
+PINNED_URL = f"git+https://github.com/myorg/pkg.git@{'0' * 40}"
+
+
+def _vcs_section() -> str:
+    """The README body under ``## VCS policy``, up to the next heading.
+
+    A heading only counts outside a fenced block, so a ``#`` comment in a
+    toml example does not cut the section short.
+    """
+    body = README.read_text(encoding="utf-8").partition("\n## VCS policy\n")[2]
+    assert body, "README.md has no VCS policy section"
+
+    lines: list[str] = []
+    fenced = False
+    for line in body.splitlines():
+        if line.startswith("```"):
+            fenced = not fenced
+        elif not fenced and line.startswith("#"):
+            break
+        lines.append(line)
+
+    return "\n".join(lines)
+
+
+def _documented_default() -> VcsConfig:
+    """The section's toml block, parsed by the registry's own ``vcs`` parser."""
+    block = re.search(r"```toml\n(.*?)\n```", _vcs_section(), re.DOTALL)
+    assert block, "the VCS policy section has no toml block"
+
+    spec = next(option for option in OPTIONS if option.key == "vcs")
+    return spec.parse(tomli.loads(block[1])["tool"]["nab"]["vcs"], where="README.md")
+
+
+def test_documented_default_is_the_shipped_default() -> None:
+    """The block the section leads with matches ``VcsConfig``, key for key."""
+    assert _documented_default() == VcsConfig()
+
+
+def test_documented_default_refuses_a_pinned_url() -> None:
+    """A commit-pinned URL is refused under the block, as the section says."""
+    with pytest.raises(UnsupportedVcsError, match=r'vcs\.policy is "block"'):
+        admit_vcs_url(PINNED_URL, _documented_default())


### PR DESCRIPTION
The README's "VCS policy" section said nab allows git URLs pinned to a commit by default, and that only a floating branch needs configuration. The default refuses every git URL: `VcsConfig` ships `policy = "block"` with empty `allowed-schemes` and `allowed-repos`, so a commit-pinned URL never reaches the pin check.

```
refusing VCS requirement
    git+https://github.com/myorg/pkg.git@0000000000000000000000000000000000000000
    reason: vcs.policy is "block" (default).
```

README.md is the PyPI description for `nab`, so it is where a reader who never opens the docs site learns the default. Following it lands on that error with nothing in the text to explain it.

The section now shows the real default block and says what each key has to be set to. It also points at `[[tool.nab.vcs-sources]]`, since a `pkg @ git+...` requirement under `[project].dependencies` clears admission and then raises `NotImplementedError`.

A new test parses the section's toml with the config registry's own `vcs` parser, compares it against `VcsConfig()`, and runs a pinned URL through `admit_vcs_url`, so the section cannot drift from the shipped default.
