### PR TITLE
Memoise `marker_variables`, 5.4% of the instructions on a 25-tuple lock

### DIFF
--- a/nab-provider/src/nab_provider/target.py
+++ b/nab-provider/src/nab_provider/target.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import re
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field, replace
+from functools import lru_cache
 from typing import TYPE_CHECKING
 
 from nab_provider._vendor.packaging import tags as ptags
@@ -263,6 +264,7 @@ _MARKER_CLAUSE_RE = re.compile(
 )
 
 
+@lru_cache(maxsize=8192)
 def marker_variables(marker_text: str) -> frozenset[str]:
     """Return the PEP 508 environment variables ``marker_text`` names.
 
@@ -282,6 +284,10 @@ def marker_variables(marker_text: str) -> frozenset[str]:
 
     Every call site passes a serialised :class:`Marker`; an input that is not
     a valid marker raises :class:`InvalidMarker`.
+
+    Memoised on the text, which a matrix lock asks for again on every
+    target.  The keys are marker texts out of resolved metadata, so the
+    distinct texts one resolve sees stay well short of ``maxsize``.
     """
     return variable_names(marker_text) & PEP508_MARKER_VARIABLES
 

--- a/nab-provider/tests/test_target.py
+++ b/nab-provider/tests/test_target.py
@@ -854,6 +854,11 @@ class TestMarkerVariables:
         """
         assert set(default_environment()) == PEP508_MARKER_VARIABLES
 
+    def test_a_repeated_marker_text_is_parsed_once(self) -> None:
+        """The second call reads the memo instead of parsing the text again."""
+        text = 'sys_platform == "linux" and python_version >= "3.10"'
+        assert marker_variables(text) is marker_variables(text)
+
 
 class TestEnvironmentDeclaration:
     """A single-environment lock declares the environment it was resolved


### PR DESCRIPTION
Memoising `marker_variables` on its text takes about 5.4% of the instructions off a universal `max-25-tuples` lock, between 236 and 239 million out of 4.37 billion, and 223 million (3.6%) off `scientific-python-multi`.

`marker_variables` parses its marker text to find the environment variables it names, and the lock emitter asks for the same texts again on every target. A `max-25-tuples` lock resolves dask across 25 python/platform tuples and makes 1,910 of those calls over 41 distinct texts, so the memo parses 41 markers where main parses 1,910.

The keys are marker texts out of resolved metadata, so the cache stays small: 41 entries after that lock and 71 after `scientific-python-multi`, against a cap of 8,192. The runs put peak memory inside about 0.3% either way.

The counts reproduce anywhere; the timings are off my machine, where `max-25-tuples` runs about 3.5% faster over 20 interleaved pairs, between about 1.7% and 5.8%, with CPU moving the same way.