### PR TITLE
Fix AttributeError on a cached sdist record with a non-text field

### DIFF
--- a/nab-index/src/nab_index/cache.py
+++ b/nab-index/src/nab_index/cache.py
@@ -415,15 +415,13 @@ class OnDiskCache:
             raw = path.read_bytes()
         except OSError:
             return None
-        try:
-            doc = json.loads(raw)
-            return (doc["pkg_info"], doc["pyproject"])
-        except (ValueError, KeyError, TypeError):
+        record = _decode_sdist_record(raw)
+        if record is None:
             logger.warning(
-                "Corrupt sdist cache record %s: not parseable; treating as a miss",
+                "Corrupt sdist cache record %s: not decodable; treating as a miss",
                 path,
             )
-            return None
+        return record
 
     def put_sdist_files(
         self,
@@ -516,8 +514,8 @@ class OnDiskCache:
 
         Parses by suffix, matching each kind's read path: ``.policy`` and
         ``.neg`` decode as a policy, ``.metadata`` as UTF-8, ``.json`` as
-        JSON (an sdist record also carries its two fields), ``.parsed`` as a
-        parsed-listing blob. Any other suffix is not a nab entry and is
+        JSON (an sdist record also carries its two text fields), ``.parsed``
+        as a parsed-listing blob. Any other suffix is not a nab entry and is
         reported clean.
         """
         try:
@@ -541,10 +539,8 @@ class OnDiskCache:
         except ValueError:
             return "not valid JSON"
         bucket = self._bucket_of(path)
-        if bucket.startswith("sdist-") and not (
-            isinstance(doc, dict) and "pkg_info" in doc and "pyproject" in doc
-        ):
-            return "sdist record missing fields"
+        if bucket.startswith("sdist-") and _sdist_record_pair(doc) is None:
+            return "sdist record fields missing or not text"
         return None
 
     def _bucket_of(self, path: Path) -> str:
@@ -575,6 +571,29 @@ class OnDiskCache:
                 continue
             removed.append(bucket.name)
         return removed
+
+
+def _sdist_record_pair(doc: object) -> tuple[str | None, str | None] | None:
+    """Return a decoded sdist record's ``(pkg_info, pyproject)`` pair, or ``None``.
+
+    Each field holds a file's text, or ``null`` for a file the sdist does not
+    ship; any other JSON type is corruption.
+    """
+    if not isinstance(doc, dict) or "pkg_info" not in doc or "pyproject" not in doc:
+        return None
+    pkg_info, pyproject = doc["pkg_info"], doc["pyproject"]
+    if not isinstance(pkg_info, str | None) or not isinstance(pyproject, str | None):
+        return None
+    return (pkg_info, pyproject)
+
+
+def _decode_sdist_record(raw: bytes) -> tuple[str | None, str | None] | None:
+    """Decode stored sdist-record bytes, or ``None`` when they are not a record."""
+    try:
+        doc = json.loads(raw)
+    except ValueError:
+        return None
+    return _sdist_record_pair(doc)
 
 
 def _read_metadata_reason(raw: bytes) -> str | None:

--- a/nab-index/src/nab_index/cache.py
+++ b/nab-index/src/nab_index/cache.py
@@ -46,7 +46,7 @@ import time
 from contextlib import suppress
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Protocol, cast
 
 from nab_provider.serialization import SimpleSerialization
 
@@ -581,7 +581,8 @@ def _sdist_record_pair(doc: object) -> tuple[str | None, str | None] | None:
     """
     if not isinstance(doc, dict) or "pkg_info" not in doc or "pyproject" not in doc:
         return None
-    pkg_info, pyproject = doc["pkg_info"], doc["pyproject"]
+    fields = cast("dict[str, object]", doc)
+    pkg_info, pyproject = fields["pkg_info"], fields["pyproject"]
     if not isinstance(pkg_info, str | None) or not isinstance(pyproject, str | None):
         return None
     return (pkg_info, pyproject)

--- a/nab-project/tests/test_cache.py
+++ b/nab-project/tests/test_cache.py
@@ -368,6 +368,30 @@ class TestOnDiskCache:
         path.write_text("not-json", encoding="utf-8")
         assert cache.get_sdist_files("foo", "1.0") is None
 
+    @pytest.mark.parametrize(
+        "record",
+        [
+            {"pkg_info": 5, "pyproject": None},
+            {"pkg_info": [], "pyproject": None},
+            {"pkg_info": "Name: foo\n", "pyproject": 5},
+        ],
+    )
+    def test_sdist_record_non_text_field_is_a_miss(
+        self, tmp_path: Path, record: dict[str, object]
+    ) -> None:
+        cache = self._make(tmp_path)
+        path = cache._sdist_path("foo", "1.0")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(record), encoding="utf-8")
+        assert cache.get_sdist_files("foo", "1.0") is None
+
+    def test_sdist_record_not_an_object_is_a_miss(self, tmp_path: Path) -> None:
+        cache = self._make(tmp_path)
+        path = cache._sdist_path("foo", "1.0")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('["Name: foo\\n", null]', encoding="utf-8")
+        assert cache.get_sdist_files("foo", "1.0") is None
+
     def test_put_metadata_rejects_multi_segment_package(self, tmp_path: Path) -> None:
         cache = self._make(tmp_path)
         with pytest.raises(ValueError, match="not a single path segment"):
