### PR TITLE
Fold four helpers into the listing entry parse, ~0.6% off a first resolve

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -85,6 +85,10 @@ _WHEEL_NAME_RE = re.compile(r"^[\w._]+\Z", re.UNICODE)
 _WHEEL_DASHES = (4, 5)
 _WHEEL_DASHES_WITH_BUILD = 5
 
+# The pre-PEP 714 spelling.  PEP 714 blesses no ``data-`` prefixed key for JSON,
+# so that spelling is never read.
+_LEGACY_METADATA_KEY = "dist-info-metadata"
+
 
 @lru_cache(maxsize=65536)
 def _canonical_version(version: str) -> str:
@@ -111,37 +115,20 @@ def _tag_triple_is_parseable(tag_str: str) -> bool:
     return all("" not in field.split(".") for field in (abis, platforms))
 
 
-def _is_usable_filename(filename: str) -> bool:
-    """Whether ``filename`` has a UTF-8 form and holds no NUL.
-
-    nab records the name in a UTF-8 lockfile and writes the artefact
-    under it, so a name failing either is unusable however well it
-    parses.  A lone surrogate has no UTF-8 form, including the
-    ``U+DC80``..``U+DCFF`` range POSIX carries through ``surrogateescape``.
-    """
-    if "\x00" in filename:
-        return False
-    try:
-        filename.encode()
-    except UnicodeEncodeError:
-        return False
-    return True
-
-
 def _parse_wheel_filename(filename: str) -> tuple[NormalizedName, str] | None:
     """Parse a wheel filename per PEP 427.
 
     Returns ``(canonical_name, version_string)`` or ``None`` for any
     filename packaging rejects (wrong extension, malformed, etc.), for a
-    version digit run past CPython's int-from-string limit, and for a name
-    :func:`_is_usable_filename` refuses.  Never raises.
+    version digit run past CPython's int-from-string limit, and for a
+    filename holding a NUL or with no UTF-8 form.  Never raises.
     The version string is the canonical form produced by
     :class:`packaging.version.Version`, so trailing-zero handling
     matches what packaging records on the file; e.g. a wheel
     declaring ``2.0.0`` in its filename comes back as ``"2.0.0"``,
     not ``"2"``.
 
-    Unusable names aside, this accepts what nab-provider's vendored
+    Those rejections aside, this accepts what nab-provider's vendored
     ``parse_wheel_filename`` accepts, but discards the ``frozenset[Tag]`` the
     tag parser builds and nab does not use. The vendored copy is the one to
     match, not the released ``packaging`` this package depends on, because the
@@ -153,7 +140,7 @@ def _parse_wheel_filename(filename: str) -> tuple[NormalizedName, str] | None:
     nab reads a build tag only to sort by it and sorts an unconvertible run
     lowest.
     """
-    if not filename.endswith(".whl") or not _is_usable_filename(filename):
+    if not filename.endswith(".whl") or "\x00" in filename:
         return None
 
     stem = filename[:-4]
@@ -167,9 +154,12 @@ def _parse_wheel_filename(filename: str) -> tuple[NormalizedName, str] | None:
         return None
 
     try:
+        # Encode only to reject a string with no UTF-8 form.
+        filename.encode()
         version = _canonical_version(parts[1])
     except ValueError:
-        # InvalidVersion, or int() refusing a digit run past CPython's limit.
+        # UnicodeEncodeError, InvalidVersion, or int() refusing a digit run
+        # past CPython's limit.
         return None
 
     bad_build = (
@@ -189,8 +179,8 @@ def _parse_sdist_filename(filename: str) -> tuple[NormalizedName, str] | None:
 
     Accepts what nab-provider's vendored ``parse_sdist_filename`` accepts,
     except ``.zip`` sdists, which nab does not support (gzip-tar only, and
-    not part of the PEP 625 standard), and names :func:`_is_usable_filename`
-    refuses.  Returns ``None`` for everything else, including a version digit
+    not part of the PEP 625 standard), and filenames holding a NUL or with no
+    UTF-8 form.  Returns ``None`` for everything else, including a version digit
     run past CPython's int-from-string limit, and never raises.  The vendored
     copy is the one to match, not the released ``packaging`` this package
     depends on; the two can differ on an empty project name, which releases
