### PR TITLE
Prune the walk-ahead prefetch to the scan's range, 63 fewer metadata fetches

### DIFF
--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -104,6 +104,9 @@ from nab_resolver.types import Incompatibility, IncompatibilityCause, Term
 
 V = Version
 
+# Excludes nothing. Used where the walk-ahead's range is not what a test checks.
+_ANY_VERSION = VersionRange.full()
+
 # The target most tests resolve against: the host machine, impersonating
 # CPython 3.12.0.  Shared because it is frozen and building one walks the
 # host's whole tag set.
@@ -626,7 +629,7 @@ class TestSidecarDigestForwarding:
         provider.fetch_versions("foo")
         coordinator.reset()
 
-        provider.prefetch_walk_ahead("foo")
+        provider._prefetch_walk_ahead("foo", _ANY_VERSION)
 
         assert _batched_digests(coordinator) == [("1.0", _sidecar_hash("1.0"))]
 
@@ -6695,7 +6698,7 @@ class TestSkipFetch:
         )
         provider.fetch_versions("pkg")
         coordinator.reset()
-        provider.prefetch_walk_ahead("pkg")
+        provider._prefetch_walk_ahead("pkg", _ANY_VERSION)
         assert _prefetched_batch_versions(coordinator) == ["1.0"]
 
 
@@ -8728,19 +8731,20 @@ class TestSpeculativePrefetchBatchLimit:
 
 
 class TestPrefetchWalkAhead:
-    """``prefetch_walk_ahead`` covers the walk past the first batch.
+    """``_prefetch_walk_ahead`` covers the walk past the first batch.
 
     Fired from ``_scan_candidates_pipelined``; submits up to
     ``DEEP_PREFETCH_COUNT`` wheel metadata requests in scan order over
-    ``versions_cache[normalized]``.  Fire-and-forget; correctness only
-    depends on it being a superset of what the resolver later asks for.
+    ``versions_cache[normalized]``, skipping the versions the scan's range
+    excludes.  Fire-and-forget: a version it skips is fetched on demand
+    when the resolver asks for it.
     """
 
     def test_no_op_when_listing_missing(self) -> None:
         """Bare provider with no cached listing makes no batch call."""
         coordinator = make_coordinator([], package="foo")
         provider = Provider(coordinator)
-        provider.prefetch_walk_ahead("foo")
+        provider._prefetch_walk_ahead("foo", _ANY_VERSION)
         assert not coordinator.calls_to("request_metadata_batch")
 
     def test_caps_at_deep_prefetch_count(self) -> None:
@@ -8750,11 +8754,42 @@ class TestPrefetchWalkAhead:
         provider = Provider(coordinator)
         provider.fetch_versions("foo")
         coordinator.reset()
-        provider.prefetch_walk_ahead("foo")
+        provider._prefetch_walk_ahead("foo", _ANY_VERSION)
         items = coordinator.calls_to("request_metadata_batch")[-1][0]
         # fetch_versions already prefetched the newest version; it fills a
         # window slot but is skipped as already-held.
         assert len(items) == provider.DEEP_PREFETCH_COUNT - 1
+
+    def test_skips_versions_outside_the_range(self) -> None:
+        """A version the scan's range excludes is not requested."""
+        wheels = [make_wheel("3.0"), make_wheel("2.0"), make_wheel("1.0")]
+        coordinator = make_coordinator(wheels, package="foo")
+        provider = Provider(coordinator)
+        provider.fetch_versions("foo")
+        coordinator.reset()
+        provider._prefetch_walk_ahead("foo", SpecifierSet(">=2.0").to_range())
+        items = coordinator.calls_to("request_metadata_batch")[-1][0]
+        versions = [ver for _, ver, _, _ in items]
+        # fetch_versions already prefetched the newest version.
+        assert versions == ["2.0"]
+
+    def test_out_of_range_version_still_fills_its_window_slot(self) -> None:
+        """The window stays the first ``DEEP_PREFETCH_COUNT`` listing versions.
+
+        Excluding a version frees no slot for a deeper one, so the walk
+        never reaches further than it does with no range at all.
+        """
+        wheels = [make_wheel(f"{i}.0") for i in range(100, 0, -1)]
+        coordinator = make_coordinator(wheels, package="foo")
+        provider = Provider(coordinator)
+        provider.fetch_versions("foo")
+        coordinator.reset()
+        provider._prefetch_walk_ahead("foo", SpecifierSet("<=90.0").to_range())
+        items = coordinator.calls_to("request_metadata_batch")[-1][0]
+        versions = [ver for _, ver, _, _ in items]
+        # The window runs 100.0 down to 37.0; 100.0 through 91.0 are out of
+        # range and 37.0 is the last slot.
+        assert versions == [f"{i}.0" for i in range(90, 36, -1)]
 
     @pytest.mark.parametrize(
         "strategy",
@@ -8773,7 +8808,7 @@ class TestPrefetchWalkAhead:
         )
         provider.fetch_versions("foo")
         coordinator.reset()
