### PR TITLE
Report an over-long or over-nested TOML value as invalid TOML

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -15,8 +15,9 @@ The property suite under ``nab-*/tests/property*/`` uses explicit
 ``PROPERTY_SETTINGS``/``DEEP_SETTINGS``/``BRUTE_FORCE_SETTINGS``
 decorators so its example budget is independent of the profile.
 
-``cap_writes`` and ``deny_access`` are here rather than in one suite's
-conftest because both the ``nab-project`` suite and the CLI suite use them.
+``cap_writes``, ``deny_access`` and ``oversized_integer`` are here rather than
+in one suite's conftest because both the ``nab-project`` suite and the CLI
+suite use them.
 """
 
 from __future__ import annotations
@@ -24,6 +25,7 @@ from __future__ import annotations
 import errno
 import io
 import os
+import sys
 from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -166,3 +168,14 @@ def cap_writes() -> Callable[[int], AbstractContextManager[None]]:
     file gets written.
     """
     return _cap_writes
+
+
+@pytest.fixture
+def oversized_integer() -> str:
+    """Return a decimal integer literal too long for ``int()`` to convert.
+
+    tomli builds a TOML integer with ``int()``, which CPython caps at
+    ``sys.get_int_max_str_digits()`` digits, so a literal this long fails the
+    parse without being a syntax error.
+    """
+    return "1" * (sys.get_int_max_str_digits() + 1)

