### PR TITLE
Memoise the partial solution's range algebra, 4.3% fewer instructions

### DIFF
--- a/nab-resolver/src/nab_resolver/partial_solution.py
+++ b/nab-resolver/src/nab_resolver/partial_solution.py
@@ -14,6 +14,7 @@ Reference: https://github.com/dart-lang/pub/blob/master/doc/solver.md#partial-so
 
 from __future__ import annotations
 
+import operator
 from collections import defaultdict
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -25,9 +26,12 @@ from .ranges import Range
 from .types import PackageType, RangeProtocol, VersionType
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator, Sequence
+    from collections.abc import Callable, Iterator, Sequence
+    from typing import TypeAlias
 
     from .types import Incompatibility, Term
+
+    _RangeOp: TypeAlias = Callable[[RangeProtocol[Any], RangeProtocol[Any]], Any]
 
 
 __all__ = [
@@ -35,6 +39,12 @@ __all__ = [
     "PartialSolution",
 ]
 
+
+# An entry in the range-algebra memo pins both of its operands, so this cap
+# bounds what the memo retains, not just how large it gets.  It sits below
+# what a large resolve fills, trading a little hit rate for a memo that clears
+# instead of holding every operand to the end.
+RANGE_OP_MEMO_MAX = 2_048
 
 # Marks a missing map entry, where None can itself be the stored value.
 _UNSET = object()
@@ -249,6 +259,14 @@ class PartialSolution(Generic[PackageType, VersionType]):
         ] = []
         self._decision_snapshots: list[ref[_Snapshot[PackageType, VersionType]]] = []
 
+        # Results of the range algebra the trail replays, keyed by operand
+        # identity.  A key is only sound while both its operands are alive, so
+        # the list beside the memo holds them and the two clear together.
+        self._range_ops: dict[
+            tuple[int, int, _RangeOp], RangeProtocol[VersionType]
+        ] = {}
+        self._range_op_operands: list[RangeProtocol[VersionType]] = []
+
     @property
     def decision_level(self) -> int:
         """Return the current decision depth."""
@@ -282,6 +300,34 @@ class PartialSolution(Generic[PackageType, VersionType]):
             return ()
         return entries
 
+    def _combine(
+        self,
+        op: _RangeOp,
+        left: RangeProtocol[VersionType],
+        right: RangeProtocol[VersionType],
+    ) -> RangeProtocol[VersionType]:
+        """Apply ``op`` to two ranges, reusing the result for a repeated pair.
+
+        Backtracking replays the trail from the same stored range objects, so
+        the same operands recur and the memo returns the object the first pass
+        built.  Reuse preserves the value because :class:`RangeProtocol`
+        requires immutable ranges.
+        """
+        key = (id(left), id(right), op)
+        memo = self._range_ops
+        hit = memo.get(key)
+        if hit is not None:
+            return hit
+
+        result: RangeProtocol[VersionType] = op(left, right)
+        if len(memo) >= RANGE_OP_MEMO_MAX:
+            memo.clear()
+            self._range_op_operands.clear()
+        memo[key] = result
+        self._range_op_operands.append(left)
+        self._range_op_operands.append(right)
+        return result
+
     def get(self, package: PackageType) -> RangeProtocol[VersionType] | None:
         """Get the combined allowed range for a package, or None if unassigned.
 
@@ -304,7 +350,7 @@ class PartialSolution(Generic[PackageType, VersionType]):
         elif negative is None:
             result = positive
         else:
-            result = positive - negative
+            result = self._combine(operator.sub, positive, negative)
 
         self._effective_range_cache[package] = result
         return result
@@ -354,24 +400,31 @@ class PartialSolution(Generic[PackageType, VersionType]):
     ) -> None:
         """Record a derivation from unit propagation.
 
