### PR TITLE
Stop blaming build-policy for a source tree with no project file

### DIFF
--- a/nab-project/src/nab_project/_sources.py
+++ b/nab-project/src/nab_project/_sources.py
@@ -190,6 +190,19 @@ def _materialize_vcs(
     )
 
 
+def _has_no_project_file(path: Path) -> bool:
+    """Whether ``path`` gives a :pep:`517` backend nothing to invoke.
+
+    Tests the same states as ``_build.runner._read_pyproject``, so a tree
+    refused here and one the build path gives up on are described in the
+    same words.
+    """
+    return (
+        path_state(path / "pyproject.toml") is PathState.ABSENT
+        and not path_state(path / "setup.py").should_read
+    )
+
+
 def extract_source_metadata(
     path: Path,
     *,
@@ -212,7 +225,9 @@ def extract_source_metadata(
     keep using the caller's path.
 
     An unreadable ``pyproject.toml`` is a read failure at every policy level,
-    since the build path cannot read it either.
+    since the build path cannot read it either.  A tree holding neither a
+    ``pyproject.toml`` nor a ``setup.py`` is refused the same way: no policy
+    level gives the backend anything to invoke.
     """
     # Imported in-function so tests can patch the module attribute, and to keep
     # ``_build.runner`` (and the ``build`` package behind it) off the import
@@ -228,6 +243,10 @@ def extract_source_metadata(
 
     if metadata is not None:
         return metadata
+
+    if _has_no_project_file(path):
+        msg = f"{descriptor}: no pyproject.toml or setup.py at {path}"
+        raise UnsupportedSdistError(msg)
 
     if kind == "local":
         allowed = {BuildPolicy.BUILD_LOCAL, BuildPolicy.BUILD_REMOTE}

--- a/nab-project/tests/test_archive.py
+++ b/nab-project/tests/test_archive.py
@@ -1625,3 +1625,74 @@ class TestArchiveBuildPolicyLevels:
     def test_level_docstring_names_archive_sources(self, member: str) -> None:
         docstring = _attribute_docstrings(BuildPolicy)[member]
         assert "archive" in docstring.lower()
+
+
+class TestSourceWithoutProjectFile:
+    """A declared source whose tree holds no pyproject.toml and no setup.py.
+
+    The static reader returns ``None`` for it just as it does for a dynamic
+    tree, but no policy level gives the backend anything to invoke, so a
+    build-policy refusal would name a remedy that cannot work.
+    """
+
+    def _extract(self, path: Path, *, kind: str, policy: BuildPolicy) -> WheelMetadata:
+        return sources.extract_source_metadata(
+            path,
+            descriptor=f"{kind} source 'pkg'",
+            policy=policy,
+            kind=kind,
+            offline=False,
+            build_config=None,
+        )
+
+    @pytest.mark.parametrize(
+        ("kind", "policy"),
+        [
+            ("archive", BuildPolicy.NEVER),
+            ("archive", BuildPolicy.BUILD_LOCAL),
+            ("archive", BuildPolicy.BUILD_REMOTE),
+            ("local", BuildPolicy.NEVER),
+            ("local", BuildPolicy.BUILD_LOCAL),
+            ("vcs", BuildPolicy.BUILD_REMOTE),
+        ],
+    )
+    def test_tree_without_a_project_file_names_the_missing_file(
+        self, kind: str, policy: BuildPolicy, tmp_path: Path
+    ) -> None:
+        with pytest.raises(UnsupportedSdistError) as excinfo:
+            self._extract(tmp_path, kind=kind, policy=policy)
+        assert str(excinfo.value) == (
+            f"{kind} source 'pkg': no pyproject.toml or setup.py at {tmp_path}"
+        )
+
+    def test_missing_subdirectory_names_the_missing_file(self, tmp_path: Path) -> None:
+        """A mistyped ``subdirectory`` lands on a path that is not there at all."""
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "pkg"\nversion = "1.0.0"\n', encoding="utf-8"
+        )
+        subdirectory = tmp_path / "nope"
+        with pytest.raises(UnsupportedSdistError) as excinfo:
+            self._extract(subdirectory, kind="archive", policy=BuildPolicy.BUILD_LOCAL)
+        assert str(excinfo.value) == (
+            f"archive source 'pkg': no pyproject.toml or setup.py at {subdirectory}"
+        )
+
+    def test_setup_py_tree_is_still_a_policy_refusal(self, tmp_path: Path) -> None:
+        """A legacy setup.py tree has a project file, so the policy refuses it."""
+        (tmp_path / "setup.py").write_text(
+            "from setuptools import setup\n\nsetup()\n", encoding="utf-8"
+        )
+        with pytest.raises(UnsupportedSdistError) as excinfo:
+            self._extract(tmp_path, kind="local", policy=BuildPolicy.NEVER)
+        assert "has dynamic metadata" in str(excinfo.value)
+
+    def test_pyproject_without_a_project_table_is_still_a_policy_refusal(
+        self, tmp_path: Path
+    ) -> None:
+        """A pyproject with no ``[project]`` is a project file, so policy decides."""
+        (tmp_path / "pyproject.toml").write_text(
+            '[build-system]\nrequires = ["setuptools"]\n', encoding="utf-8"
+        )
+        with pytest.raises(UnsupportedSdistError) as excinfo:
+            self._extract(tmp_path, kind="local", policy=BuildPolicy.NEVER)
+        assert "has dynamic metadata" in str(excinfo.value)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1739,6 +1739,36 @@ class TestLockCommandSpecific:
         assert "[project].dependencies" not in err
         assert "Traceback" not in err
 
+    def test_local_source_without_a_project_file_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A source tree with no project file reports that, not the policy.
+
+        No policy level can read metadata out of such a tree, so naming the
+        policy would point at a setting that cannot help.
+        """
+        member = tmp_path / "mylocal"
+        member.mkdir()
+        (member / "README").write_text("nothing to build here\n")
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\nname = "root"\nversion = "0"\n'
+            'dependencies = ["mylocal"]\n'
+            "[tool.nab]\n"
+            'build-policy = "never"\n'
+            "[[tool.nab.local-sources]]\n"
+            'name = "mylocal"\n'
+            'path = "mylocal"\n',
+        )
+        with pytest.raises(SystemExit, match="1"):
+            lock(pyproject, offline=True, output=Path("-"), cache=False)
+        err = capsys.readouterr().err
+        expected = (
+            "error: cannot lock: local source 'mylocal':"
+            f" no pyproject.toml or setup.py at {member}"
+        )
+        assert err.splitlines() == [expected]
+
     def test_local_source_naming_another_project_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:


### PR DESCRIPTION
A declared source whose directory holds no `pyproject.toml` and no `setup.py` is reported as having dynamic metadata, and the message points at a `build-policy` setting that cannot help. Locking a local source under `build-policy = "never"`:

    error: cannot lock: local source 'mylocal' at /tmp/nabdemo/mylocal has dynamic metadata; building requires build-policy 'build-local' but the effective policy is 'never'

Follow that advice and the build path fails on the same tree, naming the real problem:

    error: cannot lock: local source 'mylocal': no pyproject.toml or setup.py at /tmp/nabdemo/mylocal

`extract_static_metadata` returns `None` both for a tree that declares its metadata dynamically and for one with no project file at all, and `extract_source_metadata` read the second as the first.

The missing file is now checked before the policy, so every policy level reports it in the words the build path already used. That covers a directory that genuinely has no project file, and a `path` or `subdirectory` pointing at the wrong place, including one that does not exist.

The policy still decides for a `setup.py` tree and a `pyproject.toml` with no `[project]` table.

