### PR TITLE
Test that warm VCS and archive builds obey --offline

### DIFF
--- a/nab-project/tests/test_archive.py
+++ b/nab-project/tests/test_archive.py
@@ -133,9 +133,10 @@ def _provider(
     cache_dir: Path | None,
     *,
     build_policy: BuildPolicy = BuildPolicy.NEVER,
+    offline: bool = False,
 ) -> Provider:
     return Provider(
-        make_coordinator(),
+        make_coordinator(offline=offline),
         archive_sources=archive_sources,
         archive_cache_dir=cache_dir,
         build_policy=build_policy,
@@ -646,6 +647,42 @@ class TestArchiveMaterialize:
         assert dependency.samefile(dependency_alias)
         assert first.coordinator.calls_to("request_direct_archive") == []
         assert second.coordinator.calls_to("request_direct_archive") == []
+
+    def test_warm_tree_build_runs_offline(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A warm tree needs no download, so ``--offline`` only reaches its build."""
+        digest = "a" * 64
+        source = ArchiveSource(
+            name="foo", url=f"https://ex.com/foo-1.0.0.tar.gz#sha256={digest}"
+        )
+        cache = tmp_path / "arch"
+        _warm_dynamic_archive_tree(cache, digest)
+
+        captured: dict[str, object] = {}
+
+        def capturing_backend(_path: Path, **kwargs: object) -> WheelMetadata:
+            captured.update(kwargs)
+            return WheelMetadata(
+                name="foo",
+                version=Version("1.0.0"),
+                requires_python=None,
+                requires_dist=[],
+                provides_extra=[],
+            )
+
+        monkeypatch.setattr(
+            "nab_project.build_backend.extract_metadata", capturing_backend
+        )
+
+        provider = _provider(
+            [source], cache, build_policy=BuildPolicy.BUILD_REMOTE, offline=True
+        )
+        provider.fetch_versions("foo")
+
+        assert captured == {"config": None, "offline": True}
 
     @pytest.mark.parametrize(
         ("failure_target", "expected"),

--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -17,7 +17,7 @@ import zipfile
 from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, ClassVar, NoReturn, cast
+from typing import Any, ClassVar, NoReturn
 from unittest.mock import patch
 
 import httpx
@@ -4082,9 +4082,8 @@ class TestLocalSources:
 
         monkeypatch.setattr("nab_project.resolve.resolve_for_targets", _boom)
         coordinator = make_coordinator(
-            [], package="foo", build_config=NabProjectConfig()
+            [], package="foo", build_config=NabProjectConfig(), offline=True
         )
-        coordinator.offline = True
         provider = Provider(
             coordinator,
             target=_PY312,
@@ -9797,8 +9796,8 @@ class TestEffectiveBuildPolicy:
             sdist_pkg_info=PKG_INFO_DYNAMIC_DEPS,
             package="pkg",
             sdist_archive=archive_bytes,
+            offline=offline,
         )
-        coordinator.offline = offline
         provider = Provider(
             coordinator,
             target=_PY312,
@@ -10482,6 +10481,7 @@ class TestBuildRemoteFailureModes:
         build_config: NabProjectConfig | None = None,
         sdist_archive: bytes | None = None,
         sdist_archive_error: BaseException | None = None,
+        offline: bool = False,
     ) -> Provider:
         """A ``BUILD_REMOTE`` provider whose port serves the archive it is given.
 
@@ -10494,6 +10494,7 @@ class TestBuildRemoteFailureModes:
             sdist_archive=sdist_archive,
             sdist_archive_error=sdist_archive_error,
             build_config=build_config,
+            offline=offline,
         )
         return Provider(
             coordinator,
@@ -10629,8 +10630,8 @@ class TestBuildRemoteFailureModes:
             with_sdist=True,
             build_config=NabProjectConfig(),
             sdist_archive=_DYNAMIC_SDIST_TARGZ,
+            offline=True,
         )
-        cast("FakeFetchPort", provider.coordinator).offline = True
         provider.versions_cache["pkg"] = [(V("1.0"), make_sdist("1.0"))]
 
         with pytest.raises(UnsupportedSdistError, match="offline mode"):

--- a/nab-project/tests/test_vcs.py
+++ b/nab-project/tests/test_vcs.py
@@ -23,6 +23,7 @@ from nab_index.vcs import (
     prepare_clone,
 )
 from nab_project._testing.coordinator_fake import FakeFetchPort, make_coordinator
+from nab_project.config import NabProjectConfig
 from nab_project.fetch import FetchCoordinator
 from nab_project.lockfile import VcsPin, build_target_lock
 from nab_provider._vendor.packaging.requirements import Requirement
@@ -1142,6 +1143,48 @@ class TestProviderVcsIntegration:
             build_policy=BuildPolicy.BUILD_LOCAL,
         )
         with pytest.raises(UnsupportedSdistError, match="build-policy 'build-remote'"):