+        A package's first derivation of a sign has nothing to fold into, so it
+        records ``constraint`` itself.
+
         See: https://github.com/dart-lang/pub/blob/master/doc/solver.md#unit-propagation
         """
         if positive:
             # Positive derivation narrows the package's allowed range.
-            if package in self._positive_ranges:
-                new_range = self._positive_ranges[package] & constraint
-            else:
-                new_range = self._range_type.full() & constraint
+            current = self._positive_ranges.get(package)
+            new_range = (
+                constraint
+                if current is None
+                else self._combine(operator.and_, current, constraint)
+            )
             self._freeze_ranges(package)
             self._positive_ranges[package] = new_range
             if package not in self._decided_versions:
                 self._undecided.add(package)
         else:
             # Negative derivation accumulates excluded versions.
-            if package in self._negative_ranges:
-                new_range = self._negative_ranges[package] | constraint
-            else:
-                new_range = self._range_type.empty() | constraint
+            excluded = self._negative_ranges.get(package)
+            new_range = (
+                constraint
+                if excluded is None
+                else self._combine(operator.or_, excluded, constraint)
+            )
             self._negative_ranges[package] = new_range
 
         self._refresh_effective_range(package)
@@ -552,7 +605,9 @@ class PartialSolution(Generic[PackageType, VersionType]):
         elif assignment.cum_negative is None:
             effective = cum_positive
         else:
-            effective = cum_positive - assignment.cum_negative
+            effective = self._combine(
+                operator.sub, cum_positive, assignment.cum_negative
+            )
 
         return term.satisfies(effective)
 

--- a/nab-resolver/src/nab_resolver/types.py
+++ b/nab-resolver/src/nab_resolver/types.py
@@ -62,6 +62,10 @@ class RangeProtocol(Protocol[VersionType_contra]):
     term; conflict resolution's step budget reports one as an internal error
     rather than spinning on it.
 
+    Ranges must be immutable.  The resolver keeps the ones it is handed and
+    reuses the results of range operations by operand identity, so mutating
+    one afterwards changes assignments already recorded.
+
     Mixing range types within a single resolution is unsupported.
     """
 

--- a/nab-resolver/tests/test_partial_solution.py
+++ b/nab-resolver/tests/test_partial_solution.py
@@ -6,6 +6,7 @@ import gc
 
 import pytest
 
+from nab_resolver import partial_solution
 from nab_resolver.partial_solution import PartialSolution
 from nab_resolver.ranges import Range
 from nab_resolver.types import Incompatibility, IncompatibilityCause, Term
@@ -524,3 +525,89 @@ class TestSnapshots:
         assert len(ps._decision_snapshots) == 1
         assert dict(latest) == {"foo": 3}
         assert list(kept) == ["foo"]
