### PR TITLE
Drop a wheel with a corrupt bz2 METADATA instead of failing the resolve

### DIFF
--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -21,13 +21,11 @@ multi-index router can treat local and remote indexes uniformly.
 from __future__ import annotations
 
 import errno
-import lzma
 import os
 import re
 import stat
 import sys
 import zipfile
-import zlib
 from email.parser import BytesParser, Parser
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -414,21 +412,21 @@ def _read_sdist_requires_python(sdist_path: Path) -> str | None:
 
 
 def _read_wheel_requires_python(wheel_path: Path, expected: str) -> str | None:
-    """Return ``Requires-Python`` from a wheel's METADATA, or ``None``."""
+    """Return ``Requires-Python`` from a wheel's METADATA, or ``None``.
+
+    A wheel that cannot be opened, read or decompressed answers ``None``, so
+    one bad file does not fail the listing that carries the package's other
+    versions.
+    """
     try:
         with zipfile.ZipFile(wheel_path) as archive:
             member = wheel_metadata_member(archive.namelist(), expected)
             if member is None:
                 return None
             raw = archive.read(member)
-    except (
-        zipfile.BadZipFile,
-        OSError,
-        UnsupportedWheelError,
-        zlib.error,
-        lzma.LZMAError,
-        RuntimeError,
-    ):
+    except Exception:  # noqa: BLE001 - untrusted archive bytes
+        # Corrupt content raises a different type per compression method, and
+        # zstd's does not exist before 3.14, so an explicit list leaves holes.
         return None
 
     value = BytesParser().parsebytes(raw, headersonly=True).get("Requires-Python")
@@ -491,9 +489,10 @@ def read_wheel_metadata(wheel_path: Path) -> str | None:
     directories, or one naming a different distribution, raises
     :class:`UnsupportedWheelError` rather than reading another package's
     metadata.  Returns ``None`` when the archive cannot be parsed, its name is
-    not a wheel filename, or it carries no METADATA member.  A wheel that
-    cannot be opened raises :class:`UnreadableLocalIndexError` instead, so a
-    permission or mount fault is not read as a wheel that declares nothing.
+    not a wheel filename, it carries no METADATA member, or that member does
+    not decompress and decode.  A filesystem fault raises
+    :class:`UnreadableLocalIndexError` instead, so a permission or mount fault
+    is not read as a wheel that declares nothing.
     """
     parsed = _parse_wheel_filename(wheel_path.name)
     if parsed is None:
@@ -504,16 +503,20 @@ def read_wheel_metadata(wheel_path: Path) -> str | None:
             if member is None:
                 return None
             return zf.read(member).decode("utf-8")
+    except UnsupportedWheelError:
+        # Not corrupt content: the catch-all below would otherwise swallow it.
+        raise
     except OSError as exc:
+        # bz2 reports a corrupt member as a plain OSError; only a filesystem
+        # fault carries an errno.
+        if exc.errno is None:
+            return None
+
         msg = f"cannot read local wheel {wheel_path}: {exc}"
         raise UnreadableLocalIndexError(msg) from exc
-    except (
-        zipfile.BadZipFile,
-        UnicodeDecodeError,
-        zlib.error,
-        lzma.LZMAError,
-        RuntimeError,
-    ):
+    except Exception:  # noqa: BLE001 - untrusted archive bytes
+        # Corrupt content raises a different type per compression method, and
+        # zstd's does not exist before 3.14, so an explicit list leaves holes.
         return None
 
 

--- a/nab-project/tests/test_local_index.py
+++ b/nab-project/tests/test_local_index.py
@@ -206,6 +206,23 @@ def _write_corrupt_lzma_wheel(path: Path, name: str, version: str) -> None:
     path.write_bytes(bytes(raw))
 
 
+def _write_corrupt_bz2_wheel(path: Path, name: str, version: str) -> None:
+    """Write a wheel whose bz2-compressed METADATA holds a corrupt stream.
+
+    The central directory stays intact, so the archive opens and lists its
+    members; only the member's bz2 magic is broken, which bz2 reports as a
+    plain OSError rather than an error type of its own.
+    """
+    member = f"{name}-{version}.dist-info/METADATA"
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_BZIP2) as zf:
+        zf.writestr(
+            member,
+            f"Metadata-Version: 2.1\nName: {name}\nVersion: {version}\n"
+            "Requires-Python: >=3.12\n",
+        )
+    path.write_bytes(path.read_bytes().replace(b"BZh", b"BZx", 1))
+
+
 def _write_corrupt_sdist(path: Path, name: str, version: str) -> None:
     """Write an sdist whose PKG-INFO body is behind a corrupt deflate block.
 
