### PR TITLE
Fix RecursionError traceback from an over-nested PEP 508 marker

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -15,9 +15,9 @@ The property suite under ``nab-*/tests/property*/`` uses explicit
 ``PROPERTY_SETTINGS``/``DEEP_SETTINGS``/``BRUTE_FORCE_SETTINGS``
 decorators so its example budget is independent of the profile.
 
-``cap_writes``, ``deny_access``, ``oversized_integer`` and
-``refuse_over_nested`` are here rather than in one suite's conftest because
-the ``nab-index``, ``nab-project`` and CLI suites all use them.
+``cap_writes``, ``deny_access``, ``oversized_integer``,
+``over_nested_marker`` and ``refuse_over_nested`` are here rather than in
+one suite's conftest because each is used by more than one suite.
 """
 
 from __future__ import annotations
@@ -207,3 +207,14 @@ def oversized_integer() -> str:
     parse without being a syntax error.
     """
     return "1" * (sys.get_int_max_str_digits() + 1)
+
+
+@pytest.fixture
+def over_nested_marker() -> str:
+    """Return a PEP 508 marker nested past what the interpreter can parse.
+
+    The parser spends two frames per parenthesised level, so nesting to the
+    recursion limit overflows the stack from any starting depth.
+    """
+    depth = sys.getrecursionlimit()
+    return "(" * depth + "os_name == 'posix'" + ")" * depth

--- a/nab-project/src/nab_project/_build/runner.py
+++ b/nab-project/src/nab_project/_build/runner.py
@@ -45,6 +45,7 @@ from nab_provider._vendor.packaging.utils import canonicalize_name, parse_wheel_
 from nab_provider._vendor.packaging.version import Version
 from nab_provider.errors import UnsupportedWheelError
 from nab_provider.metadata import WheelMetadata, validate_specifier_versions
