### PR TITLE
Stop scanning whole listings to prefetch metadata, ~1% off an airflow lock

### DIFF
--- a/nab-project/src/nab_project/fetch.py
+++ b/nab-project/src/nab_project/fetch.py
@@ -1042,16 +1042,24 @@ class FetchCoordinator:
     ) -> None:
         """Enqueue metadata for the newest candidates of a stored listing.
 
-        Files are oldest-first. One wheel per version: the first with a sidecar
-        is the one the provider picks for that version's metadata.
-        """
-        first_wheel: dict[str, WheelFile] = {}
-        for f in files:
-            if isinstance(f, WheelFile) and f.has_metadata:
-                first_wheel.setdefault(f.version, f)
+        Assumes a listing is oldest-first and keeps a version's files together,
+        which nab does not enforce. An index that interleaves versions warms an
+        older release, costing a request rather than a wrong resolve.
 
-        newest = list(first_wheel.values())[-self.PREFETCH_METADATA_COUNT :]
-        for w in newest:
+        One wheel per version: the first with a sidecar is the one the provider
+        picks for that version's metadata. The backwards walk assigns
+        unconditionally, so that first wheel is the one left in place.
+        """
+        wanted = self.PREFETCH_METADATA_COUNT
+        newest: dict[str, WheelFile] = {}
+        for f in reversed(files):
+            if not (isinstance(f, WheelFile) and f.has_metadata):
+                continue
+            if f.version not in newest and len(newest) == wanted:
+                break
+            newest[f.version] = f
+
+        for w in reversed(newest.values()):
             url = w.metadata_url
             assert url is not None
             self.request_metadata(package, w.version, url, w.metadata_hash)


### PR DESCRIPTION
A warm `nab lock` of `apache-airflow==3.0.3`, `pandas==2.2.3` and `SQLAlchemy==1.4.54` (129 packages) hands its metadata prefetch 87,926 listing entries across 129 calls, and the scan now walks 2,478 of them. Under callgrind that is 66 to 70 million of the lock's 6.7 billion instructions. Both walks enqueue the same 129 metadata URLs, so only the scan's cost changes.

`FetchCoordinator._prefetch_metadata_after_listing` built a dict of the first sidecar-bearing wheel of every version, then sliced the last `PREFETCH_METADATA_COUNT` entries off it. That constant is 1, so all but one were built and dropped. The walk now runs from the end and stops once it holds that many, still taking the first wheel within a version.

Over the nine listings a README quick-start lock hands it, a call costs about 1.8 microseconds instead of about 88, 0.8 ms of that lock. Forty interleaved pairs of the airflow lock rule out only a wall regression above about 2%.

The two walks agree only while a listing keeps a version's files together, which none of the 138 listings measured here breaks. One that did would warm an older release: a wasted request, not a different resolve.