### PR TITLE
Fix "not found on any configured index" for an index-pinned package

### DIFF
--- a/docs/reference/diagnostics.md
+++ b/docs/reference/diagnostics.md
@@ -47,3 +47,4 @@ Diagnostics:
 | `requires-python` never gets a `try:` | The override that lifts it replaces the package's declared metadata, so the line names the target instead: `no file supports Python 3.12`. |
 | An extras line can be about the base package | `foo[bar]` has versions only where `foo` does, so a filter that empties `foo`'s listing gives the line and its `try:` under `foo[bar]`, naming `foo` as the entry to edit. |
 | Some lines name no setting | Nothing in the configuration produced them, such as `package not found on any configured index` or `the index lists this package but every file is yanked`. |
+| A routed package is missing from one index, not from all of them | An `index` entry is a strict pin, so the line names that index: `not found on index 'internal', the only index this package is routed to`. |

--- a/nab-index/src/nab_index/multi_index.py
+++ b/nab-index/src/nab_index/multi_index.py
@@ -184,7 +184,12 @@ class MultiIndexClient:
         """Close all clients on exit."""
         await self.aclose()
 
-    def _override_index(self, package: str) -> str | None:
+    def pinned_index(self, package: str) -> str | None:
+        """Return the index a routing override pins ``package`` to, or ``None``.
+
+        A pin is a strict route: a pinned package skips the walk over the
+        configured order, so the index named here is the only one asked.
+        """
         return self._override_map.get(_normalise_name(package))
 
     async def get_files(self, package: str) -> list[WheelFile | SdistFile]:
@@ -195,7 +200,7 @@ class MultiIndexClient:
         client.  Raises :class:`~nab_index.cache.OfflineError` when no
         index served a listing and at least one was skipped offline.
         """
-        override = self._override_index(package)
+        override = self.pinned_index(package)
         if override is not None:
             client = self._clients[override]
             files = await client.get_files(package)

--- a/nab-project/src/nab_project/fetch.py
+++ b/nab-project/src/nab_project/fetch.py
@@ -1093,13 +1093,20 @@ class FetchCoordinator:
         index returned no listing on every walk) falls back to the
         first configured index name so consumers always see
         something.
+
+        The router also says whether a routing override chose that index,
+        which the name alone cannot: an empty walk records the first
+        configured index too.  A route over a lone index holds no other
+        index back, so it is not recorded as a pin.
         """
         if isinstance(client, MultiIndexClient):
             routed = client.route_for(package)
             name = routed if routed is not None else self.indexes[0].name
+            pinned = len(self.indexes) > 1 and client.pinned_index(package) is not None
         else:
             name = self.indexes[0].name
-        self.index.store_listing_index(package, name)
+            pinned = False
+        self.index.store_listing_index(package, name, pinned=pinned)
 
     async def _fetch_metadata(
         self,

--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -1612,6 +1612,87 @@ class TestNoVersionsReasons:
             short_reason(provider, "foo") == "package not found on any configured index"
         )
 
