### PR TITLE
Fix an empty local project page reported as an unreadable format

### DIFF
--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -228,8 +228,8 @@ def _scan_pep503_directory(
 
     The second element says the page linked a file in a format nab does
     not read, which tells a page of ``.zip`` sdists from an empty one.  The
-    third says every link on it was yanked, which tells a page of yanked
-    releases from a package this index does not carry.
+    third says every anchor naming a file was yanked, which tells a page of
+    yanked releases from a package this index does not carry.
     """
     index_html = package_dir / "index.html"
     if not _is_file(index_html):
@@ -260,6 +260,7 @@ def _scan_pep503_directory(
     files: list[WheelFile | SdistFile] = []
     unreadable = False
     yanked = 0
+    nameless = 0
 
     for anchor in anchors:
         # PEP 592: a yanked link never reaches the listing.
@@ -271,6 +272,7 @@ def _scan_pep503_directory(
             anchor.href, base_url
         )
         if filename is None:
+            nameless += 1
             continue
         if not is_readable_filename(filename):
             unreadable = True
@@ -287,7 +289,10 @@ def _scan_pep503_directory(
         )
         if record is not None:
             files.append(record)
-    return files, unreadable, bool(anchors) and yanked == len(anchors)
+
+    # A navigation link is not a release, so the all-yanked test counts only
+    # the anchors that name a file.
+    return files, unreadable, yanked > 0 and yanked == len(anchors) - nameless
 
 
 def _resolve_local_link(
@@ -295,6 +300,8 @@ def _resolve_local_link(
     base_url: str,
 ) -> tuple[str | None, str, Path | None, tuple[tuple[str, str], ...]]:
     """Resolve an anchor href to ``(filename, url, local_path, hashes)``.
+
+    ``filename`` is ``None`` when the href names no file.
 
     ``base_url`` is the page's ``<base href>`` when it carries one, else the
     ``index.html`` URL.  An href is a URL reference, so only its path
@@ -319,12 +326,25 @@ def _resolve_local_link(
     try:
         url = _normalized_url(urljoin(base_url, href_no_frag))
         parsed = urlparse(url)
+        page = urlparse(base_url)
     except ValueError:
         return (None, href_no_frag, None, hashes)
 
+    # An autoindex's navigation links name no file: "../" leaves no last
+    # segment, and a sort link is a bare query ("?C=N;O=D") resolving back to
+    # the page.
+    last_segment = parsed.path.rsplit("/", 1)[-1]
+    points_at_page = (parsed.scheme, parsed.netloc, parsed.path) == (
+        page.scheme,
+        page.netloc,
+        page.path,
+    )
+
+    if not last_segment or points_at_page:
+        return (None, url, None, hashes)
+
     if parsed.scheme in {"http", "https"}:
-        filename = unquote(parsed.path.rsplit("/", 1)[-1]) or None
-        return (filename, url, None, hashes)
+        return (unquote(last_segment), url, None, hashes)
 
     # Drop an anchor naming no local file rather than fail the whole listing.
     try:
@@ -630,7 +650,7 @@ class LocalIndexClient:
         return package in self._unreadable_only
 
     def served_all_yanked(self, package: str) -> bool:
-        """Whether a listing for ``package`` held links and yanked every one."""
+        """Whether a listing for ``package`` held file links and yanked every one."""
         return package in self._all_yanked
 
     async def get_metadata_text(

--- a/nab-project/tests/test_local_index.py
+++ b/nab-project/tests/test_local_index.py
@@ -776,6 +776,37 @@ class TestFlatWheelhouse:
         assert _read_sdist_requires_python(tmp_path / "absent.tar.gz") is None
 
 
+_NGINX_EMPTY_AUTOINDEX = (
+    "<html>\n<head><title>Index of /simple/foo/</title></head>\n"
+    "<body>\n<h1>Index of /simple/foo/</h1><hr><pre>"
+    '<a href="../">../</a>\n'
+    "</pre><hr></body>\n</html>\n"
+)
+
+_APACHE_PLAIN_EMPTY_AUTOINDEX = (
+    "<html>\n <head>\n  <title>Index of /simple/foo</title>\n </head>\n"
+    " <body>\n<h1>Index of /simple/foo</h1>\n"
+    '<ul><li><a href="/simple/"> Parent Directory</a></li>\n</ul>\n'
+    "</body></html>\n"
+)
+
+# Apache's FancyIndexing output: its sort links are bare queries, which resolve
+# against index.html to the page itself.
+_APACHE_FANCY_EMPTY_AUTOINDEX = (
+    "<html>\n <head>\n  <title>Index of /simple/foo</title>\n </head>\n"
+    " <body>\n<h1>Index of /simple/foo</h1>\n  <table>\n"
+    '   <tr><th><img src="/icons/blank.gif" alt="[ICO]"></th>'
+    '<th><a href="?C=N;O=D">Name</a></th>'
+    '<th><a href="?C=M;O=A">Last modified</a></th>'
+    '<th><a href="?C=S;O=A">Size</a></th></tr>\n'
+    '   <tr><th colspan="4"><hr></th></tr>\n'
+    '<tr><td><a href="/simple/">Parent Directory</a></td>'
+    '<td>&nbsp;</td><td align="right">  - </td></tr>\n'
+    '   <tr><th colspan="4"><hr></th></tr>\n</table>\n'
+    "</body></html>\n"
+)
+
+
 class TestPep503Directory:
     def _make_index(self, tmp_path: Path, body: str) -> Path:
         package_dir = tmp_path / "foo"
@@ -818,6 +849,53 @@ class TestPep503Directory:
         (package_dir / "bar-1.0-py3-none-any.whl").write_bytes(b"")
         client = LocalIndexClient(tmp_path.as_uri())
         assert run(client.get_files("foo")) == []
+        assert not client.served_unreadable_only("foo")
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            _NGINX_EMPTY_AUTOINDEX,
+            _APACHE_PLAIN_EMPTY_AUTOINDEX,
+            _APACHE_FANCY_EMPTY_AUTOINDEX,
+        ],
+        ids=["nginx", "apache-plain", "apache-fancy"],
+    )
+    def test_autoindex_of_empty_package_dir_lists_nothing(
+        self, tmp_path: Path, body: str
+    ) -> None:
+        """Navigation links name no file, so nothing on the page is a release."""
+        self._make_index(tmp_path, body)
+        client = LocalIndexClient(tmp_path.as_uri())
+        assert run(client.get_files("foo")) == []
+        assert not client.served_unreadable_only("foo")
+        assert not client.served_all_yanked("foo")
+
+    def test_navigation_link_beside_yanked_files_reports_all_yanked(
+        self, tmp_path: Path
+    ) -> None:
+        """A link naming no file stays out of the every-file-yanked count."""
+        body = (
+            '<a href="../">../</a>'
+            '<a href="foo-1.0-py3-none-any.whl" data-yanked="broken build">foo</a>'
+        )
+        package_dir = self._make_index(tmp_path, body)
+        (package_dir / "foo-1.0-py3-none-any.whl").write_bytes(b"")
+        client = LocalIndexClient(tmp_path.as_uri())
+        assert run(client.get_files("foo")) == []
+        assert client.served_all_yanked("foo")
+        assert not client.served_unreadable_only("foo")
+
+    def test_directory_href_named_like_a_wheel_is_dropped(self, tmp_path: Path) -> None:
+        """A trailing slash names a directory, whatever the segment before it says."""
+        body = (
+            '<a href="foo-1.0-py3-none-any.whl/">foo-1.0</a>'
+            '<a href="foo-2.0-py3-none-any.whl">foo-2.0</a>'
+        )
+        package_dir = self._make_index(tmp_path, body)
+        (package_dir / "foo-2.0-py3-none-any.whl").write_bytes(b"")
+        client = LocalIndexClient(tmp_path.as_uri())
+        result = run(client.get_files("foo"))
+        assert [r.version for r in result] == ["2.0"]
         assert not client.served_unreadable_only("foo")
 
     def test_relative_href_resolves_against_dir(self, tmp_path: Path) -> None:


### PR DESCRIPTION
An empty PEP 503 project page served from a `file://` index reports the wrong reason:

```
Diagnostics: (-v for detail)
  - foo: no file the index served is one nab can read
```

The page lists no files at all, and the same bytes over HTTPS report `package not found on any configured index`.

`_resolve_local_link` read the filename off the resolved path with `Path.name`, so an href naming no file still came back with one:

| href | filename read |
| --- | --- |
| `../` | the index directory's name |
| `/simple/` | `simple` |
| `?C=N;O=D` (Apache FancyIndexing's sort links) | `index.html` |
| `foo-1.0-py3-none-any.whl/` | `foo-1.0-py3-none-any.whl` |

The first three are not readable filenames, so an empty listing came back flagged as holding nothing readable. The last one is, so a directory was listed as a wheel.

An href now names no file when its resolved path has no last segment, or when it points back at the page itself. The remote reader already drops both: it resolves against the directory URL, where `../` and a bare query each leave an empty last segment. The local reader resolves against `index.html`, so the query case needs the second check.

The all-yanked check counted every anchor, so a `../` beside nothing but yanked files then read as absent. It now counts only the anchors naming a file.
