### PR TITLE
Exit 1 when a lock's text is not valid UTF-8

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -276,6 +276,6 @@ It shows only at normal verbosity on an stderr terminal; `--no-progress`
 | Code | Meaning |
 | ---- | ------- |
 | `0`  | Success. |
-| `1`  | Resolution failed, lockfile cannot be written (missing hash), download failed, missing `[project].dependencies`, a `--build-requirements` run whose project declares no `[build-system]`, invalid `[tool.nab]` configuration, or `--locked` found the lockfile out of date or missing. |
+| `1`  | Resolution failed, lockfile cannot be written (a missing hash, or text that is not valid UTF-8), download failed, missing `[project].dependencies`, a `--build-requirements` run whose project declares no `[build-system]`, invalid `[tool.nab]` configuration, or `--locked` found the lockfile out of date or missing. |
 | `2`  | Bad usage: an unrecognised flag or subcommand, or a malformed `--color` value or `NAB_VERBOSITY`. |
 | `130` | Interrupted with Ctrl-C. `nab` prints `error: interrupted` and exits. |

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -104,12 +104,27 @@ _DEFAULT_PROJECT_PATH = Path("pyproject.toml")
 
 
 def _emit_or_exit(emit: Callable[[], None]) -> None:
-    """Run an emit step, mapping an unwritable ``--output`` to a clean exit."""
+    """Run an emit step, mapping a write nab cannot complete to a clean exit.
+
+    A lock is written as strict UTF-8, so text carrying a surrogate from an
+    undecodable path or argument fails at the encode, not at the filesystem.
+    """
     try:
         emit()
-    except OSError as e:
+    except (OSError, UnicodeEncodeError) as e:
         _cli.printer().error(f"cannot write output: {e}")
         sys.exit(1)
+
+
+def _print_lock(text: str) -> None:
+    """Write rendered lock text to stdout, refusing text that is not valid UTF-8.
+
+    ``sys.stdout`` uses ``errors="surrogateescape"`` under the C and C.UTF-8
+    locales, where a lone surrogate would go out as a raw byte instead of
+    failing.
+    """
+    text.encode("utf-8")
+    sys.stdout.write(text)
 
 
 @app.command
@@ -714,7 +729,7 @@ def _emit_pylock(
 ) -> None:
     """Write the PEP 751 lock to a file, or print it."""
     if _cli.is_stdout(output):
-        sys.stdout.write(_write_lock_or_exit(lock_input, target=None))
+        _print_lock(_write_lock_or_exit(lock_input, target=None))
         return
 
     target = output if output is not None else default_output
