### PR TITLE
Unfold a line-folded ETag before it goes back in If-None-Match

### DIFF
--- a/nab-index/src/nab_index/cache.py
+++ b/nab-index/src/nab_index/cache.py
@@ -67,6 +67,7 @@ __all__ = [
     "OfflineError",
     "OnDiskCache",
     "is_recognized_bucket",
+    "is_sendable_etag",
 ]
 
 
@@ -108,8 +109,8 @@ class CachePolicy:
     ``fetched_at`` is the start of the freshness window: when nab received the
     response, less any Age a relaying shared cache reported.
 
-    ``etag`` is the entity tag to revalidate with. A non-ASCII tag is dropped,
-    since nab cannot send it back.
+    ``etag`` is the entity tag to revalidate with. A tag nab cannot send back
+    in a request header is dropped.
 
     ``page_url`` is the URL the stored body was retrieved from, the base its
     relative entries resolve against. It is ``None`` for the negative
@@ -610,13 +611,20 @@ def _policy_page_url(value: object) -> str | None:
     return value if isinstance(value, str) and value else None
 
 
-def _policy_etag(value: object) -> str | None:
-    """Entity tag from a policy, or None when it cannot be sent back.
+def is_sendable_etag(value: str) -> bool:
+    """Whether an entity tag can go back out in a request header.
 
-    RFC 9110 8.8.3 admits obs-text in an entity-tag, and httpx raises on a
-    non-ASCII request header value.
+    Only printable ASCII passes. RFC 9110 8.8.3 admits obs-text in an
+    entity-tag, and httpx raises on a non-ASCII request header value; a tag
+    read out of a line-folded field carries the fold's CR and LF, which
+    RFC 9112 5.2 forbids a sender to generate.
     """
-    return value if isinstance(value, str) and value.isascii() else None
+    return value.isascii() and value.isprintable()
+
+
+def _policy_etag(value: object) -> str | None:
+    """Entity tag from a policy, or None when it cannot be sent back."""
+    return value if isinstance(value, str) and is_sendable_etag(value) else None
 
 
 def _decode_policy(policy_bytes: bytes) -> CachePolicy | None:

--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING
 from nab_provider.records import select_artifact_hash
 from nab_provider.serialization import SimpleSerialization, simple_accept_header
 
-from .cache import CacheBackend, CachePolicy, OfflineError
+from .cache import CacheBackend, CachePolicy, OfflineError, is_sendable_etag
 from .client import (
     _HTTP_NOT_FOUND,
     DEFAULT_INDEX,
@@ -652,8 +652,7 @@ class CachedAsyncSimpleClient:
         """
         url = f"{self._index_url}{package}/"
         headers = {"Accept": simple_accept_header(self._serialization)}
-        # httpx raises on a non-ASCII header value.
-        if policy.etag is not None and policy.etag.isascii():
+        if policy.etag is not None and is_sendable_etag(policy.etag):
             headers["If-None-Match"] = policy.etag
         response = await self._transport.get(url, headers=headers)
         if response.status_code == _HTTP_NOT_MODIFIED:

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -253,8 +253,13 @@ _HTTP_NOT_FOUND = 404
 DEFAULT_INDEX = "https://pypi.org/simple/"
 
 
+# RFC 9112 5.2: a receiver replaces a line fold with a space before reading the
+# field value. h11 does it for httpx; http.client, which urllib3 uses, does not.
+_OBS_FOLD = re.compile(r"[\r\n]+[ \t]+")
+
+
 def _header(response: HttpResponse, key: str) -> str | None:
-    """Case-insensitive header lookup.
+    """Case-insensitive header lookup, returning an unfolded field value.
 
     The :class:`HttpResponse` Protocol only promises a plain
     :class:`Mapping`. Both real transports (httpx, urllib3) return
@@ -265,7 +270,7 @@ def _header(response: HttpResponse, key: str) -> str | None:
     target = key.lower()
     for name, value in headers.items():
         if name.lower() == target:
-            return value
+            return _OBS_FOLD.sub(" ", value)
     return None
 
 

--- a/nab-project/tests/test_cache.py
+++ b/nab-project/tests/test_cache.py
@@ -748,7 +748,7 @@ class TestEncodePolicy:
         policy = CachePolicy(fetched_at=10, max_age=20, etag='"é"')
         assert json.loads(_encode_policy(policy))["etag"] is None
 
