### PR TITLE
Name WheelHashMismatchError in lazy_wheel's module docstring

### DIFF
--- a/nab-index/src/nab_index/lazy_wheel.py
+++ b/nab-index/src/nab_index/lazy_wheel.py
@@ -7,7 +7,9 @@ capability once per run through a shared :class:`RangeCapabilityMemo`, and
 navigates the ZIP with the standard library's :class:`zipfile.ZipFile` over a
 sparse buffer so no EOCD scan, deflate, or CRC logic is hand-rolled.
 
-Two kinds of exception travel outward: a
+Three kinds of exception travel outward: a
+:class:`~nab_index.client.WheelHashMismatchError` when a full-body wheel
+disagrees with the digest its listing published, a
 :class:`~nab_index.client.MalformedSimpleResponseError` for METADATA bytes
 that are not valid UTF-8, and the transport's error when the wheel URL itself
 cannot be served (a 404 on the file, a failing plain GET).  A server that


### PR DESCRIPTION
`nab_index.lazy_wheel`'s module docstring is missing an exception. It names two that travel outward and says every other failure returns a result whose `text` is `None`. The third is `WheelHashMismatchError`, which `read_wheel_metadata_over_range`, the module's only public function, raises when a wheel that arrives as one full body disagrees with the digest its listing published.

The provider and the CLI both catch it by name, so the miss was in the summary alone. The function's own docstring already lists all three.
