### PR TITLE
Document that pairing base-group with an extra is refused

### DIFF
--- a/docs/explanation/conflicts.md
+++ b/docs/explanation/conflicts.md
@@ -103,6 +103,12 @@ project forks, and `at-most-one` and `exactly-one` say the same thing
 there. An `at-least-one` set that names either of them is refused, since
 a group that is always active means the set can never fail.
 
+Selecting an extra never deselects the project's own dependencies, so
+pairing `base-group` with an extra is refused when the config is read,
+under `at-most-one` and `exactly-one` alike. `build-group` pairs with
+an extra fine: the project's own dependencies stay in every fork of
+that set.
+
 A member belongs to at most one set, so putting the build requirements
 in a set with both the project's dependencies and `dev` is one
 three-member declaration, and it makes all three mutually exclusive:

--- a/nab-project/tests/test_config.py
+++ b/nab-project/tests/test_config.py
@@ -1038,6 +1038,21 @@ class TestMainGroup:
         with pytest.raises(ConfigError, match="nothing could install that extra"):
             read_pyproject_config(path)
 
+    def test_a_base_group_extra_set_is_refused_under_exactly_one(
+        self, tmp_path: Path
+    ) -> None:
+        """The extra makes the pair impossible, whichever exclusive policy is set."""
+        path = write(
+            tmp_path,
+            '[project.optional-dependencies]\ncli = ["clitool"]\n'
+            "[tool.nab]\n"
+            'base-group = "main"\n'
+            'conflicts = [{ members = [{ group = "main" }, { extra = "cli" }],'
+            ' policy = "exactly-one" }]\n',
+        )
+        with pytest.raises(ConfigError, match="nothing could install that extra"):
+            read_pyproject_config(path)
+
     def test_a_build_group_may_conflict_with_an_extra(self, tmp_path: Path) -> None:
         """The project's dependencies stay in every fork of that set."""
         path = write(
@@ -1050,6 +1065,10 @@ class TestMainGroup:
             'conflicts = [[{ group = "build" }, { extra = "cli" }]]\n',
         )
         assert read_pyproject_config(path).build_group == "build"
+
+    def test_doc_states_the_base_group_extra_refusal(self) -> None:
+        page = " ".join(DOCS_CONFLICTS.read_text(encoding="utf-8").lower().split())
+        assert "pairing `base-group` with an extra is refused" in page
 
     def test_build_group_rejects_the_base_group_name(self, tmp_path: Path) -> None:
         path = write(


### PR DESCRIPTION
The conflicts page names `base-group` as a conflict member and says a set may mix extras and groups, so this reads as supported:

```toml
[tool.nab]
base-group = "main"
conflicts = [[{ group = "main" }, { extra = "cli" }]]
```

nab refuses it when the config is read, before any resolve:

    error: in [tool.nab]: [tool.nab].conflicts declares base-group 'main' mutually exclusive with the extra 'cli', but an extra installs on top of the project's own dependencies and never deselects them, so nothing could install that extra

The refusal is right, so the page gains the rule: pairing `base-group` with an extra is refused under `at-most-one` and `exactly-one` alike, while `build-group` with an extra is fine. The page already covers the neighbouring cases, an `at-least-one` set naming a configured group and `build-group` against an ordinary group.

The `exactly-one` spelling of the refused set also gets a test; only the bare-list form was covered.
