### PR TITLE
Fix tutorial claim that `nab download` reads the lockfile

### DIFF
--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -68,5 +68,4 @@ For multi-platform / multi-Python locks see
 * [CLI](../reference/cli.md): every subcommand, flag, exit code, and
   environment variable.
 * [Lockfile](../reference/lockfile.md): what is in `pylock.toml`, the
-  `requirements.txt --hash` shape, and how `nab download` consumes
-  them.
+  `requirements.txt --hash` shape, and what `nab download` fetches.


### PR DESCRIPTION
The tutorial says `nab lock` wrote `pylock.toml`, then closes by pointing at the lockfile reference for "how `nab download` consumes them". Hand `nab download` that file and it exits 1:

```
$ nab download pylock.toml
error: pylock.toml is a PEP 751 lockfile, not a pyproject.  nab resolves from project inputs, so pass the pyproject.toml instead.
```

`nab download` resolves the project again and fetches the artefacts on the resulting pins. The commit that added the refusal corrected the lockfile reference and missed the tutorial's link. The bullet now says what `nab download` fetches.
