### PR TITLE
Store the parsed-listing cache with marshal, ~5% off a warm resolve

### DIFF
--- a/docs/reference/cache.md
+++ b/docs/reference/cache.md
@@ -15,12 +15,13 @@ directory is harmless and `nab cache clear` reclaims it.
 | Bucket | Holds |
 | ------ | ----- |
 | `simple-v2/` | the Simple-API listing body and a `.policy` sidecar |
-| `simple-parsed-v0/` | the parsed listing, an accelerator for the body |
+| `simple-parsed-v1/` | the parsed listing, an accelerator for the body |
 | `simple-neg-v0/` | a short-lived record that a name returned a 404 |
 | `metadata-v1/` | PEP 658 metadata and recovered wheel `METADATA`, immutable |
 | `sdist-v1/` | an sdist's `PKG-INFO` and `pyproject.toml`, immutable |
 
-Record buckets are keyed per index, so two indexes never share an entry.
+Record buckets are keyed per index, so two indexes never share an entry,
+and the parsed bucket is keyed per interpreter under that.
 A listing body is stored as PEP 691 JSON; when the index answers in PEP
 503 HTML the stored body is nab's own JSON rendering of the page. An
 index pinned to one `serialization` gets its own listing directories,
@@ -55,7 +56,7 @@ answered from cache, offline included.
 
 Turning a listing body into records means a JSON decode plus wheel and
 sdist filename parsing, which a warm resolve would otherwise repeat on
-every run. The `simple-parsed-v0/` bucket stores those records so a warm
+every run. The `simple-parsed-v1/` bucket stores those records so a warm
 hit rehydrates them and never reads the large raw body. A stale entry is
 served the same way once the index answers `304 Not Modified`, since that
 confirms the body the blob is bound to.
@@ -71,18 +72,23 @@ written by a different nab build, or is corrupt. The raw body remains
 authoritative: the accelerator is only ever a derived copy, and a rebuild
 is a reparse of whatever body is on disk.
 
-Blobs are stored as JSON, so one entry serves every interpreter sharing
-the cache. A listing nab reads no files from gets no blob, since an empty
-one could never be served: only the raw body records whether the page held
-formats nab cannot read.
+Blobs are stored with `marshal`, whose format is not portable across
+Python versions. So the bucket is keyed by interpreter as well as by
+index, and each blob names the wire form it was written in along with
+its own length and CRC32; one whose preamble or checksum does not match
+is rebuilt rather than decoded. A listing nab reads no files from gets
+no blob, since an empty one could never be served: only the raw body
+records whether the page held formats nab cannot read.
 
 ## Verifying and clearing
 
 `nab cache verify` walks the record buckets read-only and reports any
 entry that will not parse, including a parsed blob that is not decodable.
 It checks structure only, not freshness: a stale-but-valid parsed blob is
-not corrupt, since the digest binding retires it at read time. Clones and
-extracted archives hold no nab records, so `verify` skips them.
+not corrupt, since the digest binding retires it at read time. It reads
+only the bucket versions this nab writes, so a directory an upgrade
+retired is left alone rather than reported. Clones and extracted archives
+hold no nab records, so `verify` skips them.
 
 `nab cache clear` removes every bucket, clones and archives included,
 returning the cache to cold. `verify` and `clear` both refuse a root that

--- a/nab-index/src/nab_index/cache.py
+++ b/nab-index/src/nab_index/cache.py
@@ -11,7 +11,7 @@ Layout under ``root``:
     simple-v2/<index>[-<serialization>]/<package>.policy  <- {fetched_at, max_age,
                                                               etag, page_url,
                                                               body_digest}
-    simple-parsed-v0/<index>[-<serialization>]/<package>.parsed  <- parsed blob
+    simple-parsed-v1/<index>[-<serialization>]/<interpreter>/<package>.parsed  <- blob
     simple-neg-v0/<index>[-<serialization>]/<package>.neg <- {fetched_at, max_age, etag}
     metadata-v1/<index>/<package>/<url digest>.metadata
     sdist-v1/<index>/<package>/<version>.json  <- {pkg_info, pyproject}
@@ -51,6 +51,7 @@ from typing import TYPE_CHECKING, Protocol
 from nab_provider.serialization import SimpleSerialization
 
 from .atomic import atomic_write
+from .parsed_listing import INTERPRETER_TAG
 from .parsed_listing import corruption_reason as _parsed_corruption
 
 if TYPE_CHECKING:
@@ -72,7 +73,7 @@ __all__ = [
 
 
 CACHE_VERSION_SIMPLE = "v2"
-CACHE_VERSION_SIMPLE_PARSED = "v0"
+CACHE_VERSION_SIMPLE_PARSED = "v1"
 CACHE_VERSION_SIMPLE_NEG = "v0"
 CACHE_VERSION_METADATA = "v1"
 CACHE_VERSION_SDIST = "v1"
@@ -81,6 +82,19 @@ CACHE_VERSION_ARCHIVE = "v1"
 
 # Buckets of nab-written records. simple-neg-* is covered by the simple- prefix.
 ENTRY_BUCKET_PREFIXES = ("simple-", "metadata-", "sdist-")
+
+# The record buckets this build writes. A retired version keeps its prefix, so
+# nab cache clear still reclaims it, but nothing parses records written in a
+# shape this build never wrote.
+_CURRENT_ENTRY_BUCKETS = frozenset(
+    {
+        f"simple-{CACHE_VERSION_SIMPLE}",
+        f"simple-parsed-{CACHE_VERSION_SIMPLE_PARSED}",
+        f"simple-neg-{CACHE_VERSION_SIMPLE_NEG}",
+        f"metadata-{CACHE_VERSION_METADATA}",
+        f"sdist-{CACHE_VERSION_SDIST}",
+    }
+)
 
 # Buckets a resolve fills with upstream source trees. nab owns the directories,
 # not the files inside them.
@@ -133,14 +147,15 @@ class CachePolicy:
         return current - self.fetched_at < self.max_age
 
 
-def _is_entry_bucket(name: str) -> bool:
-    """Whether ``name`` is a bucket of records nab writes and parses."""
-    return any(name.startswith(prefix) for prefix in ENTRY_BUCKET_PREFIXES)
-
-
 def is_recognized_bucket(name: str) -> bool:
-    """Whether ``name`` is a bucket directory nab owns under a cache root."""
-    return _is_entry_bucket(name) or name in _RECOGNIZED_SOURCE_BUCKETS
+    """Whether ``name`` is a bucket directory nab owns under a cache root.
+
+    Retired bucket versions are included, so ``nab cache clear`` reclaims one.
+    """
+    return (
+        any(name.startswith(prefix) for prefix in ENTRY_BUCKET_PREFIXES)
+        or name in _RECOGNIZED_SOURCE_BUCKETS
+    )
 
 
 def _index_dirname(index_url: str) -> str:
@@ -225,8 +240,14 @@ class OnDiskCache:
             else f"{self._index}-{serialization.value}"
         )
         self._simple_dir = root / f"simple-{CACHE_VERSION_SIMPLE}" / simple_index