@@ -633,6 +657,19 @@ class TestCorruptEntryLogging:
         assert len(warnings) == 1
         assert str(path) in warnings[0].getMessage()
 
+    def test_non_text_sdist_field_logs_one_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        cache = self._make(tmp_path)
+        path = cache._sdist_path("foo", "1.0")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('{"pkg_info": 5, "pyproject": null}', encoding="utf-8")
+        with caplog.at_level(logging.WARNING, logger="nab_index.cache"):
+            assert cache.get_sdist_files("foo", "1.0") is None
+        warnings = _warnings(caplog)
+        assert len(warnings) == 1
+        assert str(path) in warnings[0].getMessage()
+
     def test_non_utf8_sdist_record_is_logged_miss(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
@@ -833,7 +870,23 @@ class TestReadCacheEntry:
         path = tmp_path / "sdist-v1" / "pypi" / "foo" / "1.0.json"
         path.parent.mkdir(parents=True)
         path.write_bytes(b'{"pkg_info": "x"}')
-        assert cache.read_cache_entry(path) is not None
+        assert cache.read_cache_entry(path) == "sdist record fields missing or not text"
+
+    @pytest.mark.parametrize(
+        "record",
+        [
+            {"pkg_info": 5, "pyproject": None},
+            {"pkg_info": "Name: foo\n", "pyproject": []},
+        ],
+    )
+    def test_sdist_record_non_text_field(
+        self, tmp_path: Path, record: dict[str, object]
+    ) -> None:
+        cache = self._cache(tmp_path)
+        path = tmp_path / "sdist-v1" / "pypi" / "foo" / "1.0.json"
+        path.parent.mkdir(parents=True)
+        path.write_text(json.dumps(record), encoding="utf-8")
+        assert cache.read_cache_entry(path) == "sdist record fields missing or not text"
 
     def test_valid_sdist_record(self, tmp_path: Path) -> None:
         cache = self._cache(tmp_path)


### PR DESCRIPTION
A cached sdist record whose `pkg_info` or `pyproject` field holds a JSON number, list or object is handed back as-is, and the resolve dies on it:

    File "nab_provider/store.py", line 255, in _write_metadata_slot
        text = None if data is None else metadata_header_block(data)
    File "nab_provider/metadata.py", line 191, in metadata_header_block
        lf = text.find("\n\n")
    AttributeError: 'int' object has no attribute 'find'

Two checks should have caught it, and both only looked for the keys:

- `OnDiskCache.get_sdist_files` hands back `(5, None)` for `{"pkg_info": 5, "pyproject": null}`, against a `tuple[str | None, str | None] | None` signature.
- `nab cache verify` calls the same entry clean, so the one command for finding a bad entry reports nothing.

Both now share a check that each field is a string or `null`. A record that fails it reads as a miss and is refetched, and `nab cache verify` reports `sdist record fields missing or not text`.
