### PR TITLE
Build render_lock's document once, 0.56% off a build-requirements lock

### DIFF
--- a/nab-project/src/nab_project/_lockfile/pylock.py
+++ b/nab-project/src/nab_project/_lockfile/pylock.py
@@ -232,11 +232,16 @@ def render_lock(lock_input: LockInput, *, lock_dir: Path | None = None) -> str:
     require_artifact_hashes(lock_input)
     _check_extra_names(lock_input.extras)
     pylock = build_pylock(lock_input, lock_dir=lock_dir)
+
+    # ``Pylock.validate`` is ``from_dict(to_dict())``, so validating the mapping
+    # about to be emitted runs the same check without a second ``to_dict``.
+    document = dict(pylock.to_dict())
     try:
-        pylock.validate()
+        Pylock.from_dict(document)
     except PylockValidationError as e:
         raise LockValidationError(str(e)) from e
-    return tomli_w.dumps(dict(pylock.to_dict()))
+
+    return tomli_w.dumps(document)
 
 
 def _check_extra_names(extras: Sequence[str]) -> None:


### PR DESCRIPTION
Locking this repo's build requirements (`nab lock --build-requirements`) runs 14,096,600 fewer instructions, 0.56% of that run's 2,519,632,975.

`render_lock` built the lock document twice: `Pylock.validate()` is `from_dict(to_dict())` and throws its mapping away, then `tomli_w.dumps` calls `to_dict()` again. `to_dict` is `dataclasses.asdict`, so each call deep-copies every leaf. Validating with `Pylock.from_dict(document)` and emitting that same `document` does it once, and `from_dict` only reads the mapping it is given.

The clock cannot see a change this size. The timing runs rule out a wall or CPU regression above about 2% on that lock, and put peak memory inside about 0.5% either way.
