### PR TITLE
Fix build-policy docs naming dynamic dependencies as the only build trigger

### DIFF
--- a/docs/reference/build-policy.md
+++ b/docs/reference/build-policy.md
@@ -55,13 +55,16 @@ all.
 
 ## `build-local` (default)
 
-Adds PEP 517 backend invocation on local checkouts.  When a
-`[[tool.nab.local-sources]]` entry (or a workspace member) has
-`dynamic = ["dependencies"]`, the project's
+Adds PEP 517 backend invocation on local checkouts.  When the
+static read of a `[[tool.nab.local-sources]]` entry (or a
+workspace member) comes up empty, the project's
 `[build-system].build-backend` runs inside an isolated venv via
-`nab_project._build.runner` and the
-resulting wheel `METADATA` is used.  Remote PyPI sdists, VCS
-clones, and archive sources remain static-only.
+`nab_project._build.runner` and the resulting wheel `METADATA` is
+used.  Empty means a missing or malformed `[project]`, or a
+`dynamic` list naming `version`, `requires-python`,
+`dependencies`, or `optional-dependencies`, the same cases that
+end the resolve under `never`.  Remote PyPI sdists, VCS clones,
+and archive sources remain static-only.
 
 ## `build-remote`
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -664,9 +664,12 @@ editable by default (see [Lock a workspace](../how-to/workspaces.md)).
 `subdirectory` locates the package below `path`, for monorepo
 layouts.
 
-Reading static dependencies from a local pyproject.toml works at
-every `build-policy` level.  Dynamic dependencies require
-`build-policy = "build-local"` or `"build-remote"`.
+Reading static metadata from a local pyproject.toml works at every
+`build-policy` level.  Building the project when that read comes up
+empty (a missing or malformed `[project]`, or a `dynamic` list naming
+`version`, `requires-python`, `dependencies`, or
+`optional-dependencies`) needs `build-policy = "build-local"` or
+`"build-remote"`.
 
 ## Pinned VCS sources
 
@@ -678,8 +681,8 @@ beyond `vcs.policy = "allow"`, the URL's scheme must be listed in
 `vcs.allowed-schemes` and its repository in `vcs.allowed-repos`, both
 empty by default so each denies every URL until an entry is added, and
 the URL must pin a 40-char commit hash unless `vcs.require-pin = false`.
-Reading static dependencies works at any `build-policy`.  Dynamic
-dependencies on a VCS clone require `build-policy = "build-remote"`.
+Reading static metadata works at any `build-policy`.  Building a clone
+whose static read comes up empty needs `build-policy = "build-remote"`.
 
 ```toml
 [[tool.nab.vcs-sources]]
@@ -703,8 +706,9 @@ url  = "https://example.com/my-fork-1.0.tar.gz#sha256=<hex>"
 Only `.tar.gz` source archives are supported; a wheel or other
 format is refused at parse.  A `&subdirectory=` fragment locates the
 package below the archive root, for monorepo layouts.  Reading static
-dependencies works at any `build-policy`; dynamic dependencies require
-`build-policy = "build-remote"`, like a remote sdist.
+metadata works at any `build-policy`; building the extracted tree when
+that read comes up empty needs `build-policy = "build-remote"`, like a
+remote sdist.
 
 The URL is read by its own scheme, whatever the configured indexes use:
 a `file://` archive is read from disk, and any other archive is fetched

--- a/nab-project/src/nab_project/build_backend.py
+++ b/nab-project/src/nab_project/build_backend.py
@@ -2,9 +2,10 @@
 
 Hand a source directory to :func:`extract_metadata` and get back a
 :class:`WheelMetadata`. The static pyproject.toml reader runs first;