@@ -861,7 +876,7 @@ def _emit_requirements(
     multi_target = len(lock_input.targets) > 1
     if _cli.is_stdout(output) or (output is None and multi_target):
         text, _ = _render_requirements_or_exit(lock_input, with_hashes)
-        sys.stdout.write(text)
+        _print_lock(text)
         return
 
     target = output if output is not None else default_output
@@ -1005,7 +1020,7 @@ def _write_requirements_files(rendered: list[_RenderedFile]) -> None:
             staged.append((tmp, item))
             tmp.write_text(item.text, encoding="utf-8")
             tmp.chmod(_destination_mode(item.path))
-    except OSError:
+    except (OSError, UnicodeEncodeError):
         for tmp, _ in staged:
             _discard(tmp)
         raise

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,6 +38,7 @@ from nab._lock import (
     _BUILD_DEFAULT_OUTPUT,
     _determine_lock_anchor,
     _emit,
+    _emit_or_exit,
     _emit_pylock,
     lock,
     resolve_extra_selection,
@@ -56,6 +57,7 @@ from nab.cli import (
     main,
 )
 from nab.output import Printer, ProgressReporter, Verbosity
+from nab_index.atomic import atomic_write_text
 from nab_index.httpx_async_transport import HttpxAsyncTransport
 from nab_index.local_index import LocalIndexClient, UnreadableLocalIndexError
 from nab_index.transport import HttpError
@@ -4724,6 +4726,119 @@ class TestLockProvenanceCliOverrides:
             app.cli(args=["lock", str(pyproject), "--output", str(out)], prog="nab")
         recorded = tomli.loads(out.read_text())["tool"]["nab"]["command-line"]
         assert recorded == ["nab", "lock", "--offline"]
+
+
+class TestLockNonUtf8Text:
+    """Text that will not encode as UTF-8 exits 1 with a message, not a traceback.
+
+    Python decodes ``sys.argv`` and path arguments with ``surrogateescape`` on
+    POSIX, so a byte that is not valid UTF-8 reaches the lock as a lone surrogate.
+    """
+
+    def _bad_argv(self) -> list[str]:
+        """An invocation whose ``--cache-dir`` carries a byte that is not UTF-8."""
+        return ["nab", "lock", "--cache-dir", "/tmp/cache-\udce9"]
+
+    def test_argv_byte_exits_when_writing_the_file(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The recorded command line lands in ``[tool.nab]``, so the write fails."""
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        with (
+            patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()),
+            patch.object(sys, "argv", self._bad_argv()),
+            pytest.raises(SystemExit) as exc,
+        ):
+            lock(pyproject, output=out, offline=True, cache=False)
+
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "cannot write output" in err
+        assert "\\udce9" in err
+
+        assert not out.exists()
+
+    def test_argv_byte_exits_when_printing(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Printing refuses the byte even where stdout would escape it.
+
+        ``sys.stdout`` carries ``errors="surrogateescape"`` under the C and
+        C.UTF-8 locales, where the write emits the raw byte rather than failing.
+        """
+        pyproject = _make_pyproject(tmp_path)
+        raw = io.BytesIO()
+        stream = io.TextIOWrapper(raw, encoding="utf-8", errors="surrogateescape")
+        with (
+            patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()),
+            patch.object(sys, "argv", self._bad_argv()),
+            patch.object(sys, "stdout", stream),
+            pytest.raises(SystemExit) as exc,
+        ):
+            lock(pyproject, output=Path("-"), offline=True, cache=False)
+
+        assert exc.value.code == 1
+        assert "cannot write output" in capsys.readouterr().err
+
+        stream.flush()
+        assert raw.getvalue() == b""
+
+    def test_any_unencodable_lock_text_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The guard is on the write, so any unencodable field exits the same way.
+
+        A directory name that is not valid UTF-8 reaches the packages table just
+        as the command line reaches ``[tool.nab]``.
+        """
+        out = tmp_path / "pylock.toml"
+        with pytest.raises(SystemExit) as exc:
+            _emit_or_exit(lambda: atomic_write_text(out, 'directory = "src-\udce9"\n'))
+
+        assert exc.value.code == 1
+        assert "cannot write output" in capsys.readouterr().err
+
+        assert not out.exists()
+
+    def test_template_stages_are_discarded_on_unencodable_text(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A tuple whose text will not encode leaves no staged file behind."""
+        pyproject = _universal_pyproject(tmp_path)
+        out = tmp_path / "req-{python_version}.txt"
+        with (
+            patch(
+                "nab.cli.resolve_for_targets",
+                return_value=_multi_tuple_universal_result(),
+            ),
+            patch(
+                "nab._lock.write_requirements_without_hashes",
+                return_value="pkg @ file:///src-\udce9\n",
+            ),
+            pytest.raises(SystemExit) as exc,
+        ):
+            lock(pyproject, format="requirements-without-hashes", output=out)
+
+        assert exc.value.code == 1
+        assert "cannot write output" in capsys.readouterr().err
+
+        assert not list(tmp_path.glob("*.tmp"))
+        assert not list(tmp_path.glob("req-*.txt"))
+
+    def test_requirements_format_still_locks(self, tmp_path: Path) -> None:
+        """The requirements formats record no ``[tool.nab]``, so they still lock."""
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "requirements.txt"
+        with (
+            patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()),
+            patch.object(sys, "argv", self._bad_argv()),
+        ):
+            lock(
+                pyproject, output=out, format="requirements", offline=True, cache=False
+            )
+
+        assert "foo==1.0" in out.read_text()
 
 
 class TestGroupAndExtraSelection:


### PR DESCRIPTION
`nab lock` ends in a traceback when the lock's text is not valid UTF-8, and printing that same lock to stdout instead writes the raw byte and exits 0. A `--cache-dir` carrying one byte that is not UTF-8 is enough: Python decodes `sys.argv` and filesystem paths with `surrogateescape`, so the byte reaches the lock text as a lone surrogate, and the command line is recorded in `[tool.nab]`.

To a file, the write fails at the encode and nothing catches it:

      File ".../nab_index/atomic.py", line 86, in atomic_write_text
        f.write(text)
    UnicodeEncodeError: 'utf-8' codec can't encode character '\udce9' in position 434: surrogates not allowed

To stdout it is quieter and worse. `sys.stdout` carries `errors="surrogateescape"` under the C and C.UTF-8 locales, so the byte passes through and the run reports success on a lock that is not the UTF-8 a TOML document has to be.

The fix:

- `_emit_or_exit` treats `UnicodeEncodeError` like `OSError`, so the write reports `error: cannot write output: ...` and exits 1
- printing encodes the text first, so a stream with `surrogateescape` never gets the chance to pass the byte through
- the templated requirements path staged its files under `except OSError` alone, so an encode failure left every `.tmp` behind; it now discards them

Both paths now exit 1 and leave nothing written.
