### PR TITLE
Exit 120 instead of crashing when stdout or stderr is closed at startup

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -278,4 +278,5 @@ It shows only at normal verbosity on an stderr terminal; `--no-progress`
 | `0`  | Success. |
 | `1`  | Resolution failed, lockfile cannot be written (a missing hash, or text that is not valid UTF-8), download failed, missing `[project].dependencies`, a `--build-requirements` run whose project declares no `[build-system]`, invalid `[tool.nab]` configuration, or `--locked` found the lockfile out of date or missing. |
 | `2`  | Bad usage: an unrecognised flag or subcommand, or a malformed `--color` value or `NAB_VERBOSITY`. |
+| `120` | Output was lost: `nab` wrote to a stdout or stderr that was closed before it started, or flushing one of them at exit failed. |
 | `130` | Interrupted with Ctrl-C. `nab` prints `error: interrupted` and exits. |

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -7,13 +7,14 @@ translation that only :mod:`nab._lock` and :mod:`nab._download` use.
 
 The subcommands live in :mod:`nab._lock`, :mod:`nab._download`,
 :mod:`nab._config_cmd`, and :mod:`nab._cache_cmd`; this module imports
-them so their ``@app.command`` decorators run before :func:`main` calls
-``app.cli()``.
+them so their ``@app.command`` decorators run before :func:`main` runs
+the CLI.
 """
 
 from __future__ import annotations
 
 import gc
+import io
 import os
 import sys
 from contextlib import contextmanager
@@ -24,6 +25,7 @@ from typing import TYPE_CHECKING, Annotated, Literal, NoReturn
 
 import tomli
 import tyro
+from typing_extensions import override
 from tyro.extras import SubcommandApp
 
 from nab._version import __version__
@@ -875,8 +877,24 @@ from . import _lock as _lock_module  # noqa: E402, F401 - side-effect
 
 
 def main() -> None:
+    """Run the CLI, exiting 120 when output went to a stream closed at startup."""
+    _replace_closed_std_streams()
+
+    try:
+        _run_cli()
+    except SystemExit:
+        if _output_was_dropped():
+            raise SystemExit(_FLUSH_FAILED_EXIT_CODE) from None
+        raise
+
+    if _output_was_dropped():
+        raise SystemExit(_FLUSH_FAILED_EXIT_CODE)
+
+
+def _run_cli() -> None:
     """Parse the global flags and run the requested subcommand."""
-    global _printer  # noqa: PLW0603 - the run's printer is a module singleton main() sets
+    global _printer  # noqa: PLW0603 - the run's printer is a module singleton, set here
+
     # Tyro's SubcommandApp does not surface global flags, so ``--version`` and
     # the output flags (-v/-q, --color, --no-progress) are parsed before
     # ``app.cli()`` sees the sub-command.
@@ -911,6 +929,43 @@ def _system_exit_status(code: object) -> int:
         return code
     sys.stderr.write(f"{code}\n")
     return 1
+
+
+class _ClosedStream(io.StringIO):
+    """Stands in for a standard stream CPython left unset.
+
+    ``sys.stdout`` and ``sys.stderr`` are ``None`` when their descriptor was
+    closed before the process started. Text written here goes nowhere, and
+    ``dropped`` records that a write reached it.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.dropped = False
+
+    @override
+    def write(self, text: str, /) -> int:
+        self.dropped = True
+        return len(text)
+
+
+def _replace_closed_std_streams() -> None:
+    """Give each standard stream CPython left unset something to write to."""
+    # typeshed types these as never None, so widen before testing.
+    stdout: TextIO | None = sys.stdout
+    stderr: TextIO | None = sys.stderr
+    if stdout is None:
+        sys.stdout = _ClosedStream()
+    if stderr is None:
+        sys.stderr = _ClosedStream()
+
+
+def _output_was_dropped() -> bool:
+    """Report whether the run wrote to a stream that could not take it."""
+    return any(
+        isinstance(stream, _ClosedStream) and stream.dropped
+        for stream in (sys.stdout, sys.stderr)
+    )
 
 
 def _flush_stream(stream: TextIO) -> bool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5873,6 +5873,99 @@ class TestConsoleEntry:
         mock_exit.assert_not_called()
 
 
