### PR TITLE
Slice a marker's quoted string, don't parse it, ~3.3% off a 25-tuple lock

### DIFF
--- a/nab-provider/src/nab_provider/_vendor/packaging/PROVENANCE.md
+++ b/nab-provider/src/nab_provider/_vendor/packaging/PROVENANCE.md
@@ -41,12 +41,17 @@ most one checked-in patch.
     Upstream's opening `assert isinstance(marker, (list, tuple, str))` is
     dropped, so a value of any other type now returns unchanged instead of
     tripping the assertion.
+  - `_parser.py`: `process_python_str` returns the body between the token's
+    quotes when that body is ASCII and holds no backslash, newline, carriage
+    return or NUL, and calls `ast.literal_eval` otherwise. The `QUOTED_STRING`
+    rule admits no string prefix, so a token takes the same value either way.
 
   Upstream PRs are planned for the bound ordering, the direct subset and
   disjoint walks, `filter`'s `assume_sorted` fast path,
   `from_bounds`/`snap_bounds`/`release_intervals`, the prepared marker
   environment, and the marker-item serialisation. `relation` is not proposed
-  yet: most of its win is available from the direct walks alone.
+  yet: most of its win is available from the direct walks alone. The
+  quoted-string slice is not proposed anywhere yet.
 - `tasks/vendor-packaging.sh` fetches `pypa/packaging` at the pin, replaces this
   package with the pristine `src/packaging/` tree plus the repo-root license
   texts, and reapplies the patch. `--check` rebuilds into a temp location and
@@ -121,11 +126,12 @@ Not reachable:
   id it knows.
 
 pypa/packaging#1213 merged `Value.serialize`'s quote handling in the form nab
-already carried, so the patch's `_parser.py` hunk is gone. It still does not
-re-escape a backslash, so a value holding one does not survive a `str()` round
-trip; pypa/packaging#1374 proposes the fix and this pin is behind it. Its
-`ValueError` on a value holding both quote characters is unreachable: nab never
-constructs a `Value`, and a parsed value cannot hold its own delimiter.
+already carried, so the patch's `_parser.py` serialisation hunk is gone. It
+still does not re-escape a backslash, so a value holding one does not survive a
+`str()` round trip; pypa/packaging#1374 proposes the fix and this pin is behind
+it. Its `ValueError` on a value holding both quote characters is unreachable:
+nab never constructs a `Value`, and a parsed value cannot hold its own
+delimiter.
 
 `nab_index` used `[\w\d._]*` for the wheel name where the vendored copy has used
 `[\w._]+` since before the previous pin, so `-1.0-py3-none-any.whl` parsed to an

--- a/nab-provider/src/nab_provider/_vendor/packaging/_parser.py
+++ b/nab-provider/src/nab_provider/_vendor/packaging/_parser.py
@@ -394,8 +394,15 @@ def process_env_var(env_var: str) -> Variable:
 
 
 def process_python_str(python_str: str) -> Value:
-    value = ast.literal_eval(python_str)
-    return Value(str(value))
+    # QUOTED_STRING admits no prefix and no embedded delimiter, so an ASCII body
+    # holding no backslash, line break or NUL is what the literal parse returns.
+    # The rest keeps that parse, for the escapes it expands and the bodies it rejects.
+    body = python_str[1:-1]
+    if body.isascii() and not (
+        "\\" in body or "\n" in body or "\r" in body or "\0" in body
+    ):
+        return Value(body)
+    return Value(str(ast.literal_eval(python_str)))
 
 
 def _parse_marker_op(tokenizer: Tokenizer) -> Op:

--- a/nab-provider/tests/test_vendor_marker_quoted_string.py
+++ b/nab-provider/tests/test_vendor_marker_quoted_string.py
@@ -1,0 +1,64 @@
+"""Tests for the vendored parser's quoted-string handling.
+
+``process_python_str`` slices the quotes off the token when the body is ASCII and
+holds no backslash, line break or NUL, and falls back to ``ast.literal_eval``
+otherwise. Both paths reach the same value, and a body Python rejects is still a
+syntax error.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+
+from nab_provider._vendor.packaging._parser import MarkerItem, parse_marker
+from nab_provider._vendor.packaging._tokenizer import ParserSyntaxError
+
+
+def parsed_value(marker: str) -> str:
+    """The right-hand value of a marker holding one comparison."""
+    return cast("MarkerItem", parse_marker(marker)[0])[2].value
+
+
+class TestQuotedString:
+    @pytest.mark.parametrize(
+        ("marker", "expected"),
+        [
+            ("os_name == 'posix'", "posix"),
+            ('os_name == "posix"', "posix"),
+            ("os_name == 'it\"s'", 'it"s'),
+            ('os_name == "it\'s"', "it's"),
+            ("os_name == ''", ""),
+            ('os_name == "3"', "3"),
+            ('python_version >= "3.10"', "3.10"),
+            ('os_name == "  spaced  "', "  spaced  "),
+            ('os_name == "café"', "café"),
+        ],
+    )
+    def test_the_body_between_the_quotes_is_the_value(
+        self, marker: str, expected: str
+    ) -> None:
+        assert parsed_value(marker) == expected
+
+    @pytest.mark.parametrize(
+        ("marker", "expected"),
+        [
+            (r"os_name == 'a\nb'", "a\nb"),
+            (r'os_name == "a\tb"', "a\tb"),
+            (r"os_name == 'a\\b'", "a\\b"),
+            (r"os_name == 'a\x41b'", "aAb"),
+        ],
+    )
+    def test_a_backslash_still_reaches_the_literal_parse(
+        self, marker: str, expected: str
+    ) -> None:
+        assert parsed_value(marker) == expected
+
+    @pytest.mark.parametrize(
+        "body",
+        ["a\nb", "a\rb", "a\0b", "a\\", f"a{chr(0xD800)}b", f"a{chr(0xDC80)}b"],
+    )
+    def test_a_body_python_rejects_is_a_syntax_error(self, body: str) -> None:
+        with pytest.raises(ParserSyntaxError, match="Invalid quoted string"):
+            parse_marker(f"os_name == '{body}'")

--- a/tasks/vendoring/packaging.patch
+++ b/tasks/vendoring/packaging.patch
@@ -1949,6 +1949,28 @@ index 0000000..9e908b1
 +        _clause_formula(sorted(clause, key=_atom_key)) for clause in residual
 +    )
 +    return make_and([*lead, inner])
+diff --git a/nab-provider/src/nab_provider/_vendor/packaging/_parser.py b/nab-provider/src/nab_provider/_vendor/packaging/_parser.py
+index 245ed43..1efb387 100644
+--- a/nab-provider/src/nab_provider/_vendor/packaging/_parser.py
++++ b/nab-provider/src/nab_provider/_vendor/packaging/_parser.py
+@@ -394,8 +394,15 @@ def process_env_var(env_var: str) -> Variable:
+ 
+ 
+ def process_python_str(python_str: str) -> Value:
+-    value = ast.literal_eval(python_str)
+-    return Value(str(value))
++    # QUOTED_STRING admits no prefix and no embedded delimiter, so an ASCII body
++    # holding no backslash, line break or NUL is what the literal parse returns.
++    # The rest keeps that parse, for the escapes it expands and the bodies it rejects.
++    body = python_str[1:-1]
++    if body.isascii() and not (
++        "\\" in body or "\n" in body or "\r" in body or "\0" in body
++    ):
++        return Value(body)
++    return Value(str(ast.literal_eval(python_str)))
+ 
+ 
+ def _parse_marker_op(tokenizer: Tokenizer) -> Op:
 diff --git a/nab-provider/src/nab_provider/_vendor/packaging/_ranges.py b/nab-provider/src/nab_provider/_vendor/packaging/_ranges.py
 index e312a1f..29c32bc 100644
 --- a/nab-provider/src/nab_provider/_vendor/packaging/_ranges.py


### PR DESCRIPTION
78,488,903 instructions come off a warm `universal:max-25-tuples` resolve, 3.3% of the 2,373,233,084 it costs on main, when a marker's quoted string is sliced out of its token instead of parsed by `ast.literal_eval`. Two repeats put the saving at 78,110,875 and 78,615,029.

`QUOTED_STRING` is `('[^']*')|("[^"]*")`, which admits no string prefix and no embedded delimiter, so the body between the quotes is already the value. Two kinds of body still need the parse, so the guard is `body.isascii()` plus four characters:

- a backslash, which `ast.literal_eval` expands, or a NUL, LF or CR, which it rejects
- a lone surrogate, which it cannot encode as source, and which `isascii()` catches

Over every codepoint in `range(0x110000)`, in both quote styles and four body positions, the two agree on the value and on the exception type.

The same scenario's calls:

    ast.literal_eval  1,300 -> 0
    ast.parse         1,300 -> 0
    builtins.compile  1,434 -> 134
    str.isascii         628 -> 1,928

Those counts reproduce anywhere; a local timing does not. Twelve paired runs over the 19-scenario canary set rule out a wall regression above about 3%, a CPU regression above about 1.8% and a peak-RSS move beyond about 2.1% either way.

`PROVENANCE.md` and the vendoring patch record the divergence, which has not been proposed upstream.
