### PR TITLE
Fix raw traceback when TMPDIR contains the PATH separator

### DIFF
--- a/nab-project/src/nab_project/_build/env.py
+++ b/nab-project/src/nab_project/_build/env.py
@@ -278,10 +278,12 @@ class NabBuildEnv:
         builder = venv.EnvBuilder(
             with_pip=False, symlinks=_supports_symlinks(), clear=False
         )
+
+        # From 3.11, venv refuses an env path containing os.pathsep with a ValueError.
         try:
             wheel_dir.mkdir()
             builder.create(self._venv_path)
-        except OSError as exc:
+        except (OSError, ValueError) as exc:
             msg = f"could not create build venv at {self._venv_path}: {exc}"
             raise BuildEnvError(msg) from exc
 

--- a/nab-project/tests/test_build_runner.py
+++ b/nab-project/tests/test_build_runner.py
@@ -17,6 +17,7 @@ import base64
 import hashlib
 import io
 import json
+import os
 import struct
 import subprocess
 import sys
@@ -2255,6 +2256,20 @@ class _StubEnvBuilder:
         path.mkdir(parents=True, exist_ok=True)
 
 
+class _PathsepRefusingEnvBuilder:
+    """Stand in for ``venv.EnvBuilder`` on 3.11+: refuses an ``os.pathsep`` path."""
+
+    def __init__(self, **_kw: object) -> None:
+        pass
+
+    def create(self, path: Path) -> None:
+        msg = (
+            f"Refusing to create a venv in {path} because it contains"
+            f" the PATH separator {os.pathsep}."
+        )
+        raise ValueError(msg)
+
+
 class TestBuildEnvMissingExtra:
     """A build requirement naming an undeclared extra fails the build env."""
 
@@ -3423,6 +3438,22 @@ class TestNabBuildEnvEnterInstall:
             env.__enter__()
         assert env._tmpdir is None  # type: ignore[attr-defined]
 
+    def test_enter_wraps_venv_create_valueerror(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A ValueError from ``venv.EnvBuilder.create`` is wrapped as
+        BuildEnvError, and the temp directory is still cleaned up.
+
+        From 3.11 ``venv`` refuses an env path containing ``os.pathsep``,
+        which is where a TMPDIR named with one puts it.
+        """
+        monkeypatch.setattr("venv.EnvBuilder", _PathsepRefusingEnvBuilder)
+        env = NabBuildEnv(requires=[], config=NabProjectConfig())
+        with pytest.raises(BuildEnvError, match="build venv"):
+            env.__enter__()
+        assert env._tmpdir is None  # type: ignore[attr-defined]
+
     def test_enter_wraps_inner_project_write_oserror(
         self,
         tmp_path: Path,
@@ -3878,6 +3909,30 @@ class TestVenvSchemeProbeIsolation:
         paths = _venv_scheme_paths(Path(sys.executable))
 
         assert paths["purelib"] == sysconfig.get_paths()["purelib"]
+
+
+class TestRunBuildBackendVenvRefused:
+    """A ValueError from venv creation surfaces as BuildBackendError."""
+
+    def test_valueerror_surfaces_as_build_backend_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The wrapped ValueError reaches the caller with its venv path."""
+        monkeypatch.setattr("venv.EnvBuilder", _PathsepRefusingEnvBuilder)
+
+        source = tmp_path / "src"
+        source.mkdir()
+        (source / "pyproject.toml").write_text(
+            '[build-system]\nrequires = []\nbuild-backend = "dummyreq.backend"\n',
+            encoding="utf-8",
+        )
+
+        with pytest.raises(
+            BuildBackendError,
+            match=r"build env setup for 'dummyreq\.backend' failed: could not"
+            r" create build venv at .*: Refusing to create a venv",
+        ):
+            run_build_backend(source, config=NabProjectConfig())
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
On Python 3.11 and up, `nab lock` dies with a traceback instead of reporting a build failure when `TMPDIR` contains the PATH separator and a source has to be built:

    ValueError: Refusing to create a venv in /tmp/a:b/nab-build-env-z_rmnzlp/venv because it contains the PATH separator :.

`venv.EnvBuilder.create` has refused a path holding `os.pathsep` since 3.11, and the venv step only wrapped `OSError`. `run_build_backend` documents `BuildBackendError` on any failure, and nothing between the two catches the `ValueError`, so the sdist is never skipped and a declared source never reports as unbuildable. On 3.10 `venv` has no such refusal, so this is inert there.

Catching `ValueError` there too gives the documented error, and the source reports as unbuildable the way an `OSError` from the same call already does:

    build env setup for 'dummyreq.backend' failed: could not create build venv at /tmp/a:b/nab-build-env-_ne9j_d7/venv: Refusing to create a venv in /tmp/a:b/nab-build-env-_ne9j_d7/venv because it contains the PATH separator :.