-dynamic ``project.dependencies`` fall through to a PEP 517 backend
-invocation inside :class:`~nab_project._build.env.NabBuildEnv`. The
-dynamic path needs a :class:`NabProjectConfig`.
+a directory :func:`extract_static_metadata` returns ``None`` for falls
+through to a PEP 517 backend invocation inside
+:class:`~nab_project._build.env.NabBuildEnv`. The dynamic path needs a
+:class:`NabProjectConfig`.
 """
 
 from __future__ import annotations

--- a/nab-project/tests/test_build_backend.py
+++ b/nab-project/tests/test_build_backend.py
@@ -3,7 +3,8 @@
 Covers the static path (``extract_static_metadata``) and the
 dynamic dispatch in ``extract_metadata``, including the
 ``BuildBackendError`` raised when the caller did not supply the
-``NabProjectConfig`` the runner needs.
+``NabProjectConfig`` the runner needs, and the build-policy page's
+account of when the dynamic path runs.
 """
 
 from __future__ import annotations
@@ -35,6 +36,11 @@ from nab_provider.requirements_file import InvalidProjectRequirementError
 def _write_pyproject(tmp: Path, body: str) -> Path:
     (tmp / "pyproject.toml").write_text(body, encoding="utf-8")
     return tmp
+
+
+DOCS_BUILD_POLICY = (
+    Path(__file__).resolve().parents[2] / "docs" / "reference" / "build-policy.md"
+)
 
 
 class TestExtractStaticMetadata:
@@ -607,3 +613,48 @@ class TestStaticExtractAugmentParity:
         )
         with pytest.raises(ValueError, match="Expected"):
             parse_metadata(md)
+
+
+class TestBuildLocalDocSection:
+    """The build-policy page's ``build-local`` section against the static read.
+
+    A local checkout goes to a backend when ``extract_static_metadata``
+    returns ``None`` for it, so the section names the shapes that produce
+    one.  A read that raises instead, on an unreadable file or a corrupt
+    static value, never reaches a backend and is outside that claim.
+    """
+
+    @staticmethod
+    def _build_local_section() -> str:
+        """Return the ``build-local`` section, down to the next heading."""
+        text = DOCS_BUILD_POLICY.read_text(encoding="utf-8")
+        start = text.index("## `build-local` (default)")
+        return text[start:].split("\n## ", 1)[0]
+
+    @pytest.mark.parametrize(
+        "field",
+        ["dependencies", "optional-dependencies", "version", "requires-python"],
+    )
+    def test_section_names_every_dynamic_field(
+        self, field: str, tmp_path: Path
+    ) -> None:
+        _write_pyproject(
+            tmp_path,
+            f"""
+            [project]
+            name = "foo"
+            version = "1.0"
+            dynamic = ["{field}"]
+            """,
+        )
+        assert extract_static_metadata(tmp_path) is None
+
+        assert f"`{field}`" in self._build_local_section()
+
+    def test_section_names_a_missing_project_table(self, tmp_path: Path) -> None:
+        _write_pyproject(tmp_path, '[build-system]\nrequires = ["setuptools"]\n')
+        assert extract_static_metadata(tmp_path) is None
+
+        section = self._build_local_section()
+        assert "missing" in section
+        assert "`[project]`" in section


### PR DESCRIPTION
The `build-local` section of the build-policy reference said a local checkout reaches a PEP 517 backend when it has `dynamic = ["dependencies"]`. What actually sends it there is a static read that comes up empty:

* a missing or malformed `[project]`
* a `dynamic` list naming `version`, `requires-python`, `dependencies`, or `optional-dependencies`

The page contradicted itself in two places. Its `never` section already lists all of those as the cases that end the resolve. "Choosing a level" calls a checkout with `dynamic = ["version"]` from hatch-vcs the common case `build-local` exists for, which the old sentence said would not build.

The configuration reference carried the same "dynamic dependencies require ..." line for local sources, VCS sources, and archive sources, and `build_backend`'s module docstring said it too. All four now describe the empty static read.

The new test reads the `build-local` section and checks the four dynamic fields and the missing `[project]` case against `extract_static_metadata`: each has to stop the static reader and be named in the section.