+            provider.fetch_versions("foo")
+
+    def test_warm_clone_build_refused_under_an_offline_coordinator(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A warm clone needs no fetch, so the refusal comes from its build env."""
+        sha = "a" * 40
+        clone_dir = tmp_path / "cache" / "vcs" / "k" / sha
+        _mark_complete(clone_dir)
+        (clone_dir / "pyproject.toml").write_text(
+            '[project]\nname = "foo"\nversion = "1.0"\ndynamic = ["dependencies"]\n'
+            '\n[build-system]\nrequires = ["hatchling"]\n'
+            'build-backend = "hatchling.build"\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setattr("nab_index.vcs._repo_key", lambda _url: "k")
+
+        def _boom(*_args: object, **_kwargs: object) -> object:
+            raise AssertionError("offline must not reach the network")
+
+        monkeypatch.setattr("nab_project.resolve.resolve_for_targets", _boom)
+
+        provider = Provider(
+            make_coordinator(build_config=NabProjectConfig(), offline=True),
+            vcs_config=VcsConfig(
+                policy=VcsPolicy.ALLOW,
+                allowed_schemes=frozenset({"git+https"}),
+                allowed_repos=("https://example.com/",),
+                require_pin=True,
+            ),
+            vcs_sources=[
+                VcsSource(name="foo", url=f"git+https://example.com/foo.git@{sha}"),
+            ],
+            vcs_cache_dir=tmp_path / "cache",
+            build_policy=BuildPolicy.BUILD_REMOTE,
+        )
+        with pytest.raises(
+            UnsupportedSdistError,
+            match="build requirements unavailable in offline mode: hatchling",
+        ):
             provider.fetch_versions("foo")
 
     def test_dynamic_backend_mutation_does_not_poison_cached_clone(

--- a/nab-provider/src/nab_provider/testing.py
+++ b/nab-provider/src/nab_provider/testing.py
@@ -209,6 +209,7 @@ class FakeFetchPort:
         serve_range: Callable[[str, str, str], None],
         serve_archive: Callable[[str, str], None],
         build_config: object = None,
+        offline: bool = False,
         materialize: Callable[..., SourceMaterialization] | None = None,
         build_sdist: Callable[..., WheelMetadata] | None = None,
         read_wheel: Callable[[Path], str | None] | None = None,
@@ -217,7 +218,7 @@ class FakeFetchPort:
         self.index = index
         # Not on the port: the engine reads it off its coordinator.
         self.indexes = [IndexConfig(DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL)]
-        self.offline = False
+        self.offline = offline
         self.build_config = build_config
 
         self._serve_metadata = serve_metadata
@@ -491,6 +492,7 @@ def make_coordinator(  # noqa: PLR0913 - one keyword per index slot a test pre-l
     sdist_archive: bytes | None = None,
     sdist_archive_error: BaseException | None = None,
     build_config: object = None,
+    offline: bool = False,
     materialize: Callable[..., SourceMaterialization] | None = None,
     build_sdist: Callable[..., WheelMetadata] | None = None,
     read_wheel: Callable[[Path], str | None] | None = None,
@@ -527,6 +529,8 @@ def make_coordinator(  # noqa: PLR0913 - one keyword per index slot a test pre-l
       :class:`NotImplementedError` without them.  ``read_wheel`` opens a wheel
       the listing serves off disk; without it the metadata keywords answer
       that request too.
+
+    ``offline`` starts the port offline, as ``--offline`` does for a real run.
     """
     index = InMemoryIndex()
 
@@ -558,6 +562,7 @@ def make_coordinator(  # noqa: PLR0913 - one keyword per index slot a test pre-l
             sdist_archive_error=sdist_archive_error,
         ),
         build_config=build_config,
+        offline=offline,
         materialize=materialize,
         build_sdist=build_sdist,
         read_wheel=read_wheel,


### PR DESCRIPTION
Nothing pinned `--offline` reaching the build backend for VCS or archive sources. `_sources.py` calls `extract_source_metadata` once per source kind, each passing `offline=port.offline`, and only the local call had a test behind it.

The VCS path has a test that never gets that far: `test_declared_source_is_not_cloned_offline` runs with an empty cache under `build-policy = never`, so the clone is refused and the build never starts. Archives had nothing. Only three tests in the suite put a fake port offline, and all three sit on the local-source or sdist paths.

Both new tests start from a warm cache, so there is nothing to fetch and the build is the only thing left that reads `--offline`:

- `test_warm_clone_build_refused_under_an_offline_coordinator` uses a warm clone and asserts the refusal comes from the build env (`build requirements unavailable in offline mode: hatchling`), with `resolve_for_targets` patched to fail if anything reaches the network.
- `test_warm_tree_build_runs_offline` uses a warm extracted archive tree and asserts the backend is called with `offline=True`.

`FakeFetchPort` hardcoded `offline = False` with no way to set it at construction, so the three existing tests assigned `coordinator.offline` afterwards. It takes an `offline` keyword now and those sites use it.
