### PR TITLE
Write the parsed-listing hash cell as a pair, ~2.6% fewer instructions

### DIFF
--- a/nab-index/src/nab_index/parsed_listing.py
+++ b/nab-index/src/nab_index/parsed_listing.py
@@ -25,10 +25,12 @@ Wire form (a preamble line, then ``marshal`` of ``[header, rows]``):
   type-checked on the way back, and ``requires_python`` and hash-algorithm
   names are re-interned via ``sys.intern`` so the round trip reproduces the
   dedup the wire parse builds.
-* the two integrity cells carry the index's own table, as a mapping, when the
-  record was built from one, and the parsed pairs otherwise. A rehydrated
-  record defers the same way, so a listing pays the integrity parse only for
-  the files a resolve reads.
+* the two integrity cells carry the table a record holds unparsed, when it was
+  built from one, and the parsed pairs otherwise. A one-algorithm table rides
+  as the ``(algo, digest)`` tuple the record holds, anything else as the
+  mapping the index served; a held digest is judged when the field is read,
+  not here. A rehydrated record defers the same way, so a listing pays the
+  integrity parse only for the files a resolve reads.
 
 An entry serves the one interpreter the cache keys its bucket on, and a body
 this module will not parse is a miss, never an exception reaching the caller.
@@ -42,6 +44,7 @@ import zlib
 from typing import TYPE_CHECKING, NamedTuple
 
 from nab_provider.records import (
+    HeldTable,
     SdistFile,
     WheelFile,
     rehydrated_sdist,
@@ -66,7 +69,7 @@ __all__ = [
 # blob surfacing under the current bucket. Bump it when the header or row shape
 # changes, or when the same body parses to different records: ``body_digest``
 # pins only the input.
-FORMAT_VERSION = 4
+FORMAT_VERSION = 5
 # Serialization variant that wrote the rows, so a future codec switch
 # self-heals rather than misdecodes.
 CODEC = 2
@@ -128,24 +131,24 @@ class ParsedListing(NamedTuple):
 
 
 def _hashes_cell(record: WheelFile | SdistFile) -> object:
-    """Return the row cell for ``hashes``: the raw table, or the parsed pairs.
+    """Return the row cell for ``hashes``: the held table, or the parsed pairs.
 
-    A record built from the index's own table writes that table, so encoding a
-    fresh listing does not force the parse it deferred. The parsed pairs go out
-    as lists, the one shape the row checks accept, since ``marshal`` round-trips
-    a tuple as a tuple.
+    A record built from the index's own table writes what it holds, so encoding
+    a fresh listing does not force the parse it deferred. The parsed pairs go
+    out as lists, which is what tells them from a held pair: ``marshal``
+    round-trips a tuple as a tuple.
     """
-    raw = record.raw_hashes()
-    if raw is not None:
-        return raw
+    held = record.held_hashes()
+    if held is not None:
+        return held
     return [list(pair) for pair in record.hashes]
 
 
 def _sidecar_cell(wheel: WheelFile) -> object:
-    """Return the row cell for ``metadata_hash``, raw table or parsed pair."""
-    raw = wheel.raw_sidecar()
-    if raw is not None:
-        return raw
+    """Return the row cell for ``metadata_hash``, held table or parsed pair."""
+    held = wheel.held_sidecar()
+    if held is not None:
+        return held
     return None if wheel.metadata_hash is None else list(wheel.metadata_hash)
 
 
@@ -367,8 +370,8 @@ def _decode_row(row: object) -> WheelFile | SdistFile:
 def _decode_wheel(row: Sequence[object]) -> WheelFile:
     """Rehydrate a wheel row.
 
-    An integrity cell holding the index's own table passes through unparsed,
-    for the record to parse on first read; any other form is parsed here.
+    An integrity cell the row carries as a table reaches the record unparsed,
+    for its first read to parse; any other form is parsed here.
     """
     (
         _,
@@ -396,6 +399,9 @@ def _decode_wheel(row: Sequence[object]) -> WheelFile:
     ):
         raise _BadRowError
 
+    held_hashes = _held_table(hashes)
+    held_sidecar = _held_table(metadata_hash)
+
     return rehydrated_wheel(
         filename,
         url,
@@ -403,11 +409,11 @@ def _decode_wheel(row: Sequence[object]) -> WheelFile:
         None if requires_python is None else sys.intern(requires_python),
         has_metadata,
         upload_time,
-        hashes if isinstance(hashes, dict) else _hashes(hashes),
+        () if held_hashes is not None else _hashes(hashes),
+        held_hashes,
         size,
-        metadata_hash
-        if isinstance(metadata_hash, dict)
-        else _pair_or_none(metadata_hash),
+        None if held_sidecar is not None else _pair_or_none(metadata_hash),
+        held_sidecar,
     )
 
 
@@ -425,13 +431,16 @@ def _decode_sdist(row: Sequence[object]) -> SdistFile:
     ):
         raise _BadRowError
 
+    held_hashes = _held_table(hashes)
+
     return rehydrated_sdist(
         filename,
         url,
         version,
         None if requires_python is None else sys.intern(requires_python),
         upload_time,
-        hashes if isinstance(hashes, dict) else _hashes(hashes),
+        () if held_hashes is not None else _hashes(hashes),
+        held_hashes,
         size,
     )
 
@@ -452,6 +461,22 @@ def _pair(value: object) -> tuple[str, str]:
 
 def _pair_or_none(value: object) -> tuple[str, str] | None:
     return None if value is None else _pair(value)
+
+
+def _held_table(cell: object) -> HeldTable:
+    """Return the table ``cell`` carries for the record to hold, else ``None``.
+
+    A tuple is the ``(algo, digest)`` pair a one-algorithm table compacts to,
+    and its algorithm is interned here so a rehydrated record dedups names the
+    way a fresh parse does. The digest is left as it stands: a held table is
+    judged when the field is read.
+    """
+    if type(cell) is tuple:
+        algo, digest = cell
+        if type(algo) is not str:
+            raise _BadRowError
+        return (sys.intern(algo), digest)
+    return cell if type(cell) is dict else None
 
 
 def _hashes(value: object) -> tuple[tuple[str, str], ...]:

--- a/nab-index/tests/test_parsed_listing_codec.py
+++ b/nab-index/tests/test_parsed_listing_codec.py
@@ -5,7 +5,7 @@ The exact-equivalence contract is proved by the Hypothesis harness in
 is opt-in (``-m property``) and does not run under the coverage gate, so these
 plain unit tests drive every branch of the codec: the wheel/sdist tag split,
 present and absent ``requires_python``, present and absent ``metadata_hash``,
-the integrity cells in both their raw and their parsed form, the preamble and
+the integrity cells in both their held and their parsed form, the preamble and
 checksum gates, each header / digest gate that turns a stale or foreign blob
 into a decode-to-``None`` miss, and the field checks that keep a hand-written
 row from reaching a record.
@@ -170,6 +170,22 @@ def test_requires_python_and_algo_reinterned_by_identity() -> None:
     assert decoded[2].requires_python is None
 
 
+def test_a_held_pair_interns_an_algorithm_the_blob_did_not() -> None:
+    """A blob need not carry interned names, so the decode interns them itself."""
+    algo = b"sha256".decode()
+    assert algo is not SHA256
+
+    decoded = decode(_wheel_row_with(_W_HASHES, (algo, DIGEST)), _policy())
+
+    assert decoded is not None
+    wheel = decoded.files[0]
+    assert isinstance(wheel, WheelFile)
+
+    held = wheel.held_hashes()
+    assert isinstance(held, tuple)
+    assert held[0] is SHA256
+
+
 def test_empty_listing_roundtrips() -> None:
     assert _roundtrip([]) == []
 
@@ -326,8 +342,12 @@ def test_unknown_tag_on_a_well_formed_row_is_miss(tag: object) -> None:
         (_W_HASHES, [["sha256"]]),
         (_W_HASHES, [["sha256", 5]]),
         (_W_HASHES, ["sha256"]),
+        # A held pair is two cells, the first of them a string.
+        (_W_HASHES, (5, "dead")),
+        (_W_HASHES, ("sha256",)),
         (_W_METADATA_HASH, "sha256"),
         (_W_METADATA_HASH, ["sha256", "dead", "extra"]),
+        (_W_METADATA_HASH, ("sha256", "dead", "extra")),
     ],
 )
 def test_wrong_field_type_is_miss(index: int, value: object) -> None:
@@ -472,13 +492,27 @@ def _deferred_wheel(hashes: object, *, sidecar: object) -> WheelFile:
     return wheel
 
 
-def test_unparsed_tables_ride_the_wire_as_the_index_served_them() -> None:
+def _deferred_sdist(hashes: object) -> SdistFile:
+    """An sdist holding ``hashes`` as the index served them."""
+    sdist = SdistFile(
+        filename="pkg-1.0.tar.gz",
+        url="https://files.example/pkg-1.0.tar.gz",
+        version="1.0",
+        requires_python=None,
+        upload_time=None,
+    )
+    defer_hashes(sdist, hashes)
+    return sdist
+
+
+def test_a_one_algorithm_table_rides_the_wire_as_a_pair() -> None:
+    """The row carries the pair the record holds, not the mapping it came from."""
     wheel = _deferred_wheel({"SHA256": DIGEST.upper()}, sidecar={"sha256": DIGEST})
 
     rows = _document(encode([wheel], DIGEST))[1]
 
-    assert rows[0][_W_HASHES] == {"SHA256": DIGEST.upper()}
-    assert rows[0][_W_METADATA_HASH] == {"sha256": DIGEST}
+    assert rows[0][_W_HASHES] == ("SHA256", DIGEST.upper())
+    assert rows[0][_W_METADATA_HASH] == (SHA256, DIGEST)
 
 
 def test_a_value_that_is_not_an_object_rides_as_its_parse() -> None:
@@ -491,13 +525,34 @@ def test_a_value_that_is_not_an_object_rides_as_its_parse() -> None:
     assert rows[0][_W_METADATA_HASH] is None
 
 
+def test_a_held_pair_carries_a_digest_the_parse_will_drop() -> None:
+    """A held table is judged on read, so a bad digest rides the wire intact."""
+    (wheel,) = _roundtrip([_deferred_wheel({"sha256": 5}, sidecar=True)])
+
+    assert wheel.held_hashes() == (SHA256, 5)
+    assert wheel.hashes == ()
+
+
 def test_a_many_algorithm_table_defers_as_the_index_served_it() -> None:
-    wheel = _deferred_wheel({"sha256": DIGEST, "sha512": "f" * 128}, sidecar=True)
+    table = {"sha256": DIGEST, "sha512": "f" * 128}
+    wheel = _deferred_wheel(table, sidecar=table)
 
     rows = _document(encode([wheel], DIGEST))[1]
 
-    assert rows[0][_W_HASHES] == {"sha256": DIGEST, "sha512": "f" * 128}
+    assert rows[0][_W_HASHES] == table
+    assert rows[0][_W_METADATA_HASH] == table
     assert wheel.hashes == ((SHA256, DIGEST), (SHA512, "f" * 128))
+
+
+def test_a_many_algorithm_table_survives_the_round_trip_deferred() -> None:
+    table = {"sha256": DIGEST, "sha512": "f" * 128}
+
+    (wheel,) = _roundtrip([_deferred_wheel(table, sidecar=table)])
+
+    assert wheel.held_hashes() == table
+    assert wheel.held_sidecar() == table
+    assert wheel.hashes == ((SHA256, DIGEST), (SHA512, "f" * 128))
+    assert wheel.metadata_hash == (SHA256, DIGEST)
 
 
 def test_a_rehydrated_record_defers_the_same_parse() -> None:
@@ -505,26 +560,26 @@ def test_a_rehydrated_record_defers_the_same_parse() -> None:
         [_deferred_wheel({"SHA256": DIGEST.upper()}, sidecar={"sha256": DIGEST})]
     )
 
-    assert wheel.raw_hashes() == {"SHA256": DIGEST.upper()}
-    assert wheel.raw_sidecar() == {"sha256": DIGEST}
+    assert wheel.held_hashes() == ("SHA256", DIGEST.upper())
+    assert wheel.held_sidecar() == (SHA256, DIGEST)
     assert wheel.hashes == ((SHA256, DIGEST),)
     assert wheel.metadata_hash == (SHA256, DIGEST)
 
 
 def test_a_rehydrated_sdist_defers_its_hashes() -> None:
-    sdist = SdistFile(
-        filename="pkg-1.0.tar.gz",
-        url="https://files.example/pkg-1.0.tar.gz",
-        version="1.0",
-        requires_python=None,
-        upload_time=None,
-    )
-    defer_hashes(sdist, {"SHA256": DIGEST.upper()})
+    (decoded,) = _roundtrip([_deferred_sdist({"SHA256": DIGEST.upper()})])
 
-    (decoded,) = _roundtrip([sdist])
-
-    assert decoded.raw_hashes() == {"SHA256": DIGEST.upper()}
+    assert decoded.held_hashes() == ("SHA256", DIGEST.upper())
     assert decoded.hashes == ((SHA256, DIGEST),)
+
+
+def test_a_rehydrated_sdist_defers_a_many_algorithm_table() -> None:
+    table = {"sha256": DIGEST, "sha512": "f" * 128}
+
+    (decoded,) = _roundtrip([_deferred_sdist(table)])
+
+    assert decoded.held_hashes() == table
+    assert decoded.hashes == ((SHA256, DIGEST), (SHA512, "f" * 128))
 
 
 def test_a_row_is_the_same_whether_or_not_the_record_was_read() -> None:

--- a/nab-project/tests/test_cached_client.py
+++ b/nab-project/tests/test_cached_client.py
@@ -356,9 +356,9 @@ class TestMetadataHashParsing:
 
         wheel, sdist = _parse_files(data, "https://example.com/simple/", "foo")
 
-        assert wheel.raw_hashes() == {"SHA256": "A" * 64}
-        assert wheel.raw_sidecar() == {"sha256": "b" * 64}
-        assert sdist.raw_hashes() == {"sha256": "c" * 64}
+        assert wheel.held_hashes() == ("SHA256", "A" * 64)
+        assert wheel.held_sidecar() == ("sha256", "b" * 64)
+        assert sdist.held_hashes() == ("sha256", "c" * 64)
 
         assert wheel.hashes == (("sha256", "a" * 64),)
         assert wheel.metadata_hash == ("sha256", "b" * 64)

--- a/nab-provider/src/nab_provider/records.py
+++ b/nab-provider/src/nab_provider/records.py
@@ -24,6 +24,7 @@ __all__ = [
     "DEFAULT_INDEX_NAME",
     "DEFAULT_INDEX_URL",
     "DistFile",
+    "HeldTable",
     "IndexConfig",
     "RangeMetadataResult",
     "RangeOutcome",
@@ -103,6 +104,12 @@ def sidecar_hash(value: object) -> tuple[str, str] | None:
     return select_artifact_hash(published)
 
 
+# What a record holds for a field it has not parsed yet: the ``(algo, digest)``
+# pair a one-algorithm table compacts to, or the mapping the index served.
+# ``None`` where the caller has a parsed value instead.
+HeldTable = tuple[str, object] | dict[Any, Any] | None
+
+
 def _compact_table(table: dict[object, object]) -> object:
     """Return the form of ``table`` a record holds until something reads it.
 
@@ -154,7 +161,7 @@ class _DeferredIntegrity:
 
     __slots__ = ()
 
-    _raw_hashes: object
+    _raw_hashes: HeldTable
 
     def __getattr__(self, name: str) -> object:
         if name != "hashes":
@@ -164,10 +171,10 @@ class _DeferredIntegrity:
         object.__setattr__(self, "hashes", value)
         return value
 
-    def raw_hashes(self) -> object:
-        """Return the ``hashes`` table this record was built from, else ``None``."""
+    def held_hashes(self) -> HeldTable:
+        """Return the ``hashes`` table this record holds unparsed, else ``None``."""
         try:
-            return _expand_table(self._raw_hashes)
+            return self._raw_hashes
         except AttributeError:
             return None
 
@@ -177,7 +184,7 @@ class _WheelIntegrity(_DeferredIntegrity, _MetadataUrlMemo):
 
     __slots__ = ("_raw_hashes", "_raw_metadata")
 
-    _raw_metadata: object
+    _raw_metadata: HeldTable
 
     def __getattr__(self, name: str) -> object:
         if name != "metadata_hash":
@@ -187,10 +194,10 @@ class _WheelIntegrity(_DeferredIntegrity, _MetadataUrlMemo):
         object.__setattr__(self, "metadata_hash", value)
         return value
 
-    def raw_sidecar(self) -> object:
-        """Return the sidecar value this wheel was built from, else ``None``."""
+    def held_sidecar(self) -> HeldTable:
+        """Return the sidecar table this wheel holds unparsed, else ``None``."""
         try:
-            return _expand_table(self._raw_metadata)
+            return self._raw_metadata
         except AttributeError:
             return None
 
@@ -327,23 +334,26 @@ _set_wheel_raw_hashes = _slot_writer(_WheelIntegrity, "_raw_hashes")
 _set_wheel_raw_metadata = _slot_writer(_WheelIntegrity, "_raw_metadata")
 
 
-def rehydrated_wheel(  # noqa: PLR0913, PLR0917 - the record's fields, in its own order
+def rehydrated_wheel(  # noqa: PLR0913, PLR0917 - the record's fields, plus held tables
     filename: str,
     url: str,
     version: str,
     requires_python: str | None,
     has_metadata: bool,  # noqa: FBT001 - a field, not a flag
     upload_time: str | None,
-    hashes: tuple[tuple[str, str], ...] | dict[Any, Any],
+    hashes: tuple[tuple[str, str], ...],
+    held_hashes: HeldTable,
     size: int | None,
-    metadata_hash: tuple[str, str] | dict[Any, Any] | None,
+    metadata_hash: tuple[str, str] | None,
+    held_sidecar: HeldTable,
 ) -> WheelFile:
     """Return a wheel rebuilt from a cached listing row.
 
-    ``hashes`` and ``metadata_hash`` each take either a parsed value or the
-    index's own table, and a table is held raw for the field's first read to
-    parse.  Deferring a field means leaving its slot unwritten, which
-    ``__init__`` cannot do, so this writes the slots directly.
+    A field arrives either parsed, in ``hashes`` / ``metadata_hash``, or as the
+    table to hold, in ``held_hashes`` / ``held_sidecar``, which the record
+    parses on first read.  A held mapping is compacted on the way in, a held
+    pair stored as it stands.  Deferring a field means leaving its slot
+    unwritten, which ``__init__`` cannot do, so this writes the slots directly.
 
     ``local_path`` is ``None``: a cached listing row carries none.
     """
@@ -357,15 +367,19 @@ def rehydrated_wheel(  # noqa: PLR0913, PLR0917 - the record's fields, in its ow
     _set_wheel_size(wheel, size)
     _set_wheel_local_path(wheel, None)
 
-    if isinstance(hashes, dict):
-        _set_wheel_raw_hashes(wheel, _compact_table(hashes))
-    else:
+    if type(held_hashes) is tuple:
+        _set_wheel_raw_hashes(wheel, held_hashes)
+    elif held_hashes is None:
         _set_wheel_hashes(wheel, hashes)
-
-    if isinstance(metadata_hash, dict):
-        _set_wheel_raw_metadata(wheel, _compact_table(metadata_hash))
     else:
+        _set_wheel_raw_hashes(wheel, _compact_table(held_hashes))
+
+    if type(held_sidecar) is tuple:
+        _set_wheel_raw_metadata(wheel, held_sidecar)
+    elif held_sidecar is None:
         _set_wheel_metadata_hash(wheel, metadata_hash)
+    else:
+        _set_wheel_raw_metadata(wheel, _compact_table(held_sidecar))
 
     return wheel
 
@@ -427,7 +441,8 @@ def rehydrated_sdist(
     version: str,
     requires_python: str | None,
     upload_time: str | None,
-    hashes: tuple[tuple[str, str], ...] | dict[Any, Any],
+    hashes: tuple[tuple[str, str], ...],
+    held_hashes: HeldTable,
     size: int | None,
 ) -> SdistFile:
     """Return a source distribution rebuilt from a cached listing row.
@@ -444,10 +459,12 @@ def rehydrated_sdist(
     _set_sdist_size(sdist, size)
     _set_sdist_local_path(sdist, None)
 
-    if isinstance(hashes, dict):
-        _set_sdist_raw_hashes(sdist, _compact_table(hashes))
-    else:
+    if type(held_hashes) is tuple:
+        _set_sdist_raw_hashes(sdist, held_hashes)
+    elif held_hashes is None:
         _set_sdist_hashes(sdist, hashes)
+    else:
+        _set_sdist_raw_hashes(sdist, _compact_table(held_hashes))
 
     return sdist
 

--- a/nab-provider/tests/test_record_deferral.py
+++ b/nab-provider/tests/test_record_deferral.py
@@ -79,10 +79,10 @@ def test_a_read_keeps_the_table_it_parsed() -> None:
     wheel = _deferred_wheel({"sha256": DIGEST}, sidecar={"sha256": DIGEST})
 
     assert wheel.hashes == ((SHA256, DIGEST),)
-    assert wheel.raw_hashes() == {"sha256": DIGEST}
+    assert wheel.held_hashes() == (SHA256, DIGEST)
 
     assert wheel.metadata_hash == (SHA256, DIGEST)
-    assert wheel.raw_sidecar() == {"sha256": DIGEST}
+    assert wheel.held_sidecar() == (SHA256, DIGEST)
 
 
 @pytest.mark.parametrize(
@@ -131,8 +131,8 @@ def test_two_threads_reading_one_deferred_field_both_get_it(
 def test_a_value_that_is_not_a_table_defers_nothing() -> None:
     wheel = _deferred_wheel(["sha256", DIGEST], sidecar=True)
 
-    assert wheel.raw_hashes() is None
-    assert wheel.raw_sidecar() is None
+    assert wheel.held_hashes() is None
+    assert wheel.held_sidecar() is None
     assert wheel.hashes == ()
     assert wheel.metadata_hash is None
 
@@ -140,7 +140,7 @@ def test_a_value_that_is_not_a_table_defers_nothing() -> None:
 def test_a_table_keyed_by_a_non_string_defers_as_it_stands() -> None:
     wheel = _deferred_wheel({7: DIGEST}, sidecar=True)
 
-    assert wheel.raw_hashes() == {7: DIGEST}
+    assert wheel.held_hashes() == {7: DIGEST}
     assert wheel.hashes == ()
 
 


### PR DESCRIPTION
A warm `pip:langchain-ml-course` resolve retires 2.630% fewer instructions, and a warm `uv:boto3-urllib3-transient` resolve 2.669% fewer. The counts are taken under `PYTHONHASHSEED=0` and reproduce anywhere; the timing bounds at the end are local.

| scenario | base | branch | delta |
| --- | --- | --- | --- |
| warm `pip:langchain-ml-course` | 13,283,598,927 | 12,934,184,454 | -349,414,473 |
| warm `uv:boto3-urllib3-transient` | 5,660,405,543 | 5,509,326,631 | -151,078,912 |

Both counted runs of `pip:langchain-ml-course` made 544 decisions over 167,427 distributions, so the two sides did the same resolve. On `uv:boto3-urllib3-transient` the branch run made one more decision than the base, 401 against 400, and still counted fewer instructions.

Stacked on #969, so the diff and the numbers are against that branch.

The parsed-listing cache stored a one-algorithm integrity table as a one-key mapping, which the decoder turned straight back into the `(algo, digest)` tuple a record already holds. A warm `pip:langchain-ml-course` resolve made that round trip 316,818 times. The cell now rides the row as the tuple.

- `_hashes_cell` and `_sidecar_cell` write what the new `held_hashes()` / `held_sidecar()` return instead of expanding the pair to a mapping first.
- `_decode_wheel` and `_decode_sdist` pass the cell through `_held_table`, which interns the algorithm and rejects a non-string one.
- `rehydrated_wheel` and `rehydrated_sdist` take the held cell in its own parameter, store a pair as it stands, and compact only a mapping.

A table with more than one algorithm still goes out as the mapping, and the raw-parse path keeps deferring the same way. `FORMAT_VERSION` goes from 4 to 5, so a blob the old code wrote is a miss and gets rewritten.

That bump is also why the timing runs say so little: the two sides cannot share a cache entry, so a run that follows a switch re-parses raw listings. They rule out a wall regression above about 40% and a peak-memory regression above about 3.6%, and nothing smaller. No measurement put the branch above the base on wall time, CPU, or memory.

The allocation trace does not settle memory either way: its two runs made 554 and 505 decisions, so they did different work.
