### PR TITLE
Keep html.parser and urllib.request off the CLI import, ~4% of it

### DIFF
--- a/nab-index/src/nab_index/_html_page.py
+++ b/nab-index/src/nab_index/_html_page.py
@@ -1,0 +1,117 @@
+"""HTML parsing for :pep:`503` project pages.
+
+Separate from :mod:`nab_index._pep503` so that importing the reader does not
+pull in :mod:`html.parser`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from html.parser import HTMLParser
+
+from typing_extensions import override
+
+__all__ = [
+    "Anchor",
+    "ProjectPageParser",
+]
+
+_REQUIRES_PYTHON_ATTR = "data-requires-python"
+_YANKED_ATTR = "data-yanked"
+_CORE_METADATA_ATTR = "data-core-metadata"
+_LEGACY_METADATA_ATTR = "data-dist-info-metadata"
+_UPLOAD_TIME_ATTR = "data-upload-time"
+_REPOSITORY_VERSION_META = "pypi:repository-version"
+
+# HTML's ASCII whitespace set: a URL attribute's value may be surrounded by it.
+_HTML_WHITESPACE = "\t\n\f\r "
+
+
+@dataclass(frozen=True, slots=True)
+class Anchor:
+    """One ``<a>`` link on a project page.
+
+    ``metadata`` is the :pep:`714` ``data-core-metadata`` value, falling back
+    to the legacy ``data-dist-info-metadata`` when only that is set, and
+    ``None`` when the anchor declares neither.
+
+    ``upload_time`` is the ``data-upload-time`` value. No specification
+    covers it (:pep:`700` defines ``upload-time`` for the JSON serialization
+    only), so an index is free to omit it, and PyPI and download.pytorch.org
+    both do. It is read because it is the only upload time an HTML page can
+    carry.
+    """
+
+    href: str
+    requires_python: str | None
+    metadata: str | None
+    yanked: bool
+    upload_time: str | None
+
+
+def _anchor(attrs: list[tuple[str, str | None]]) -> Anchor | None:
+    """Build an :class:`Anchor` from a tag's attributes, or ``None`` if hrefless."""
+    href: str | None = None
+    requires_python: str | None = None
+    yanked = False
+    core_metadata: str | None = None
+    legacy_metadata: str | None = None
+    upload_time: str | None = None
+
+    for name, value in attrs:
+        if name == "href":
+            href = value
+        elif name == _REQUIRES_PYTHON_ATTR:
+            requires_python = value
+        elif name == _YANKED_ATTR:
+            yanked = True
+        elif name == _CORE_METADATA_ATTR:
+            core_metadata = value
+        elif name == _LEGACY_METADATA_ATTR:
+            legacy_metadata = value
+        elif name == _UPLOAD_TIME_ATTR:
+            upload_time = value
+
+    if href is None:
+        return None
+
+    metadata = core_metadata if core_metadata is not None else legacy_metadata
+    return Anchor(
+        href.strip(_HTML_WHITESPACE), requires_python, metadata, yanked, upload_time
+    )
+
+
+class ProjectPageParser(HTMLParser):
+    """Collect a project page's anchors and its first ``<base href>``.
+
+    Also records whether the page declares the :pep:`629` repository version.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.anchors: list[Anchor] = []
+        self.base_href: str | None = None
+        self.declares_repository_version = False
+
+    @override
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag == "meta":
+            for name, value in attrs:
+                if name == "name" and value == _REPOSITORY_VERSION_META:
+                    self.declares_repository_version = True
+                    break
+            return
+
+        if tag == "base":
+            if self.base_href is None:
+                for name, value in attrs:
+                    if name == "href":
+                        self.base_href = value
+                        break
+            return
+
+        if tag != "a":
+            return
+        anchor = _anchor(attrs)
+        if anchor is not None:
+            self.anchors.append(anchor)

--- a/nab-index/src/nab_index/_pep503.py
+++ b/nab-index/src/nab_index/_pep503.py
@@ -9,126 +9,28 @@ from __future__ import annotations
 
 import hashlib
 import json
-from dataclasses import dataclass
-from html.parser import HTMLParser
+from typing import TYPE_CHECKING
 from urllib.parse import unquote, urljoin, urlsplit
-
-from typing_extensions import override
 
 from nab_provider.digest import is_hex_digest
 
+if TYPE_CHECKING:
+    from ._html_page import Anchor, ProjectPageParser
+
 __all__ = [
-    "Anchor",
     "hash_fragment",
     "json_listing",
     "metadata_declaration",
     "read_page",
 ]
 
-_REQUIRES_PYTHON_ATTR = "data-requires-python"
-_YANKED_ATTR = "data-yanked"
-_CORE_METADATA_ATTR = "data-core-metadata"
-_LEGACY_METADATA_ATTR = "data-dist-info-metadata"
-_UPLOAD_TIME_ATTR = "data-upload-time"
-_REPOSITORY_VERSION_META = "pypi:repository-version"
 
-# HTML's ASCII whitespace set: a URL attribute's value may be surrounded by it.
-_HTML_WHITESPACE = "\t\n\f\r "
-
-
-@dataclass(frozen=True, slots=True)
-class Anchor:
-    """One ``<a>`` link on a project page.
-
-    ``metadata`` is the :pep:`714` ``data-core-metadata`` value, falling back
-    to the legacy ``data-dist-info-metadata`` when only that is set, and
-    ``None`` when the anchor declares neither.
-
-    ``upload_time`` is the ``data-upload-time`` value. No specification
-    covers it (:pep:`700` defines ``upload-time`` for the JSON serialization
-    only), so an index is free to omit it, and PyPI and download.pytorch.org
-    both do. It is read because it is the only upload time an HTML page can
-    carry.
-    """
-
-    href: str
-    requires_python: str | None
-    metadata: str | None
-    yanked: bool
-    upload_time: str | None
-
-
-def _anchor(attrs: list[tuple[str, str | None]]) -> Anchor | None:
-    """Build an :class:`Anchor` from a tag's attributes, or ``None`` if hrefless."""
-    href: str | None = None
-    requires_python: str | None = None
-    yanked = False
-    core_metadata: str | None = None
-    legacy_metadata: str | None = None
-    upload_time: str | None = None
-
-    for name, value in attrs:
-        if name == "href":
-            href = value
-        elif name == _REQUIRES_PYTHON_ATTR:
-            requires_python = value
-        elif name == _YANKED_ATTR:
-            yanked = True
-        elif name == _CORE_METADATA_ATTR:
-            core_metadata = value
-        elif name == _LEGACY_METADATA_ATTR:
-            legacy_metadata = value
-        elif name == _UPLOAD_TIME_ATTR:
-            upload_time = value
-
-    if href is None:
-        return None
-
-    metadata = core_metadata if core_metadata is not None else legacy_metadata
-    return Anchor(
-        href.strip(_HTML_WHITESPACE), requires_python, metadata, yanked, upload_time
-    )
-
-
-class _ProjectPageParser(HTMLParser):
-    """Collect a project page's anchors and its first ``<base href>``.
-
-    Also records whether the page declares the :pep:`629` repository version.
-    """
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.anchors: list[Anchor] = []
-        self.base_href: str | None = None
-        self.declares_repository_version = False
-
-    @override
-    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
-        if tag == "meta":
-            for name, value in attrs:
-                if name == "name" and value == _REPOSITORY_VERSION_META:
-                    self.declares_repository_version = True
-                    break
-            return
-
-        if tag == "base":
-            if self.base_href is None:
-                for name, value in attrs:
-                    if name == "href":
-                        self.base_href = value
-                        break
-            return
-
-        if tag != "a":
-            return
-        anchor = _anchor(attrs)
-        if anchor is not None:
-            self.anchors.append(anchor)
-
-
-def _parse(text: str) -> _ProjectPageParser:
+def _parse(text: str) -> ProjectPageParser:
     """Run the page parser over ``text``."""