-        provider.prefetch_walk_ahead("foo")
+        provider._prefetch_walk_ahead("foo", _ANY_VERSION)
         items = coordinator.calls_to("request_metadata_batch")[-1][0]
         versions = [ver for _, ver, _, _ in items]
         # fetch_versions already prefetched 1.0, the oldest; it fills a window
@@ -8790,7 +8825,7 @@ class TestPrefetchWalkAhead:
         provider.fetch_versions("foo")
         provider.deps_cache[("foo", V("2.0"))] = {}
         coordinator.reset()
-        provider.prefetch_walk_ahead("foo")
+        provider._prefetch_walk_ahead("foo", _ANY_VERSION)
         items = coordinator.calls_to("request_metadata_batch")[-1][0]
         versions = [ver for _, ver, _, _ in items]
         assert "2.0" not in versions
@@ -8812,7 +8847,7 @@ class TestPrefetchWalkAhead:
         provider = Provider(coordinator)
         provider.fetch_versions("foo")
         coordinator.reset()
-        provider.prefetch_walk_ahead("foo")
+        provider._prefetch_walk_ahead("foo", _ANY_VERSION)
         items = coordinator.calls_to("request_metadata_batch")[-1][0]
         versions = [ver for _, ver, _, _ in items]
         assert versions == ["2.0", "1.0"]
@@ -8828,7 +8863,7 @@ class TestPrefetchWalkAhead:
         assert two.metadata_url is not None
         coordinator.request_metadata("foo", "2.0", two.metadata_url, None)
         coordinator.reset()
-        provider.prefetch_walk_ahead("foo")
+        provider._prefetch_walk_ahead("foo", _ANY_VERSION)
         items = coordinator.calls_to("request_metadata_batch")[-1][0]
         versions = [ver for _, ver, _, _ in items]
         assert "2.0" not in versions
@@ -8849,7 +8884,7 @@ class TestPrefetchWalkAhead:
         provider = Provider(coordinator)
         provider.fetch_versions("foo")
         coordinator.reset()
