### PR TITLE
Parse indexes, vcs-sources and archive-sources through one helper

### DIFF
--- a/nab-project/src/nab_project/config.py
+++ b/nab-project/src/nab_project/config.py
@@ -15,7 +15,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta, timezone
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, NamedTuple, cast
 from urllib.parse import urlsplit
 
 import tomli
@@ -88,7 +88,7 @@ from .workspace import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Iterator, Mapping, Sequence
     from collections.abc import Set as AbstractSet
     from pathlib import Path
 
@@ -1904,53 +1904,85 @@ def _environment_from_effective(
     return environment
 
 
-_INDEX_KEYS = frozenset({"name", "url", "serialization"})
+_NAME_URL_KEYS = frozenset({"name", "url"})
 
 
-def _parse_indexes(value: object) -> tuple[IndexConfig, ...]:
+class _NameUrlTable(NamedTuple):
+    """One checked entry of a ``name``/``url`` array of tables.
+
+    ``table`` is the raw entry, for a caller that reads further keys.
+    """
+
+    index: int
+    name: str
+    url: str
+    table: dict[str, Any]
+
+
+def _iter_name_url_tables(
+    label: str, value: object, *, keys: frozenset[str] = _NAME_URL_KEYS
+) -> Iterator[_NameUrlTable]:
+    """Yield each entry of a ``name``/``url`` array of tables, rejecting bad ones.
+
+    Lazy, so a caller's own check on an entry runs before the next is checked.
+    """
     if not isinstance(value, list):
-        msg = f"indexes must be an array of tables, got {type(value).__name__}"
+        msg = f"{label} must be an array of tables, got {type(value).__name__}"
         raise ConfigError(msg)
 
-    if not value:
-        msg = "indexes must contain at least one entry when present"
-        raise ConfigError(msg)
-
-    out: list[IndexConfig] = []
     for i, entry in enumerate(value):
         if not isinstance(entry, dict):
-            msg = f"indexes[{i}] must be a table, got {type(entry).__name__}"
+            msg = f"{label}[{i}] must be a table, got {type(entry).__name__}"
             raise ConfigError(msg)
-        unknown = sorted(set(entry) - _INDEX_KEYS)
+
+        unknown = sorted(set(entry) - keys)
         if unknown:
-            msg = (
-                f"unknown indexes[{i}] keys: {unknown!r};"
-                f" expected {sorted(_INDEX_KEYS)!r}"
-            )
+            msg = f"unknown {label}[{i}] keys: {unknown!r}; expected {sorted(keys)!r}"
             raise ConfigError(msg)
+
         try:
             name = entry["name"]
             url = entry["url"]
         except KeyError as missing:
-            msg = f"indexes[{i}] missing required key {missing!s}"
+            msg = f"{label}[{i}] missing required key {missing!s}"
             raise ConfigError(msg) from None
+
         if not isinstance(name, str) or not isinstance(url, str):
-            msg = f"indexes[{i}] name and url must be strings"
+            msg = f"{label}[{i}] name and url must be strings"
             raise ConfigError(msg)
-        if "serialization" in entry and is_file_url(url):
+
+        yield _NameUrlTable(index=i, name=name, url=url, table=entry)
+
+
+_INDEX_KEYS = frozenset({"name", "url", "serialization"})
+
+
+def _parse_indexes(value: object) -> tuple[IndexConfig, ...]:
+    out: list[IndexConfig] = []
+    for entry in _iter_name_url_tables("indexes", value, keys=_INDEX_KEYS):
+        if "serialization" in entry.table and is_file_url(entry.url):
             msg = (
-                f"indexes[{i}].serialization is not settable on a file:// index:"
-                " a local index is read from disk with no Accept negotiation,"
-                f" so the pin would do nothing.  Drop it from index {name!r}."
+                f"indexes[{entry.index}].serialization is not settable on a"
+                " file:// index: a local index is read from disk with no"
+                " Accept negotiation, so the pin would do nothing."
+                f"  Drop it from index {entry.name!r}."
             )
             raise ConfigError(msg)
+
         serialization = _parse_enum(
-            f"indexes[{i}].serialization",
-            entry.get("serialization"),
+            f"indexes[{entry.index}].serialization",
+            entry.table.get("serialization"),
             SimpleSerialization,
             SimpleSerialization.NEGOTIATE,
         )
-        out.append(IndexConfig(name=name, url=url, serialization=serialization))
+        out.append(
+            IndexConfig(name=entry.name, url=entry.url, serialization=serialization)
+        )
+
+    if not out:
+        msg = "indexes must contain at least one entry when present"
+        raise ConfigError(msg)
+
     _check_index_name_uniqueness(out)
     return tuple(out)
 
@@ -2696,68 +2728,18 @@ def _parse_local_sources(
     )
 
 
-_VCS_SOURCE_KEYS = frozenset({"name", "url"})
-
-
 def _parse_vcs_sources(value: object) -> tuple[VcsSource, ...]:
-    if not isinstance(value, list):
-        msg = f"vcs-sources must be an array of tables, got {type(value).__name__}"
-        raise ConfigError(msg)
-    out: list[VcsSource] = []
-    for i, entry in enumerate(value):
-        if not isinstance(entry, dict):
-            msg = f"vcs-sources[{i}] must be a table, got {type(entry).__name__}"
-            raise ConfigError(msg)
-        unknown = sorted(set(entry) - _VCS_SOURCE_KEYS)
-        if unknown:
-            msg = (
-                f"unknown vcs-sources[{i}] keys: {unknown!r};"
-                f" expected {sorted(_VCS_SOURCE_KEYS)!r}"
-            )
-            raise ConfigError(msg)
-        try:
-            name = entry["name"]
-            url = entry["url"]
-        except KeyError as missing:
-            msg = f"vcs-sources[{i}] missing required key {missing!s}"
-            raise ConfigError(msg) from None
-        if not isinstance(name, str) or not isinstance(url, str):
-            msg = f"vcs-sources[{i}] name and url must be strings"
-            raise ConfigError(msg)
-        out.append(VcsSource(name=name, url=url))
-    return tuple(out)
-
-
-_ARCHIVE_SOURCE_KEYS = frozenset({"name", "url"})
+    return tuple(
+        VcsSource(name=entry.name, url=entry.url)
+        for entry in _iter_name_url_tables("vcs-sources", value)
+    )
 
 
 def _parse_archive_sources(value: object) -> tuple[ArchiveSource, ...]:
-    if not isinstance(value, list):
-        msg = f"archive-sources must be an array of tables, got {type(value).__name__}"
-        raise ConfigError(msg)
     out: list[ArchiveSource] = []
-    for i, entry in enumerate(value):
-        if not isinstance(entry, dict):
-            msg = f"archive-sources[{i}] must be a table, got {type(entry).__name__}"
-            raise ConfigError(msg)
-        unknown = sorted(set(entry) - _ARCHIVE_SOURCE_KEYS)
-        if unknown:
-            msg = (
-                f"unknown archive-sources[{i}] keys: {unknown!r};"
-                f" expected {sorted(_ARCHIVE_SOURCE_KEYS)!r}"
-            )
-            raise ConfigError(msg)
-        try:
-            name = entry["name"]
-            url = entry["url"]
-        except KeyError as missing:
-            msg = f"archive-sources[{i}] missing required key {missing!s}"
-            raise ConfigError(msg) from None
-        if not isinstance(name, str) or not isinstance(url, str):
-            msg = f"archive-sources[{i}] name and url must be strings"
-            raise ConfigError(msg)
-        _validate_archive_url(i, url)
-        out.append(ArchiveSource(name=name, url=url))
+    for entry in _iter_name_url_tables("archive-sources", value):
+        _validate_archive_url(entry.index, entry.url)
+        out.append(ArchiveSource(name=entry.name, url=entry.url))
     return tuple(out)
 
 


### PR DESCRIPTION
`_parse_indexes`, `_parse_vcs_sources` and `_parse_archive_sources` each carried their own copy of the same checks for a `name`/`url` array of tables: the array check, the per-entry table check, the unknown-key check, the required-key lookup, the string-type check, and all five error messages spelled out again in every copy. The vcs and archive copies differed only in the record they build and one `_validate_archive_url` call.

The checks now live in `_iter_name_url_tables`, which yields a checked `(index, name, url, table)` per entry, and each of the five messages is spelled out once. The record carries the raw table because `_parse_indexes` still reads `serialization` off it. The three parsers go from 101 lines to 39, and `config.py` loses 18.

Behaviour is unchanged, error strings and their index included. Two orderings needed care:

- A non-list `indexes` still reports the type error rather than the emptiness one, so the emptiness check moved below the loop.
- The helper is a generator, so a parser's own check on an entry still runs before the next entry is shaped: `archive-sources` rejects entry 0's missing hash before it looks at entry 1.

`_ARCHIVE_SOURCE_KEYS` is gone and `_VCS_SOURCE_KEYS` becomes the helper's default `_NAME_URL_KEYS`; `_INDEX_KEYS` keeps its name and is passed in as the extended set.
