### PR TITLE
Fix `nab lock --locked` rejecting a respelled requires-python

### DIFF
--- a/nab-project/tests/test_lockfile_validate.py
+++ b/nab-project/tests/test_lockfile_validate.py
@@ -83,6 +83,19 @@ def test_requires_python_reformatted_but_equal_does_not_fire() -> None:
     assert envelope(committed, requires_python="<4,>=3.8") is None
 
 
+def test_requires_python_respelled_clause_does_not_fire() -> None:
+    committed = make_pylock(requires_python=">=3.8,!=3.9.0,!=3.9.1")
+    assert envelope(committed, requires_python=">=3.8,!=v3.9.0,!=3.9.1") is None
+    assert envelope(committed, requires_python=">=3.8,!=3.9.0,!=0!3.9.1") is None
+
+
+def test_requires_python_respelled_with_a_changed_bound_fires() -> None:
+    committed = make_pylock(requires_python=">=3.8,!=3.9.0,!=3.9.1")
+    result = envelope(committed, requires_python=">=3.8,!=v3.9.0,!=3.9.2")
+    assert result is not None
+    assert "requires-python" in result.reason
+
+
 def test_requires_python_both_absent_does_not_fire() -> None:
     committed = make_pylock(requires_python=None)
     assert envelope(committed, requires_python=None) is None

--- a/nab-provider/src/nab_provider/_vendor/packaging/specifiers.py
+++ b/nab-provider/src/nab_provider/_vendor/packaging/specifiers.py
@@ -829,9 +829,15 @@ class SpecifierSet(BaseSpecifier):
         self._prereleases = prereleases
 
     def _canonical_specs(self) -> tuple[Specifier, ...]:
-        """Deduplicate, sort, and cache specs for order-sensitive operations."""
+        """Deduplicate, sort, and cache specs for order-sensitive operations.
+
+        Sorting on each clause's equality key rather than its text gives two equal
+        sets the same order, so ``__eq__`` and ``__hash__`` agree across respellings.
+        """
         if not self._canonicalized:
-            self._specs = tuple(dict.fromkeys(sorted(self._specs, key=str)))
+            self._specs = tuple(
+                dict.fromkeys(sorted(self._specs, key=lambda s: s._canonical_spec))
+            )
             self._canonicalized = True
         return self._specs
 

--- a/nab-provider/tests/test_vendor_specifier_set_equality.py
+++ b/nab-provider/tests/test_vendor_specifier_set_equality.py
@@ -1,0 +1,57 @@
+"""Tests for ``SpecifierSet`` equality and hashing in the vendored packaging tree.
+
+A set compares as the sorted tuple of its clauses, so the sort key decides
+whether two sets holding the same clauses line up. Sorting on each clause's
+equality key rather than its text lets ``!=v3.9.0`` match ``!=3.9.0`` and keeps
+``__hash__`` agreeing with ``__eq__``.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from nab_provider._vendor.packaging.specifiers import SpecifierSet
+
+PLAIN = ">=3.8,!=3.9.0,!=3.9.1"
+
+#: Spellings PEP 440 makes equal to ``PLAIN``.
+RESPELLINGS = [
+    ">=3.8,!=v3.9.0,!=3.9.1",
+    ">=3.8,!=3.9.0,!=0!3.9.1",
+    ">=3.8,!=3.9.0.0,!=3.9.1",
+    "!=3.9.1,>=v3.8.0,!=3.9.0",
+]
+
+_OVERSIZED = "9" * (sys.get_int_max_str_digits() + 1)
+
+
+@pytest.mark.parametrize("respelling", RESPELLINGS)
+def test_a_respelled_clause_compares_and_hashes_equal(respelling: str) -> None:
+    plain = SpecifierSet(PLAIN)
+    respelled = SpecifierSet(respelling)
+
+    assert plain == respelled
+    assert hash(plain) == hash(respelled)
+    assert respelled in {plain}
+
+
+@pytest.mark.parametrize("respelling", RESPELLINGS)
+def test_a_changed_clause_stays_unequal_across_spellings(respelling: str) -> None:
+    assert SpecifierSet(">=3.8,!=3.9.0,!=3.9.2") != SpecifierSet(respelling)
+
+
+def test_equality_is_transitive_across_spellings() -> None:
+    sets = [SpecifierSet(text) for text in [PLAIN, *RESPELLINGS]]
+
+    for left in sets:
+        for right in sets:
+            assert left == right
+
+
+def test_comparing_single_clause_sets_converts_no_version() -> None:
+    # A set of at most one clause is canonical at construction, so comparing
+    # these sorts nothing. The digit run passes int()'s limit, so converting
+    # either version would raise.
+    assert SpecifierSet("") != SpecifierSet(f">={_OVERSIZED}")


### PR DESCRIPTION
`nab lock --locked` rejects a lockfile whose `requires-python` was respelled without changing what it means. Writing `!=v3.9.0` for `!=3.9.0`, or `!=0!3.9.1` for `!=3.9.1`, is enough:

```
the lockfile requires-python !=3.9.0,!=3.9.1,>=3.8 does not match this run's !=3.9.1,!=v3.9.0,>=3.8
```

Both spellings hold the same three clauses, in a different order. `SpecifierSet.__eq__` compares the sorted tuple of clauses, and the clauses themselves compare canonically, so `!=v3.9.0` does equal `!=3.9.0`.

The sort key was `str`, the raw spelling. `!=v3.9.0` sorts after `!=3.9.1` because `v` sorts after `3`, while `!=3.9.0` sorts before it, so the two tuples never line up element by element. `__hash__` reads the same tuple, so a set or dict lookup misses too.

Sorting on `Specifier._canonical_spec`, the key `Specifier.__eq__` and `__hash__` already use, gives two equal sets the same order. `str(SpecifierSet(...))` now orders clauses by that key too; each clause still renders as it was written.

One thing to decide before this can merge. It edits the vendored packaging tree directly and does not regenerate `tasks/vendoring/packaging.patch`, so the `vendored packaging` check is expected to fail. That patch does not touch `specifiers.py`, so `_canonical_specs` here is unmodified pypa/packaging at the pinned commit and the defect is upstream's. Three ways it could land:

- upstream the fix to pypa/packaging and move the pin
- extend the vendoring patch to carry it
- drop it