+class TestClosedStandardStreams:
+    """Tests for a run started with stdout or stderr closed.
+
+    CPython leaves the matching ``sys`` attribute as ``None`` when the
+    descriptor is closed before the process starts. ``os._exit`` ends the
+    process outright, so the tests that go through ``console_entry`` patch it.
+    """
+
+    def test_closed_stdout_exits_120(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``--version`` with no stdout exits 120 instead of crashing."""
+        monkeypatch.setattr(sys, "argv", ["nab", "--version"])
+        monkeypatch.setattr(sys, "stdout", None)
+        with patch("nab.cli.os._exit") as mock_exit:
+            console_entry()
+        mock_exit.assert_called_once_with(120)
+
+    def test_an_unwritten_closed_stream_exits_zero(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``--version`` writes no diagnostics, so a closed stderr loses nothing."""
+        monkeypatch.setattr(sys, "argv", ["nab", "--version"])
+        monkeypatch.setattr(sys, "stderr", None)
+        with patch("nab.cli.os._exit") as mock_exit:
+            console_entry()
+        mock_exit.assert_called_once_with(0)
+
+    def test_closed_stderr_keeps_the_lockfile(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The lock still lands; only the run summary has nowhere to go."""
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        monkeypatch.setattr(
+            sys, "argv", ["nab", "lock", str(pyproject), "--output", str(out)]
+        )
+        monkeypatch.setattr(sys, "stderr", None)
+        with (
+            patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()),
+            patch("nab.cli.os._exit") as mock_exit,
+        ):
+            console_entry()
+        assert 'name = "foo"' in out.read_text()
+        mock_exit.assert_called_once_with(120)
+
+    def test_closed_stderr_before_the_printer_exists(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A bad ``--color`` value is reported before the printer is built."""
+        monkeypatch.setattr(sys, "argv", ["nab", "--color", "rainbow", "lock"])
+        monkeypatch.setattr(sys, "stderr", None)
+        with patch("nab.cli.os._exit") as mock_exit:
+            console_entry()
+        mock_exit.assert_called_once_with(120)
+
+    def test_both_streams_closed_exits_120(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Losing both streams still exits 120."""
+        monkeypatch.setattr(sys, "argv", ["nab", "--color", "rainbow", "lock"])
+        monkeypatch.setattr(sys, "stdout", None)
+        monkeypatch.setattr(sys, "stderr", None)
+        with patch("nab.cli.os._exit") as mock_exit:
+            console_entry()
+        mock_exit.assert_called_once_with(120)
+
+    def test_python_dash_m_exits_120(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``python -m nab`` exits 120 rather than returning normally."""
+        monkeypatch.setattr(sys, "argv", ["nab", "--version"])
+        monkeypatch.setattr(sys, "stdout", None)
+        with pytest.raises(SystemExit) as excinfo:
+            runpy.run_module("nab", run_name="__main__")
+        assert excinfo.value.code == 120
+
+    def test_python_dash_m_reports_a_loss_over_the_command_status(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failing command whose error had nowhere to go exits 120, not 2."""
+        monkeypatch.setattr(sys, "argv", ["nab", "--color", "rainbow", "lock"])
+        monkeypatch.setattr(sys, "stderr", None)
+        with pytest.raises(SystemExit) as excinfo:
+            runpy.run_module("nab", run_name="__main__")
+        assert excinfo.value.code == 120
+
+    def test_python_dash_m_with_open_streams_keeps_its_status(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A run that loses no output keeps its own exit status."""
+        monkeypatch.setattr(sys, "argv", ["nab", "--color", "rainbow", "lock"])
+        with pytest.raises(SystemExit) as excinfo:
+            runpy.run_module("nab", run_name="__main__")
+        assert excinfo.value.code == 2
+
+
 class TestSystemExitStatus:
     """Tests for mapping a ``SystemExit`` code to a process status."""
 


### PR DESCRIPTION
`nab --version >&-` prints a traceback and exits 1:

```
  File ".../src/nab/cli.py", line 885, in main
    sys.stdout.write(f"nab {__version__}\n")
    ^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'write'
```

CPython sets `sys.stdout` or `sys.stderr` to `None` when the descriptor was closed before the process started, and the CLI assumed a stream was always there. It already exits 120 when a flush cannot land its output, but that check needs a stream to flush.

nab now replaces a `None` stream at startup with a sink that records whether anything was written to it. A run that wrote to one exits 120.

- Work still finishes. `nab lock` with stderr closed writes the lockfile, then exits 120 because only the run summary was lost.
- A closed stream nothing wrote to is not a loss: `nab --version 2>&-` exits 0.
- Lost output outranks the command's own status: `nab --color rainbow lock` exits 2 normally, 120 when the error had nowhere to go.
- `python -m nab` reports the same status as the installed `nab` command.

120 was never documented, so the exit-status table in the CLI reference now lists it.