@@ -287,6 +304,20 @@ def _write_unsupported_compression_wheel(
             "Requires-Python: >=3.12\n",
         )
     _patch_wheel_member(path, member, method=method)
+
+
+_ZIP_ZSTANDARD = 93
+
+
+def _write_corrupt_zstd_wheel(path: Path, name: str, version: str) -> None:
+    """Write a wheel whose METADATA member claims zstd over bytes that are not.
+
+    The method is spelled as its number because ``zipfile.ZIP_ZSTANDARD`` only
+    exists from 3.14, where reading the member raises ``ZstdError``: an
+    ``Exception`` subclass that is not an ``OSError``.  Before 3.14 the method
+    is merely unsupported.
+    """
+    _write_unsupported_compression_wheel(path, name, version, method=_ZIP_ZSTANDARD)
 
 
 def _write_encrypted_metadata_wheel(path: Path, name: str, version: str) -> None:
@@ -684,6 +715,22 @@ class TestFlatWheelhouse:
 
     def test_requires_python_none_for_corrupt_lzma(self, tmp_path: Path) -> None:
         _write_corrupt_lzma_wheel(tmp_path / "foo-1.0-py3-none-any.whl", "foo", "1.0")
+        client = LocalIndexClient(tmp_path.as_uri())
+        files = run(client.get_files("foo"))
+        assert len(files) == 1
+        assert files[0].requires_python is None
+
+    def test_requires_python_none_for_corrupt_bz2(self, tmp_path: Path) -> None:
+        _write_corrupt_bz2_wheel(tmp_path / "foo-1.0-py3-none-any.whl", "foo", "1.0")
+        client = LocalIndexClient(tmp_path.as_uri())
+        files = run(client.get_files("foo"))
+        assert len(files) == 1
+        assert files[0].requires_python is None
+
+    def test_requires_python_none_for_corrupt_zstd(self, tmp_path: Path) -> None:
+        # The listing runs before any version is chosen, so an error here loses
+        # the package's other versions too, not just this wheel.
+        _write_corrupt_zstd_wheel(tmp_path / "foo-1.0-py3-none-any.whl", "foo", "1.0")
         client = LocalIndexClient(tmp_path.as_uri())
         files = run(client.get_files("foo"))
         assert len(files) == 1
@@ -1614,6 +1661,16 @@ class TestReadWheelMetadata:
         _write_corrupt_lzma_wheel(wheel, "foo", "1.0")
         assert read_wheel_metadata(wheel) is None
 
+    def test_returns_none_for_corrupt_bz2(self, tmp_path: Path) -> None:
+        wheel = tmp_path / "foo-1.0-py3-none-any.whl"
+        _write_corrupt_bz2_wheel(wheel, "foo", "1.0")
+        assert read_wheel_metadata(wheel) is None
+
+    def test_returns_none_for_corrupt_zstd(self, tmp_path: Path) -> None:
+        wheel = tmp_path / "foo-1.0-py3-none-any.whl"
+        _write_corrupt_zstd_wheel(wheel, "foo", "1.0")
+        assert read_wheel_metadata(wheel) is None
+
     def test_returns_none_for_non_wheel_filename(self, tmp_path: Path) -> None:
         assert read_wheel_metadata(tmp_path / "notes.txt") is None
 
@@ -1633,6 +1690,22 @@ class TestReadWheelMetadata:
             read_wheel_metadata(wheel)
         assert str(wheel) in str(caught.value)
         assert "Permission denied" in str(caught.value)
