### PR TITLE
Defer html.parser and urllib.request, 36M instructions off CLI startup

### DIFF
--- a/nab-index/src/nab_index/_html_page.py
+++ b/nab-index/src/nab_index/_html_page.py
@@ -1,0 +1,116 @@
+"""HTML tokenizing for :pep:`503` project pages.
+
+Imported only when an HTML project page is parsed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from html.parser import HTMLParser
+
+from typing_extensions import override
+
+__all__ = [
+    "Anchor",
+    "ProjectPageParser",
+]
+
+_REQUIRES_PYTHON_ATTR = "data-requires-python"
+_YANKED_ATTR = "data-yanked"
+_CORE_METADATA_ATTR = "data-core-metadata"
+_LEGACY_METADATA_ATTR = "data-dist-info-metadata"
+_UPLOAD_TIME_ATTR = "data-upload-time"
+_REPOSITORY_VERSION_META = "pypi:repository-version"
+
+# HTML's ASCII whitespace set: a URL attribute's value may be surrounded by it.
+_HTML_WHITESPACE = "\t\n\f\r "
+
+
+@dataclass(frozen=True, slots=True)
+class Anchor:
+    """One ``<a>`` link on a project page.
+
+    ``metadata`` is the :pep:`714` ``data-core-metadata`` value, falling back
+    to the legacy ``data-dist-info-metadata`` when only that is set, and
+    ``None`` when the anchor declares neither.
+
+    ``upload_time`` is the ``data-upload-time`` value. No specification
+    covers it (:pep:`700` defines ``upload-time`` for the JSON serialization
+    only), so an index is free to omit it, and PyPI and download.pytorch.org
+    both do. It is read because it is the only upload time an HTML page can
+    carry.
+    """
+
+    href: str
+    requires_python: str | None
+    metadata: str | None
+    yanked: bool
+    upload_time: str | None
+
+
+def _anchor(attrs: list[tuple[str, str | None]]) -> Anchor | None:
+    """Build an :class:`Anchor` from a tag's attributes, or ``None`` if hrefless."""
+    href: str | None = None
+    requires_python: str | None = None
+    yanked = False
+    core_metadata: str | None = None
+    legacy_metadata: str | None = None
+    upload_time: str | None = None
+
+    for name, value in attrs:
+        if name == "href":
+            href = value
+        elif name == _REQUIRES_PYTHON_ATTR:
+            requires_python = value
+        elif name == _YANKED_ATTR:
+            yanked = True
+        elif name == _CORE_METADATA_ATTR:
+            core_metadata = value
+        elif name == _LEGACY_METADATA_ATTR:
+            legacy_metadata = value
+        elif name == _UPLOAD_TIME_ATTR:
+            upload_time = value
+
+    if href is None:
+        return None
+
+    metadata = core_metadata if core_metadata is not None else legacy_metadata
+    return Anchor(
+        href.strip(_HTML_WHITESPACE), requires_python, metadata, yanked, upload_time
+    )
+
+
+class ProjectPageParser(HTMLParser):
+    """Collect a project page's anchors and its first ``<base href>``.
+
+    Also records whether the page declares the :pep:`629` repository version.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.anchors: list[Anchor] = []
+        self.base_href: str | None = None
+        self.declares_repository_version = False
+
+    @override
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag == "meta":
+            for name, value in attrs:
+                if name == "name" and value == _REPOSITORY_VERSION_META:
+                    self.declares_repository_version = True
+                    break
+            return
+
+        if tag == "base":
+            if self.base_href is None:
+                for name, value in attrs:
+                    if name == "href":
+                        self.base_href = value
+                        break
+            return
+
+        if tag != "a":
+            return
+        anchor = _anchor(attrs)
+        if anchor is not None:
+            self.anchors.append(anchor)

--- a/nab-index/src/nab_index/_pep503.py
+++ b/nab-index/src/nab_index/_pep503.py
@@ -9,126 +9,28 @@ from __future__ import annotations
 
 import hashlib
 import json
-from dataclasses import dataclass
-from html.parser import HTMLParser
+from typing import TYPE_CHECKING
 from urllib.parse import unquote, urljoin, urlsplit
-
-from typing_extensions import override
 
 from nab_provider.digest import is_hex_digest
 
+if TYPE_CHECKING:
+    from ._html_page import Anchor, ProjectPageParser
+
 __all__ = [
-    "Anchor",
     "hash_fragment",
     "json_listing",
     "metadata_declaration",
     "read_page",
 ]
 
-_REQUIRES_PYTHON_ATTR = "data-requires-python"
-_YANKED_ATTR = "data-yanked"
-_CORE_METADATA_ATTR = "data-core-metadata"
-_LEGACY_METADATA_ATTR = "data-dist-info-metadata"
-_UPLOAD_TIME_ATTR = "data-upload-time"
-_REPOSITORY_VERSION_META = "pypi:repository-version"
 
-# HTML's ASCII whitespace set: a URL attribute's value may be surrounded by it.
-_HTML_WHITESPACE = "\t\n\f\r "
-
-
-@dataclass(frozen=True, slots=True)
-class Anchor:
-    """One ``<a>`` link on a project page.
-
-    ``metadata`` is the :pep:`714` ``data-core-metadata`` value, falling back
-    to the legacy ``data-dist-info-metadata`` when only that is set, and
-    ``None`` when the anchor declares neither.
-
-    ``upload_time`` is the ``data-upload-time`` value. No specification
-    covers it (:pep:`700` defines ``upload-time`` for the JSON serialization
-    only), so an index is free to omit it, and PyPI and download.pytorch.org
-    both do. It is read because it is the only upload time an HTML page can
-    carry.
-    """
-
-    href: str
-    requires_python: str | None
-    metadata: str | None
-    yanked: bool
-    upload_time: str | None
-
-
-def _anchor(attrs: list[tuple[str, str | None]]) -> Anchor | None:
-    """Build an :class:`Anchor` from a tag's attributes, or ``None`` if hrefless."""
-    href: str | None = None
-    requires_python: str | None = None
-    yanked = False
-    core_metadata: str | None = None
-    legacy_metadata: str | None = None
-    upload_time: str | None = None
-
-    for name, value in attrs:
-        if name == "href":
-            href = value
-        elif name == _REQUIRES_PYTHON_ATTR:
-            requires_python = value
-        elif name == _YANKED_ATTR:
-            yanked = True
-        elif name == _CORE_METADATA_ATTR:
-            core_metadata = value
-        elif name == _LEGACY_METADATA_ATTR:
-            legacy_metadata = value
-        elif name == _UPLOAD_TIME_ATTR:
-            upload_time = value
-
-    if href is None:
-        return None
-
-    metadata = core_metadata if core_metadata is not None else legacy_metadata
-    return Anchor(
-        href.strip(_HTML_WHITESPACE), requires_python, metadata, yanked, upload_time
-    )
-
-
-class _ProjectPageParser(HTMLParser):
-    """Collect a project page's anchors and its first ``<base href>``.
-
-    Also records whether the page declares the :pep:`629` repository version.
-    """
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.anchors: list[Anchor] = []
-        self.base_href: str | None = None
-        self.declares_repository_version = False
-
-    @override
-    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
-        if tag == "meta":
-            for name, value in attrs:
-                if name == "name" and value == _REPOSITORY_VERSION_META:
-                    self.declares_repository_version = True
-                    break
-            return
-
-        if tag == "base":
-            if self.base_href is None:
-                for name, value in attrs:
-                    if name == "href":
-                        self.base_href = value
-                        break
-            return
-
-        if tag != "a":
-            return
-        anchor = _anchor(attrs)
-        if anchor is not None:
-            self.anchors.append(anchor)
-
-
-def _parse(text: str) -> _ProjectPageParser:
+def _parse(text: str) -> ProjectPageParser:
     """Run the page parser over ``text``."""
