### PR TITLE
Test build-config forwarding through resolve_for_targets

### DIFF
--- a/nab-project/tests/test_resolve.py
+++ b/nab-project/tests/test_resolve.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import sys
 from pathlib import Path
-from typing import ClassVar
+from typing import ClassVar, NoReturn
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -60,6 +60,7 @@ from nab_provider._vendor.packaging.ranges import VersionRange
 from nab_provider._vendor.packaging.requirements import Requirement
 from nab_provider._vendor.packaging.version import Version
 from nab_provider.marker_holds import dependency_marker_holds
+from nab_provider.metadata import WheelMetadata
 from nab_provider.provider import (
     BuildPolicy,
     LocalSource,
@@ -5947,3 +5948,67 @@ class TestConfiguredGroupConflictDivergentPins:
         assert versions() == {"23.2"}
         assert versions(dependency_groups=["main"]) == {"23.2"}
         assert versions(dependency_groups=["build"]) == {"24.2"}
+
+
+class _NoIndexTransport:
+    """Transport that fails the test on any request: this resolve needs no index."""
+
+    async def get(self, url: str, *, headers: dict[str, str] | None = None) -> NoReturn:
+        msg = f"unexpected index request to {url}"
+        raise AssertionError(msg)
+
+    async def aclose(self) -> None:
+        return None
+
+
+class TestBuildConfigPlumbing:
+    """A resolve's own config is the one its PEP 517 builds run under.
+
+    Only a dynamic-metadata source reaches a build: the static reader
+    returns ``None`` for it, so materialising the source falls through to
+    ``build_backend.extract_metadata``, which refuses without a config.
+    The backend run itself is stubbed, so no build venv is created.
+    """
+
+    def _project(self, tmp_path: Path) -> Path:
+        """Write a project whose only dependency is a dynamic local source."""
+        source = tmp_path / "dyn"
+        source.mkdir()
+        (source / "pyproject.toml").write_text(
+            '[project]\nname = "dyn"\ndynamic = ["version"]\n', encoding="utf-8"
+        )
+
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "proj"\nversion = "0"\ndependencies = ["dyn"]\n'
+            "[tool.nab]\n"
+            'build-policy = "build-local"\n'
+            "[[tool.nab.local-sources]]\n"
+            'name = "dyn"\n'
+            'path = "dyn"\n',
+            encoding="utf-8",
+        )
+        return pyproject
+
+    def test_dynamic_local_source_builds_under_the_project_config(
+        self, tmp_path: Path
+    ) -> None:
+        """``resolve_for_targets`` hands its config to the coordinator it opens."""
+        pyproject = self._project(tmp_path)
+        config = read_pyproject_config(pyproject)
+        built = WheelMetadata(name="dyn", version=Version("7.0"))
+
+        with patch(
+            "nab_project._build.runner.run_build_backend", return_value=built
+        ) as runner:
+            result = resolve_for_targets(
+                pyproject,
+                _NoIndexTransport(),
+                config=config,
+                cache_dir=tmp_path / "cache",
+            )
+
+        assert result.success
+        assert _pins(result) == {"dyn": Version("7.0")}
+
+        assert runner.call_args.kwargs["config"] is config

--- a/nab-project/tests/test_resolve_targets.py
+++ b/nab-project/tests/test_resolve_targets.py
@@ -65,7 +65,6 @@ from nab_provider._vendor.packaging.ranges import VersionRange
 from nab_provider._vendor.packaging.requirements import Requirement
 from nab_provider._vendor.packaging.version import Version
 from nab_provider.marker_holds import dependency_marker_holds
-from nab_provider.metadata import WheelMetadata
 from nab_provider.provider import (
     ArchiveSource,
     BuildPolicy,
@@ -1771,58 +1770,6 @@ class TestCutoffAndOverridePlumbing:
 
         override = '[tool.nab.index.pypi]\nuploaded-prior-to = "2024-03-01T00:00:00Z"\n'
         assert self._pins(tmp_path, override) == {"foo": Version("1.0")}
-
-
-class TestBuildConfigPlumbing:
-    """The project's config reaches the PEP 517 build a resolve triggers.
-
-    Only a source with dynamic metadata gets that far: the static reader
-    returns ``None`` for it, so the provider falls through to
-    ``build_backend.extract_metadata``, which refuses without a config.
-    The backend run itself is stubbed, so no build venv is created.
-    """
-
-    def _project(self, tmp_path: Path) -> Path:
-        """Write a project whose only dependency is a dynamic local source."""
-        source = tmp_path / "dyn"
-        source.mkdir()
-        (source / "pyproject.toml").write_text(
-            '[project]\nname = "dyn"\ndynamic = ["version"]\n', encoding="utf-8"
-        )
-
-        pyproject = tmp_path / "pyproject.toml"
-        pyproject.write_text(
-            '[project]\nname = "proj"\nversion = "0"\ndependencies = ["dyn"]\n'
-            "[tool.nab]\n"
-            'build-policy = "build-local"\n'
-            "[[tool.nab.local-sources]]\n"
-            'name = "dyn"\n'
-            'path = "dyn"\n',
-            encoding="utf-8",
-        )
-        return pyproject
-
-    def test_dynamic_local_source_builds_under_the_project_config(
-        self, tmp_path: Path
-    ) -> None:
-        """The config the resolve runs under is the one the build receives."""
-        config = read_pyproject_config(self._project(tmp_path))
-        built = WheelMetadata(name="dyn", version=Version("7.0"))
-
-        coordinator = make_coordinator(
-            listings={}, auto_metadata=True, build_config=config
-        )
-        with patch(
-            "nab_project._build.runner.run_build_backend", return_value=built
-        ) as runner:
-            result = resolve_with_coordinator(
-                coordinator, _one_target(), _reqs("dyn"), config=config
-            )
-
-        assert result.success
-        assert result.target_results[0].pins == {"dyn": Version("7.0")}
-
-        assert runner.call_args.kwargs["config"] is config
 
 
 class TestRunPassSerial:


### PR DESCRIPTION
`TestBuildConfigPlumbing` builds the fake port with the config it then asserts on, and never calls `resolve_for_targets`, so it passes whether or not the forward exists:

    coordinator = make_coordinator(
        listings={}, auto_metadata=True, build_config=config
    )
    ...
    assert runner.call_args.kwargs["config"] is config

The forward it was meant to pin is `build_config=config` on the `FetchCoordinator` that `resolve_for_targets` opens (`nab-project/src/nab_project/resolve.py:221`). Nothing else covers it: every other test naming the argument hands it to the coordinator or the fake directly.

That keyword is the only route a project's config takes into a PEP 517 build. Without it `extract_metadata` refuses the dynamic path, and dynamic-metadata local sources, VCS clones, extracted archives and remote sdists all stop resolving.

The test pinned a real forward when #860 added it, back when the argument sat on the per-target `Provider(...)`. "Put source and build I/O behind the port" moved it to the coordinator the same day and kept the assertion green by handing the fake the config.

The rewritten test starts at `resolve_for_targets` with a real `pyproject.toml`, so the config it checks is the one the resolve read for itself. It moves to `test_resolve.py` with the other entry-point tests. Only `run_build_backend` is stubbed, so `extract_metadata`'s refusal still decides the outcome, and the transport raises on any request, since resolving one local source needs no index.
