### PR TITLE
Read max-age from a repeated Cache-Control line on the urllib3 backend

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -258,8 +258,17 @@ DEFAULT_INDEX = "https://pypi.org/simple/"
 _OBS_FOLD = re.compile(r"[\r\n]+[ \t]+")
 
 
+# RFC 9110 5.3: repeated field lines combine into one comma-separated value only
+# where the field is defined as a list. Cache-Control is the only such field read
+# here.
+_LIST_VALUED_FIELDS = frozenset({"cache-control"})
+
+
 def _header(response: HttpResponse, key: str) -> str | None:
     """Case-insensitive header lookup, returning an unfolded field value.
+
+    Repeated lines of a list-valued field are joined in order; for any other
+    field the first line is the value.
 
     The :class:`HttpResponse` Protocol only promises a plain
     :class:`Mapping`. Both real transports (httpx, urllib3) return
@@ -268,10 +277,12 @@ def _header(response: HttpResponse, key: str) -> str | None:
     """
     headers = response.headers
     target = key.lower()
-    for name, value in headers.items():
-        if name.lower() == target:
-            return _OBS_FOLD.sub(" ", value)
-    return None
+    lines = [value for name, value in headers.items() if name.lower() == target]
+    if not lines:
+        return None
+
+    value = ", ".join(lines) if target in _LIST_VALUED_FIELDS else lines[0]
+    return _OBS_FOLD.sub(" ", value)
 
 
 def _is_html_listing(content_type: str | None) -> bool:

--- a/nab-project/tests/test_cached_client.py
+++ b/nab-project/tests/test_cached_client.py
@@ -22,6 +22,7 @@ from urllib.parse import urljoin, urlsplit, urlunsplit
 
 import pytest
 from packaging.utils import canonicalize_name
+from urllib3 import HTTPHeaderDict
 
 import nab_index.cache as cache_mod
 import nab_index.cached_client as cached_client_mod
@@ -167,6 +168,14 @@ class _PathRoutingTransport:
 
     async def aclose(self) -> None:
         return None
+
+
+def _field_lines(*lines: tuple[str, str]) -> HTTPHeaderDict:
+    """Headers holding one entry per field line, the shape urllib3 returns."""
+    headers = HTTPHeaderDict()
+    for name, value in lines:
+        headers.add(name, value)
+    return headers
 
 
 def _make_cache(tmp_path: Path) -> OnDiskCache:
@@ -909,7 +918,7 @@ class TestFreshnessLifetime:
     def _frozen_clock(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(time, "time", lambda: self._NOW)
 
-    def _lifetime(self, headers: dict[str, str]) -> int:
+    def _lifetime(self, headers: Mapping[str, str]) -> int:
         return _freshness_lifetime(_FakeResponse(b"", headers=headers))
 
     def _http_date(self, offset: float) -> str:
@@ -920,6 +929,12 @@ class TestFreshnessLifetime:
 
     def test_heuristic_when_cache_control_carries_no_max_age(self) -> None:
         assert self._lifetime({"cache-control": "public"}) == 600
+
+    def test_max_age_read_from_a_second_cache_control_line(self) -> None:
+        lines = _field_lines(
+            ("Cache-Control", "public"), ("Cache-Control", "max-age=60")
+        )
+        assert self._lifetime(lines) == 60
 
     def test_max_age_outranks_expires(self) -> None:
         headers = {
@@ -1029,6 +1044,38 @@ class TestHeader:
         """RFC 9112 5.2: a receiver replaces a line fold with a space."""
         resp = _FakeResponse(b"", headers={"etag": '"abc\r\n def"'})
         assert _header(resp, "etag") == '"abc def"'
+
+    def test_repeated_field_lines_are_combined(self) -> None:
+        """RFC 9110 5.3: repeated lines are one value, joined in order."""
+        resp = _FakeResponse(
+            b"",
+            headers=_field_lines(
+                ("Cache-Control", "public"),
+                ("Cache-Control", "max-age=60"),
+            ),
+        )
+        assert _header(resp, "cache-control") == "public, max-age=60"
+
+    def test_combined_lines_are_unfolded(self) -> None:
+        resp = _FakeResponse(
+            b"",
+            headers=_field_lines(
+                ("Cache-Control", "public,\r\n max-age=60"),
+                ("Cache-Control", "no-transform"),
+            ),
+        )
+        assert _header(resp, "cache-control") == "public, max-age=60, no-transform"
+
+    def test_repeated_singleton_field_keeps_the_first_line(self) -> None:
+        """A field that is not defined as a list is not combined."""
+        resp = _FakeResponse(
+            b"",
+            headers=_field_lines(
+                ("Content-Type", "text/html"),
+                ("Content-Type", "text/html"),
+            ),
+        )
+        assert _header(resp, "content-type") == "text/html"
 
 
 class TestGetFiles:
@@ -4785,3 +4832,54 @@ class TestAssumeFreshFloor:
         assert pkg_info == "Name: cached\n"
         assert pyproject is None
         assert transport.calls == []
+
+
+class TestRepeatedCacheControlLines:
+    """An index that sends Cache-Control on two field lines."""
+
+    _LINES = (("Cache-Control", "public"), ("Cache-Control", "max-age=60"))
+
+    def _stored_policy(
+        self, tmp_path: Path, response: _FakeResponse, seed: CachePolicy | None = None
+    ) -> CachePolicy:
+        """Serve ``response`` to one get_files and return the policy it stored.
+
+        ``seed`` pre-fills the cache, so the request goes out as a
+        revalidation rather than a cold fetch.
+        """
+        cache = _make_cache(tmp_path)
+        if seed is not None:
+            cache.put_simple("pkg", LISTING_BYTES, seed)
+
+        transport = _FakeTransport([response])
+
+        async def go() -> list:
+            client = CachedAsyncSimpleClient(transport, cache)
+            try:
+                return await client.get_files("pkg")
+            finally:
+                await client.aclose()
+
+        assert len(asyncio.run(go())) == 1
+
+        cached = cache.get_simple("pkg")
+        assert cached is not None
+        return cached[1]
+
+    def test_cold_fetch_stores_max_age_from_the_second_line(
+        self, tmp_path: Path
+    ) -> None:
+        response = _FakeResponse(LISTING_BYTES, headers=_field_lines(*self._LINES))
+
+        policy = self._stored_policy(tmp_path, response)
+
+        assert policy.max_age == 60
+        assert not policy.is_fresh(policy.fetched_at + 120)
+
+    def test_304_reads_max_age_instead_of_the_heuristic(self, tmp_path: Path) -> None:
+        response = _FakeResponse(b"", status=304, headers=_field_lines(*self._LINES))
+        seed = CachePolicy(fetched_at=0, max_age=1, etag="v1")
+
+        policy = self._stored_policy(tmp_path, response, seed)
+
+        assert policy.max_age == 60


### PR DESCRIPTION
On the default urllib3 backend, a listing whose Cache-Control arrives split over two field lines is cached for the 600s heuristic default instead of the max-age it was sent:

    Cache-Control: public
    Cache-Control: max-age=60

`_header` walked `headers.items()` and returned the first match. urllib3's `HTTPHeaderDict.items()` yields one entry per field line, so nothing after the first line was ever read. httpx combines repeated lines inside `items()`, so the httpx backend never saw this.

Every place freshness is decided takes that value: a listing fetch, a 304 that restates Cache-Control, and the negative policy for a name-level 404.

RFC 9110 5.3 combines repeated lines only for a field defined as a list, so the join covers Cache-Control alone, the one list-valued field read here. Content-Type, ETag, Date, Expires and Age still take the first line.
