### PR TITLE
Memoise Marker.__str__ on the instance, ~1.7% off max-25-tuples

### DIFF
--- a/nab-provider/src/nab_provider/_vendor/packaging/PROVENANCE.md
+++ b/nab-provider/src/nab_provider/_vendor/packaging/PROVENANCE.md
@@ -40,7 +40,9 @@ most one checked-in patch.
     comprehension, which puts the `[[...]]` unwrap under the list branch.
     Upstream's opening `assert isinstance(marker, (list, tuple, str))` is
     dropped, so a value of any other type now returns unchanged instead of
-    tripping the assertion.
+    tripping the assertion. `Marker.__str__` holds its result in a
+    `_serialized` slot, so the `__hash__` and `__eq__` built on it walk the
+    node tree once per instance instead of once per call.
   - `_parser.py`: `process_python_str` returns the body between the token's
     quotes when that body is ASCII and holds no backslash, newline, carriage
     return or NUL, and calls `ast.literal_eval` otherwise. The `QUOTED_STRING`
@@ -51,7 +53,8 @@ most one checked-in patch.
   `from_bounds`/`snap_bounds`/`release_intervals`, the prepared marker
   environment, and the marker-item serialisation. `relation` is not proposed
   yet: most of its win is available from the direct walks alone. The
-  quoted-string slice is not proposed anywhere yet.
+  quoted-string slice is not proposed anywhere yet, and neither is the
+  `Marker.__str__` memo.
 - `tasks/vendor-packaging.sh` fetches `pypa/packaging` at the pin, replaces this
   package with the pristine `src/packaging/` tree plus the repo-root license
   texts, and reapplies the patch. `--check` rebuilds into a temp location and

--- a/nab-provider/src/nab_provider/_vendor/packaging/markers.py
+++ b/nab-provider/src/nab_provider/_vendor/packaging/markers.py
@@ -440,7 +440,7 @@ class Marker:
         release.
     """
 
-    __slots__ = ("_markers",)
+    __slots__ = ("_markers", "_serialized")
 
     def __init__(self, marker: str) -> None:
         # Note: We create a Marker object without calling this constructor in
@@ -483,7 +483,13 @@ class Marker:
         return new
 
     def __str__(self) -> str:
-        return _format_marker(self._markers)
+        # _markers is never rebound after construction, so serialise once.
+        try:
+            return self._serialized
+        except AttributeError:
+            serialized = _format_marker(self._markers)
+            self._serialized = serialized
+            return serialized
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}({str(self)!r})>"

--- a/tasks/vendoring/packaging.patch
+++ b/tasks/vendoring/packaging.patch
@@ -2099,7 +2099,7 @@ index e312a1f..29c32bc 100644
          return hash((self.version, self.inclusive))
  
 diff --git a/nab-provider/src/nab_provider/_vendor/packaging/markers.py b/nab-provider/src/nab_provider/_vendor/packaging/markers.py
-index 609099c..fa29c65 100644
+index 609099c..07c7d81 100644
 --- a/nab-provider/src/nab_provider/_vendor/packaging/markers.py
 +++ b/nab-provider/src/nab_provider/_vendor/packaging/markers.py
 @@ -30,6 +30,7 @@ __all__ = [
@@ -2203,7 +2203,31 @@ index 609099c..fa29c65 100644
  class Marker:
      """Represents a parsed dependency marker expression.
  
-@@ -530,29 +572,22 @@ class Marker:
+@@ -398,7 +440,7 @@ class Marker:
+         release.
+     """
+ 
+-    __slots__ = ("_markers",)
++    __slots__ = ("_markers", "_serialized")
+ 
+     def __init__(self, marker: str) -> None:
+         # Note: We create a Marker object without calling this constructor in
+@@ -441,7 +483,13 @@ class Marker:
+         return new
+ 
+     def __str__(self) -> str:
+-        return _format_marker(self._markers)
++        # _markers is never rebound after construction, so serialise once.
++        try:
++            return self._serialized
++        except AttributeError:
++            serialized = _format_marker(self._markers)
++            self._serialized = serialized
++            return serialized
+ 
+     def __repr__(self) -> str:
+         return f"<{self.__class__.__name__}({str(self)!r})>"
+@@ -530,29 +578,22 @@ class Marker:
              Added the ``context`` parameter, which influences which marker names
              are considered valid.
          """


### PR DESCRIPTION
31,568,461 instructions come off a warm `universal:max-25-tuples` resolve, 1.673% of the 1,886,826,122 it costs on main. The counts reproduce anywhere; the timings are off one machine.

| scenario | main | branch | removed | share |
| --- | ---: | ---: | ---: | ---: |
| `max-25-tuples` | 1,886,826,122 | 1,855,257,661 | 31,568,461 | 1.673% |
| `max-25-tuples`, repeat | 1,886,409,168 | 1,855,426,969 | 30,982,199 | 1.642% |
| `scientific-python-multi` | 3,982,035,556 | 3,949,404,215 | 32,631,341 | 0.819% |
| `legacy-36-root-stress` | 6,967,874,035 | 6,932,102,603 | 35,771,432 | 0.513% |

The two base counts are 0.022% apart, so the saving is about 75 times the measurement's own spread. 821,194,143 of each total is the driver importing nab, counted with the resolve skipped, so the resolve alone is about 3% cheaper.

`Marker.__hash__` is `hash(str(self))` and `__eq__` compares `str(self)` with `str(other)`, so a marker's text was rebuilt from its node tree on every use. `__str__` now fills a `_serialized` slot on the first call. `Marker.__str__` is entered 4,177 times on `max-25-tuples` either way:

- 1,910 from `micro_boundary_points`, 1,108 from `__hash__`, 935 from `marker_text`, 224 from `__eq__`
- 153 still walk the tree, so `_format_marker` runs 312 times instead of 8,604

The memo ends that run holding 2,425 bytes across 41 markers, against a 16.4 MB traced peak. The 19-scenario canary set rules out a wall regression above about 3.1% and a CPU regression above about 1.6%.

It lands in the vendored packaging tree, recorded in PROVENANCE.md as not proposed upstream.