--- a/nab-project/pyproject.toml
+++ b/nab-project/pyproject.toml
@@ -23,7 +23,8 @@ dependencies = [
     "nab-provider==0.0.15.dev0",
     "nab-resolver==0.0.15.dev0",
     "nab-index==0.0.15.dev0",
-    "tomli>=2.0",
+    # toml_io builds TOMLDecodeError(msg, doc, pos), a signature 2.2 added.
+    "tomli>=2.2",
     "tomli_w>=1.2",
     "build>=1.2",
     "installer>=1.0",

--- a/nab-project/src/nab_project/_build/runner.py
+++ b/nab-project/src/nab_project/_build/runner.py
@@ -51,6 +51,7 @@ from nab_provider.requirements_file import (
 )
 from nab_resolver.errors import ResolutionError
 
+from .. import toml_io
 from ..paths import PathState, path_state
 from .env import BuildChain, BuildEnvError, NabBuildEnv
 from .errors import BuildBackendError
@@ -256,7 +257,7 @@ def _read_pyproject(source_dir: Path) -> dict:
 
     if state.should_read:
         try:
-            return tomli.loads(pyproject.read_text(encoding="utf-8"))
+            return toml_io.loads(pyproject.read_text(encoding="utf-8"))
         except (OSError, UnicodeDecodeError, tomli.TOMLDecodeError) as exc:
             msg = f"could not read pyproject.toml at {source_dir}: {exc}"
             raise BuildBackendError(msg) from exc

--- a/nab-project/src/nab_project/_lockfile/builder.py
+++ b/nab-project/src/nab_project/_lockfile/builder.py
@@ -27,6 +27,7 @@ from nab_provider.metadata import validate_specifier_versions
 from nab_provider.policy import DistPolicy
 from nab_provider.records import SdistFile, WheelFile
 
+from .. import toml_io
 from .._toml import tool_nab_section
 from ..paths import path_state
 from .groups import BASE_MEMBER
@@ -197,7 +198,7 @@ def read_lockfile_anchor(path: Path) -> datetime | None:
         return None
     try:
         with path.open("rb") as f:
-            data = tomli.load(f)
+            data = toml_io.load(f)
     except (OSError, UnicodeDecodeError, tomli.TOMLDecodeError):
         return None
     nab = tool_nab_section(data)
@@ -228,7 +229,7 @@ def read_lockfile_packages(path: Path) -> dict[str, Version] | None:
         return None
     try:
         with path.open("rb") as f:
-            data = tomli.load(f)
+            data = toml_io.load(f)
         pylock = Pylock.from_dict(data)
     except (OSError, UnicodeDecodeError, tomli.TOMLDecodeError, PylockValidationError):
         return None

--- a/nab-project/src/nab_project/_lockfile/validate.py
+++ b/nab-project/src/nab_project/_lockfile/validate.py
@@ -45,6 +45,8 @@ from nab_provider.marker_holds import UnevaluableMarkerError, dependency_marker_
 from nab_provider.metadata import validate_specifier_versions
 from nab_provider.target import NonIntervalMarkerError, micro_boundary_points
 
+from .. import toml_io
+
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping, Sequence
     from pathlib import Path
@@ -373,7 +375,7 @@ def read_committed_pylock(path: Path) -> Pylock:
     PEP 751 lock.
     """
     try:
-        data = tomli.loads(path.read_text(encoding="utf-8"))
+        data = toml_io.loads(path.read_text(encoding="utf-8"))
     except (UnicodeDecodeError, tomli.TOMLDecodeError) as e:
         raise LockfileSyntaxError(str(e)) from e
     try:

--- a/nab-project/src/nab_project/_toml.py
+++ b/nab-project/src/nab_project/_toml.py
@@ -6,6 +6,8 @@ from typing import Any
 
 import tomli
 
+from . import toml_io
+
 
 def tool_nab_section(data: dict[str, Any]) -> Any:
     """Return the raw ``[tool.nab]`` value from parsed TOML ``data``.
@@ -25,6 +27,6 @@ def parse_pyproject_table(text: str) -> dict[str, Any] | None:
     one that was never fetched, so the failure is a value not an exception.
     """
     try:
-        return tomli.loads(text)
+        return toml_io.loads(text)
     except tomli.TOMLDecodeError:
         return None

--- a/nab-project/src/nab_project/build_backend.py
+++ b/nab-project/src/nab_project/build_backend.py
@@ -29,6 +29,7 @@ from nab_provider.requirements_file import (
     require_string_list,
 )
 
+from . import toml_io
 from ._build.errors import (
     BuildBackendError as BuildBackendError,  # noqa: PLC0414  (public re-export)
 )
@@ -96,7 +97,7 @@ def extract_static_metadata(source_dir: Path) -> WheelMetadata | None:
         raise BuildBackendError(msg)
 
     try:
-        data = tomli.loads(pyproject.read_text(encoding="utf-8"))
+        data = toml_io.loads(pyproject.read_text(encoding="utf-8"))
     except OSError as exc:
         if is_absent_error(exc):
             # The presence check is racy: the file may vanish before the read.

--- a/nab-project/src/nab_project/config.py
+++ b/nab-project/src/nab_project/config.py
@@ -64,6 +64,7 @@ from nab_provider.target import (
 )
 from nab_provider.vcs_admission import VcsConfig, VcsPolicy, known_vcs_schemes
 
+from . import toml_io
 from ._toml import tool_nab_section
 from ._value import ValueType
 from .config_sources import (
@@ -933,7 +934,7 @@ def _reject_unknown_pyproject_keys(path: Path) -> None:
     """
     try:
         with path.open("rb") as f:
-            data = tomli.load(f)
+            data = toml_io.load(f)
     except (UnicodeDecodeError, tomli.TOMLDecodeError) as exc:
         msg = f"{path} is not valid TOML: {exc}"
         raise ConfigError(msg) from exc
@@ -1395,7 +1396,7 @@ def _validate_base_group_is_free(base_group: EffectiveValue, path: Path) -> None
     if name is None:
         return
     with path.open("rb") as f:
-        data = tomli.load(f)
+        data = toml_io.load(f)
     groups = data.get("dependency-groups")
     if not isinstance(groups, dict):
         return
@@ -1471,7 +1472,7 @@ def _validate_build_group_is_free(
         raise ConfigError(msg)
 
     with path.open("rb") as f:
-        data = tomli.load(f)
+        data = toml_io.load(f)
     groups = data.get("dependency-groups")
     if not isinstance(groups, dict):
         return
@@ -1500,7 +1501,7 @@ def _read_project_requires_python(path: Path) -> str | None:
     here.
     """
     with path.open("rb") as f:
-        data = tomli.load(f)
+        data = toml_io.load(f)
     project = data.get("project")
     if not isinstance(project, dict) or "requires-python" not in project:
         return None

--- a/nab-project/src/nab_project/config_sources.py
+++ b/nab-project/src/nab_project/config_sources.py
@@ -55,6 +55,7 @@ from nab_provider.records import IndexConfig
 from nab_provider.serialization import SimpleSerialization
 from nab_provider.vcs_admission import VcsConfig
 
+from . import toml_io
 from ._toml import tool_nab_section
 from ._value import ValueType
 from .fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL
@@ -1430,7 +1431,7 @@ def _read_raw_table(path: Path, kind: SourceKind) -> Mapping[str, Any]:
     # TOML is UTF-8, so a file that will not decode is invalid TOML.
     try:
         with path.open("rb") as f:
-            data = tomli.load(f)
+            data = toml_io.load(f)
     except (UnicodeDecodeError, tomli.TOMLDecodeError) as exc:
         msg = f"{path} is not valid TOML: {exc}"
         raise SourceConfigError(msg) from exc

--- a/nab-project/src/nab_project/pyproject_files.py
+++ b/nab-project/src/nab_project/pyproject_files.py
@@ -8,14 +8,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import tomli
-
 from nab_provider.requirements_file import (
     InvalidProjectRequirementError,
     InvalidProjectTableError,
     parse_requirements,
     require_string_list,
 )
+
+from . import toml_io
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -40,7 +40,7 @@ def _load_project_table(path: Path) -> Mapping[str, object]:
     :class:`InvalidProjectTableError`.
     """
     with path.open("rb") as f:
-        data = tomli.load(f)
+        data = toml_io.load(f)
     project = data.get("project", {})
     if not isinstance(project, dict):
         msg = f"[project] must be a table, got {type(project).__name__}"
@@ -58,7 +58,7 @@ def read_pyproject_dependencies(path: Path) -> list[Requirement]:
     ``dependencies``.
     """
     with path.open("rb") as f:
-        data = tomli.load(f)
+        data = toml_io.load(f)
     project = data["project"]
     if not isinstance(project, dict):
         msg = f"[project] must be a table, got {type(project).__name__}"
@@ -92,7 +92,7 @@ def read_pyproject_build_requires(path: Path) -> list[Requirement]:
     known only once the backend runs.
     """
     with path.open("rb") as f:
-        data = tomli.load(f)
+        data = toml_io.load(f)
 
     if "build-system" not in data:
         msg = (
@@ -151,7 +151,7 @@ def read_pyproject_groups(
     absent table reads as an empty dict.
     """
     with path.open("rb") as f:
-        data = tomli.load(f)
+        data = toml_io.load(f)
     raw = data.get("dependency-groups", {})
     if not isinstance(raw, dict):
         msg = f"[dependency-groups] must be a table, got {type(raw).__name__}"

--- a/nab-project/src/nab_project/toml_io.py
+++ b/nab-project/src/nab_project/toml_io.py
@@ -1,0 +1,40 @@
+"""Read TOML, reporting a document that will not parse as ``TOMLDecodeError``.
+
+tomli raises something else for two failures: a decimal integer with more digits
+than :func:`sys.get_int_max_str_digits` allows raises :class:`ValueError` out of
+:func:`int`, and inline arrays or tables nested too deeply raise
+:class:`RecursionError`.  Neither says where in the document it happened, so the
+substituted error points at the start.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import tomli
+
+if TYPE_CHECKING:
+    from typing import BinaryIO
+
+__all__ = ["load", "loads"]
+
+
+def loads(text: str) -> dict[str, Any]:
+    """Parse ``text`` as a TOML document."""
+    try:
+        return tomli.loads(text)
+    except tomli.TOMLDecodeError:
+        # A decode error is already a ValueError, so it passes through first.
+        raise
+    except (RecursionError, ValueError) as exc:
+        raise tomli.TOMLDecodeError(str(exc), text, 0) from exc
+
+
+def load(f: BinaryIO) -> dict[str, Any]:
+    """Parse the TOML document in the binary file ``f``.
+
+    Reading and decoding here rather than calling :func:`tomli.load` routes the
+    parse through :func:`loads`.  Bytes that are not UTF-8 still raise
+    :class:`UnicodeDecodeError`.
+    """
+    return loads(f.read().decode())

--- a/nab-project/src/nab_project/workspace.py
+++ b/nab-project/src/nab_project/workspace.py
@@ -28,6 +28,7 @@ import tomli
 from nab_provider._vendor.packaging.utils import canonicalize_name
 from nab_provider.policy import LocalSource
 
+from . import toml_io
 from ._toml import tool_nab_section
 from .paths import PathState, path_state, resolve_path
 
@@ -65,7 +66,7 @@ def _load_member_toml(pyproject: Path) -> dict[str, Any]:
     """
     try:
         with pyproject.open("rb") as f:
-            return tomli.load(f)
+            return toml_io.load(f)
     except (UnicodeDecodeError, tomli.TOMLDecodeError) as exc:
         msg = f"{pyproject} is not valid TOML: {exc}"
         raise WorkspaceDiscoveryError(msg) from exc
@@ -122,7 +123,7 @@ def discover_workspace_root(member_pyproject: Path) -> Path | None:
         for candidate in (parent / "pyproject.toml", parent / _PROJECT_TOML):
             try:
                 with candidate.open("rb") as f:
-                    data = tomli.load(f)
+                    data = toml_io.load(f)
             except (OSError, UnicodeDecodeError, tomli.TOMLDecodeError):
                 continue
             declared, _label = _workspace_declaration(data, candidate)

--- a/nab-project/tests/test_build_backend.py
+++ b/nab-project/tests/test_build_backend.py
@@ -126,6 +126,21 @@ class TestExtractStaticMetadata:
             extract_static_metadata(tmp_path)
         assert isinstance(caught.value.__cause__, UnicodeDecodeError)
 
+    def test_oversized_integer_toml_reports_the_parse_error(
+        self, tmp_path: Path, oversized_integer: str
+    ) -> None:
+        """An integer past the int-from-string limit does not parse either."""
+        _write_pyproject(
+            tmp_path,
+            '[project]\nname = "foo"\nversion = "1.0"\n'
+            f"[tool.other]\ncount = {oversized_integer}\n",
+        )
+        with pytest.raises(
+            BuildBackendError, match="could not read pyproject.toml"
+        ) as caught:
+            extract_static_metadata(tmp_path)
+        assert isinstance(caught.value.__cause__, tomli.TOMLDecodeError)
+
     def test_no_project_table_returns_none(self, tmp_path: Path) -> None:
         _write_pyproject(tmp_path, '[build-system]\nrequires = ["setuptools"]\n')
         assert extract_static_metadata(tmp_path) is None

--- a/nab-project/tests/test_build_runner.py
+++ b/nab-project/tests/test_build_runner.py
@@ -427,6 +427,15 @@ class TestRunBuildBackend:
         with pytest.raises(BuildBackendError, match="no pyproject.toml or setup.py"):
             run_build_backend(tmp_path, config=config)
 
+    def test_oversized_integer_pyproject(
+        self, tmp_path: Path, config: NabProjectConfig, oversized_integer: str
+    ) -> None:
+        (tmp_path / "pyproject.toml").write_text(
+            f"[tool.other]\ncount = {oversized_integer}\n", encoding="utf-8"
+        )
+        with pytest.raises(BuildBackendError, match="could not read pyproject.toml"):
+            run_build_backend(tmp_path, config=config)
+
     def test_unsearchable_pyproject_reports_the_errno(
         self,
         tmp_path: Path,

--- a/nab-project/tests/test_config.py
+++ b/nab-project/tests/test_config.py
@@ -321,6 +321,23 @@ class TestTopLevelKeys:
         with pytest.raises(ConfigError, match="not valid TOML"):
             read_pyproject_config(path)
 
+    def test_oversized_integer_rejected(
+        self, tmp_path: Path, oversized_integer: str
+    ) -> None:
+        # The literal sits in a table nab never reads, and still fails the parse.
+        path = write(tmp_path, f"[tool.other]\ncount = {oversized_integer}\n")
+        with pytest.raises(ConfigError, match="not valid TOML"):
+            read_pyproject_config(path)
+
+    def test_over_nested_inline_arrays_rejected(self, tmp_path: Path) -> None:
+        # tomli reports nesting this deep as a RecursionError, not a decode error.
+        depth = 1100
+        path = write(
+            tmp_path, "[tool.other]\nvalue = " + "[" * depth + "]" * depth + "\n"
+        )
+        with pytest.raises(ConfigError, match="not valid TOML"):
+            read_pyproject_config(path)
+
     def test_unreadable_rejected(self, tmp_path: Path) -> None:
         path = write(tmp_path, '[project]\nname = "demo"\n')
         denied = PermissionError(errno.EACCES, "Permission denied", str(path))

--- a/nab-project/tests/test_config_sources.py
+++ b/nab-project/tests/test_config_sources.py
@@ -638,6 +638,17 @@ class TestLoadTomlLayerDirect:
         with pytest.raises(SourceConfigError, match="not valid TOML"):
             _load_toml_layer(path, SourceKind.PYPROJECT)
 
+    def test_oversized_integer_pyproject_errors(
+        self, tmp_path: Path, oversized_integer: str
+    ) -> None:
+        # The literal sits in a table nab never reads, and still fails the parse.
+        path = _write(
+            tmp_path / "pyproject.toml",
+            f"[tool.other]\ncount = {oversized_integer}\n",
+        )
+        with pytest.raises(SourceConfigError, match="not valid TOML"):
+            _load_toml_layer(path, SourceKind.PYPROJECT)
+
     def test_unreadable_file_errors(self, tmp_path: Path) -> None:
         path = _write(tmp_path / "nab.toml", 'resolution = "lowest"\n')
         denied = PermissionError(errno.EACCES, "Permission denied", str(path))

--- a/nab-project/tests/test_lockfile.py
+++ b/nab-project/tests/test_lockfile.py
@@ -1892,6 +1892,17 @@ class TestReadLockfileAnchor:
         path.write_bytes(b"\xff\xfe not utf-8")
         assert read_lockfile_anchor(path) is None
 
+    def test_returns_none_when_integer_too_long(
+        self, tmp_path: Path, oversized_integer: str
+    ) -> None:
+        # The anchor is there and valid; the file still will not parse.
+        path = tmp_path / "pylock.toml"
+        path.write_text(
+            "[tool.nab]\ncreated-at = 2026-05-01T00:00:00+00:00\n"
+            f"[tool.other]\ncount = {oversized_integer}\n"
+        )
+        assert read_lockfile_anchor(path) is None
+
     def test_returns_none_when_no_tool_nab(self, tmp_path: Path) -> None:
         path = tmp_path / "pylock.toml"
         path.write_text('lock-version = "1.0"\n')

--- a/nab-project/tests/test_toml_io.py
+++ b/nab-project/tests/test_toml_io.py
@@ -1,0 +1,165 @@
+"""Tests for the TOML reader every nab parse goes through."""
+
+from __future__ import annotations
+
+import ast
+import io
+from pathlib import Path
+
+import pytest
+import tomli
+
+from nab_project import toml_io
+
+WORKSPACE = Path(__file__).resolve().parents[2]
+
+SHIPPED_PACKAGES = (
+    WORKSPACE / "src" / "nab",
+    *sorted(WORKSPACE.glob("nab-*/src/nab_*")),
+)
+"""The source trees the census walks, globbed rather than listed.
+
+A tree the glob missed would leave the census with nothing to find, so the
+test asserts this set before walking it.
+"""
+
+OVER_NESTED = 1100
+"""Deeper than tomli will follow into an inline array or table."""
+
+
+def _reaches_a_parser(node: ast.AST) -> bool:
+    """Whether ``node`` reaches a TOML parser other than ``toml_io``'s.
+
+    An alias or a ``from`` import binds the parser under a name no walk over
+    attributes would catch, and ``tomllib`` is a second parser, so the imports
+    count as much as the calls.  Plain ``import tomli`` stays allowed, since
+    modules import it to name ``TOMLDecodeError``.
+    """
+    if isinstance(node, ast.Attribute):
+        return (
+            isinstance(node.value, ast.Name)
+            and node.value.id == "tomli"
+            and node.attr in {"load", "loads"}
+        )
+    if isinstance(node, ast.Import):
+        return any(
+            alias.name == "tomllib"
+            or (alias.name == "tomli" and alias.asname is not None)
+            for alias in node.names
+        )
+    if isinstance(node, ast.ImportFrom):
+        if node.module == "tomllib":
+            return True
+        return node.module == "tomli" and any(
+            alias.name in {"load", "loads"} for alias in node.names
+        )
+    return False
+
+
+def parser_references(source: str) -> list[int]:
+    """Return the lines of ``source`` that reach a parser other than ``toml_io``."""
+    return sorted(
+        node.lineno
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, (ast.stmt, ast.expr)) and _reaches_a_parser(node)
+    )
+
+
+class TestParseFailures:
+    def test_syntax_error_stays_a_decode_error(self) -> None:
+        with pytest.raises(tomli.TOMLDecodeError, match="Invalid value"):
+            toml_io.loads("count = [")
+
+    def test_oversized_integer_becomes_a_decode_error(
+        self, oversized_integer: str
+    ) -> None:
+        with pytest.raises(tomli.TOMLDecodeError, match="Exceeds the limit"):
+            toml_io.loads(f"count = {oversized_integer}")
+
+    def test_oversized_integer_in_a_binary_file(self, oversized_integer: str) -> None:
+        handle = io.BytesIO(f"count = {oversized_integer}\n".encode())
+        with pytest.raises(tomli.TOMLDecodeError, match="Exceeds the limit"):
+            toml_io.load(handle)
+
+    # tomli's compiled build trips its own nesting guard and the pure-Python
+    # build CPython's recursion limit, so the wording differs but the cause
+    # does not.
+    def test_over_nested_arrays_become_a_decode_error(self) -> None:
+        document = "value = " + "[" * OVER_NESTED + "]" * OVER_NESTED
+        with pytest.raises(tomli.TOMLDecodeError) as excinfo:
+            toml_io.loads(document)
+        assert isinstance(excinfo.value.__cause__, RecursionError)
+
+    def test_over_nested_tables_become_a_decode_error(self) -> None:
+        document = "value = " + "{ a = " * OVER_NESTED + "1" + " }" * OVER_NESTED
+        with pytest.raises(tomli.TOMLDecodeError) as excinfo:
+            toml_io.loads(document)
+        assert isinstance(excinfo.value.__cause__, RecursionError)
+
+    def test_undecodable_bytes_stay_a_unicode_error(self) -> None:
+        # The decode runs before the parse, so it is not folded.
+        with pytest.raises(UnicodeDecodeError):
+            toml_io.load(io.BytesIO(b'name = "\xe9"'))
+
+    def test_substituted_error_carries_the_document(
+        self, oversized_integer: str
+    ) -> None:
+        text = f"count = {oversized_integer}\n"
+        with pytest.raises(tomli.TOMLDecodeError) as excinfo:
+            toml_io.loads(text)
+        assert "Exceeds the limit" in excinfo.value.msg
+        assert excinfo.value.doc == text
+        assert excinfo.value.pos == 0
+
+
+class TestParseSuccess:
+    def test_loads_returns_the_table(self) -> None:
+        assert toml_io.loads('[project]\nname = "demo"\n') == {
+            "project": {"name": "demo"}
+        }
+
+    def test_load_returns_the_table(self) -> None:
+        assert toml_io.load(io.BytesIO(b"count = 1\n")) == {"count": 1}
+
+
+class TestCensus:
+    """Every shipped module parses through :mod:`nab_project.toml_io`."""
+
+    def test_census_sees_the_forms_it_bans(self) -> None:
+        source = (
+            "import tomli\n"
+            "import tomli as t\n"
+            "import tomllib\n"
+            "from tomli import loads\n"
+            "from tomli import TOMLDecodeError\n"
+            "from tomllib import load\n"
+            "tomli.loads(text)\n"
+            "tomli.TOMLDecodeError\n"
+        )
+        assert parser_references(source) == [2, 3, 4, 6, 7]
+
+    def test_census_reads_the_wrapper_itself(self) -> None:
+        # toml_io holds the last such call, so finding it is what says the
+        # walk can see one at all.
+        source = WORKSPACE / "nab-project" / "src" / "nab_project" / "toml_io.py"
+        assert len(parser_references(source.read_text(encoding="utf-8"))) == 1
+
+    def test_every_parse_goes_through_toml_io(self) -> None:
+        # A glob that missed a package would leave nothing to find.
+        assert [package.name for package in SHIPPED_PACKAGES] == [
+            "nab",
+            "nab_index",
+            "nab_project",
+            "nab_provider",
+            "nab_resolver",
+        ]
+
+        found: list[str] = []
+        for package in SHIPPED_PACKAGES:
+            for path in sorted(package.rglob("*.py")):
+                if "_vendor" in path.parts or path.name == "toml_io.py":
+                    continue
+                lines = parser_references(path.read_text(encoding="utf-8"))
+                found.extend(f"{path.relative_to(WORKSPACE)}:{line}" for line in lines)
+
+        assert found == []

--- a/nab-project/tests/test_workspace.py
+++ b/nab-project/tests/test_workspace.py
@@ -105,6 +105,24 @@ class TestDiscoverWorkspaceRoot:
         )
         assert discover_workspace_root(member) == (tmp_path / "ws" / "pyproject.toml")
 
+    def test_skips_oversized_integer_intermediate_pyprojects(
+        self, tmp_path: Path, oversized_integer: str
+    ) -> None:
+        _write(
+            tmp_path / "ws" / "pyproject.toml",
+            '[project]\nname = "ws"\nversion = "0"\n'
+            "[tool.nab.workspace]\nmembers = []\n",
+        )
+        _write(
+            tmp_path / "ws" / "broken" / "pyproject.toml",
+            f"[tool.other]\ncount = {oversized_integer}\n",
+        )
+        member = _write(
+            tmp_path / "ws" / "broken" / "pkg" / "pyproject.toml",
+            '[project]\nname = "pkg"\nversion = "0"\n',
+        )
+        assert discover_workspace_root(member) == (tmp_path / "ws" / "pyproject.toml")
+
     def test_walks_past_pyproject_without_workspace_table(self, tmp_path: Path) -> None:
         _write(
             tmp_path / "outer" / "pyproject.toml",
@@ -382,6 +400,25 @@ class TestReadWorkspaceMembers:
         member = _write(
             tmp_path / "pkg" / "pyproject.toml",
             "name = 'pkg-b\n",
+        )
+        with pytest.raises(
+            WorkspaceDiscoveryError,
+            match=rf"{re.escape(str(member))} is not valid TOML",
+        ):
+            read_workspace_members(root)
+
+    def test_member_oversized_integer_raises(
+        self, tmp_path: Path, oversized_integer: str
+    ) -> None:
+        root = _write(
+            tmp_path / "pyproject.toml",
+            '[project]\nname = "ws"\nversion = "0"\n'
+            "[tool.nab.workspace]\n"
+            'members = ["pkg"]\n',
+        )
+        member = _write(
+            tmp_path / "pkg" / "pyproject.toml",
+            f"[tool.other]\ncount = {oversized_integer}\n",
         )
         with pytest.raises(
             WorkspaceDiscoveryError,

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -29,6 +29,7 @@ import tomli_w
 import tyro
 
 from nab._version import __version__
+from nab_project import toml_io
 from nab_project.config import (
     ConfigError,
     NabProjectConfig,
@@ -359,7 +360,7 @@ def _packages_only(text: str) -> str:
     run) so two locks compare equal whenever their packages, environments,
     and metadata match.
     """
-    data = tomli.loads(text)
+    data = toml_io.loads(text)
     data.pop("tool", None)
     return tomli_w.dumps(data)
 

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -27,6 +27,7 @@ import tyro
 from tyro.extras import SubcommandApp
 
 from nab._version import __version__
+from nab_project import toml_io
 from nab_project.config import (
     ConfigError,
     NabProjectConfig,
@@ -517,7 +518,7 @@ def _is_pylock(path: Path) -> bool:
     the pyproject parser to report.
     """
     try:
-        data = tomli.loads(path.read_text(encoding="utf-8"))
+        data = toml_io.loads(path.read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError, tomli.TOMLDecodeError):
         return False
     return "lock-version" in data and "project" not in data

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1745,6 +1745,21 @@ class TestLockCommandSpecific:
             lock(pyproject, output=Path("-"))
         assert "is not valid TOML" in capsys.readouterr().err
 
+    def test_oversized_integer_toml_exits(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        oversized_integer: str,
+    ) -> None:
+        """An integer too long to convert reports a clean message, not a traceback."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            f"[project]\ndependencies = []\n[tool.other]\ncount = {oversized_integer}\n"
+        )
+        with pytest.raises(SystemExit, match="1"):
+            lock(pyproject, output=Path("-"))
+        assert "is not valid TOML" in capsys.readouterr().err
+
     def test_unreadable_toml_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
@@ -4924,6 +4939,20 @@ class TestGroupAndExtraSelection:
     ) -> None:
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_bytes(b"[project]\nname = '\xe9'\n[dependency-groups]\n")
+        with pytest.raises(SystemExit, match="1"):
+            resolve_group_selection(pyproject, groups=(), all_groups=True)
+        assert "is not valid TOML" in capsys.readouterr().err
+
+    def test_all_groups_oversized_integer_exits(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        oversized_integer: str,
+    ) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            f"[project]\nname = 'x'\n[tool.other]\ncount = {oversized_integer}\n"
+        )
         with pytest.raises(SystemExit, match="1"):
             resolve_group_selection(pyproject, groups=(), all_groups=True)
         assert "is not valid TOML" in capsys.readouterr().err

--- a/tests/test_lock_locked.py
+++ b/tests/test_lock_locked.py
@@ -1110,6 +1110,25 @@ def test_invalid_toml_precondition(
     mock.assert_not_called()
 
 
+def test_oversized_integer_precondition(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], oversized_integer: str
+) -> None:
+    pyproject = _write_pyproject(tmp_path, '[project]\ndependencies = ["foo"]\n')
+    out = tmp_path / "pylock.toml"
+    out.write_text(
+        f'lock-version = "1.0"\n[tool.other]\ncount = {oversized_integer}\n',
+        encoding="utf-8",
+    )
+
+    mock = _locked_mock()
+    with pytest.raises(SystemExit) as exc:
+        _run_locked(pyproject, out, mock)
+
+    assert exc.value.code == 1
+    assert "is not valid TOML" in capsys.readouterr().err
+    mock.assert_not_called()
+
+
 def test_non_pep751_precondition(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
`nab lock`, `nab download` and `nab config` print a traceback when any TOML file they read holds a decimal integer with more digits than `sys.get_int_max_str_digits()` allows (4300 by default). tomli builds TOML integers with `int()`, so that case comes out as a bare `ValueError`, and nab's readers only catch `TOMLDecodeError`:

```
  File ".../nab_project/config_sources.py", line 1345, in _read_raw_table
    data = tomli.load(f)
ValueError: Exceeds the limit (4300 digits) for integer string conversion: value has 4301 digits; use sys.set_int_max_str_digits() to increase the limit
```

The value does not have to be one nab reads. A key under `[tool.other]` is enough, in `pyproject.toml`, in `nab.toml`, or in a committed `pylock.toml`.

A second failure escapes the same way: an inline array or table nested past tomli's 1000-level limit raises `RecursionError`.

Both now go through `nab_project.toml_io`, which re-raises them as `TOMLDecodeError` so the existing handlers name the file:

```
error: in [tool.nab]: pyproject.toml is not valid TOML: Exceeds the limit (4300 digits) for integer string conversion: value has 4301 digits; use sys.set_int_max_str_digits() to increase the limit (at line 1, column 1)
```

Neither underlying error carries a position, so the substituted one points at the start of the document.

The 18 parse sites across 10 modules all call the wrapper, and a test walks the shipped source with `ast` and fails on a `tomli.load` or `tomli.loads` added outside it. The tomli floor moves to 2.2 for the `TOMLDecodeError(msg, doc, pos)` constructor.
