### PR TITLE
Stop a working-directory sysconfig.py from redirecting build installs

### DIFF
--- a/nab-project/src/nab_project/_build/env.py
+++ b/nab-project/src/nab_project/_build/env.py
@@ -738,10 +738,13 @@ def _venv_scheme_paths(python_executable: Path) -> dict[str, str]:
     ``sysconfig`` has no ``headers`` scheme, and its ``include`` names
     the base interpreter rather than the venv, so the header root comes
     from the venv's own prefix instead.
+
+    ``-I`` keeps the current directory off the probe's ``sys.path``, so a
+    ``json.py`` or ``sysconfig.py`` sitting there cannot answer it.
     """
     try:
         result = subprocess.run(  # noqa: S603 - controlled command, no shell
-            [str(python_executable), "-c", _SCHEME_PROBE],
+            [str(python_executable), "-I", "-c", _SCHEME_PROBE],
             capture_output=True,
             text=True,
             check=True,

--- a/nab-project/tests/test_build_runner.py
+++ b/nab-project/tests/test_build_runner.py
@@ -20,6 +20,7 @@ import json
 import struct
 import subprocess
 import sys
+import sysconfig
 import tarfile
 import tempfile
 import zipfile
@@ -3782,6 +3783,24 @@ class TestVenvSchemeProbeErrors:
         monkeypatch.setattr(subprocess, "run", _run)
         with pytest.raises(BuildEnvError, match="interpreter probe"):
             _venv_scheme_paths(Path("/nonexistent/venv/bin/python"))
+
+
+class TestVenvSchemeProbeIsolation:
+    """A module in the working directory must not answer the scheme probe."""
+
+    def test_sysconfig_module_in_the_working_directory_is_ignored(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Runs a real interpreter, so ``-I`` is what the assertion pins."""
+        (tmp_path / "sysconfig.py").write_text(
+            "def get_paths():\n    return {'purelib': '/elsewhere/site-packages'}\n",
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(tmp_path)
+
+        paths = _venv_scheme_paths(Path(sys.executable))
+
+        assert paths["purelib"] == sysconfig.get_paths()["purelib"]
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
A `sysconfig.py` sitting in the directory nab was invoked from redirects where `[build-system].requires` gets installed.

The build env asks its venv interpreter where wheels go by running a scheme probe as `python -c`, and that subprocess inherits nab's working directory. `-c` puts the current directory first on `sys.path`, so a `sysconfig.py` or `json.py` sitting there answers the probe instead of the stdlib:

    # from a directory holding a sysconfig.py that defines get_paths()
    $ python3 -c "$_SCHEME_PROBE"
    {"paths": {"purelib": "/elsewhere/site-packages"}, "prefix": "/usr", "py_version": "3.12"}

`installer` unpacks the build requirements into those paths, so they land wherever the shadowing module points: outside the venv the backend then runs in, and outside the temp tree nab cleans up.

The probe now runs with `-I`, which keeps the current directory off its `sys.path` and stops `PYTHONPATH` and `PYTHONHOME` reaching it as well. The backend subprocess already runs with `PYTHONPATH` cleared; the probe had no equivalent.