-    @pytest.mark.parametrize("etag", ['"é"', 123, []])
+    @pytest.mark.parametrize("etag", ['"é"', '"abc\r\n def"', 123, []])
     def test_unusable_etag_is_dropped(self, tmp_path: Path, etag: object) -> None:
         cache = OnDiskCache(tmp_path, "https://pypi.org/simple")
         cache.put_simple("foo", b"{}", _FRESH)

--- a/nab-project/tests/test_cached_client.py
+++ b/nab-project/tests/test_cached_client.py
@@ -1025,6 +1025,11 @@ class TestHeader:
         resp = _FakeResponse(b"", headers={})
         assert _header(resp, "etag") is None
 
+    def test_line_folded_value_is_unfolded(self) -> None:
+        """RFC 9112 5.2: a receiver replaces a line fold with a space."""
+        resp = _FakeResponse(b"", headers={"etag": '"abc\r\n def"'})
+        assert _header(resp, "etag") == '"abc def"'
+
 
 class TestGetFiles:
     def test_cold_cache_fetches_and_stores(self, tmp_path: Path) -> None:
@@ -1342,6 +1347,47 @@ class TestGetFiles:
             "pkg",
             LISTING_BYTES,
             CachePolicy(fetched_at=0, max_age=1, etag='"é"'),
+        )
+        transport = _FakeTransport(
+            [_FakeResponse(LISTING_BYTES, headers={"etag": '"ok"'})]
+        )
+
+        assert len(_run_get_files(transport, cache, "pkg")) == 1
+
+        sent = transport.calls[0][1]
+        assert sent is not None
+        assert "If-None-Match" not in sent
+
+    def test_line_folded_etag_revalidates_on_one_line(self, tmp_path: Path) -> None:
+        """A tag that arrives line-folded is stored and sent back on one line."""
+        cache = _make_cache(tmp_path)
+        transport = _FakeTransport(
+            [
+                _FakeResponse(
+                    LISTING_BYTES,
+                    headers={"etag": '"abc\r\n def"', "cache-control": "max-age=0"},
+                ),
+                _FakeResponse(b"", status=304, headers={}),
+            ]
+        )
+
+        assert len(_run_get_files(transport, cache, "pkg")) == 1
+        stored = cache.get_simple("pkg")
+        assert stored is not None
+        assert stored[1].etag == '"abc def"'
+
+        assert len(_run_get_files(transport, cache, "pkg")) == 1
+        sent = transport.calls[1][1]
+        assert sent is not None
+        assert sent["If-None-Match"] == '"abc def"'
+
+    def test_stale_skips_folded_etag_kept_by_backend(self, tmp_path: Path) -> None:
+        """A folded tag a backend keeps on read still must not be sent."""
+        cache = _MemoryPolicyCache(tmp_path)
+        cache.put_simple(
+            "pkg",
+            LISTING_BYTES,
+            CachePolicy(fetched_at=0, max_age=1, etag='"abc\r\n def"'),
         )
         transport = _FakeTransport(
             [_FakeResponse(LISTING_BYTES, headers={"etag": '"ok"'})]


### PR DESCRIPTION
An ETag that arrives line-folded is stored with its CR LF and sent straight back in `If-None-Match`, so the revalidation request carries a fold that RFC 9112 5.2 forbids a sender to generate.

A server is entitled to answer 400 to that. nab does not retry that status, and does not retry the request without the header, so the fetch fails and the cache entry keeps the same tag for the next run.

This is what `http.client` puts on the wire for a stored tag of `"abc\r\n def"`:

    GET /simple/pkg/ HTTP/1.1
    If-None-Match: "abc
     def"

Only the urllib3 backend gets that far, and it is the default. CPython's response parser keeps the fold, while h11 under httpx replaces it with a space on read and refuses to send a value holding CR or LF at all. The stored tag was screened with `.isascii()`, which a fold passes.

The fix is on both sides of the cache:

- `_header` unfolds a field value as it reads it, so both transports hand the same tag onward.
- Storing and sending require printable ASCII, so a folded tag already in a cache, or one a backend hands back unscreened, is dropped rather than sent.