@@ -201,7 +191,7 @@ def _parse_sdist_filename(filename: str) -> tuple[NormalizedName, str] | None:
     MUST drop files whose canonical name does not match the queried
     package.  See :func:`_parse_files`.
     """
-    if not filename.endswith(".tar.gz") or not _is_usable_filename(filename):
+    if not filename.endswith(".tar.gz") or "\x00" in filename:
         return None
 
     stem = filename[: -len(".tar.gz")]
@@ -210,9 +200,12 @@ def _parse_sdist_filename(filename: str) -> tuple[NormalizedName, str] | None:
         return None
 
     try:
+        # Encode only to reject a string with no UTF-8 form.
+        filename.encode()
         version = _canonical_version(version_part)
     except ValueError:
-        # InvalidVersion, or int() refusing a digit run past CPython's limit.
+        # UnicodeEncodeError, InvalidVersion, or int() refusing a digit run
+        # past CPython's limit.
         return None
 
     return (_intern_name(name_part), version)
@@ -567,7 +560,16 @@ def _parse_file_entry(
     if file_url is None:
         return None
 
-    size = _parse_size(file_info.get("size"))
+    # bool is an int subclass, so reject it explicitly rather than read True as 1.
+    raw_size = file_info.get("size")
+    size = (
+        raw_size
+        if isinstance(raw_size, int)
+        and not isinstance(raw_size, bool)
+        and raw_size >= 0
+        else None
+    )
+
     # ``requires-python`` has only a few dozen distinct values across
     # all of PyPI (``>=3.7``, ``>=3.8`` etc.) but appears once per
     # wheel.  Interning collapses the duplicates into one shared
@@ -593,13 +595,20 @@ def _parse_file_entry(
         parsed_name, version = wheel_parsed
         if parsed_name != expected:
             return None
-        sidecar = _metadata_value(file_info)
+        # PEP 714: ``core-metadata`` wins when present, so ``false`` there
+        # means no sidecar even if a stale legacy entry lingers.  Its value is
+        # ``true`` or the digest table, and both promise ``<file>.metadata``.
+        sidecar = (
+            file_info["core-metadata"]
+            if "core-metadata" in file_info
+            else file_info.get(_LEGACY_METADATA_KEY)
+        )
         wheel = WheelFile(
             filename=filename,
             url=file_url,
             version=version,
             requires_python=requires_python,
-            has_metadata=_advertises_sidecar(sidecar),
+            has_metadata=sidecar is True or isinstance(sidecar, dict),
             upload_time=upload_time,
             size=size,
         )
@@ -623,40 +632,6 @@ def _parse_file_entry(
     )
     defer_hashes(sdist, raw_hashes)
     return sdist
-
-
-def _parse_size(value: object) -> int | None:
-    # bool is an int subclass, so reject it explicitly rather than read True as 1.
-    if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
-        return value
-    return None
-
-
-_LEGACY_METADATA_KEY = "dist-info-metadata"
-
-
-def _metadata_value(file_info: _FileEntry) -> object:
-    """Return the metadata field, applying PEP 714 key precedence.
-
-    When ``core-metadata`` is present it wins and the legacy
-    ``dist-info-metadata`` key is ignored, so ``core-metadata: false``
-    means no sidecar even if a stale legacy entry lingers.  The legacy key
-    applies only when ``core-metadata`` is absent.  ``data-dist-info-metadata``
-    is the HTML attribute name and never appears in the JSON response.
-    """
-    if "core-metadata" in file_info:
-        return file_info.get("core-metadata")
-    return file_info.get(_LEGACY_METADATA_KEY)
-
-
-def _advertises_sidecar(value: object) -> bool:
-    """Return True when a metadata value promises a PEP 658/714 sidecar.
-
-    The value is either ``true`` (the sidecar exists, with no digest
-    published) or the digest table itself; both mean the index will serve
-    ``<file>.metadata``.
-    """
-    return value is True or isinstance(value, dict)
 
 
 def _verify_metadata_hash(content: bytes, metadata_hash: tuple[str, str]) -> None:

--- a/nab-project/tests/test_cached_client.py
+++ b/nab-project/tests/test_cached_client.py
@@ -42,8 +42,6 @@ from nab_index.client import (
     SdistHashMismatchError,
     WheelFile,
     WheelHashMismatchError,
-    _advertises_sidecar,
-    _metadata_value,
     _normalized_url,
     _parse_files,
     _parse_sdist_filename,
@@ -202,14 +200,26 @@ def _build_tarball(members: list[tuple[str, bytes]]) -> bytes:
     return buf.getvalue()
 
 
+def _parsed_wheel(file_info: Mapping[Any, object]) -> WheelFile:
+    """The ``WheelFile`` ingest builds for an entry carrying ``file_info``."""
+    entry: dict[Any, object] = {
+        "filename": "foo-1.0-py3-none-any.whl",
+        "url": "https://example.com/foo-1.0-py3-none-any.whl",
+        **file_info,
+    }
+    (wheel,) = _parse_files({"files": [entry]}, "https://example.com/", "foo")
+    assert isinstance(wheel, WheelFile)
+    return wheel
+
+
 def _has_metadata(file_info: Mapping[Any, object]) -> bool:
     """Whether ``file_info`` advertises a sidecar, read the way ingest reads it."""
-    return _advertises_sidecar(_metadata_value(file_info))
+    return _parsed_wheel(file_info).has_metadata
 
 
 def _metadata_hash(file_info: Mapping[Any, object]) -> tuple[str, str] | None:
     """The sidecar hash ``file_info`` publishes, read the way ingest reads it."""
-    return sidecar_hash(_metadata_value(file_info))
+    return _parsed_wheel(file_info).metadata_hash
 
 
 class TestHasMetadataFlag:
@@ -837,6 +847,9 @@ class TestParseHashes:
 
     def test_uppercase_digest_kept_lowercased(self) -> None:
         assert parse_hash_table({"sha256": "A" * 64}) == (("sha256", "a" * 64),)
+
+    def test_bare_true_publishes_no_sidecar_hash(self) -> None:
+        assert sidecar_hash(True) is None  # noqa: FBT003
 
 
 class TestSelectArtifactHash:

--- a/nab-project/tests/test_simple_client_size.py
+++ b/nab-project/tests/test_simple_client_size.py
@@ -1,46 +1,39 @@
 """Tests for ``size`` parsing in nab_index's Simple API JSON parser.
 
 bool is an int subclass, so a plain ``isinstance(value, int)`` check would