+    def test_route_to_an_index_without_the_package_names_that_index(
+        self, tmp_path: Path
+    ) -> None:
+        """A pinned package missing from its index is not missing everywhere.
+
+        The route is why the index holding ``foo`` was never asked, so the
+        line has to name the one index that was.
+        """
+        public = tmp_path / "pypi"
+        public.mkdir()
+        (public / "foo-1.0-py3-none-any.whl").write_bytes(b"")
+        internal = tmp_path / "internal"
+        internal.mkdir()
+
+        with FetchCoordinator(
+            transport=Urllib3AsyncTransport(),
+            indexes=[
+                IndexConfig("pypi", public.as_uri()),
+                IndexConfig("internal", internal.as_uri()),
+            ],
+            index_routes=[IndexRoute("foo", "internal")],
+        ) as coordinator:
+            provider = Provider(coordinator)
+            provider.choose_version("foo", SpecifierSet("").to_range())
+
+        assert rendered_reason(provider, "foo") == (
+            "not found on index 'internal', the only index this package is routed to"
+        )
+
+    def test_route_over_a_lone_index_still_names_absence(self, tmp_path: Path) -> None:
+        """A route that holds no index back leaves the absence line alone."""
+        internal = tmp_path / "internal"
+        internal.mkdir()
+        with FetchCoordinator(
+            transport=Urllib3AsyncTransport(),
+            indexes=[IndexConfig("internal", internal.as_uri())],
+            index_routes=[IndexRoute("foo", "internal")],
+        ) as coordinator:
+            provider = Provider(coordinator)
+            provider.choose_version("foo", SpecifierSet("").to_range())
+
+        assert (
+            short_reason(provider, "foo") == "package not found on any configured index"
+        )
+
+    def test_yanked_page_on_the_routed_index_still_names_the_yank(
+        self, tmp_path: Path
+    ) -> None:
+        """The route is the weakest answer: a page that says more wins."""
+        body = json.dumps(
+            {
+                "files": [
+                    {
+                        "filename": "foo-1.0-py3-none-any.whl",
+                        "url": "https://internal.example/foo-1.0-py3-none-any.whl",
+                        "yanked": True,
+                    }
+                ]
+            }
+        ).encode()
+        stale = CachePolicy(fetched_at=0, max_age=1, etag=None)
+        OnDiskCache(tmp_path, "https://internal.example/simple/").put_simple(
+            "foo", body, stale
+        )
+        with FetchCoordinator(
+            transport=Urllib3AsyncTransport(),
+            cache_dir=tmp_path,
+            offline=True,
+            indexes=[
+                IndexConfig("pypi", DEFAULT_INDEX_URL),
+                IndexConfig("internal", "https://internal.example/simple/"),
+            ],
+            index_routes=[IndexRoute("foo", "internal")],
+        ) as coordinator:
+            provider = Provider(coordinator)
+            provider.choose_version("foo", SpecifierSet("").to_range())
+
+        assert short_reason(provider, "foo") == (
+            "the index lists this package but every file is yanked"
+        )
+
     def test_all_yanked_listing_reports_the_yank_not_absence(
         self, tmp_path: Path
     ) -> None:

--- a/nab-provider/src/nab_provider/_provider/listing_diagnosis.py
+++ b/nab-provider/src/nab_provider/_provider/listing_diagnosis.py
@@ -59,6 +59,7 @@ if TYPE_CHECKING:
         "unreadable-only",
         "yanked-only",
         "absent",
+        "pinned-absent",
         "filtered-empty",
         "blockers",
         "extra-undeclared",
@@ -130,6 +131,7 @@ class ReasonKind:
     UNREADABLE_ONLY: Final = "unreadable-only"
     YANKED_ONLY: Final = "yanked-only"
     ABSENT: Final = "absent"
+    PINNED_ABSENT: Final = "pinned-absent"
     FILTERED_EMPTY: Final = "filtered-empty"
     BLOCKERS: Final = "blockers"
     EXTRA_UNDECLARED: Final = "extra-undeclared"
@@ -349,15 +351,16 @@ OFFLINE_MISS = NoVersionsReason(ReasonKind.OFFLINE_MISS)
 UNREADABLE_ONLY = NoVersionsReason(ReasonKind.UNREADABLE_ONLY)
 YANKED_ONLY = NoVersionsReason(ReasonKind.YANKED_ONLY)
 ABSENT = NoVersionsReason(ReasonKind.ABSENT)
+PINNED_ABSENT = NoVersionsReason(ReasonKind.PINNED_ABSENT)
 FILTERED_EMPTY = NoVersionsReason(ReasonKind.FILTERED_EMPTY)
 EXTRA_BASE_EMPTY = NoVersionsReason(ReasonKind.EXTRA_BASE_EMPTY)
 
 
 NO_MATCH = Diagnostic("no version matches the requirement")
 
