### PR TITLE
Refuse a build requirement whose built wheel names another release

### DIFF
--- a/docs/reference/build-policy.md
+++ b/docs/reference/build-policy.md
@@ -145,6 +145,13 @@ backend than `[build-system].requires` asked for without saying so.  The
 requirement resolves as written and the refusal names the version it
 landed on.
 
+What the build produces has to be the release nab resolved, because
+the dependencies installed beside it were resolved for that release.
+A backend that computes its own version and emits another one is
+refused, naming the requirement and the name and version its wheel
+filename carries.  Versions compare as PEP 440 does, so `1.0` and
+`1.0.0` are one release while `1.0+local` is another.
+
 A build already in the chain cannot be re-entered:
 
 ```text

--- a/nab-project/src/nab_project/_build/env.py
+++ b/nab-project/src/nab_project/_build/env.py
@@ -41,7 +41,11 @@ from installer.sources import WheelFile
 
 from nab_index.client import extract_sdist_archive
 from nab_index.urllib3_async_transport import Urllib3AsyncTransport
-from nab_provider._vendor.packaging.utils import canonicalize_name
+from nab_provider._vendor.packaging.utils import (
+    canonicalize_name,
+    parse_wheel_filename,
+)
+from nab_provider._vendor.packaging.version import Version
 from nab_provider.errors import MissingExtraError
 from nab_provider.policy import BuildPolicy, DistPolicy
 from nab_provider.requirements_file import InvalidProjectRequirementError
@@ -185,8 +189,14 @@ def chain_label(name: str, version: str) -> str:
 class _PendingBuild:
     """A build requirement this env has to build before it can install it."""
 
-    label: str
+    name: str
+    version: str
     sdist: SdistArtifact
+
+    @property
+    def label(self) -> str:
+        """The chain entry naming this build."""
+        return chain_label(self.name, self.version)
 
 
 class NabBuildEnv:
@@ -561,14 +571,17 @@ class NabBuildEnv:
             )
             raise BuildEnvError(msg)
 
-        to_build.append(_PendingBuild(label=label, sdist=pin.sdist))
+        to_build.append(
+            _PendingBuild(name=pin.name, version=pin.version, sdist=pin.sdist)
+        )
         return replace(pin, wheels=())
 
     def _build_requirement(self, pending: _PendingBuild, wheel_dir: Path) -> Path:
         """Build the downloaded sdist of ``pending`` and return the wheel's path.
 
         The wheel lands beside the downloaded artifacts, which live as
-        long as the env does.
+        long as the env does.  A wheel naming another release is
+        refused.
         """
         # Late import: ``runner`` imports this module at module load.
         from .runner import build_wheel_for_install
@@ -590,7 +603,7 @@ class NabBuildEnv:
                 msg = f"build requirement {label} could not be extracted: {exc}"
                 raise BuildEnvError(msg) from exc
             try:
-                return build_wheel_for_install(
+                built = build_wheel_for_install(
                     source_dir,
                     output_dir=wheel_dir,
                     config=self._config,
@@ -600,6 +613,32 @@ class NabBuildEnv:
             except BuildBackendError as exc:
                 msg = f"build requirement {label} could not be built: {exc}"
                 raise BuildEnvError(msg) from exc
+
+            _check_built_identity(pending, built)
+            return built
+
+
+def _check_built_identity(pending: _PendingBuild, wheel: Path) -> None:
+    """Raise unless ``wheel``'s filename names the release ``pending`` pinned.
+
+    A backend picks the name and version it emits, and the env's other
+    wheels were resolved for the release the pin names.
+    """
+    try:
+        name, version, _build, _tags = parse_wheel_filename(wheel.name)
+    except ValueError as exc:
+        msg = (
+            f"build requirement {pending.label} produced {wheel.name!r},"
+            f" which is not a wheel filename: {exc}"
+        )
+        raise BuildEnvError(msg) from exc
+
+    if name != canonicalize_name(pending.name) or version != Version(pending.version):
+        msg = (
+            f"build requirement {pending.label} built a wheel whose filename"
+            f" names {name}=={version}, not the release the resolve pinned"
+        )
+        raise BuildEnvError(msg)
 
 
 def _chain_suffix(chain: BuildChain) -> str:

--- a/nab-project/tests/test_build_runner.py
+++ b/nab-project/tests/test_build_runner.py
@@ -25,7 +25,7 @@ import tempfile
 import zipfile
 from collections.abc import Callable
 from contextlib import AbstractContextManager
-from dataclasses import fields
+from dataclasses import fields, replace
 from datetime import datetime, timezone
 from importlib.util import cache_from_source
 from pathlib import Path
@@ -2944,7 +2944,8 @@ class TestBuildRequirementBuildFailures:
     """
 
     PENDING = _PendingBuild(
-        label="demo 1.0",
+        name="demo",
+        version="1.0",
         sdist=SdistArtifact(
             filename="demo-1.0.tar.gz",
             url="https://pypi.example/demo-1.0.tar.gz",
@@ -3067,6 +3068,97 @@ class TestBuildRequirementBuildFailures:
             build_wheel_for_install(
                 source_dir, output_dir=tmp_path / "out", config=NabProjectConfig()
             )
+
+
+class TestBuiltWheelIdentity:
+    """``_build_requirement`` refuses a wheel naming another release.
+
+    The backend picks the name and version it emits, and the env's
+    other wheels were resolved for the release the pin names.
+    """
+
+    PENDING = _PendingBuild(
+        name="build-stub",
+        version="1.0",
+        sdist=SdistArtifact(
+            filename="build_stub-1.0.tar.gz",
+            url="https://pypi.example/build_stub-1.0.tar.gz",
+            hashes=(("sha256", "1" * 64),),
+        ),
+    )
+
+    def _built(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        filename: str,
+        pending: _PendingBuild | None = None,
+    ) -> Path:
+        """Run ``_build_requirement`` over a build emitting ``filename``.
+
+        ``pending`` defaults to :attr:`PENDING`, whose name is already
+        canonical.
+        """
+        pending = pending or self.PENDING
+        (tmp_path / pending.sdist.filename).write_bytes(b"sdist")
+
+        monkeypatch.setattr(
+            env_mod, "extract_sdist_archive", lambda _data, target: target
+        )
+        monkeypatch.setattr(
+            runner_mod,
+            "build_wheel_for_install",
+            MagicMock(return_value=tmp_path / filename),
+        )
+        env = NabBuildEnv(requires=[], config=NabProjectConfig(build_requires_depth=1))
+
+        return env._build_requirement(pending, tmp_path)
+
+    def test_another_version_is_refused(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A backend computing a version other than the one pinned."""
+        with pytest.raises(BuildEnvError, match=r"names build-stub==0\.0\.0"):
+            self._built(monkeypatch, tmp_path, "build_stub-0.0.0-py3-none-any.whl")
+
+    def test_another_project_is_refused(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A wheel for another project, leaving the requirement unmet."""
+        with pytest.raises(BuildEnvError, match=r"names otherpkg==9\.9"):
+            self._built(monkeypatch, tmp_path, "otherpkg-9.9-py3-none-any.whl")
+
+    def test_output_that_is_not_a_wheel_is_refused(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``build`` joins the hook's result on without checking it."""
+        with pytest.raises(BuildEnvError, match="not a wheel filename"):
+            self._built(monkeypatch, tmp_path, "dist.zip")
+
+    @pytest.mark.parametrize(
+        ("pinned", "filename"),
+        [
+            ("build-stub", "build_stub-1.0-py3-none-any.whl"),
+            ("Build.Stub", "build_stub-1.0-py3-none-any.whl"),
+            ("build-stub", "build_stub-1.0.0-py3-none-any.whl"),
+        ],
+        ids=["as-pinned", "spelled-differently", "same-release"],
+    )
+    def test_the_pinned_release_is_installed(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        pinned: str,
+        filename: str,
+    ) -> None:
+        """The comparison is by canonical name and PEP 440 version.
+
+        A wheel filename escapes the project name, and ``1.0`` and
+        ``1.0.0`` are one release.
+        """
+        pending = replace(self.PENDING, name=pinned)
+
+        assert self._built(monkeypatch, tmp_path, filename, pending).name == filename
 
 
 class _CleanupErrorTemporaryDirectory:


### PR DESCRIPTION
A build requirement whose resolved version publishes no wheel this host can install is built from its sdist, and whatever comes back is installed into the build venv unchecked. The name and version on that wheel are the backend's to choose, so a backend that computes its own version at build time installs a release nobody resolved, beside dependencies resolved for the pinned one. A wheel for another project leaves the requirement unmet.

Nothing in between checks: nab takes the pinned version off the sdist filename, and `build`'s `project.build("wheel", ...)` joins the basename the hook returns onto the output directory as-is.

The build now compares the filename against the pin and refuses:

    build requirement setuptools-scm 8.1.0 built a wheel whose filename names setuptools-scm==0.1.dev1+dirty, not the release the resolve pinned

Output that is not a wheel filename is refused the same way, quoting what came back.

Names compare canonically, so `build_stub-1.0-py3-none-any.whl` satisfies a `build-stub` pin, and versions compare as PEP 440 does: `1.0` and `1.0.0` are one release, `1.0+local` is another.