+
+
+class TestRangeOperationMemo:
+    """The memo over the range algebra a replayed trail repeats."""
+
+    def _cause(self) -> Incompatibility[str, int]:
+        """An incompatibility to stand as the cause of a derivation."""
+        return Incompatibility(
+            [Term("foo", Range.at_least(5))],
+            cause=IncompatibilityCause.NO_VERSIONS,
+        )
+
+    def test_a_first_derivation_records_the_constraint_itself(self) -> None:
+        """Folding into full() or empty() is skipped, so neither is memoised."""
+        ps: PartialSolution[str, int] = PartialSolution()
+        cause = self._cause()
+        allowed = Range.at_least(1)
+        excluded = Range.singleton(4)
+
+        ps.derive("foo", allowed, positive=True, cause=cause)
+        ps.derive("bar", excluded, positive=False, cause=cause)
+
+        assert ps.positive_range("foo") is allowed
+        assert ps._negative_ranges["bar"] is excluded
+        assert ps._range_ops == {}
+
+    def test_a_later_exclusion_unions_through_the_memo(self) -> None:
+        ps: PartialSolution[str, int] = PartialSolution()
+        cause = self._cause()
+
+        ps.derive("foo", Range.singleton(4), positive=False, cause=cause)
+        ps.derive("foo", Range.singleton(7), positive=False, cause=cause)
+
+        excluded = ps._negative_ranges["foo"]
+        assert 4 in excluded
+        assert 7 in excluded
+        assert len(ps._range_ops) == 1
+
+    def test_a_memoised_combine_keeps_its_operands_alive(self) -> None:
+        """The memo's id() keys stay valid only while it holds both operands."""
+        ps: PartialSolution[str, int] = PartialSolution()
+        cause = self._cause()
+        current = Range.at_least(1)
+        constraint = Range.at_most(9)
+
+        ps.derive("foo", current, positive=True, cause=cause)
+        ps.derive("foo", constraint, positive=True, cause=cause)
+
+        assert ps._range_op_operands[-2] is current
+        assert ps._range_op_operands[-1] is constraint
+
+    def test_replayed_derivation_reuses_the_range_object(self) -> None:
+        """Re-deriving after a backtrack returns the object the first pass built."""
+        ps: PartialSolution[str, int] = PartialSolution()
+        cause = self._cause()
+        constraint = Range.at_most(9)
+
+        ps.derive("foo", Range.at_least(1), positive=True, cause=cause)
+        ps.decide("bar", 1)
+        ps.derive("foo", constraint, positive=True, cause=cause)
+        first = ps.get("foo")
+
+        ps.backtrack(0)
+        ps.derive("foo", constraint, positive=True, cause=cause)
+
+        assert ps.get("foo") is first
+
+    def test_overflow_drops_the_memo_and_the_operands_it_holds(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Passing the cap clears both, and the range it answers stays right."""
+        monkeypatch.setattr(partial_solution, "RANGE_OP_MEMO_MAX", 1)
+        ps: PartialSolution[str, int] = PartialSolution()
+        cause = self._cause()
+
+        ps.derive("foo", Range.at_least(1), positive=True, cause=cause)
+        ps.derive("foo", Range.at_most(9), positive=True, cause=cause)
+        ps.derive("foo", Range.at_most(8), positive=True, cause=cause)
+
+        assert len(ps._range_ops) == 1
+        assert len(ps._range_op_operands) == 2
+
+        effective = ps.get("foo")
+        assert effective is not None
+        assert 5 in effective
+        assert 9 not in effective

--- a/nab-resolver/tests/test_range_benchmark.py
+++ b/nab-resolver/tests/test_range_benchmark.py
@@ -64,8 +64,8 @@ SUITE_PROFILE = {
         membership_tests=363,
         intervals_seen=755,
         largest_range=8,
-        hash_misses=102,
-        equality_calls=199,
+        hash_misses=64,
+        equality_calls=161,
     ),
     "conflict-free-fanout": Profile(
         rounds=8,
@@ -74,8 +74,8 @@ SUITE_PROFILE = {
         membership_tests=308,
         intervals_seen=308,
         largest_range=1,
-        hash_misses=12,
-        equality_calls=29,
+        hash_misses=5,
+        equality_calls=22,
     ),
 }
 


### PR DESCRIPTION
1,262,131,439 instructions off a `pip:langchain-ml-course --resolution lowest` resolve, 29,309,838,181 down to 28,047,706,742, or 4.31% of the whole run. Both sides made 10,218 decisions over 10,418 rounds and resolved the same 207 packages, so this is the same search doing less work.

Backtracking replays the trail from the same stored `Range` objects, so `PartialSolution` recomputes the same unions, intersections and differences over the same operands. `_combine` keys each result on operand identity and hands back the object the first pass built, and a package's first derivation of a sign records the constraint itself rather than intersecting `full()` or uniting `empty()`. `RangeProtocol` states the immutability that reuse depends on.

A memo entry pins both of its operands, so it costs memory. The cap is 2,048 entries, which turns 7,013 of that resolve's 11,404 `_combine` calls into hits and adds between a few hundred kB and about 1 MB of traced peak across the 19-scenario canary set.

The instruction counts are callgrind under `PYTHONHASHSEED=0`, so they reproduce anywhere. The clock cannot see a change this size: the timing runs rule out a wall regression above about 6% and a CPU regression above about 8%.