+        # Keyed by interpreter as well as by index: the blob's wire form is
+        # not portable across Python versions, so two interpreters sharing a
+        # root would otherwise overwrite each other's entry on every run.
         self._parsed_dir = (
-            root / f"simple-parsed-{CACHE_VERSION_SIMPLE_PARSED}" / simple_index
+            root
+            / f"simple-parsed-{CACHE_VERSION_SIMPLE_PARSED}"
+            / simple_index
+            / INTERPRETER_TAG
         )
         self._neg_dir = root / f"simple-neg-{CACHE_VERSION_SIMPLE_NEG}" / simple_index
         self._metadata_dir = root / f"metadata-{CACHE_VERSION_METADATA}" / self._index
@@ -486,13 +507,16 @@ class OnDiskCache:
         ]
 
     def _entry_bucket_dirs(self) -> list[Path]:
-        """Return the bucket entries holding records nab wrote.
+        """Return the bucket entries holding records this build wrote.
 
-        The source buckets are excluded: they hold upstream files, not
-        nab records.
+        The source buckets hold upstream files rather than nab records, and a
+        retired bucket version holds a record shape this build cannot judge.
+        Neither is walked.
         """
         return [
-            child for child in self._root_children() if _is_entry_bucket(child.name)
+            child
+            for child in self._root_children()
+            if child.name in _CURRENT_ENTRY_BUCKETS
         ]
 
     def iter_cache_entries(self) -> Iterator[Path]:

--- a/nab-index/src/nab_index/parsed_listing.py
+++ b/nab-index/src/nab_index/parsed_listing.py
@@ -50,6 +50,7 @@ from nab_provider.records import (
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from typing import TypeGuard
 
     from .cache import CachePolicy
 
@@ -302,7 +303,7 @@ def _checksum_holds(blob: bytes, payload: memoryview) -> bool:
     return len(payload) == length and zlib.crc32(payload) == crc
 
 
-def _names_this_build(header: object) -> bool:
+def _names_this_build(header: object) -> TypeGuard[list[object]]:
     """Whether ``header`` is this build's shape and names its codec."""
     return (
         isinstance(header, list)

--- a/nab-index/src/nab_index/parsed_listing.py
+++ b/nab-index/src/nab_index/parsed_listing.py
@@ -5,8 +5,12 @@ resolve skips ``json.loads`` and wheel/sdist filename parsing. This module
 owns the record<->bytes translation; :class:`~nab_index.cache.OnDiskCache`
 treats the blob as opaque and knows nothing about record shapes.
 
-Wire form (UTF-8 JSON of ``[header, rows]``):
+Wire form (a preamble line, then ``marshal`` of ``[header, rows]``):
 
+* the preamble names the marshal version and interpreter that wrote the
+  payload, then the payload's length and CRC32. ``marshal``'s format is not
+  portable across Python versions, so a blob whose preamble or checksum does
+  not match is a miss and never reaches ``marshal.loads``.
 * header ``[format, codec, key_scheme, body_digest, zip_sdists]`` is checked
   before anything is trusted. A reader on a different ``format``, ``codec``, or
   ``key_scheme`` treats the entry as a miss and rebuilds, so a cache written by
@@ -21,20 +25,20 @@ Wire form (UTF-8 JSON of ``[header, rows]``):
   type-checked on the way back, and ``requires_python`` and hash-algorithm
   names are re-interned via ``sys.intern`` so the round trip reproduces the
   dedup the wire parse builds.
-* the two integrity cells carry the index's own table, as a JSON object, when
-  the record was built from one, and the parsed pairs otherwise. A rehydrated
+* the two integrity cells carry the index's own table, as a mapping, when the
+  record was built from one, and the parsed pairs otherwise. A rehydrated
   record defers the same way, so a listing pays the integrity parse only for
   the files a resolve reads.
 
-The blob is portable: one entry serves every interpreter that shares the cache,
-and a body this module will not parse is a miss, never an exception reaching
-the caller.
+An entry serves the one interpreter the cache keys its bucket on, and a body
+this module will not parse is a miss, never an exception reaching the caller.
 """
 
 from __future__ import annotations
 
-import json
+import marshal
 import sys
+import zlib
 from typing import TYPE_CHECKING, NamedTuple
 
 from nab_provider.records import (
@@ -49,7 +53,13 @@ if TYPE_CHECKING:
 
     from .cache import CachePolicy
 
-__all__ = ["ParsedListing", "corruption_reason", "decode", "encode"]
+__all__ = [
+    "INTERPRETER_TAG",
+    "ParsedListing",
+    "corruption_reason",
+    "decode",
+    "encode",
+]
 
 # Record version, redundant with the bucket suffix but guards against a stale
 # blob surfacing under the current bucket. Bump it when the header or row shape
@@ -58,10 +68,34 @@ __all__ = ["ParsedListing", "corruption_reason", "decode", "encode"]
 FORMAT_VERSION = 4
 # Serialization variant that wrote the rows, so a future codec switch
 # self-heals rather than misdecodes.
-CODEC = 1
+CODEC = 2
 # Version sort-key scheme the rows carry; 0 == no precomputed keys. A later
 # scheme bumps this and self-heals via a reparse.
 KEY_SCHEME = 0
+
+# Pinned rather than taken from ``marshal.version`` so the wire form is a
+# property of this module and not of the interpreter reading it.
+_MARSHAL_VERSION = 4
+
+# What ``__pycache__`` keys on, and what the cache keys the parsed bucket on.
+# ``cache_tag`` is None on an implementation with no bytecode cache.
+INTERPRETER_TAG = sys.implementation.cache_tag or "unknown"
+
+# The magic every blob opens with, whoever wrote it.
+_MAGIC = b"nab-parsed-listing "
+
+# The preamble a blob this build can read opens with.
+_WIRE_FORM = _MAGIC + f"m{_MARSHAL_VERSION}.{INTERPRETER_TAG} ".encode()
+# The payload's length and CRC32, as two zero-padded 32-bit hex fields.
+_CHECK = b"%08x %08x\n"
+_HEX_LEN = 8
+_LEN_AT = len(_WIRE_FORM)
+_CRC_AT = _LEN_AT + _HEX_LEN + 1
+_PAYLOAD_AT = _CRC_AT + _HEX_LEN + 1
+
+# Tells "this blob carries no document" apart from a document that is itself
+# ``None``, which no encode writes but a hand-written blob could.
+_UNREADABLE = object()
 
 _TOP_LEN = 2
 _HEADER_LEN = 5
@@ -96,16 +130,22 @@ def _hashes_cell(record: WheelFile | SdistFile) -> object:
     """Return the row cell for ``hashes``: the raw table, or the parsed pairs.
 
     A record built from the index's own table writes that table, so encoding a
-    fresh listing does not force the parse it deferred.
+    fresh listing does not force the parse it deferred. The parsed pairs go out
+    as lists, the one shape the row checks accept, since ``marshal`` round-trips
+    a tuple as a tuple.
     """
     raw = record.raw_hashes()
-    return record.hashes if raw is None else raw
+    if raw is not None:
+        return raw
+    return [list(pair) for pair in record.hashes]
 
 
 def _sidecar_cell(wheel: WheelFile) -> object:
     """Return the row cell for ``metadata_hash``, raw table or parsed pair."""
     raw = wheel.raw_sidecar()
-    return wheel.metadata_hash if raw is None else raw
+    if raw is not None:
+        return raw
+    return None if wheel.metadata_hash is None else list(wheel.metadata_hash)
 
 
 def encode(
@@ -154,25 +194,21 @@ def encode(
             )
     header = [*_BUILD_ID, body_digest, sorted(zip_sdists)]
 
-    # Escape non-ASCII: a field kept verbatim from the listing, such as
-    # ``requires_python``, can hold a lone surrogate with no UTF-8 form.
-    return json.dumps([header, rows], separators=(",", ":")).encode()
+    return _frame(marshal.dumps([header, rows], _MARSHAL_VERSION))
 
 
 def decode(blob: bytes, policy: CachePolicy) -> ParsedListing | None:
     """Decode a cache blob back to a parsed listing, or ``None`` to force a miss.
 
     Returns ``None`` (treat as a cache miss and rebuild from the raw body) when
-    the blob does not decode, is the wrong shape, was written by a different
-    build (``format`` / ``codec`` / ``key_scheme``), or is not bound to
-    ``policy``'s body (``body_digest``).  Otherwise rehydrates the records,
-    re-interning ``requires_python`` and hash-algorithm names so string identity
-    matches a fresh parse.
+    the preamble names another interpreter, the payload fails its checksum or
+    does not unmarshal, the document is the wrong shape, the header names a
+    different build (``format`` / ``codec`` / ``key_scheme``), or the blob is
+    not bound to ``policy``'s body (``body_digest``). Otherwise rehydrates the
+    records, re-interning ``requires_python`` and hash-algorithm names so string
+    identity matches a fresh parse.
     """
-    try:
-        loaded = json.loads(blob)
-    except ValueError:
-        return None
+    loaded = _payload(blob)
     if not (isinstance(loaded, list) and len(loaded) == _TOP_LEN):
         return None
     header, rows = loaded
@@ -195,17 +231,29 @@ def corruption_reason(blob: bytes) -> str | None:
 
     Distinguishes genuine corruption (garbage or truncated bytes, or a
     same-build blob whose rows are the wrong shape) from a benign miss, where
-    the header names a different build or binds a different body. The read path
-    warns only on the former. Every check past the build cells runs only once
-    the header names this exact build, since a foreign build may have written a
-    shape this one never did; checking earlier would misreport version skew as
-    corruption. This is a second pass used only to gate that warning;
-    :func:`decode` returns ``None`` for every miss reason alike.
+    the preamble names another interpreter, the header names another build, or
+    the blob binds a different body. The read path warns only on the former.
+
+    Every check past the build cells runs only once the header names this exact
+    build, since a foreign build may have written a shape this one never did;
+    checking earlier would misreport version skew as corruption. This is a
+    second pass used only to gate that warning; :func:`decode` returns ``None``
+    for every miss reason alike.
     """
-    try:
-        loaded = json.loads(blob)
-    except ValueError:
-        return "not valid JSON"
+    if not blob.startswith(_WIRE_FORM):
+        return None if blob.startswith(_MAGIC) else "not this codec's wire form"
+    loaded = _payload(blob)
+    if loaded is _UNREADABLE:
+        return "unreadable payload"
+    return _document_fault(loaded)
+
+
+def _document_fault(loaded: object) -> str | None:
+    """Return the fault in the decoded document ``loaded``, else ``None``.
+
+    Reached only once the preamble names this build, so all that is left to
+    judge is the document's own shape.
+    """
     if not (isinstance(loaded, list) and len(loaded) == _TOP_LEN):
         return "unexpected top-level shape"
     header, rows = loaded
@@ -218,6 +266,40 @@ def corruption_reason(blob: bytes) -> str | None:
     except (ValueError, TypeError):
         return "unexpected row shape"
     return None
+
+
+def _frame(payload: bytes) -> bytes:
+    """Prefix ``payload`` with the wire form it is in, its length and its CRC32."""
+    return _WIRE_FORM + _CHECK % (len(payload), zlib.crc32(payload)) + payload
+
+
+def _payload(blob: bytes) -> object:
+    """Return the document ``blob`` carries, or ``_UNREADABLE``.
+
+    ``marshal.loads`` sizes an allocation from a length prefix it reads out of
+    the buffer it is handed, so a payload whose own length and CRC32 do not
+    match the preamble never reaches it.
+    """
+    if not blob.startswith(_WIRE_FORM):
+        return _UNREADABLE
+    payload = memoryview(blob)[_PAYLOAD_AT:]
+    if not _checksum_holds(blob, payload):
+        return _UNREADABLE
+    try:
+        return marshal.loads(payload)  # noqa: S302
+    # marshal's failure modes on a payload it rejects are not a documented set.
+    except Exception:  # noqa: BLE001
+        return _UNREADABLE
+
+
+def _checksum_holds(blob: bytes, payload: memoryview) -> bool:
+    """Whether the preamble's length and CRC32 match the payload behind it."""
+    try:
+        length = int(blob[_LEN_AT : _LEN_AT + _HEX_LEN], 16)
+        crc = int(blob[_CRC_AT : _CRC_AT + _HEX_LEN], 16)
+    except ValueError:
+        return False
+    return len(payload) == length and zlib.crc32(payload) == crc
 
 
 def _names_this_build(header: object) -> bool:
@@ -353,8 +435,8 @@ def _decode_sdist(row: Sequence[object]) -> SdistFile:
     )
 
 