+
+    def test_read_fault_raises_index_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A read fault carries an errno, so it must raise, not read back as None.
+        wheel = tmp_path / "foo-1.0-py3-none-any.whl"
+        _write_wheel(wheel, "foo", "1.0")
+
+        def failing_read(self: zipfile.ZipFile, name: str) -> bytes:
+            raise OSError(errno.EIO, "Input/output error", str(wheel))
+
+        monkeypatch.setattr(zipfile.ZipFile, "read", failing_read)
+
+        with pytest.raises(UnreadableLocalIndexError) as caught:
+            read_wheel_metadata(wheel)
+        assert "Input/output error" in str(caught.value)
 
     def test_rejects_multiple_dist_info_dirs(self, tmp_path: Path) -> None:
         wheel = tmp_path / "foo-1.0-py3-none-any.whl"

--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -255,6 +255,19 @@ def _write_local_wheel(path: Path, name: str, version: str) -> None:
         zf.writestr(member, make_metadata(name, version))
 
 
+def _write_corrupt_bz2_wheel(path: Path, name: str, version: str) -> None:
+    """Write a wheel whose bz2-compressed METADATA holds a corrupt stream.
+
+    The central directory stays intact, so the archive opens and lists its
+    members; only the member's bz2 magic is broken, which bz2 reports as a
+    plain OSError rather than an error type of its own.
+    """
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_BZIP2) as zf:
+        member = f"{name}-{version}.dist-info/METADATA"
+        zf.writestr(member, make_metadata(name, version))
+    path.write_bytes(path.read_bytes().replace(b"BZh", b"BZx", 1))
+
+
 def _deny_zip_open(monkeypatch: pytest.MonkeyPatch, target: Path) -> None:
     """Make opening ``target`` as a zip fail with EACCES.
 
@@ -3069,6 +3082,29 @@ class TestGetDependencies:
 
         with pytest.raises(UnreadableLocalIndexError, match="Permission denied"):
             provider.choose_version("foo", root_reqs["foo"])
+
+    def test_corrupt_local_wheel_pins_the_older_version(self, tmp_path: Path) -> None:
+        """A wheel whose METADATA will not decompress rejects only that version.
+
+        The archive opens and lists its members, so the failure is the wheel's
+        own content rather than a filesystem fault: 1.0 drops and 0.9 answers.
+        """
+        readable = tmp_path / "foo-0.9-py3-none-any.whl"
+        _write_local_wheel(readable, "foo", "0.9")
+        corrupt = tmp_path / "foo-1.0-py3-none-any.whl"
+        _write_corrupt_bz2_wheel(corrupt, "foo", "1.0")
+
+        coordinator = make_coordinator(
+            [
+                make_wheel("0.9", has_metadata=False, local_path=readable),
+                make_wheel("1.0", has_metadata=False, local_path=corrupt),
+            ],
+            package="foo",
+        )
+        root_reqs = {"foo": SpecifierSet(">=0").to_range()}
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
+
+        assert provider.choose_version("foo", root_reqs["foo"]) == V("0.9")
 
     def test_unreadable_local_wheel_falls_back_to_sdist(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
A local wheel whose METADATA member is bz2-compressed and corrupt fails the whole resolve:

    error: cannot lock: cannot read local wheel /wheels/foo-1.0-py3-none-any.whl: Invalid data stream

The same corruption under deflate or LZMA drops only that version, and the resolve carries on with the next one.

bz2 is the one zip decompressor that reports a bad stream as a plain `OSError`, and the handler added in #764 covers the member read as well as the open. An `OSError` is now a filesystem fault only when it carries an errno; bz2's does not, so a corrupt member reads back as `None` like every other method.

The explicit lists of decompression error types come out too. Each method raises its own type, and zstd's `compression.zstd.ZstdError` subclasses `Exception` directly and only exists from 3.14, so on 3.14 a corrupt zstd member escaped both lists:

- `read_wheel_metadata`, reached once a version is chosen, failed the resolve.
- `_read_wheel_requires_python`, reached while listing a flat wheelhouse, escaped `get_files` as a raw `ZstdError` and took every version of that package with it.

Both readers catch broadly instead, as `lazy_wheel`'s range reader already does; `read_wheel_metadata` re-raises `UnsupportedWheelError` first, so a wheel whose `.dist-info` names another distribution still fails.