-        provider.prefetch_walk_ahead("foo")
+        provider._prefetch_walk_ahead("foo", _ANY_VERSION)
         items = coordinator.calls_to("request_metadata_batch")[-1][0]
         assert any(
             ver == "1.0" and url.endswith(".whl.metadata") for _, ver, url, _ in items
@@ -8865,7 +8900,7 @@ class TestPrefetchWalkAhead:
         provider = Provider(coordinator)
         provider.fetch_versions("foo")
         coordinator.reset()
-        provider.prefetch_walk_ahead("foo")
+        provider._prefetch_walk_ahead("foo", _ANY_VERSION)
         items = coordinator.calls_to("request_metadata_batch")[-1][0]
         versions = [ver for _, ver, _, _ in items]
         assert versions == ["2.0"]
@@ -8880,7 +8915,7 @@ class TestPrefetchWalkAhead:
         provider = Provider(coordinator)
         provider.fetch_versions("foo")
         coordinator.reset()
-        provider.prefetch_walk_ahead("foo")
+        provider._prefetch_walk_ahead("foo", _ANY_VERSION)
         items = coordinator.calls_to("request_metadata_batch")[-1][0]
         versions = [ver for _, ver, _, _ in items]
         assert versions == ["1.0"]
@@ -8892,11 +8927,11 @@ class TestPrefetchWalkAhead:
         provider = Provider(coordinator)
         provider.fetch_versions("foo")
         coordinator.reset()
-        provider.prefetch_walk_ahead("foo")
+        provider._prefetch_walk_ahead("foo", _ANY_VERSION)
         assert not coordinator.calls_to("request_metadata_batch")
 
     def test_fires_when_pipelined_scan_engages(self) -> None:
-        """Trip the look-ahead scan: walk_ahead fires before the 8-batch starts."""
+        """Trip the look-ahead scan: walk_ahead fires with the range being scanned."""
         # foo's first candidate (3.0) requires bar<2.0 but the resolver has
         # already decided bar==3.0; that rejection drives _run_full_scan into
         # _scan_candidates_pipelined, which fires the deep prefetch.
@@ -8912,11 +8947,13 @@ class TestPrefetchWalkAhead:
         root_reqs = {"foo": VersionRange.full(admit_arbitrary=False)}
         provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         provider.receive_partial_solution_hint({}, {"bar": V("3.0")})
+
+        version_range = SpecifierSet(">=2.0").to_range()
         with patch.object(
-            provider, "prefetch_walk_ahead", wraps=provider.prefetch_walk_ahead
+            provider, "_prefetch_walk_ahead", wraps=provider._prefetch_walk_ahead
         ) as spy:
-            provider.choose_version("foo", VersionRange.full())
-        spy.assert_called_with("foo")
+            provider.choose_version("foo", version_range)
+        spy.assert_called_with("foo", version_range)
 
     def test_does_not_fire_when_first_candidate_accepted(self) -> None:
         """No rejection means no pipelined scan and no deep prefetch."""
@@ -8929,7 +8966,7 @@ class TestPrefetchWalkAhead:
         root_reqs = {"foo": SpecifierSet(">=1.0").to_range()}
         provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         with patch.object(
-            provider, "prefetch_walk_ahead", wraps=provider.prefetch_walk_ahead
+            provider, "_prefetch_walk_ahead", wraps=provider._prefetch_walk_ahead
         ) as spy:
             provider.choose_version("foo", SpecifierSet(">=1.0").to_range())
         spy.assert_not_called()

--- a/nab-provider/src/nab_provider/_provider/listing.py
+++ b/nab-provider/src/nab_provider/_provider/listing.py
@@ -27,7 +27,7 @@ from ..vcs_admission import UnsupportedVcsError
 from .metadata_resolver import pick_dist_for_metadata, version_dists
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Mapping, Sequence
+    from collections.abc import Iterable, Iterator, Mapping, Sequence
     from datetime import datetime
     from typing import Literal, TypeAlias
 
@@ -948,6 +948,7 @@ def _excluded_by_upload_time(
 def prefetch_walk_ahead(
     provider: Provider,
     normalized: str,
+    version_range: RangeProtocol[Version],
     deep_count: int,
 ) -> None:
     """Submit metadata for the next ``deep_count`` wheels of ``normalized``.
@@ -955,6 +956,10 @@ def prefetch_walk_ahead(
     Called at the top of the pipelined scan, so a walk that runs past the
     first ``PREFETCH_BATCH`` window hits cache instead of paying one RTT
     per visit.
+
+    ``version_range`` is the range the scan walks.  A version outside it
+    is not requested, since the scan never reaches it, but it still fills
+    its window slot.
 
     Takes each version's artifact from
     :func:`~nab_provider._provider.metadata_resolver.version_dists`, so the
@@ -976,13 +981,7 @@ def prefetch_walk_ahead(
     )
 
     items: list[tuple[str, str, str, tuple[str, str] | None]] = []
-    seen_versions: set[Version] = set()
-    for version, _ in ordered:
-        if version in seen_versions:
-            continue
-        seen_versions.add(version)
-        if len(seen_versions) > deep_count:
-            break
+    for version in _walk_ahead_window(ordered, version_range, deep_count):
         if (normalized, version) in provider.deps_cache:
             continue
         dist = picked[version]
@@ -995,6 +994,27 @@ def prefetch_walk_ahead(
         items.append((normalized, dist.version, url, dist.metadata_hash))
     if items:
         provider.coordinator.request_metadata_batch(items)
+
+
+def _walk_ahead_window(
+    ordered: Sequence[tuple[Version, DistFile]],
+    version_range: RangeProtocol[Version],
+    deep_count: int,
+) -> Iterator[Version]:
+    """Yield the in-range versions among the first ``deep_count`` distinct ones.
+
+    An excluded version still consumes its slot, so the window covers the
+    same stretch of the listing whatever the range is.
+    """
+    seen: set[Version] = set()
+    for version, _ in ordered:
+        if version in seen:
+            continue
+        seen.add(version)
+        if len(seen) > deep_count:
+            return
+        if version in version_range:
+            yield version
 
 
 def prefetch_batch(

--- a/nab-provider/src/nab_provider/provider.py
+++ b/nab-provider/src/nab_provider/provider.py
@@ -1168,9 +1168,13 @@ class Provider:
         """See :func:`nab_provider._provider.listing.speculative_prefetch`."""
         _listing.speculative_prefetch(self, normalized, versions)
 
-    def prefetch_walk_ahead(self, normalized: str) -> None:
+    def _prefetch_walk_ahead(
+        self, normalized: str, version_range: RangeProtocol[Version]
+    ) -> None:
         """See :func:`nab_provider._provider.listing.prefetch_walk_ahead`."""
-        _listing.prefetch_walk_ahead(self, normalized, self.DEEP_PREFETCH_COUNT)
+        _listing.prefetch_walk_ahead(
+            self, normalized, version_range, self.DEEP_PREFETCH_COUNT
+        )
 
     def filter_distributions(
         self, normalized: str, files: Sequence[WheelFile | SdistFile]
@@ -1227,7 +1231,13 @@ class Provider:
 
         wheel_by_version = self._wheel_by_version(normalized, version_list)
         return self._run_full_scan(
-            normalized, first, candidates, wheel_by_version, package, all_versions
+            normalized,
+            first,
+            candidates,
+            wheel_by_version,
+            package,
+            all_versions,
+            version_range,
         )
 
     def _ordered_candidates(
@@ -1392,6 +1402,7 @@ class Provider:
         wheel_by_version: dict[Version, DistFile],
         package: str,
         all_versions: list[Version],
+        version_range: RangeProtocol[Version],
     ) -> Version | None:
         """Run the decision-aware look-ahead scan over candidates.
 
@@ -1409,6 +1420,7 @@ class Provider:
             list(rest),
             wheel_by_version,
             broad_rejections,
+            version_range,
             first_candidate=first,
         )
         if found is not None:
@@ -1430,6 +1442,7 @@ class Provider:
         remaining: list[Version],
         wheel_by_version: dict[Version, DistFile],
         broad_rejections: int,
+        version_range: RangeProtocol[Version],
         *,
         first_candidate: Version | None = None,
     ) -> Version | None:
@@ -1451,7 +1464,7 @@ class Provider:
         abort path.
         """
         # Front-load deep metadata so a walk past the first batch hits cache.
-        self.prefetch_walk_ahead(normalized)
+        self._prefetch_walk_ahead(normalized, version_range)
 
         starts_iter = iter(range(0, len(remaining), self.PREFETCH_BATCH))
         in_flight: deque[

--- a/nab-provider/tests/test_provider_declared_target.py
+++ b/nab-provider/tests/test_provider_declared_target.py
@@ -77,6 +77,8 @@ def _make_coordinator(
     return make_coordinator(wheels, package=package, auto_metadata=True)
 
 
+_ANY_VERSION = VersionRange.full()
+
 _LINUX_TARGET = ResolveTarget.for_declared(
     python_version="3.11", spec=PlatformSpec("linux_x86_64")
 )
@@ -1517,7 +1519,7 @@ class TestTwoInstallableSiblingWheels:
         provider.fetch_versions("pkg")
         coordinator.reset()
 
-        provider.prefetch_walk_ahead("pkg")
+        provider._prefetch_walk_ahead("pkg", _ANY_VERSION)
 
         items = coordinator.calls_to("request_metadata_batch")[-1][0]
         assert [url for _pkg, _ver, url, _hash in items] == [_sidecar(_LINUX_WHEEL)]


### PR DESCRIPTION
A `nab lock` of the README quick start (`starlette<=0.36.0`, `fastapi<=0.115.2`) makes 103 metadata requests instead of 166, reads the same 78 documents and emits the same 9 pins. All 63 that go away are fastapi sidecars above the root's `<=0.115.2` cap; nothing else asked for them and nothing read them.

`prefetch_walk_ahead` front-loads the first 64 distinct versions of a listing whatever the scan is looking for, while `choose_version` already knows the range it walks. It now gets that range and skips the versions outside it. An excluded version still fills its window slot, so the walk covers the same stretch of the listing and the request count can only fall. A version it skips is fetched on demand if the resolver reaches it.

Those requests were not buying latency. With every metadata fetch charged a fixed delay, the same lock runs about 7% faster at 30 ms (0.53 s to 0.49 s) and about 8% faster at 100 ms (1.30 s to 1.19 s); the branch was ahead in all 25 paired rounds at each delay.

`Provider.prefetch_walk_ahead` becomes `_prefetch_walk_ahead`; nothing but the class and its own tests called it, and it is in no documentation.