-# JSON hands back only its own types, so an exact type check is enough to keep a
-# hand-written or corrupt blob from reaching a record's fields.
+# An exact type check keeps a hand-written or corrupt blob from reaching a
+# record's fields.
 def _text(value: object) -> str:
     if type(value) is not str:
         raise _BadRowError

--- a/nab-index/tests/test_index_parsed_cache.py
+++ b/nab-index/tests/test_index_parsed_cache.py
@@ -15,6 +15,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import marshal
 from collections.abc import Coroutine, Mapping
 from pathlib import Path
 from typing import Any, TypeVar
@@ -34,10 +35,24 @@ from nab_index.cache import (
 )
 from nab_index.cached_client import CachedAsyncSimpleClient, ParsedCacheStats
 from nab_index.client import SdistFile, WheelFile, _parse_files
-from nab_index.parsed_listing import corruption_reason, decode, encode
+from nab_index.parsed_listing import (
+    _MARSHAL_VERSION,
+    _PAYLOAD_AT,
+    INTERPRETER_TAG,
+    _frame,
+    corruption_reason,
+    decode,
+    encode,
+)
 
 # Derived so a bucket-version bump does not need every path updated.
 _SIMPLE_BUCKET = f"simple-{CACHE_VERSION_SIMPLE}"