-    parser = _ProjectPageParser()
+    # Deferred to keep html.parser off the CLI's import path.
+    from ._html_page import ProjectPageParser  # noqa: PLC0415
+
+    parser = ProjectPageParser()
     parser.feed(text)
     return parser
 

--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -32,7 +32,6 @@ from email.parser import BytesParser, Parser
 from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import unquote, urljoin, urlparse, urlsplit
-from urllib.request import url2pathname
 
 from packaging.utils import canonicalize_name as _canonical
 from packaging.utils import parse_sdist_filename
@@ -128,6 +127,9 @@ def parse_file_url(url: str) -> Path:
     if parsed.scheme != "file":
         msg = f"expected file:// URL, got {url!r}"
         raise ValueError(msg)
+
+    # Deferred to keep urllib.request off the CLI's import path.
+    from urllib.request import url2pathname  # noqa: PLC0415
 
     netloc = parsed.netloc
     if not netloc or netloc == "localhost":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5897,6 +5897,16 @@ assert not leaked, f"importing nab.cli loaded {leaked}"
 """
 
 
+_STDLIB_MODULE_PROBE = """
+import sys
+
+import nab.cli
+
+leaked = sorted({"html.parser", "urllib.request"} & sys.modules.keys())
+assert not leaked, f"importing nab.cli loaded {leaked}"
+"""
+
+
 class TestCliImportPath:
     """What importing :mod:`nab.cli` is allowed to pull in."""
 
@@ -5904,6 +5914,16 @@ class TestCliImportPath:
         """Neither library belongs on the path of a command that never fetches."""
         subprocess.run(  # noqa: S603 - the probe is this file's own source
             [sys.executable, "-c", _HTTP_LIBRARY_PROBE], check=True
+        )
+
+    def test_html_parser_and_urllib_request_stay_unimported(self) -> None:
+        """Neither belongs on startup: one reads an HTML page, one a file:// URL.
+
+        Matched on full module names rather than first path components,
+        since :mod:`urllib.parse` is always loaded.
+        """
+        subprocess.run(  # noqa: S603 - the probe is this file's own source
+            [sys.executable, "-c", _STDLIB_MODULE_PROBE], check=True
         )
 
 


### PR DESCRIPTION
`html.parser` and `urllib.request` no longer load when the CLI starts, so a whole `nab cache dir` run costs about 36.4 million fewer instructions locally, 1.12 billion down to 1.09 billion, 3.2%. The count behind it reproduces anywhere: `import nab.cli` leaves 386 entries in `sys.modules` instead of 395, those two modules and the seven they pull in.

- `nab-index/src/nab_index/_html_page.py` takes the PEP 503 tokenizing verbatim out of `_pep503.py`, imported by `_parse` when a project page is parsed. `_ProjectPageParser` becomes `ProjectPageParser`.
- `url2pathname` is imported inside `parse_file_url`, after the scheme check.

Both imports sit in function bodies, against the module-scope rule: deferring them is the point, and each carries a comment saying so. The first HTML page and the first `file://` URL pay their import.