### PR TITLE
Fix universal-mode hint pointing nab.toml at [tool.nab.matrix]

### DIFF
--- a/nab-project/src/nab_project/config.py
+++ b/nab-project/src/nab_project/config.py
@@ -726,22 +726,32 @@ def _config_from_effective(
     if mode is ResolveMode.UNIVERSAL and matrix is None:
         if mode_value.origin.kind is SourceKind.CLI:
             msg = (
-                "--project-mode universal needs a [tool.nab.matrix] table, but"
-                " a matrix can only be declared in the project file (there is"
-                " no --project-matrix flag). Add [tool.nab.matrix] to the"
-                " project's pyproject.toml or nab.toml, or drop --project-mode"
-                " universal."
+                "--project-mode universal needs a matrix table, but a matrix"
+                " can only be declared in a project file (there is no"
+                " --project-matrix flag). Add [tool.nab.matrix] to the"
+                " project's pyproject.toml, or a top-level [matrix] table to"
+                " the project's nab.toml, or drop --project-mode universal."
             )
         else:
+            # PROJECT_TOML is the project-dir nab.toml, whose keys are top-level.
+            table = (
+                "top-level [matrix] table in nab.toml"
+                if mode_value.origin.kind is SourceKind.PROJECT_TOML
+                else "[tool.nab.matrix] table in pyproject.toml"
+            )
             msg = (
-                "mode = 'universal' requires a [tool.nab.matrix] table"
-                " declaring python and platforms"
+                f"mode = 'universal' requires a {table} declaring python and platforms"
             )
         raise ConfigError(msg)
     if mode is ResolveMode.SPECIFIC and matrix is not None:
         if not mode_value.origin.outranks(matrix_value.origin):
+            declared_table = (
+                "[matrix] in nab.toml"
+                if matrix_value.origin.kind is SourceKind.PROJECT_TOML
+                else "[tool.nab.matrix] in pyproject.toml"
+            )
             msg = (
-                "[tool.nab.matrix] is set but mode is 'specific'; set"
+                f"{declared_table} is set but mode is 'specific'; set"
                 " mode = 'universal' to resolve for every target the matrix"
                 " declares, or remove the table. The multi-target lockfile"
                 " format universal mode produces is experimental."

--- a/nab-project/tests/test_config.py
+++ b/nab-project/tests/test_config.py
@@ -202,8 +202,25 @@ class TestCliOverridesFold:
                 path, discover_workspace=False, cli_overrides={"mode": "universal"}
             )
         message = str(excinfo.value)
-        assert "[tool.nab.matrix]" in message
         assert "there is no --project-matrix" in message
+        assert "[tool.nab.matrix] to the project's pyproject.toml" in message
+        assert "top-level [matrix] table to the project's nab.toml" in message
+
+    def test_cli_mode_universal_satisfied_by_nab_toml_matrix(
+        self, tmp_path: Path
+    ) -> None:
+        """A top-level [matrix] in nab.toml satisfies --project-mode universal."""
+        path = write(tmp_path, '[project]\nname = "x"\nversion = "0"\n')
+        (tmp_path / "nab.toml").write_text(
+            '[matrix]\npython = ">=3.11,<3.13"\nplatforms = ["linux_x86_64"]\n',
+            encoding="utf-8",
+        )
+        config = read_pyproject_config(
+            path, discover_workspace=False, cli_overrides={"mode": "universal"}
+        )
+        assert config.mode is ResolveMode.UNIVERSAL
+        assert config.matrix is not None
+        assert config.matrix.platforms == (PlatformSpec("linux_x86_64"),)
 
     def test_cli_mode_specific_shadows_declared_matrix(self, tmp_path: Path) -> None:
         path = write(
@@ -254,8 +271,21 @@ class TestMode:
         with pytest.raises(ConfigError) as excinfo:
             read_pyproject_config(path)
         message = str(excinfo.value)
-        assert "requires a [tool.nab.matrix]" in message
+        assert "requires a [tool.nab.matrix] table in pyproject.toml" in message
         assert "--project-matrix" not in message
+
+    def test_universal_from_nab_toml_requires_top_level_matrix(
+        self, tmp_path: Path
+    ) -> None:
+        """A mode set in nab.toml is told to add [matrix] there, not to pyproject."""
+        path = write(tmp_path, '[project]\nname = "x"\nversion = "0"\n')
+        (tmp_path / "nab.toml").write_text('mode = "universal"\n', encoding="utf-8")
+        with pytest.raises(ConfigError) as excinfo:
+            read_pyproject_config(path, discover_workspace=False)
+        message = str(excinfo.value)
+        assert "requires a top-level [matrix] table in nab.toml" in message
+        assert "[tool.nab.matrix]" not in message
+        assert "pyproject.toml" not in message
 
     def test_matrix_without_universal_mode_rejected(self, tmp_path: Path) -> None:
         path = write(
@@ -265,9 +295,25 @@ class TestMode:
         with pytest.raises(ConfigError) as excinfo:
             read_pyproject_config(path)
         message = str(excinfo.value)
+        assert "[tool.nab.matrix] in pyproject.toml is set" in message
         assert "set mode = 'universal'" in message
         assert "resolve for every target the matrix declares" in message
         assert "matrix-based resolver" not in message
+
+    def test_nab_toml_matrix_without_universal_mode_names_its_own_table(
+        self, tmp_path: Path
+    ) -> None:
+        """A matrix declared in nab.toml is named as the [matrix] table there."""
+        path = write(tmp_path, '[project]\nname = "x"\nversion = "0"\n')
+        (tmp_path / "nab.toml").write_text(
+            '[matrix]\npython = ">=3.11"\nplatforms = ["linux_x86_64"]\n',
+            encoding="utf-8",
+        )
+        with pytest.raises(ConfigError) as excinfo:
+            read_pyproject_config(path, discover_workspace=False)
+        message = str(excinfo.value)
+        assert "[matrix] in nab.toml is set" in message
+        assert "[tool.nab.matrix]" not in message
 
     def test_matrix_with_specific_mode_in_same_file_rejected(
         self, tmp_path: Path

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -1147,9 +1147,9 @@ class TestProjectCliOverrides:
             self._lock_config(
                 proj, hermetic_roots / "pylock.toml", ["--project-mode", "universal"]
             )
-        assert "--project-mode universal needs a [tool.nab.matrix] table" in (
-            capsys.readouterr().err
-        )
+        err = capsys.readouterr().err
+        assert "--project-mode universal needs a matrix table" in err
+        assert "a top-level [matrix] table to the project's nab.toml" in err
 
     def test_project_decision_order_reaches_resolve(self, hermetic_roots: Path) -> None:
         # The file declares stable, so a resolve seeing arrival read the flag.


### PR DESCRIPTION
`mode = "universal"` in a project `nab.toml` with no matrix declared named a table that file rejects, and named no file at all:

    mode = 'universal' requires a [tool.nab.matrix] table declaring python and platforms

`[tool.nab.matrix]` is the `pyproject.toml` spelling; a `nab.toml` takes the same keys at the top level. Add `[tool.nab.matrix]` to `nab.toml` and the next run is `'tool' is not a valid nab setting`. Add a top-level `[matrix]` to `pyproject.toml`, where nothing reads it, and the same error comes back.

The mode/matrix errors now name the spelling and the file together, following the file the key came from:

- `mode = "universal"` with no matrix: `a [tool.nab.matrix] table in pyproject.toml`, or `a top-level [matrix] table in nab.toml`
- a matrix under `mode = "specific"`: `[tool.nab.matrix] in pyproject.toml`, or `[matrix] in nab.toml`
- `--project-mode universal`, which either file can satisfy: both spellings, each with its file

The config reference's own `nab.toml` example sets `mode = "universal"`, so this is easy to hit.