+# The parsed bucket keys the interpreter under the index directory.
+_PARSED_PARTS = (
+    f"simple-parsed-{CACHE_VERSION_SIMPLE_PARSED}",
+    "pypi",
+    INTERPRETER_TAG,
+)
 
 _FRESH = CachePolicy(fetched_at=0, max_age=600, etag=None)
 
@@ -171,15 +186,11 @@ class TestGetSimpleParsedBucket:
         cache.put_simple_parsed("foo", b"\x00blob\x01")
         assert cache.get_simple_parsed("foo") == b"\x00blob\x01"
 
-    def test_written_under_parsed_bucket(self, tmp_path: Path) -> None:
+    def test_written_under_the_interpreter_keyed_bucket(self, tmp_path: Path) -> None:
+        """The interpreter is a path segment, so two never share an entry."""
         cache = _cache(tmp_path)
         cache.put_simple_parsed("foo", b"blob")
-        expected = (
-            tmp_path
-            / f"simple-parsed-{CACHE_VERSION_SIMPLE_PARSED}"
-            / "pypi"
-            / "foo.parsed"
-        )
+        expected = tmp_path.joinpath(*_PARSED_PARTS, "foo.parsed")
         assert expected.read_bytes() == b"blob"
 
     def test_miss_returns_none(self, tmp_path: Path) -> None:
@@ -204,7 +215,7 @@ class TestGetSimpleParsedBucket:
         with pytest.raises(OSError, match="disk full"):
             cache.put_simple_parsed("foo", b"partial")
         assert cache.get_simple_parsed("foo") == b"good"
-        parent = tmp_path / f"simple-parsed-{CACHE_VERSION_SIMPLE_PARSED}" / "pypi"
+        parent = tmp_path.joinpath(*_PARSED_PARTS)
         assert [p.name for p in parent.iterdir()] == ["foo.parsed"]
 
 
@@ -243,24 +254,14 @@ class TestReadCacheEntryParsed:
     def test_valid_parsed_is_clean(self, tmp_path: Path) -> None:
         cache = _cache(tmp_path)
         cache.put_simple_parsed("foo", encode(_PARSED, "a" * 64))
-        path = (
-            tmp_path
-            / f"simple-parsed-{CACHE_VERSION_SIMPLE_PARSED}"
-            / "pypi"
-            / "foo.parsed"
-        )
+        path = tmp_path.joinpath(*_PARSED_PARTS, "foo.parsed")
         assert cache.read_cache_entry(path) is None
 
     def test_structurally_corrupt_parsed(self, tmp_path: Path) -> None:
         cache = _cache(tmp_path)
-        path = (
-            tmp_path
-            / f"simple-parsed-{CACHE_VERSION_SIMPLE_PARSED}"
-            / "pypi"
-            / "foo.parsed"
-        )
+        path = tmp_path.joinpath(*_PARSED_PARTS, "foo.parsed")
         path.parent.mkdir(parents=True)