-    parser = _ProjectPageParser()
+    # Late import: html.parser loads only when a page is parsed.
+    from ._html_page import ProjectPageParser  # noqa: PLC0415
+
+    parser = ProjectPageParser()
     parser.feed(text)
     return parser
 

--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -32,7 +32,6 @@ from email.parser import BytesParser, Parser
 from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import unquote, urljoin, urlparse, urlsplit
-from urllib.request import url2pathname
 
 from packaging.utils import canonicalize_name as _canonical
 from packaging.utils import parse_sdist_filename
@@ -128,6 +127,9 @@ def parse_file_url(url: str) -> Path:
     if parsed.scheme != "file":
         msg = f"expected file:// URL, got {url!r}"
         raise ValueError(msg)
+
+    # Late import: urllib.request loads only when a file:// URL is parsed.
+    from urllib.request import url2pathname  # noqa: PLC0415
 
     netloc = parsed.netloc
     if not netloc or netloc == "localhost":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5785,6 +5785,16 @@ assert not leaked, f"importing nab.cli loaded {leaked}"
 """
 
 
+_STDLIB_MODULE_PROBE = """
+import sys
+
+import nab.cli
+
+leaked = sorted({"html.parser", "urllib.request"} & sys.modules.keys())
+assert not leaked, f"importing nab.cli loaded {leaked}"
+"""
+
+
 class TestCliImportPath:
     """What importing :mod:`nab.cli` is allowed to pull in."""
 
@@ -5792,6 +5802,16 @@ class TestCliImportPath:
         """Neither library belongs on the path of a command that never fetches."""
         subprocess.run(  # noqa: S603 - the probe is this file's own source
             [sys.executable, "-c", _HTTP_LIBRARY_PROBE], check=True
+        )
+
+    def test_html_parser_and_urllib_request_stay_unimported(self) -> None:
+        """Neither belongs on startup: one reads an HTML page, one a file:// URL.
+
+        Matched on full module names rather than first path components,
+        since :mod:`urllib.parse` is always loaded.
+        """
+        subprocess.run(  # noqa: S603 - the probe is this file's own source
+            [sys.executable, "-c", _STDLIB_MODULE_PROBE], check=True
         )
 
 


### PR DESCRIPTION
`import nab.cli` loads `html.parser` and `urllib.request`, and a resolve against a JSON index reaches neither. Deferring both takes about 35.7 million instructions off the import, 3.9% of it, and about 30.9 million off a 2-package `nab lock`, 2.4% of that command.

| workload | main | branch | removed | share |
| --- | --- | --- | --- | --- |
| `import nab.cli` | 910,418,047 | 874,696,046 | 35,722,001 | 3.92% |
| `nab lock`, 2 packages | 1,308,798,691 | 1,277,946,133 | 30,852,558 | 2.36% |
| `nab lock`, 16 packages | 2,166,092,581 | 2,137,239,460 | 28,853,121 | 1.33% |

Callgrind with `PYTHONHASHSEED=0`; both locks go through `nab.cli.main` offline against the benchmark cache. Repeating a run moves these counts by up to about 4 parts in 100,000, so read the savings to three figures rather than to the digit. The share shrinks as the resolve grows, which is what a fixed startup cost does.

The clock can see it on the 2-package lock: 60 runs each side put it between about 0.8% and 5% faster locally, with a middle estimate near 3.5%, and peak memory between 3.0% and 3.7% smaller (medians 40.4 MB against 39.1 MB).

On the 16-package lock the saving is below what the timing could resolve, so that run only rules out a wall regression above about 0.2%; peak memory there is between 2.0% and 2.4% smaller. On the 19-scenario canary set the timing cannot separate the two either, ruling out a wall regression above about 5%: one process imports once there and then resolves all 19.

`html.parser` could not be deferred where it stood, since `_pep503` subclasses `HTMLParser` and a base class has to exist when the class body runs. The tokenizing half moves to a new `nab_index/_html_page.py` that `_pep503._parse` imports, so `client.py` and `local_index.py` keep their module-scope `_pep503` imports and only a page that is actually parsed loads the parser.

`urllib.request` is one late import in `local_index.parse_file_url`, the only caller of `url2pathname`; that module brings `http.client`, `ssl`, `hashlib` and `email` with it.

`tarfile` stays at module scope. Deferring it means `_SUPPORTS_DATA_FILTER` stops being a module-scope constant, which `test_archive.py` sets by name, and stubbing it out of the branch's import is worth 4,259,837 instructions, 0.49% of that import.

A probe in `tests/test_cli.py` imports `nab.cli` in a subprocess and fails if either module reaches `sys.modules`; it matches full module names because `urllib.parse` is always loaded.
