### PR TITLE
Import the CLI with the cyclic collector off, 2.3% off a nab lock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ Source = "https://github.com/notatallshaw/nab"
 Changelog = "https://github.com/notatallshaw/nab/releases"
 
 [project.scripts]
-nab = "nab.cli:console_entry"
+nab = "nab._entry:console_entry"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/nab/_entry.py
+++ b/src/nab/_entry.py
@@ -1,0 +1,32 @@
+"""Process entry for the installed ``nab`` command."""
+
+from __future__ import annotations
+
+import gc
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import NoReturn
+
+
+def console_entry() -> NoReturn:
+    """Import the CLI with the cyclic collector off, then hand the process to it.
+
+    The console script names this module rather than :mod:`nab.cli` so that no
+    part of the CLI's import graph is built while the collector is on: the
+    import allocates a graph the process keeps, and every pass over it frees
+    almost none of it. Freezing empties the generations the import filled, so
+    re-enabling does not trigger a pass over the whole graph.
+
+    Only the installed command takes this path, so importing :mod:`nab.cli`
+    leaves the collector as it found it.
+    """
+    gc.disable()
+    try:
+        from nab.cli import console_entry as run_cli  # noqa: PLC0415
+    finally:
+        if hasattr(gc, "freeze"):  # PyPy has no gc.freeze
+            gc.freeze()
+        gc.enable()
+
+    run_cli()

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -1,0 +1,89 @@
+"""Tests for the installed ``nab`` command's process entry."""
+
+from __future__ import annotations
+
+import builtins
+import gc
+import importlib
+from pathlib import Path
+from typing import Any
+
+import pytest
+import tomli
+
+from nab._entry import console_entry
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.usefixtures("restored_gc_state")
+def test_imports_the_cli_while_the_collector_is_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The collector is off at the moment the ``nab.cli`` import runs.
+
+    The saving is the import running with the collector off, so the state is
+    read from inside the import: an import hoisted out of the disabled window
+    has to turn this test red.
+    """
+    enabled_at_import: list[bool] = []
+    real_import = builtins.__import__
+
+    def record_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "nab.cli":
+            enabled_at_import.append(gc.isenabled())
+        return real_import(name, *args, **kwargs)
+
+    # A real freeze would make every object the test session holds permanent.
+    monkeypatch.setattr(gc, "freeze", lambda: None)
+
+    monkeypatch.setattr("nab.cli.console_entry", lambda: None)
+    monkeypatch.setattr(builtins, "__import__", record_import)
+
+    console_entry()
+
+    assert enabled_at_import == [False]
+
+
+@pytest.mark.usefixtures("restored_gc_state")
+def test_freezes_the_import_graph_before_enabling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The freeze runs while the collector is still off, the CLI once it is on."""
+    events: list[tuple[str, bool]] = []
+    monkeypatch.setattr(gc, "freeze", lambda: events.append(("freeze", gc.isenabled())))
+    monkeypatch.setattr(
+        "nab.cli.console_entry", lambda: events.append(("cli", gc.isenabled()))
+    )
+
+    console_entry()
+
+    assert events == [("freeze", False), ("cli", True)]
+
+
+@pytest.mark.usefixtures("restored_gc_state")
+def test_without_gc_freeze_still_reenables_the_collector(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The collector comes back on an interpreter without ``gc.freeze``."""
+    enabled_during: list[bool] = []
+    monkeypatch.delattr(gc, "freeze")
+    monkeypatch.setattr(
+        "nab.cli.console_entry", lambda: enabled_during.append(gc.isenabled())
+    )
+
+    console_entry()
+
+    assert enabled_during == [True]
+
+
+def test_console_script_runs_the_collector_off_entry() -> None:
+    """``[project.scripts]`` points the ``nab`` command at this module.
+
+    The console script is the only thing that reaches it, so a target left on
+    ``nab.cli`` would pass every other test.
+    """
+    pyproject = tomli.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    module_name, _, attribute = pyproject["project"]["scripts"]["nab"].partition(":")
+
+    assert getattr(importlib.import_module(module_name), attribute) is console_entry


### PR DESCRIPTION
About 34.3M instructions off `nab --version` and 34.8M off a 6-package `nab lock`, counted with callgrind under `PYTHONHASHSEED=0`:

| workload | base | branch | saving |
| --- | --- | --- | --- |
| `nab --version` | 950,583,668 | 916,292,307 | 34.27M to 34.29M (3.6%) |
| `nab lock`, 6 packages, warm cache, `--offline` | 1,480,988,854 | 1,446,184,371 | 34.75M to 34.80M (2.3%) |

The CLI's import builds a graph the process keeps until it exits, so a collector pass over it frees almost nothing. `[project.scripts]` now names a 32-line module that disables the collector, imports `nab.cli`, freezes, re-enables and hands over; the lock then runs 19 generation-0 collections instead of 80, and 1 generation-1 instead of 7. `nab.cli` is unchanged, so importing it as a library leaves the collector on.

The same lock is about 3.7% faster on the clock and 3.6% cheaper on CPU, a command that takes about 0.26 s.

The cost is memory: 72,805 more bytes of peak traced allocation on the lock (26,281,971 against 26,209,166) and about 160 to 190 KB more peak RSS, the import-time cyclic garbage the disabled collector never reclaims.

Not measured: on CPython 3.14.0 through 3.14.4 `gc.freeze()` scales with live objects, and this call freezes 64,463 of them.