-        path.write_bytes(b"\xff\xfe not json")
+        path.write_bytes(b"\xff\xfe not a parsed-listing blob")
         assert cache.read_cache_entry(path) is not None
 
 
@@ -576,15 +577,25 @@ def _warm_bound(
     return files, digest
 
 
+def _rewrap(document: object) -> bytes:
+    """A blob this build reads, carrying ``document`` whatever its shape."""
+    return _frame(marshal.dumps(document, _MARSHAL_VERSION))
+
+
+def _document(blob: bytes) -> object:
+    """The document ``blob`` carries."""
+    return marshal.loads(blob[_PAYLOAD_AT:])  # noqa: S302
+
+
 def _tamper_header(blob: bytes, index: int, value: object) -> bytes:
-    header, rows = json.loads(blob)
+    header, rows = _document(blob)
     header[index] = value
-    return json.dumps([header, rows]).encode()
+    return _rewrap([header, rows])
 
 
 def _tamper_rows(blob: bytes, value: object) -> bytes:
-    header, _rows = json.loads(blob)
-    return json.dumps([header, value]).encode()
+    header, _rows = _document(blob)
+    return _rewrap([header, value])
 
 
 class TestReadPathParsedHit:
@@ -1001,17 +1012,17 @@ class TestReadPathRevalidate:
 
 class TestParsedCorruptionReason:
     def test_garbage_is_corrupt(self) -> None:
-        assert corruption_reason(b"not json") is not None
+        assert corruption_reason(b"not a parsed-listing blob") is not None
 
     def test_truncated_is_corrupt(self) -> None:
         blob = encode(_PARSED, "a" * 64)
         assert corruption_reason(blob[: len(blob) // 2]) is not None
 
     def test_wrong_top_shape_is_corrupt(self) -> None:
-        assert corruption_reason(json.dumps([1, 2, 3]).encode()) is not None
+        assert corruption_reason(_rewrap([1, 2, 3])) is not None
 
     def test_wrong_header_shape_is_corrupt(self) -> None:
-        assert corruption_reason(json.dumps(["bad", "rows"]).encode()) is not None
+        assert corruption_reason(_rewrap(["bad", "rows"])) is not None
 
     @pytest.mark.parametrize(
         "rows",

--- a/nab-index/tests/test_parsed_listing_codec.py
+++ b/nab-index/tests/test_parsed_listing_codec.py
@@ -5,15 +5,16 @@ The exact-equivalence contract is proved by the Hypothesis harness in
 is opt-in (``-m property``) and does not run under the coverage gate, so these
 plain unit tests drive every branch of the codec: the wheel/sdist tag split,
 present and absent ``requires_python``, present and absent ``metadata_hash``,
-the integrity cells in both their raw and their parsed form, each header /
-digest gate that turns a stale or foreign blob into a decode-to-``None`` miss,
-and the field checks that keep a hand-written row from reaching a record.
+the integrity cells in both their raw and their parsed form, the preamble and
+checksum gates, each header / digest gate that turns a stale or foreign blob
+into a decode-to-``None`` miss, and the field checks that keep a hand-written
+row from reaching a record.
 """
 
 from __future__ import annotations
 
 import dataclasses
-import json
+import marshal
 import sys
 
 import pytest
@@ -21,11 +22,17 @@ import pytest
 from nab_index.cache import CachePolicy
 from nab_index.client import SdistFile, WheelFile
 from nab_index.parsed_listing import (
+    _HEX_LEN,
+    _LEN_AT,
+    _MARSHAL_VERSION,
+    _PAYLOAD_AT,
     _TAG_SDIST,
     _TAG_WHEEL,
+    _WIRE_FORM,
     CODEC,
     FORMAT_VERSION,
     KEY_SCHEME,
+    _frame,
     corruption_reason,
     decode,
     encode,
@@ -33,6 +40,26 @@ from nab_index.parsed_listing import (
 from nab_provider.records import defer_hashes, defer_sidecar_hash
 
 DIGEST = "a" * 64
+
+# A preamble naming another interpreter. It carries no checksum, since the
+# prefix check rejects it before anything reads one.
+_FOREIGN_PREAMBLE = b"nab-parsed-listing m4.some-other-interpreter "
+
+
+def _blob(document: object) -> bytes:
+    """A blob this build will read, carrying ``document`` whatever its shape."""
+    return _frame(marshal.dumps(document, _MARSHAL_VERSION))
+
+
+def _document(blob: bytes) -> object:
+    """The document ``blob`` carries, read the way :func:`decode` reads it."""
+    return marshal.loads(blob[_PAYLOAD_AT:])  # noqa: S302
+
+
+def _flip_bit(blob: bytes, offset: int) -> bytes:
+    """``blob`` with the low bit of the byte at ``offset`` inverted."""
+    return blob[:offset] + bytes([blob[offset] ^ 1]) + blob[offset + 1 :]
+
 
 SHA256 = sys.intern("sha256")
 SHA512 = sys.intern("sha512")
@@ -157,45 +184,48 @@ def test_metadata_hash_present_and_absent() -> None:
 
 
 def test_lone_surrogate_in_field_round_trips() -> None:
-    """A field with no UTF-8 form still round-trips, escaped in the blob.
+    """A field with no UTF-8 form still round-trips.
 
-    ``json.loads`` accepts an unpaired ``\\udXXX`` escape, so a listing can put
-    one in ``requires-python``, which ``_parse_files`` keeps verbatim.
+    A listing can put an unpaired surrogate in ``requires-python``, which
+    ``_parse_files`` keeps verbatim.
     """
     record = dataclasses.replace(SDIST_FULL, requires_python=f"{RP}\ud800")
 
     assert _roundtrip([record]) == [record]
 
 
-def test_blob_is_portable_json() -> None:
-    """The wire form carries no interpreter tag, so any reader can decode it."""
-    header, rows = json.loads(encode(SAMPLE, DIGEST))
+def test_blob_names_its_wire_form_and_the_build_inside() -> None:
+    """The preamble pins the wire form; the header names the build."""
+    blob = encode(SAMPLE, DIGEST)
+    assert blob.startswith(_WIRE_FORM)
+
+    header, rows = _document(blob)
     assert header == [FORMAT_VERSION, CODEC, KEY_SCHEME, DIGEST, []]
     assert [row[0] for row in rows] == [_TAG_WHEEL, _TAG_SDIST, _TAG_WHEEL, _TAG_SDIST]
 
 
 def _tamper_header(index: int, value: object) -> bytes:
-    header, rows = json.loads(encode(SAMPLE, DIGEST))
+    header, rows = _document(encode(SAMPLE, DIGEST))
     header[index] = value
-    return json.dumps([header, rows]).encode()
+    return _blob([header, rows])
 
 
 def _blob_with_rows(rows: object) -> bytes:
     """A blob whose header names this exact build, over caller-supplied rows."""
-    header, _rows = json.loads(encode(SAMPLE, DIGEST))
-    return json.dumps([header, rows]).encode()
+    header, _rows = _document(encode(SAMPLE, DIGEST))
+    return _blob([header, rows])
 
 
 def _wheel_row_with(index: int, value: object) -> bytes:
     """A blob holding one wheel row with a single field replaced."""
-    _header, rows = json.loads(encode([WHEEL_FULL], DIGEST))
+    _header, rows = _document(encode([WHEEL_FULL], DIGEST))
     rows[0][index] = value
     return _blob_with_rows(rows)
 
 
 def _sdist_row_with(index: int, value: object) -> bytes:
     """A blob holding one sdist row with a single field replaced."""
-    _header, rows = json.loads(encode([SDIST_FULL], DIGEST))
+    _header, rows = _document(encode([SDIST_FULL], DIGEST))
     rows[0][index] = value
     return _blob_with_rows(rows)
 
@@ -228,12 +258,14 @@ def test_policy_without_digest_is_miss() -> None:
     "blob",
     [
         b"",
-        b"not json",
+        b"no preamble",
         b"\xff\xfe not utf-8",
-        json.dumps(7).encode(),
-        json.dumps([1, 2, 3]).encode(),
-        json.dumps(["bad-header", []]).encode(),
-        json.dumps([[0, 1, 0], []]).encode(),
+        _frame(b"\xff\xfe not a payload"),
+        _FOREIGN_PREAMBLE + b"whatever that build wrote",
+        _blob(7),
+        _blob([1, 2, 3]),
+        _blob(["bad-header", []]),
+        _blob([[0, 1, 0], []]),
     ],
 )
 def test_malformed_blob_is_miss(blob: bytes) -> None:
@@ -269,7 +301,7 @@ def test_unknown_tag_on_a_well_formed_row_is_miss(tag: object) -> None:
     The row keeps sdist arity, so a codec that fell through to the sdist branch
     instead of rejecting would decode it happily. That is what this pins.
     """
-    _header, rows = json.loads(encode([SDIST_FULL], DIGEST))
+    _header, rows = _document(encode([SDIST_FULL], DIGEST))
     assert len(rows[0]) == _SDIST_ROW_LEN
     rows[0][0] = tag
     assert decode(_blob_with_rows(rows), _policy()) is None
@@ -299,7 +331,7 @@ def test_unknown_tag_on_a_well_formed_row_is_miss(tag: object) -> None:
     ],
 )
 def test_wrong_field_type_is_miss(index: int, value: object) -> None:
-    """A field JSON allows but the record does not never reaches a record."""
+    """A field the wire form allows but the record does not never reaches one."""
     assert decode(_wheel_row_with(index, value), _policy()) is None
 
 
@@ -334,9 +366,10 @@ def test_absent_optional_fields_decode_as_none() -> None:
 @pytest.mark.parametrize(
     ("blob", "reason"),
     [
-        (b"not json", "not valid JSON"),
-        (json.dumps(7).encode(), "unexpected top-level shape"),
-        (json.dumps(["bad-header", []]).encode(), "unexpected header shape"),
+        (b"no preamble", "not this codec's wire form"),
+        (_frame(b"\xff\xfe not a payload"), "unreadable payload"),
+        (_blob(7), "unexpected top-level shape"),
+        (_blob(["bad-header", []]), "unexpected header shape"),
     ],
 )
 def test_corruption_reason_names_the_structural_fault(blob: bytes, reason: str) -> None:
@@ -344,9 +377,9 @@ def test_corruption_reason_names_the_structural_fault(blob: bytes, reason: str) 
 
 
 def test_zip_sdists_round_trip_sorted() -> None:
-    """The dropped releases ride the header, sorted so a blob is byte-stable."""
+    """The dropped releases ride the header, sorted rather than in set order."""
     blob = encode(SAMPLE, DIGEST, frozenset({"2.0", "1.0"}))
-    header = json.loads(blob)[0]
+    header = _document(blob)[0]
     decoded = decode(blob, _policy())
 
     assert header[_H_ZIP_SDISTS] == ["1.0", "2.0"]
@@ -356,7 +389,7 @@ def test_zip_sdists_round_trip_sorted() -> None:
 
 @pytest.mark.parametrize("cell", ["1.0", {"1.0": True}, [1.0], [None]])
 def test_bad_zip_sdists_cell_is_miss(cell: object) -> None:
-    """A cell JSON allows but the header does not rebuilds rather than crashes."""
+    """A cell the wire form allows but the header does not rebuilds, not crashes."""
     assert decode(_tamper_header(_H_ZIP_SDISTS, cell), _policy()) is None
 
 
@@ -378,6 +411,46 @@ def test_corruption_reason_passes_a_valid_blob() -> None:
 def test_foreign_build_header_is_not_corruption() -> None:
     """Version skew is a benign miss, so the read path rebuilds without warning."""
     assert corruption_reason(_tamper_header(_H_CODEC, CODEC + 1)) is None
+
+
+def test_foreign_preamble_is_a_miss_and_not_corruption() -> None:
+    """A blob another interpreter wrote is never handed to ``marshal``."""
+    blob = _FOREIGN_PREAMBLE + b"whatever that build wrote"
+
+    assert decode(blob, _policy()) is None
+    assert corruption_reason(blob) is None
+
+
+def test_a_flipped_length_field_is_a_miss() -> None:
+    """A length that no longer matches the payload stops the decode.
+
+    ``marshal`` reads a container's element count straight out of the buffer
+    and allocates from it, so a payload nothing has vouched for can ask for a
+    billion-element list rather than raise.
+    """
+    blob = _flip_bit(encode(SAMPLE, DIGEST), _LEN_AT)
+
+    assert decode(blob, _policy()) is None
+    assert corruption_reason(blob) == "unreadable payload"
+
+
+def test_a_flipped_payload_byte_is_a_miss_not_altered_records() -> None:
+    """A flip inside a filename still unmarshals, to a document that is wrong."""
+    blob = encode(SAMPLE, DIGEST)
+    flipped = _flip_bit(blob, blob.index(b"pkg-1.0-py3-none-any.whl"))
+    assert _document(flipped) != _document(blob)
+
+    assert decode(flipped, _policy()) is None
+    assert corruption_reason(flipped) == "unreadable payload"
+
+
+def test_a_non_hex_length_field_is_a_miss() -> None:
+    """A preamble whose length field is not a number reads as corruption."""
+    blob = encode(SAMPLE, DIGEST)
+    blob = blob[:_LEN_AT] + b"." * _HEX_LEN + blob[_LEN_AT + _HEX_LEN :]
+
+    assert decode(blob, _policy()) is None
+    assert corruption_reason(blob) == "unreadable payload"
 
 
 def test_digest_mismatch_is_not_corruption() -> None:
@@ -402,7 +475,7 @@ def _deferred_wheel(hashes: object, *, sidecar: object) -> WheelFile:
 def test_unparsed_tables_ride_the_wire_as_the_index_served_them() -> None:
     wheel = _deferred_wheel({"SHA256": DIGEST.upper()}, sidecar={"sha256": DIGEST})
 
-    rows = json.loads(encode([wheel], DIGEST))[1]
+    rows = _document(encode([wheel], DIGEST))[1]
 
     assert rows[0][_W_HASHES] == {"SHA256": DIGEST.upper()}
     assert rows[0][_W_METADATA_HASH] == {"sha256": DIGEST}
@@ -412,7 +485,7 @@ def test_a_value_that_is_not_an_object_rides_as_its_parse() -> None:
     """Only a table defers, so any other value writes what the record parsed."""
     wheel = _deferred_wheel(["sha256", DIGEST], sidecar=True)
 
-    rows = json.loads(encode([wheel], DIGEST))[1]
+    rows = _document(encode([wheel], DIGEST))[1]
 
     assert rows[0][_W_HASHES] == []
     assert rows[0][_W_METADATA_HASH] is None
@@ -421,7 +494,7 @@ def test_a_value_that_is_not_an_object_rides_as_its_parse() -> None:
 def test_a_many_algorithm_table_defers_as_the_index_served_it() -> None:
     wheel = _deferred_wheel({"sha256": DIGEST, "sha512": "f" * 128}, sidecar=True)
 
-    rows = json.loads(encode([wheel], DIGEST))[1]
+    rows = _document(encode([wheel], DIGEST))[1]
 
     assert rows[0][_W_HASHES] == {"sha256": DIGEST, "sha512": "f" * 128}
     assert wheel.hashes == ((SHA256, DIGEST), (SHA512, "f" * 128))

--- a/nab-project/tests/property_python/test_parsed_listing_equiv.py
+++ b/nab-project/tests/property_python/test_parsed_listing_equiv.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import dataclasses
 import hashlib
 import json
+import marshal
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -42,7 +43,14 @@ from nab_index.client import (
     WheelFile,
     _parse_files,
 )
-from nab_index.parsed_listing import decode, encode
+from nab_index.parsed_listing import (
+    _MARSHAL_VERSION,
+    _PAYLOAD_AT,
+    _WIRE_FORM,
+    _frame,
+    decode,
+    encode,
+)
 
 from .strategies import PROPERTY_SETTINGS
 
@@ -235,12 +243,22 @@ def _sample_blob() -> tuple[bytes, CachePolicy]:
     return encode(parsed, digest), policy
 
 
+def _document(blob: bytes) -> Any:
+    """The document ``blob`` carries, read the way :func:`decode` reads it."""
+    return marshal.loads(blob[_PAYLOAD_AT:])  # noqa: S302
+
+
+def _reframe(document: object) -> bytes:
+    """A blob this build will read, carrying ``document`` whatever its shape."""
+    return _frame(marshal.dumps(document, _MARSHAL_VERSION))
+
+
 def _retamper(header_index: int, value: object) -> tuple[bytes, CachePolicy]:
     """Re-encode a valid blob with one header field replaced."""
     blob, policy = _sample_blob()
-    header, rows = json.loads(blob)
+    header, rows = _document(blob)
     header[header_index] = value
-    return json.dumps([header, rows]).encode(), policy
+    return _reframe([header, rows]), policy
 
 
 def test_digest_mismatch_decodes_to_none() -> None:
@@ -272,10 +290,12 @@ def test_key_scheme_mismatch_decodes_to_none() -> None:
     assert decode(blob, policy) is None
 
 
-def test_blob_carries_no_interpreter_tag() -> None:
-    """The wire form is portable, so a blob written anywhere decodes here."""
+def test_corpus_blob_names_its_wire_form_and_build() -> None:
+    """``marshal`` is not portable, so the preamble pins the wire form."""
     blob, policy = _sample_blob()
-    header, _rows = json.loads(blob)
+    assert blob.startswith(_WIRE_FORM)
+
+    header, _rows = _document(blob)
     *build, digest, zip_sdists = header
 
     assert all(isinstance(cell, int) for cell in build)
@@ -288,21 +308,22 @@ def test_blob_carries_no_interpreter_tag() -> None:
     "blob",
     [
         b"",
-        b"not-json-bytes",
+        b"no preamble",
         b"\xff\xfe not utf-8",
-        json.dumps(42).encode(),
-        json.dumps([1, 2, 3]).encode(),
-        json.dumps(["shorthdr", "rows"]).encode(),
+        _frame(b"\xff\xfe not a payload"),
+        _reframe(42),
+        _reframe([1, 2, 3]),
+        _reframe(["shorthdr", "rows"]),
     ],
 )
 def test_garbage_blob_decodes_to_none(blob: bytes) -> None:
-    """Truncated, non-JSON, or wrong-shaped blobs are misses, not crashes."""
+    """Garbage, unreadable, and wrong-shaped blobs are misses, not crashes."""
     _, policy = _sample_blob()
     assert decode(blob, policy) is None
 
 
 def test_truncated_blob_decodes_to_none() -> None:
-    """A valid blob cut short raises inside json and is treated as a miss."""
+    """A valid blob cut short fails its checksum and is treated as a miss."""
     blob, policy = _sample_blob()
     assert decode(blob[: len(blob) // 2], policy) is None
 

--- a/tests/test_cache_cmd.py
+++ b/tests/test_cache_cmd.py
@@ -8,12 +8,19 @@ import pytest
 
 from nab import cli as nab_cli
 from nab.cli import app
-from nab_index.cache import CACHE_VERSION_SIMPLE, CachePolicy, OnDiskCache
+from nab_index.cache import (
+    CACHE_VERSION_SIMPLE,
+    CACHE_VERSION_SIMPLE_PARSED,
+    CachePolicy,
+    OnDiskCache,
+)
+from nab_index.parsed_listing import INTERPRETER_TAG
 from nab_index.parsed_listing import encode as _encode_parsed
 from nab_project.config_sources import SourceRoots
 
 # Derived so a bucket-version bump does not need every path updated.
 SIMPLE_BUCKET = f"simple-{CACHE_VERSION_SIMPLE}"
+PARSED_PARTS = (f"simple-parsed-{CACHE_VERSION_SIMPLE_PARSED}", "pypi", INTERPRETER_TAG)
 
 _FRESH = CachePolicy(fetched_at=0, max_age=600, etag=None)
 
@@ -284,12 +291,32 @@ class TestCacheVerify:
     ) -> None:
         root = tmp_path / "cache"
         _populate(root)
-        parsed_path = root / "simple-parsed-v0" / "pypi" / "foo.parsed"
-        parsed_path.write_bytes(b"not json data")
+        parsed_path = root.joinpath(*PARSED_PARTS, "foo.parsed")
+        parsed_path.write_bytes(b"not a parsed-listing blob")
         _run_cache(["verify", "--cache-dir", str(root)])
         err = capsys.readouterr().err
         assert str(parsed_path) in err
-        assert "not valid JSON" in err
+        assert "not this codec's wire form" in err
+
+    def test_retired_bucket_is_not_read(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """An upgrade leaves the old bucket behind; verify must not judge it.
+
+        Its files are in a shape this build never wrote, so reading them would
+        report one corruption per cached package until ``clear`` runs.
+        """
+        root = tmp_path / "cache"
+        _populate(root)
+        retired = root / "simple-parsed-v0" / "pypi" / "foo.parsed"
+        retired.parent.mkdir(parents=True)
+        # The JSON wire form the retired bucket version held.
+        retired.write_bytes(b'[[4, 1, 0, "' + b"a" * 64 + b'", []], []]')
+
+        _run_cache(["verify", "--cache-dir", str(root)])
+
+        assert capsys.readouterr().err == ""
+        assert retired.exists()
 
     def test_does_not_read_through_symlinked_bucket(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
Decoding the 245 parsed-listing blobs a warm `pip:langchain-ml-course` resolve reads costs 5,520,946,244 instructions as JSON and 4,180,335,656 as `marshal`: 1,340,610,588 removed, 24% of the decode, about 22.5 million a blob against 17.1 million. A whole run of that scenario retires around 13.3 billion, so the saving is roughly a tenth of the process, approximate because that denominator moves with the resolve. The counts come from callgrind with `PYTHONHASHSEED=0` and reproduce anywhere; the timings below are local.

Stacked on #965; the diff and the numbers are against that branch.

A warm resolve gets faster on the clock too. Over 12 runs of each side on the same scenario it is between about 2% and 7% faster, middle estimate near 5.5%, with peak RSS down about 5.6%, 240 MB to 226 MB. Blobs shrink 5.1%, 71,657,489 bytes to 68,022,002, and both codecs rehydrate the same 167,507 records, field for field.

There is a cost, and it lands on the first run after an upgrade, which rebuilds the parsed cache because the bucket moves to `simple-parsed-v1`. Peak RSS on that run is about 15 MB higher, 234 MB to 248 MB, somewhere between 3% and 6.5%, and the extra is unaccounted for. The timing runs on a rebuilding cache cannot see a change below about 2%, so they only rule out a slowdown larger than that.

The wire form:

- a preamble names the marshal version and `sys.implementation.cache_tag`, then the payload's length and CRC32. Decode checks all of it before unmarshalling, since `marshal.loads` sizes an allocation from a count it reads out of the buffer it is handed.
- the parsed bucket is keyed by interpreter as well as by index, because the format is not portable across Python versions.
- `CODEC` goes to 2 and the bucket to `simple-parsed-v1`, so entries an older build wrote read as a miss and get rebuilt.
- `nab cache verify` walks only the bucket versions this build writes; a retired one is still reclaimed by `nab cache clear`.

The header, the row shapes and the field checks are unchanged. The one encode-side change is that the parsed integrity pairs go out as lists, since `marshal` round-trips a tuple as a tuple where JSON did not.

Ruff's S302 fires on the one `marshal.loads` and carries a `# noqa`; the function's docstring says why the payload is checked before it gets there. If `marshal` is not welcome on this path, pickle protocol 5 does the same job for a smaller saving.
