### PR TITLE
Fix config reference promising uploaded-prior-to values nab rejects

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -62,11 +62,11 @@ build-group = "build"
 requires-python = ">=3.10"
 
 # Reproducibility cutoff.  Distributions uploaded after this timestamp
-# are ignored.  Accepts ISO 8601 strings, native TOML datetimes, or a
-# "P<n>D" duration relative to the resolve anchor.  Artifacts from a
-# local file:// index carry no upload time and are always kept.  An
-# HTML listing rarely carries one either, and those files are then
-# excluded; see "Serialization" below.
+# are ignored.  Accepts an ISO 8601 string or a native TOML datetime,
+# each with an explicit timezone offset, or a "P<n>D" duration relative
+# to the resolve anchor.  Artifacts from a local file:// index carry no
+# upload time and are always kept.  An HTML listing rarely carries one
+# either, and those files are then excluded; see "Serialization" below.
 uploaded-prior-to = "2026-05-01T00:00:00Z"
 
 # Version selection within an allowed range.  Mirrors uv's --resolution.
@@ -298,8 +298,8 @@ A body sets any combination of:
 * `dist-policy`: an enum string, or `{ policy = "...",
   trust-unverified-deps = true|false }`.
 * `build-policy`: an enum string.
-* `uploaded-prior-to`: a datetime, a `P<n>D` duration, or `false` (no
-  cutoff for the selected versions).
+* `uploaded-prior-to`: a datetime with an explicit timezone offset, a
+  `P<n>D` duration, or `false` (no cutoff for the selected versions).
 * `index`: route the selected packages to this declared index (a
   strict pin: only that index is consulted).  Routing requires
   bare-name selectors, because the routing decision happens before any

--- a/nab-project/tests/test_config.py
+++ b/nab-project/tests/test_config.py
@@ -130,18 +130,44 @@ def indexes_doc_example() -> str:
     return blocks[0]
 
 
-def default_groups_doc_comment() -> str:
-    """Return the comment above ``default-groups`` in the config reference."""
+def top_level_doc_comment(key: str) -> str:
+    """Return the comment above ``key`` in the config reference's example block."""
     lines = first_tool_nab_example().splitlines()
     for i, line in enumerate(lines):
-        if line.startswith("default-groups"):
+        if line.startswith(key):
             comment: list[str] = []
             j = i - 1
             while j >= 0 and lines[j].lstrip().startswith("#"):
                 comment.insert(0, lines[j].lstrip("# ").rstrip())
                 j -= 1
             return " ".join(comment)
-    raise AssertionError("no default-groups key in the config reference example")
+    msg = f"no {key} key in the config reference example"
+    raise AssertionError(msg)
+
+
+def override_body_doc_bullet(key: str) -> str:
+    """Return the config reference's override-body bullet for ``key``.
+
+    Bullets wrap across source lines, so the text comes back on one line.
+    """
+    text = DOCS_CONFIGURATION.read_text()
+    section = re.search(
+        r"^A body sets any combination of:\n\n(.*?)\n\n",
+        text,
+        flags=re.DOTALL | re.MULTILINE,
+    )
+    if section is None:
+        raise AssertionError("no override-body list in configuration.md")
+
+    bullet = re.search(
+        rf"^\* `{re.escape(key)}`:(.*?)(?=^\* |\Z)",
+        section.group(1),
+        flags=re.DOTALL | re.MULTILINE,
+    )
+    if bullet is None:
+        msg = f"no {key} bullet in configuration.md's override body"
+        raise AssertionError(msg)
+    return " ".join(bullet.group(1).split())
 
 
 class TestCliOverridesFold:
@@ -884,13 +910,13 @@ class TestDefaultGroups:
     def test_doc_describes_resolve_activation(self) -> None:
         # default-groups activates the groups for the resolve, not just records
         # them in the lockfile, so the reference has to say so.
-        comment = default_groups_doc_comment().lower()
+        comment = top_level_doc_comment("default-groups").lower()
         assert any(word in comment for word in ("resolve", "activat")), comment
 
     def test_doc_notes_the_conflict_fork(self) -> None:
         # A default that --groups joins to another member of its conflict
         # set forks rather than unions, so "every resolve" needs the caveat.
-        comment = default_groups_doc_comment()
+        comment = top_level_doc_comment("default-groups")
         assert "forks" in comment, comment
 
 
@@ -1470,6 +1496,27 @@ class TestUploadedPriorTo:
             ),
         ):
             read_pyproject_config(path)
+
+    def test_top_level_doc_states_the_offset_requirement(self) -> None:
+        # Offset-less values are ISO 8601 strings and TOML datetimes too, so
+        # naming those two forms is not enough on its own.
+        comment = top_level_doc_comment("uploaded-prior-to").lower()
+        assert "timezone offset" in comment, comment
+
+    def test_override_doc_states_the_offset_requirement(self) -> None:
+        bullet = override_body_doc_bullet("uploaded-prior-to").lower()
+        assert "timezone offset" in bullet, bullet
+
+    def test_top_level_doc_example_carries_an_offset(self, tmp_path: Path) -> None:
+        """The reference's own example has to be a value the parser accepts."""
+        block = first_tool_nab_example()
+        match = re.search(r"^uploaded-prior-to = (.*)$", block, re.MULTILINE)
+        assert match is not None, "top-level example dropped uploaded-prior-to"
+
+        path = write(tmp_path, f"[tool.nab]\nuploaded-prior-to = {match.group(1)}\n")
+        dt = read_pyproject_config(path).uploaded_prior_to
+        assert dt is not None
+        assert dt.utcoffset() is not None
 
 
 class TestPolicies:


### PR DESCRIPTION
The config reference says `uploaded-prior-to` accepts "ISO 8601 strings, native TOML datetimes". `2026-05-01T00:00:00` is both, and nab rejects it:

```
uploaded-prior-to ISO datetime must include an explicit timezone offset (e.g. 'Z' or '+00:00'); got '2026-05-01T00:00:00'
```

A bare TOML local-date-time is rejected the same way. The requirement is deliberate, so a cutoff means the same instant wherever the lockfile is read, but neither the top-level example comment nor the override-body bullet mentioned it.

Both now say so, and the tests that read the reference check each place and parse the example's own value.