-# The four situations the index client answers on its own.  None of them is
-# a walk, so only the two with something to add carry a ``-v`` body: for the
-# other two, saying the same fact at more length is not detail.
+# The four situations the index client answers on its own with a fixed line.
+# None of them is a walk, so only the two with something to add carry a ``-v``
+# body: for the other two, saying the same fact at more length is not detail.
 FIXED_DIAGNOSTICS: dict[Kind, Diagnostic] = {
     ReasonKind.OFFLINE_MISS: Diagnostic(
         "offline mode skipped an index with no cached listing",
@@ -379,6 +382,19 @@ FIXED_DIAGNOSTICS: dict[Kind, Diagnostic] = {
     ),
     ReasonKind.ABSENT: Diagnostic("package not found on any configured index"),
 }
+
+
+def pinned_index_diagnostic(index_name: str) -> Diagnostic:
+    """Say that the one index the package is routed to does not carry it.
+
+    Missing from a pinned index is not missing from the configured set: the
+    route is why no other index was asked.  Built rather than fixed, since
+    the line names the index.
+    """
+    return Diagnostic(
+        f"not found on index {index_name!r}, the only index this package is routed to"
+    )
+
 
 _NO_SDIST_TAIL = "the files nab read hold no sdist to build from"
 

--- a/nab-provider/src/nab_provider/provider.py
+++ b/nab-provider/src/nab_provider/provider.py
@@ -1748,6 +1748,8 @@ class Provider:
             return _diagnosis.UNREADABLE_ONLY
         if index.is_all_yanked_listing(normalized):
             return _diagnosis.YANKED_ONLY
+        if index.is_pinned_listing(normalized):
+            return _diagnosis.PINNED_ABSENT
         return _diagnosis.ABSENT
 
     def _capture_lookahead_blockers(
@@ -1866,11 +1868,25 @@ class Provider:
             return _diagnosis.blockers_diagnostic(
                 self, normalized, recorded.blockers, recorded.metadata
             )
+        if recorded.kind == _diagnosis.ReasonKind.PINNED_ABSENT:
+            return self._render_pinned_absent_reason(package)
         if recorded.kind == _diagnosis.ReasonKind.EXTRA_BASE_EMPTY:
             return self._render_extra_base_reason(package)
         if recorded.kind in _EXTRA_KINDS:
             return self._render_extra_reason(package, recorded)
         return self._render_listing_reason(package, recorded)
+
+    def _render_pinned_absent_reason(self, package: str) -> Diagnostic:
+        """Render a package routed to an index that does not carry it.
+
+        The name is read back from the store, which recorded it in the call
+        that marked the pin, so the marker carries nothing and the record
+        path stays allocation-free.
+        """
+        _, _, normalized = self.split_and_normalize(package)
+        index_name = self.serving_index(normalized)
+        assert index_name is not None
+        return _diagnosis.pinned_index_diagnostic(index_name)
 
     def _render_extra_base_reason(self, package: str) -> Diagnostic:
         """Render an extras proxy whose base package ran out of versions.

--- a/nab-provider/src/nab_provider/store.py
+++ b/nab-provider/src/nab_provider/store.py
@@ -68,6 +68,9 @@ class InMemoryIndex:
         self._listings: dict[str, list[WheelFile | SdistFile]] = {}
         self._listing_errors: dict[str, BaseException] = {}
         self._listing_indexes: dict[str, str] = {}
+        # Packages a routing override sent to one index, which left the
+        # other configured indexes unasked.
+        self._pinned_listings: set[str] = set()
         # Packages whose empty listing stands for an index skipped offline.
         self._offline_listing_misses: set[str] = set()
         # Packages whose empty listing stands for a page of formats nab cannot read.
@@ -185,14 +188,26 @@ class InMemoryIndex:
         """Return ``package``'s recorded listing fetch error, or ``None``."""
         return self._listing_errors.get(package)
 
-    def store_listing_index(self, package: str, index_name: str) -> None:
-        """Record which configured index served ``package``."""
+    def store_listing_index(
+        self, package: str, index_name: str, *, pinned: bool = False
+    ) -> None:
+        """Record which configured index served ``package``.
+
+        ``pinned`` marks ``index_name`` as an index a routing override
+        chose, which left the other configured indexes unasked.
+        """
         with self._lock:
             self._listing_indexes[package] = index_name
+            if pinned:
+                self._pinned_listings.add(package)
 
     def get_listing_index(self, package: str) -> str | None:
         """Return the configured index name that served ``package``, or ``None``."""
         return self._listing_indexes.get(package)
+
+    def is_pinned_listing(self, package: str) -> bool:
+        """Whether a routing override kept other indexes from serving ``package``."""
+        return package in self._pinned_listings
 
     def _read_metadata(
         self, package: str, version: str, metadata_url: str | None


### PR DESCRIPTION
A package an `index` entry routes to one index was reported as missing from every configured index when that index did not carry it:

```
Diagnostics:
  - foo: package not found on any configured index
```

The route is why no other index was asked, so the line sent the reader looking at the package name rather than at the route. It now names the index that was asked:

```
Diagnostics:
  - foo: not found on index 'internal', the only index this package is routed to
```

The pin comes from the router that made the routing decision, recorded when the listing lands, rather than from the overrides the provider holds. A route over a single configured index holds no other index back, so it keeps the absence line.

The cases that already avoided the absence wording are checked first and unchanged: an offline skip, a page of formats nab cannot read, a page whose every file is yanked, and a listing the filter emptied.