+from nab_provider.pep508 import parse_requirement
 from nab_provider.requirements_file import (
     InvalidProjectRequirementError,
     require_string_list,
@@ -511,7 +512,7 @@ def _parse_metadata(metadata_path: Path) -> WheelMetadata:
     requires_dist: list[Requirement] = []
     for raw in msg_obj.get_all("Requires-Dist") or ():
         try:
-            req = Requirement(raw)
+            req = parse_requirement(raw)
             validate_specifier_versions(req.specifier)
         except ValueError as exc:
             msg = f"backend METADATA has an invalid Requires-Dist: {exc}"

--- a/nab-project/src/nab_project/_lockfile/validate.py
+++ b/nab-project/src/nab_project/_lockfile/validate.py
@@ -38,7 +38,6 @@ import tomli
 
 from nab_provider._vendor.packaging.markers import UndefinedEnvironmentName
 from nab_provider._vendor.packaging.pylock import Pylock, PylockValidationError
-from nab_provider._vendor.packaging.requirements import Requirement
 from nab_provider._vendor.packaging.specifiers import SpecifierSet
 from nab_provider._vendor.packaging.utils import canonicalize_name
 from nab_provider.marker_holds import (
@@ -47,6 +46,7 @@ from nab_provider.marker_holds import (
     dependency_marker_holds,
 )
 from nab_provider.metadata import validate_specifier_versions
+from nab_provider.pep508 import parse_requirement
 from nab_provider.target import NonIntervalMarkerError, micro_boundary_points
 
 from .. import toml_io
@@ -57,6 +57,7 @@ if TYPE_CHECKING:
 
     from nab_provider._vendor.packaging.markers import Marker
     from nab_provider._vendor.packaging.pylock import Package
+    from nab_provider._vendor.packaging.requirements import Requirement
     from nab_provider._vendor.packaging.version import Version
     from nab_provider.target import ResolveTarget
 
@@ -446,7 +447,7 @@ def check_locked(  # noqa: PLR0913 - the envelope fields and the validity inputs
     )
     if direct is not None:
         return direct
-    parsed = [Requirement(text) for text in constraints]
+    parsed = [parse_requirement(text) for text in constraints]
     return check_constraints(
         committed,
         parsed,

--- a/nab-project/src/nab_project/config.py
+++ b/nab-project/src/nab_project/config.py
@@ -22,7 +22,6 @@ import tomli
 from typing_extensions import override
 
 from nab_index.local_index import is_file_url
-from nab_provider._vendor.packaging.requirements import Requirement
 from nab_provider._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
 from nab_provider._vendor.packaging.utils import InvalidName, canonicalize_name
 from nab_provider._vendor.packaging.version import Version
@@ -33,6 +32,7 @@ from nab_provider.errors import (
 )
 from nab_provider.iso8601 import parse_iso_datetime
 from nab_provider.overrides import IndexOverride, PackageOverride
+from nab_provider.pep508 import parse_requirement
 from nab_provider.policy import (
     ArchiveSource,
     BuildPolicy,
@@ -94,6 +94,8 @@ if TYPE_CHECKING:
     from collections.abc import Iterator, Mapping, Sequence
     from collections.abc import Set as AbstractSet
     from pathlib import Path
+
+    from nab_provider._vendor.packaging.requirements import Requirement
 
 __all__ = [
     "ConfigError",
@@ -1299,7 +1301,7 @@ def _require_constraint(key: str, item: str) -> None:
     URLs are rejected here rather than only at resolve.
     """
     try:
-        req = Requirement(item)
+        req = parse_requirement(item)
         # a specifier defers parsing its versions; to_range() forces it
         req.specifier.to_range()
     except ValueError as exc:
@@ -2282,7 +2284,7 @@ def _requirement_from_selector(raw: str, where: str) -> Requirement:
     package name and an optional version specifier.
     """
     try:
-        requirement = Requirement(raw)
+        requirement = parse_requirement(raw)
         # a specifier defers parsing its versions; to_range() forces it
         requirement.specifier.to_range()
     except ValueError as exc:
@@ -2591,7 +2593,7 @@ def _parse_override_dependencies(
             )
             raise ConfigError(msg)
         try:
-            requirement = Requirement(item)
+            requirement = parse_requirement(item)
             # a specifier defers parsing its versions; to_range() forces it
             requirement.specifier.to_range()
         except ValueError as exc:

--- a/nab-project/src/nab_project/resolve.py
+++ b/nab-project/src/nab_project/resolve.py
@@ -32,9 +32,9 @@ from typing import TYPE_CHECKING
 
 from nab_provider._vendor.packaging.markers import Marker
 from nab_provider._vendor.packaging.ranges import VersionRange
-from nab_provider._vendor.packaging.requirements import Requirement
 from nab_provider._vendor.packaging.utils import canonicalize_name
 from nab_provider.marker_holds import dependency_marker_holds
+from nab_provider.pep508 import parse_requirement
 from nab_provider.provider import ListingFilterCache
 from nab_provider.requirements_file import (
     expand_extra_requirements,
@@ -99,6 +99,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator, Mapping, Sequence
 
     from nab_index.transport import AsyncHttpTransport
+    from nab_provider._vendor.packaging.requirements import Requirement
     from nab_provider._vendor.packaging.version import Version
     from nab_provider.provider import ResolutionStrategy
     from nab_provider.resolver_inputs import MarkerHolds
@@ -293,7 +294,7 @@ def resolve_with_coordinator(  # noqa: PLR0913 - the knobs of a bare resolve
         fork_list = (
             list(forks) if forks is not None else [ResolveFork((), tuple(requirements))]
         )
-        constraints = [Requirement(text) for text in effective.constraints]
+        constraints = [parse_requirement(text) for text in effective.constraints]
 
         return _resolve_with_micro_narrowing(
             list(targets),

--- a/nab-project/tests/test_build_backend.py
+++ b/nab-project/tests/test_build_backend.py
@@ -289,6 +289,31 @@ class TestExtractStaticMetadata:
         with pytest.raises(InvalidProjectRequirementError, match="invalid requirement"):
             extract_static_metadata(tmp_path)
 
+    def test_over_nested_marker_raises(
+        self, tmp_path: Path, over_nested_marker: str
+    ) -> None:
+        """A marker the parser cannot recurse through is a rejected dependency."""
+        _write_pyproject(
+            tmp_path,
+            f'[project]\nname = "foo"\nversion = "1.0"\n'
+            f'dependencies = ["bar ; {over_nested_marker}"]\n',
+        )
+        with pytest.raises(InvalidProjectRequirementError, match="invalid requirement"):
+            extract_static_metadata(tmp_path)
+
+    def test_over_nested_marker_on_an_optional_dep_raises(
+        self, tmp_path: Path, over_nested_marker: str
+    ) -> None:
+        """An optional dependency parses on the extras path, and fails there."""
+        _write_pyproject(
+            tmp_path,
+            f'[project]\nname = "foo"\nversion = "1.0"\n'
+            f"[project.optional-dependencies]\n"
+            f'fast = ["bar ; {over_nested_marker}"]\n',
+        )
+        with pytest.raises(InvalidProjectRequirementError, match="invalid requirement"):
+            extract_static_metadata(tmp_path)
+
     def test_unparseable_optional_dep_raises(self, tmp_path: Path) -> None:
         """An optional dep that is not valid PEP 508 is invalid metadata; raise."""
         _write_pyproject(

--- a/nab-project/tests/test_build_runner.py
+++ b/nab-project/tests/test_build_runner.py
@@ -1121,6 +1121,21 @@ class TestParseMetadata:
         with pytest.raises(BuildBackendError, match="invalid Requires-Dist"):
             _parse_metadata(path)
 
+    def test_over_nested_requires_dist_marker_raises(
+        self, tmp_path: Path, over_nested_marker: str
+    ) -> None:
+        """A marker the parser cannot recurse through is malformed METADATA."""
+        from nab_project._build.runner import _parse_metadata
+
+        path = tmp_path / "METADATA"
+        path.write_text(
+            "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\n"
+            f"Requires-Dist: click ; {over_nested_marker}\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(BuildBackendError, match="invalid Requires-Dist"):
+            _parse_metadata(path)
+
     def test_oversized_requires_python_raises(self, tmp_path: Path) -> None:
         """A specifier parses fine and only fails when something compares it."""
         from nab_project._build.runner import _parse_metadata

--- a/nab-project/tests/test_requirements_file.py
+++ b/nab-project/tests/test_requirements_file.py
@@ -202,6 +202,18 @@ class TestReadPyprojectDependencies:
         ):
             read_pyproject_dependencies(p)
 
+    def test_over_nested_marker_raises(
+        self, tmp_path: object, over_nested_marker: str
+    ) -> None:
+        """A marker the parser cannot recurse through is a rejected dependency."""
+        p = Path(str(tmp_path)) / "pyproject.toml"
+        p.write_text(f'[project]\ndependencies = ["foo ; {over_nested_marker}"]\n')
+        with pytest.raises(
+            InvalidProjectRequirementError,
+            match=r"\[project\].dependencies: .*nested too deeply",
+        ):
+            read_pyproject_dependencies(p)
+
     def test_at_limit_specifier_version_is_read(self, tmp_path: object) -> None:
         """A run of exactly the limit converts, so it stays a legal dependency."""
         p = Path(str(tmp_path)) / "pyproject.toml"
@@ -388,6 +400,16 @@ class TestResolveGroupsToRequirements:
         ):
             resolve_groups_to_requirements({"dev": ["pytest >= bad junk"]}, ("dev",))
 
+    def test_over_nested_marker_raises(self, over_nested_marker: str) -> None:
+        """An over-nested marker fails inside the loader, before the guarded parse."""
+        with pytest.raises(
+            InvalidProjectRequirementError,
+            match=r"\[dependency-groups\]: .*nested too deeply",
+        ):
+            resolve_groups_to_requirements(
+                {"dev": [f"foo ; {over_nested_marker}"]}, ("dev",)
+            )
+
     @pytest.mark.parametrize("operator", ["==", "==="])
     def test_oversized_specifier_version_raises(self, operator: str) -> None:
         """An oversized version converts only on comparison; parsing forces it."""
@@ -516,7 +538,7 @@ class TestExpandSelfExtras:
             return req
 
         monkeypatch.setattr(
-            "nab_provider.requirements_file.Requirement", reversed_extras
+            "nab_provider.requirements_file.parse_requirement", reversed_extras
         )
         assert expand_self_extras(opt, "mypkg", ["all"]) == ["all", "a", "b", "c"]
 
@@ -798,7 +820,7 @@ class TestExpandExtraRequirements:
             return req
 
         monkeypatch.setattr(
-            "nab_provider.requirements_file.Requirement", reversed_extras
+            "nab_provider.requirements_file.parse_requirement", reversed_extras
         )
         out = expand_extra_requirements(opt, "mypkg", ["all"])
         assert [r.name for r in out] == ["depA", "depB", "depC"]

--- a/nab-provider/src/nab_provider/metadata.py
+++ b/nab-provider/src/nab_provider/metadata.py
@@ -15,14 +15,15 @@ from dataclasses import dataclass, field
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 
-from nab_provider._vendor.packaging.requirements import Requirement
 from nab_provider._vendor.packaging.specifiers import SpecifierSet
 from nab_provider._vendor.packaging.version import InvalidVersion, Version
+from nab_provider.pep508 import parse_requirement
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
     from nab_provider._vendor.packaging.markers import Marker
+    from nab_provider._vendor.packaging.requirements import Requirement
 
 __all__ = [
     "DEPENDENCY_FIELDS",
@@ -122,7 +123,7 @@ def _intern_marker(marker: Marker) -> Marker:
 
 @lru_cache(maxsize=16384)
 def _parse_requirement_cached(req_str: str) -> Requirement:
-    """Cache ``Requirement(req_str)`` parsing across wheel metadata.
+    """Cache ``parse_requirement(req_str)`` across wheel metadata.
 
     The same dep strings (``numpy>=1.26``, ``pydantic<3``, etc.) recur
     across many wheels in a dependency graph.  ``Requirement`` exposes
@@ -131,7 +132,7 @@ def _parse_requirement_cached(req_str: str) -> Requirement:
     Raises ``ValueError`` when the string does not parse or a clause
     version will not convert.
     """
-    req = Requirement(req_str)
+    req = parse_requirement(req_str)
     validate_specifier_versions(req.specifier)
     if req.marker is not None:
         req.marker = _intern_marker(req.marker)

--- a/nab-provider/src/nab_provider/pep508.py
+++ b/nab-provider/src/nab_provider/pep508.py
@@ -1,0 +1,26 @@
+"""Parse PEP 508 requirement strings.
+
+The vendored parser recurses through each parenthesised marker group, so a
+deeply nested marker raises ``RecursionError`` instead of
+``InvalidRequirement``.
+"""
+
+from __future__ import annotations
+
+from nab_provider._vendor.packaging.requirements import InvalidRequirement, Requirement
+
+__all__ = ["NESTED_MARKER_MESSAGE", "parse_requirement"]
+
+NESTED_MARKER_MESSAGE = "marker is nested too deeply to parse"
+
+
+def parse_requirement(text: str) -> Requirement:
+    """Return ``text`` parsed as a PEP 508 requirement.
+
+    Raises :class:`InvalidRequirement` for a malformed string and for a marker
+    whose nesting exhausts the stack.
+    """
+    try:
+        return Requirement(text)
+    except RecursionError as exc:
+        raise InvalidRequirement(NESTED_MARKER_MESSAGE) from exc

--- a/nab-provider/src/nab_provider/requirements_file.py
+++ b/nab-provider/src/nab_provider/requirements_file.py
@@ -8,17 +8,19 @@ from typing import TYPE_CHECKING
 from nab_provider._vendor.packaging.dependency_groups import resolve_dependency_groups
 from nab_provider._vendor.packaging.errors import ExceptionGroup
 from nab_provider._vendor.packaging.markers import Marker
-from nab_provider._vendor.packaging.requirements import Requirement
 from nab_provider._vendor.packaging.utils import canonicalize_name
 
 from .marker_holds import dependency_marker_holds, intractable_as_error, marker_set
 from .metadata import validate_specifier_versions
+from .pep508 import NESTED_MARKER_MESSAGE, parse_requirement
 from .resolver_inputs import (
     raise_for_unsatisfiable as raise_for_unsatisfiable,  # noqa: PLC0414  (re-export)
 )
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+
+    from nab_provider._vendor.packaging.requirements import Requirement
 
 __all__ = [
     "InvalidProjectRequirementError",
@@ -62,7 +64,7 @@ def _add_extra_marker(dep_str: str, extra_name: str) -> str:
     :class:`InvalidName` instead of producing a marker that gates the dep
     wrongly.
     """
-    req = Requirement(dep_str)
+    req = parse_requirement(dep_str)
     canonical_extra = canonicalize_name(extra_name, validate=True)
     extra_marker = f'extra == "{canonical_extra}"'
     if req.marker is not None:
@@ -86,7 +88,7 @@ def parse_project_requirement(
     """
     try:
         text = _add_extra_marker(dep_str, extra) if extra is not None else dep_str
-        req = Requirement(text)
+        req = parse_requirement(text)
         validate_specifier_versions(req.specifier)
     except ValueError as exc:
         msg = f"invalid requirement in {source}: {exc}"
@@ -200,7 +202,7 @@ def _self_references(
     """
     for req_str in canonical_deps.get(extra, ()):
         try:
-            req = Requirement(req_str)
+            req = parse_requirement(req_str)
         except (ValueError, TypeError):
             continue
         if canonicalize_name(req.name) == canonical_project:
@@ -402,6 +404,11 @@ def resolve_groups_to_requirements(
         return []
     try:
         resolved = resolve_dependency_groups(groups, *selected)
+    except RecursionError as exc:
+        # The vendored loader parses each entry itself, so an over-nested
+        # marker never reaches the guarded parse below.
+        msg = f"invalid requirement in [dependency-groups]: {NESTED_MARKER_MESSAGE}"
+        raise InvalidProjectRequirementError(msg) from exc
     except ExceptionGroup as group:
         detail = "; ".join(str(e) for e in group.exceptions)
         if all(isinstance(e, LookupError) for e in group.exceptions):

--- a/nab-provider/src/nab_provider/testing.py
+++ b/nab-provider/src/nab_provider/testing.py
@@ -21,10 +21,10 @@ from __future__ import annotations
 import threading
 from typing import TYPE_CHECKING, Any, TypeVar
 
-from ._vendor.packaging.requirements import Requirement
 from ._vendor.packaging.utils import canonicalize_name
 from .errors import IndexAccessError
 from .overrides import PackageOverride
+from .pep508 import parse_requirement
 from .records import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL, IndexConfig
 from .store import InMemoryIndex
 
@@ -71,7 +71,7 @@ def _done_event() -> threading.Event:
 
 def pkg_override(req_str: str, **body: object) -> PackageOverride:
     """Build a :class:`~nab_provider.overrides.PackageOverride` from a requirement."""
-    requirement = Requirement(req_str)
+    requirement = parse_requirement(req_str)
     return PackageOverride(
         requirement=requirement,
         name=canonicalize_name(requirement.name),

--- a/nab-provider/tests/test_pep508.py
+++ b/nab-provider/tests/test_pep508.py
@@ -1,0 +1,126 @@
+"""Tests for the guarded PEP 508 requirement parser."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from nab_provider._vendor.packaging.requirements import InvalidRequirement
+from nab_provider.pep508 import parse_requirement
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_SHIPPED_PACKAGES = (
+    "src/nab",
+    "nab-index/src/nab_index",
+    "nab-project/src/nab_project",
+    "nab-provider/src/nab_provider",
+    "nab-resolver/src/nab_resolver",
+)
+
+_GUARDED_PARSER = _REPO_ROOT / "nab-provider/src/nab_provider/pep508.py"
+
+
+def _direct_requirement_calls(source: str) -> list[int]:
+    """Return the lines of ``source`` that call packaging's ``Requirement``.
+
+    Import aliases are collected first, so ``R('x')`` after an ``as R`` import
+    counts, as does a module-qualified ``requirements.Requirement('x')``.
+    """
+    tree = ast.parse(source)
+    aliases = {
+        alias.asname or alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+        and (node.module or "").endswith("packaging.requirements")
+        for alias in node.names
+        if alias.name == "Requirement"
+    }
+
+    def calls_requirement(func: ast.expr) -> bool:
+        if isinstance(func, ast.Name):
+            return func.id in aliases
+        return isinstance(func, ast.Attribute) and func.attr == "Requirement"
+
+    return [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and calls_requirement(node.func)
+    ]
+
+
+def _shipped_modules() -> list[Path]:
+    """Return every shipped module the census scans."""
+    out: list[Path] = []
+    for package in _SHIPPED_PACKAGES:
+        root = _REPO_ROOT / package
+        assert root.is_dir(), f"{root} is not a package tree"
+        out.extend(
+            path
+            for path in sorted(root.rglob("*.py"))
+            if "_vendor" not in path.parts and path != _GUARDED_PARSER
+        )
+    return out
+
+
+class TestParseRequirement:
+    def test_parses_a_requirement(self) -> None:
+        req = parse_requirement("click>=8 ; os_name == 'posix'")
+        assert req.name == "click"
+        assert str(req.specifier) == ">=8"
+        assert req.marker is not None
+
+    def test_malformed_string_raises_invalid_requirement(self) -> None:
+        with pytest.raises(InvalidRequirement):
+            parse_requirement("requests >= 2.0 extra junk")
+
+    def test_moderate_nesting_still_parses(self) -> None:
+        """Ordinary parenthesised grouping is untouched by the guard."""
+        marker = "(" * 100 + "os_name == 'posix'" + ")" * 100
+        assert parse_requirement(f"foo ; {marker}").marker is not None
+
+    def test_over_nested_marker_raises_invalid_requirement(
+        self, over_nested_marker: str
+    ) -> None:
+        """Exhausting the stack is a rejected requirement, not a RecursionError."""
+        with pytest.raises(InvalidRequirement, match="nested too deeply") as caught:
+            parse_requirement(f"foo ; {over_nested_marker}")
+
+        assert isinstance(caught.value.__cause__, RecursionError)
+
+
+class TestRequirementParsingIsRouted:
+    """No shipped module calls packaging's ``Requirement`` directly.
+
+    The vendored group loader parses its own entries, out of the census's
+    reach; :func:`~nab_provider.requirements_file.resolve_groups_to_requirements`
+    guards that call.
+    """
+
+    def test_no_shipped_module_constructs_a_requirement(self) -> None:
+        modules = _shipped_modules()
+        assert modules
+
+        offenders = [
+            f"{path.relative_to(_REPO_ROOT)}:{line}"
+            for path in modules
+            for line in _direct_requirement_calls(path.read_text(encoding="utf-8"))
+        ]
+        assert offenders == []
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            "from packaging.requirements import Requirement\nRequirement('x')\n",
+            "from ._vendor.packaging.requirements import Requirement as R\nR('x')\n",
+            "from a.packaging import requirements\nrequirements.Requirement('x')\n",
+        ],
+    )
+    def test_census_catches_every_spelling(self, source: str) -> None:
+        assert _direct_requirement_calls(source) == [2]
+
+    def test_census_ignores_a_name_that_only_looks_like_one(self) -> None:
+        source = "from nab_resolver.types import RootRequirement\nRootRequirement()\n"
+        assert _direct_requirement_calls(source) == []


### PR DESCRIPTION
`nab lock` on a project whose dependency carries a marker parenthesised past the interpreter's recursion limit exits with about 3,000 lines of traceback instead of an error:

    File ".../packaging/_tokenizer.py", line 137, in check
        self.next_token = Token(name, match[0], self.position)
    RecursionError: maximum recursion depth exceeded

It now prints:

    error: invalid requirement in [project].dependencies: marker is nested too deeply to parse

The vendored PEP 508 parser recurses through each parenthesised marker group, so an over-nested marker exhausts the stack rather than raising `InvalidRequirement`. `RecursionError` is not a `ValueError`, so every guard that turns a bad requirement into a typed error missed it:

- `parse_project_requirement`, which reports `InvalidProjectRequirementError` for the project's own dependencies and for the static metadata of a declared local, VCS or archive source
- `_parse_metadata`, where `run_build_backend` documents `BuildBackendError` on any failure
- the config readers, which report `ConfigError` for a constraint, an override or a selector

`nab_provider.pep508.parse_requirement` re-raises the `RecursionError` as `InvalidRequirement`, and the 11 direct `Requirement(...)` calls in shipped code now go through it. A test scans those packages and fails on any direct call that comes back. A `[dependency-groups]` entry parses inside the vendored PEP 735 loader, so `resolve_groups_to_requirements` translates that error itself. Ordinary grouping is untouched: 100 nested levels still parse.