-accept a JSON boolean and read ``True`` as a size of 1; ``_parse_size`` drops it.
+accept a JSON boolean and read ``True`` as a size of 1; the entry parse drops it.
 """
 
 from __future__ import annotations
 
-from nab_index.client import _parse_files, _parse_size
+from nab_index.client import _parse_files
 
 
-def _file(extra: dict[str, object]) -> dict[str, object]:
-    base: dict[str, object] = {
+def _size(value: object) -> int | None:
+    """The ``size`` the record carries for an entry declaring ``value``."""
+    entry: dict[str, object] = {
         "filename": "foo-1.0-py3-none-any.whl",
         "url": "https://example.com/foo/foo-1.0-py3-none-any.whl",
         "hashes": {"sha256": "a" * 64},
+        "size": value,
     }
-    base.update(extra)
-    return base
+    files = _parse_files({"files": [entry]}, "https://example.com/", "foo")
+    return files[0].size
 
 
 def test_integer_size_preserved() -> None:
-    assert _parse_size(123) == 123
+    assert _size(4096) == 4096
 
 
 def test_boolean_size_dropped() -> None:
     for value in (True, False):
-        assert _parse_size(value) is None
+        assert _size(value) is None
 
 
 def test_non_integer_size_dropped() -> None:
-    assert _parse_size(1.5) is None
-    assert _parse_size("9") is None
-    assert _parse_size(-1) is None
+    assert _size(1.5) is None
+    assert _size("9") is None
 
 
-def test_boolean_size_does_not_reach_wheel_file() -> None:
-    data = {"files": [_file({"size": True})]}
-    files = _parse_files(data, "https://example.com/", "foo")
-    assert files[0].size is None
-
-
-def test_integer_size_reaches_wheel_file() -> None:
-    data = {"files": [_file({"size": 4096})]}
-    files = _parse_files(data, "https://example.com/", "foo")
-    assert files[0].size == 4096
+def test_negative_size_dropped() -> None:
+    assert _size(-1) is None


### PR DESCRIPTION
With the parsed-listing cache forced to miss, a `pip:google-bigquery-soda --resolution lowest` resolve walks 41,643 file entries through the JSON parse. Folding four one-expression helpers out of that walk removes 187,970 of the run's 6,282,693 calls and about 0.58% of its 8.44 billion instructions.

`_parse_size`, `_metadata_value` and `_advertises_sidecar` become expressions inside `_parse_file_entry`, and the PEP 714 lookup indexes `core-metadata` after the membership test instead of calling `.get`, which is 35,485 of those calls. `_is_usable_filename` splits in two: its NUL test joins the extension check in `_parse_wheel_filename` and `_parse_sdist_filename`, and its `filename.encode()` moves inside the `try` both already run, since `UnicodeEncodeError` is a `ValueError`. A filename that fails structurally is now rejected before it is encoded.

The clock cannot see a change this small, so the timing runs only rule out a regression: no worse than about 3.6% on wall. This pays on a first resolve only.