### PR TITLE
Keep a decision key while its listing is in flight, ~2% fewer instructions

### DIFF
--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -36,6 +36,7 @@ from .client import (
     _verify_metadata_hash,
     holds_unreadable_format,
     verify_sdist_hash,
+    zip_sdist_versions,
 )
 from .lazy_wheel import (
     RangeCapabilityMemo,
@@ -58,6 +59,7 @@ if TYPE_CHECKING:
     from packaging.utils import NormalizedName
     from typing_extensions import Self
 
+    from .parsed_listing import ParsedListing
     from .transport import AsyncHttpTransport, HttpResponse
 
 __all__ = [
@@ -230,17 +232,17 @@ def _carried_digest(policy: CachePolicy, page_url: str) -> str | None:
 
 def read_fresh_parsed_listing(
     cache: CacheBackend, package: str, *, offline: bool
-) -> list[WheelFile | SdistFile] | None:
+) -> ParsedListing | None:
     """Read a fresh (or offline) parsed listing for ``package``, or ``None``.
 
     The write-free subset of :meth:`CachedAsyncSimpleClient.get_files`' fresh-hit
     branch: same policy, same ``is_fresh() or offline`` test, same blob, same
     :func:`parsed_listing.decode`, so on a hit it returns the records
-    ``get_files`` would. Every other case (no policy, stale-online, no blob, a
-    non-binding digest, a corrupt blob, a blob holding no records) declines to
-    ``None`` and, unlike ``get_files``, never reads the raw body, revalidates,
-    rebuilds, writes, or logs. It never raises, so a caller's pending is never
-    stranded.
+    ``get_files`` would, plus the releases whose sdist the parse dropped. Every
+    other case (no policy, stale-online, no blob, a non-binding digest, a
+    corrupt blob, a blob holding no records) declines to ``None`` and, unlike
+    ``get_files``, never reads the raw body, revalidates, rebuilds, writes, or
+    logs. It never raises, so a caller's pending is never stranded.
 
     A blob that rehydrates to no records declines for the same reason
     :meth:`CachedAsyncSimpleClient._parsed_hit` does: an empty listing also has
@@ -255,7 +257,10 @@ def read_fresh_parsed_listing(
     blob = cache.get_simple_parsed(package)
     if blob is None:
         return None
-    return _decode_parsed(blob, policy) or None
+    parsed = _decode_parsed(blob, policy)
+    if parsed is None or not parsed.files:
+        return None
+    return parsed
 
 
 class SdistArchiveHold:
@@ -345,6 +350,7 @@ class CachedAsyncSimpleClient:
         self._offline = offline
         self._serialization = serialization
         self._unreadable_only: set[str] = set()
+        self._zip_sdists: dict[str, frozenset[str]] = {}
         self._range_memo = (
             range_memo if range_memo is not None else RangeCapabilityMemo()
         )
@@ -476,6 +482,8 @@ class CachedAsyncSimpleClient:
         package" and the "nothing nab reads" report. Only the raw body answers
         that, and an empty listing is small enough to reparse.
 
+        A served blob also restores the releases whose sdist the parse dropped.
+
         This is the one place that reads the blob, so it records the outcome: a
         served blob counts a ``hit``, an absent one a ``miss``, and a
         present-but-not-served one a ``rebuild``.
@@ -484,12 +492,13 @@ class CachedAsyncSimpleClient:
         if blob is None:
             self._parsed_stats.miss += 1
             return None
-        records = _decode_parsed(blob, policy)
-        if records:
+        parsed = _decode_parsed(blob, policy)
+        if parsed is not None and parsed.files:
+            self._zip_sdists[package] = parsed.zip_sdists
             self._parsed_stats.hit += 1
-            return records
+            return parsed.files
         self._parsed_stats.rebuild += 1
-        if records is not None:
+        if parsed is not None:
             return None
         reason = _parsed_corruption(blob)
         if reason is not None:
@@ -512,13 +521,16 @@ class CachedAsyncSimpleClient:
         none, so writing one would rebuild and rewrite it on every later read
         without ever serving it.
 
+        The blob also carries the releases whose sdist the parse dropped,
+        since no record survives to name them.
+
         A refused write is dropped: the blob only accelerates a read the raw
         body already answers. Only the first refusal warns.
         """
         if digest is None or not files:
             return
 
-        blob = _encode_parsed(files, digest)
+        blob = _encode_parsed(files, digest, self._zip_sdists.get(package, frozenset()))
         try:
             self._cache.put_simple_parsed(package, blob)
         except OSError as exc:
@@ -605,7 +617,7 @@ class CachedAsyncSimpleClient:
     def _parse_body(
         self, data: object, package: str, *, page_url: str | None = None
     ) -> list[WheelFile | SdistFile]:
-        """Parse a decoded listing body, marking one with no readable file.
+        """Parse a decoded listing body, recording what nab could not read in it.
 
         ``page_url`` is the URL the body was served from, which its relative
         entries resolve against.
@@ -613,11 +625,17 @@ class CachedAsyncSimpleClient:
         files = _parse_files(data, self._index_url, package, page_url=page_url)
         if not files and holds_unreadable_format(data):
             self._unreadable_only.add(package)
+
+        self._zip_sdists[package] = zip_sdist_versions(data, package)
         return files
 
     def served_unreadable_only(self, package: str) -> bool:
         """Whether a listing for ``package`` held only files nab cannot read."""
         return package in self._unreadable_only
+
+    def unreadable_sdist_versions(self, package: str) -> frozenset[str]:
+        """Versions ``package`` was served as an sdist in a format nab drops."""
+        return self._zip_sdists.get(package, frozenset())
 
     def _unmodified_records(
         self, package: str, policy: CachePolicy

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -42,6 +42,7 @@ from ._pep503 import json_listing
 from .transport import IDENTITY_HEADERS, raise_unless_ok
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
 
     from packaging.utils import NormalizedName
@@ -63,6 +64,8 @@ __all__ = [
     "holds_unreadable_format",
     "is_readable_filename",
     "verify_sdist_hash",
+    "zip_sdist_version",
+    "zip_sdist_versions",
 ]
 
 # One decoded PEP 691 ``files`` entry.  Neither its keys nor its values
@@ -218,26 +221,76 @@ def _parse_sdist_filename(filename: str) -> tuple[NormalizedName, str] | None:
     return (_intern_name(name_part), version)
 
 
-def holds_unreadable_format(data: object) -> bool:
-    """Whether a Simple-API body offers a file nab cannot read.
+def zip_sdist_version(filename: str, package: NormalizedName) -> str | None:
+    """Return the version when ``filename`` is ``package``'s ``.zip`` sdist.
 
-    nab reads wheels and ``.tar.gz`` sdists, so a page of ``.zip`` sdists
-    or ``.exe`` installers parses to no files at all.  A body that is not
-    a list of file entries answers ``False``.
+    nab reads gzip-tar sdists only, so a ``.zip`` never becomes a file
+    record and nothing else names the release it belongs to.
+
+    Returns the canonical version string, and ``None`` for any other suffix,
+    a stem carrying no version, a version that will not parse (including a
+    digit run past CPython's int-from-string limit), and a file belonging to
+    another project.  Never raises.
+    """
+    if not filename.endswith(".zip"):
+        return None
+
+    stem = filename[: -len(".zip")]
+    name_part, sep, version_part = stem.rpartition("-")
+    if not sep or not name_part:
+        return None
+
+    try:
+        version = _canonical_version(version_part)
+    except ValueError:
+        # InvalidVersion, or int() refusing a digit run past CPython's limit.
+        return None
+
+    return version if _intern_name(name_part) == package else None
+
+
+def _listed_filenames(data: object) -> Iterator[str]:
+    """Yield the unyanked filenames a Simple-API body offers.
+
+    A body that is not a list of file entries yields nothing.
     """
     if not isinstance(data, dict):
-        return False
+        return
     raw_files = data.get("files")
     if not isinstance(raw_files, list):
-        return False
+        return
 
     for file_info in raw_files:
         if not isinstance(file_info, dict) or file_info.get("yanked"):
             continue
         filename = file_info.get("filename")
-        if isinstance(filename, str) and not is_readable_filename(filename):
-            return True
-    return False
+        if isinstance(filename, str):
+            yield filename
+
+
+def holds_unreadable_format(data: object) -> bool:
+    """Whether a Simple-API body offers a file nab cannot read.
+
+    nab reads wheels and ``.tar.gz`` sdists, so a page of ``.zip`` sdists
+    or ``.exe`` installers parses to no files at all.
+    """
+    return any(
+        not is_readable_filename(filename) for filename in _listed_filenames(data)
+    )
+
+
+def zip_sdist_versions(data: object, package: str) -> frozenset[str]:
+    """Versions of ``package`` a Simple-API body offers as ``.zip`` sdists.
+
+    The parse drops these, so the set is the only record that the release
+    published an sdist.
+    """
+    expected = canonicalize_name(package)
+    return frozenset(
+        version
+        for filename in _listed_filenames(data)
+        if (version := zip_sdist_version(filename, expected)) is not None
+    )
 
 
 def is_readable_filename(filename: str) -> bool:

--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -30,12 +30,11 @@ import zipfile
 import zlib
 from email.parser import BytesParser, Parser
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 from urllib.parse import unquote, urljoin, urlparse, urlsplit
 from urllib.request import url2pathname
 
 from packaging.utils import canonicalize_name as _canonical
-from packaging.utils import parse_sdist_filename
 
 from nab_provider.errors import IndexAccessError, UnsupportedWheelError
 
@@ -48,6 +47,7 @@ from .client import (
     _parse_sdist_filename,
     _parse_wheel_filename,
     is_readable_filename,
+    zip_sdist_version,
 )
 
 if TYPE_CHECKING:
@@ -215,21 +215,31 @@ def _is_dir(path: Path) -> bool:
 _FLAT_EXTS = re.compile(r"\.(whl|tar\.gz)$", re.IGNORECASE)
 
 
+class _ScanResult(NamedTuple):
+    """What one scan of a local index found for a package.
+
+    ``unreadable`` says the listing offered a file in a format nab does not
+    read, and ``zip_sdists`` names the releases it offered as ``.zip``
+    sdists.  Neither leaves a record in ``files``.
+    """
+
+    files: list[WheelFile | SdistFile]
+    unreadable: bool
+    zip_sdists: frozenset[str]
+
+
 def _scan_pep503_directory(
     package_dir: Path,
-    canonical: str,
-) -> tuple[list[WheelFile | SdistFile], bool]:
+    canonical: NormalizedName,
+) -> _ScanResult:
     """Parse ``<package>/index.html`` and return file records.
 
     ``package_dir`` has to be absolute, because the page's URI is the base
     for its relative links.
-
-    The second element says the page linked a file in a format nab does
-    not read, which tells a page of ``.zip`` sdists from an empty one.
     """
     index_html = package_dir / "index.html"
     if not _is_file(index_html):
-        return [], False
+        return _ScanResult([], unreadable=False, zip_sdists=frozenset())
 
     try:
         text = index_html.read_text(encoding="utf-8")
@@ -238,23 +248,11 @@ def _scan_pep503_directory(
         raise MalformedLocalListingError(msg) from exc
 
     anchors, base_href = read_page(text)
-
-    # RFC 3986 section 5.1.3: the base is the URI the page was read from, not
-    # its realpath.
-    base_url = index_html.as_uri()
-    if base_href is not None:
-        # A base href every relative anchor resolves against, so one that
-        # cannot be parsed leaves the whole page's targets unknown. Fail
-        # loudly rather than fall back to the page URL, which would resolve
-        # each link to a different file than the page names.
-        try:
-            base_url = urljoin(base_url, base_href)
-        except ValueError as exc:
-            msg = f"{index_html} has an unparseable <base href>: {exc}"
-            raise MalformedLocalListingError(msg) from exc
+    base_url = _page_base_url(index_html, base_href)
 
     files: list[WheelFile | SdistFile] = []
     unreadable = False
+    zip_sdists: set[str] = set()
 
     for anchor in anchors:
         # PEP 592: a yanked link never reaches the listing.
@@ -268,6 +266,9 @@ def _scan_pep503_directory(
             continue
         if not is_readable_filename(filename):
             unreadable = True
+            zip_version = zip_sdist_version(filename, canonical)
+            if zip_version is not None:
+                zip_sdists.add(zip_version)
             continue
 
         record = _make_record(
@@ -281,7 +282,26 @@ def _scan_pep503_directory(
         )
         if record is not None:
             files.append(record)
-    return files, unreadable
+    return _ScanResult(files, unreadable=unreadable, zip_sdists=frozenset(zip_sdists))
+
+
+def _page_base_url(index_html: Path, base_href: str | None) -> str:
+    """Return the URI a page's relative anchors resolve against.
+
+    RFC 3986 section 5.1.3: the base is the URI the page was read from, not
+    its realpath.  A ``<base href>`` overrides it; one that cannot be parsed
+    fails loudly rather than falling back to the page URL, which would
+    resolve every link to a different file than the page names.
+    """
+    page_url = index_html.as_uri()
+    if base_href is None:
+        return page_url
+
+    try:
+        return urljoin(page_url, base_href)
+    except ValueError as exc:
+        msg = f"{index_html} has an unparseable <base href>: {exc}"
+        raise MalformedLocalListingError(msg) from exc
 
 
 def _resolve_local_link(
@@ -332,25 +352,27 @@ def _resolve_local_link(
 def _scan_flat_wheelhouse(
     root: Path,
     package: str,
-) -> tuple[list[WheelFile | SdistFile], bool]:
+) -> _ScanResult:
     """Find all dists for ``package`` in a flat directory of files.
 
     Entries are sorted because the listing order breaks ties between dists at
     one version, and ``iterdir`` order comes from the filesystem.
 
-    The second element says the directory holds a ``.zip`` sdist for
-    ``package``, a format nab does not read.  One directory serves every
-    package, so a file that does not name ``package`` says nothing about it.
+    One directory serves every package, so a file that does not name
+    ``package`` says nothing about it: only a ``.zip`` sdist of ``package``
+    makes the scan unreadable.
     """
     canonical = _canonical(package)
     files: list[WheelFile | SdistFile] = []
-    unreadable = False
+    zip_sdists: set[str] = set()
 
     for entry in sorted(root.iterdir()):
         if not _is_file(entry):
             continue
         if _FLAT_EXTS.search(entry.name) is None:
-            unreadable = unreadable or _is_zip_sdist(entry.name, canonical)
+            zip_version = zip_sdist_version(entry.name, canonical)
+            if zip_version is not None:
+                zip_sdists.add(zip_version)
             continue
         requires_python = _flat_requires_python(entry, canonical)
         record = _make_record(
@@ -364,19 +386,9 @@ def _scan_flat_wheelhouse(
         )
         if record is not None:
             files.append(record)
-    return files, unreadable
-
-
-def _is_zip_sdist(filename: str, canonical: str) -> bool:
-    """Whether ``filename`` is a ``.zip`` sdist belonging to ``canonical``."""
-    if not filename.endswith(".zip"):
-        return False
-    try:
-        name, _ = parse_sdist_filename(filename)
-    except ValueError:
-        # InvalidSdistFilename, or int() refusing a digit run past CPython's limit.
-        return False
-    return name == canonical
+    return _ScanResult(
+        files, unreadable=bool(zip_sdists), zip_sdists=frozenset(zip_sdists)
+    )
 
 
 def _flat_requires_python(entry: Path, canonical: str) -> str | None:
@@ -576,6 +588,7 @@ class LocalIndexClient:
         root = parse_file_url(index_url)
         self._root = Path(os.path.abspath(root))  # noqa: PTH100
         self._unreadable_only: set[str] = set()
+        self._zip_sdists: dict[str, frozenset[str]] = {}
 
     async def aclose(self) -> None:
         """No-op; nothing to release."""
@@ -600,22 +613,27 @@ class LocalIndexClient:
 
         try:
             if _is_file(package_dir / "index.html"):
-                files, unreadable = _scan_pep503_directory(package_dir, canonical)
+                scan = _scan_pep503_directory(package_dir, canonical)
             elif not _is_dir(self._root):
-                files, unreadable = [], False
+                scan = _ScanResult([], unreadable=False, zip_sdists=frozenset())
             else:
-                files, unreadable = _scan_flat_wheelhouse(self._root, package)
+                scan = _scan_flat_wheelhouse(self._root, package)
         except OSError as exc:
             msg = f"cannot read local index {self._root}: {exc}"
             raise UnreadableLocalIndexError(msg) from exc
 
-        if not files and unreadable:
+        if not scan.files and scan.unreadable:
             self._unreadable_only.add(package)
-        return files
+        self._zip_sdists[package] = scan.zip_sdists
+        return scan.files
 
     def served_unreadable_only(self, package: str) -> bool:
         """Whether a listing for ``package`` held only files nab cannot read."""
         return package in self._unreadable_only
+
+    def unreadable_sdist_versions(self, package: str) -> frozenset[str]:
+        """Versions ``package`` was served as an sdist in a format nab drops."""
+        return self._zip_sdists.get(package, frozenset())
 
     async def get_metadata_text(
         self,

--- a/nab-index/src/nab_index/multi_index.py
+++ b/nab-index/src/nab_index/multi_index.py
@@ -64,6 +64,10 @@ class IndexClient(Protocol):
         """Whether a listing for ``package`` held only files nab cannot read."""
         ...
 
+    def unreadable_sdist_versions(self, package: str) -> frozenset[str]:
+        """Versions ``package`` was served as an sdist in a format nab drops."""
+        ...
+
     async def get_metadata_text(
         self,
         package: str,
@@ -234,6 +238,19 @@ class MultiIndexClient:
         """
         return any(
             client.served_unreadable_only(package) for client in self._clients.values()
+        )
+
+    def unreadable_sdist_versions(self, package: str) -> frozenset[str]:
+        """Versions any walked index served as an sdist in a format nab drops.
+
+        Every client is asked, for the same reason as
+        :meth:`served_unreadable_only`: the routed one need not be the one
+        that served the dropped file.
+        """
+        return frozenset(
+            version
+            for client in self._clients.values()
+            for version in client.unreadable_sdist_versions(package)
         )
 
     async def get_metadata_text(

--- a/nab-index/src/nab_index/parsed_listing.py
+++ b/nab-index/src/nab_index/parsed_listing.py
@@ -7,13 +7,14 @@ treats the blob as opaque and knows nothing about record shapes.
 
 Wire form (UTF-8 JSON of ``[header, rows]``):
 
-* header ``[format, codec, key_scheme, body_digest]`` is checked before
-  anything is trusted. A reader on a different ``format``, ``codec``, or
+* header ``[format, codec, key_scheme, body_digest, zip_sdists]`` is checked
+  before anything is trusted. A reader on a different ``format``, ``codec``, or
   ``key_scheme`` treats the entry as a miss and rebuilds, so a cache written by
   an older build self-heals instead of misdecoding. ``body_digest`` binds the
   blob to the raw body it was parsed from; :func:`decode` rejects a blob whose
   digest does not equal the policy's, so a raw-body update invalidates the
-  derived form.
+  derived form. ``zip_sdists`` names the releases the listing offered only as a
+  ``.zip`` sdist, which the parse drops, leaving them in no row.
 * rows hold one entry per surviving record, in the order the wire parse
   returned them, so a downstream stable-sort tie-break stays identical. Each
   row is a flat list tagged wheel or sdist by its first element. Every field is
@@ -34,7 +35,7 @@ from __future__ import annotations
 
 import json
 import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 from nab_provider.records import (
     SdistFile,
@@ -48,13 +49,13 @@ if TYPE_CHECKING:
 
     from .cache import CachePolicy
 
-__all__ = ["corruption_reason", "decode", "encode"]
+__all__ = ["ParsedListing", "corruption_reason", "decode", "encode"]
 
 # Record version, redundant with the bucket suffix but guards against a stale
-# blob surfacing under the current bucket. Bump it when the row shape changes
-# or when the same body parses to different records: ``body_digest`` pins only
-# the input.
-FORMAT_VERSION = 3
+# blob surfacing under the current bucket. Bump it when the header or row shape
+# changes, or when the same body parses to different records: ``body_digest``
+# pins only the input.
+FORMAT_VERSION = 4
 # Serialization variant that wrote the rows, so a future codec switch
 # self-heals rather than misdecodes.
 CODEC = 1
@@ -63,14 +64,32 @@ CODEC = 1
 KEY_SCHEME = 0
 
 _TOP_LEN = 2
-_HEADER_LEN = 4
+_HEADER_LEN = 5
 _PAIR_LEN = 2
 _TAG_WHEEL = 0
 _TAG_SDIST = 1
 
+# The header's first cells name the build that wrote the blob; the last two
+# carry its data.
+_BUILD_ID = (FORMAT_VERSION, CODEC, KEY_SCHEME)
+_BUILD_CELLS = len(_BUILD_ID)
+_H_DIGEST = 3
+_H_ZIP_SDISTS = 4
+
 
 class _BadRowError(ValueError):
-    """A row whose tag, arity, or field types are not what this codec wrote."""
+    """A row or header cell whose shape is not what this codec wrote."""
+
+
+class ParsedListing(NamedTuple):
+    """A decoded blob: a listing's records, and what its parse dropped.
+
+    ``zip_sdists`` names the releases the listing offered only as a ``.zip``
+    sdist, which leaves no record of its own.
+    """
+
+    files: list[WheelFile | SdistFile]
+    zip_sdists: frozenset[str]
 
 
 def _hashes_cell(record: WheelFile | SdistFile) -> object:
@@ -89,14 +108,19 @@ def _sidecar_cell(wheel: WheelFile) -> object:
     return wheel.metadata_hash if raw is None else raw
 
 
-def encode(files: list[WheelFile | SdistFile], body_digest: str) -> bytes:
+def encode(
+    files: list[WheelFile | SdistFile],
+    body_digest: str,
+    zip_sdists: frozenset[str] = frozenset(),
+) -> bytes:
     """Encode parsed listing ``files`` into a cache blob bound to ``body_digest``.
 
     ``body_digest`` is the sha256 hex of the raw body the records were parsed
     from; :func:`decode` rehydrates only when it matches the policy's digest.
-    ``local_path`` is not stored (a parsed-cache entry always comes from a
-    remote body) and ``metadata_url`` is a derived property, so neither rides
-    the wire.
+    ``zip_sdists`` names the releases whose sdist the parse dropped for its
+    format; no row can carry them. ``local_path`` is not stored (a parsed-cache
+    entry always comes from a remote body) and ``metadata_url`` is a derived
+    property, so neither rides the wire.
     """
     rows: list[list[object]] = []
     for record in files:
@@ -128,15 +152,15 @@ def encode(files: list[WheelFile | SdistFile], body_digest: str) -> bytes:
                     record.size,
                 ]
             )
-    header = [FORMAT_VERSION, CODEC, KEY_SCHEME, body_digest]
+    header = [*_BUILD_ID, body_digest, sorted(zip_sdists)]
 
     # Escape non-ASCII: a field kept verbatim from the listing, such as
     # ``requires_python``, can hold a lone surrogate with no UTF-8 form.
     return json.dumps([header, rows], separators=(",", ":")).encode()
 
 
-def decode(blob: bytes, policy: CachePolicy) -> list[WheelFile | SdistFile] | None:
-    """Decode a cache blob back to parsed records, or ``None`` to force a miss.
+def decode(blob: bytes, policy: CachePolicy) -> ParsedListing | None:
+    """Decode a cache blob back to a parsed listing, or ``None`` to force a miss.
 
     Returns ``None`` (treat as a cache miss and rebuild from the raw body) when
     the blob does not decode, is the wrong shape, was written by a different
@@ -152,21 +176,16 @@ def decode(blob: bytes, policy: CachePolicy) -> list[WheelFile | SdistFile] | No
     if not (isinstance(loaded, list) and len(loaded) == _TOP_LEN):
         return None
     header, rows = loaded
-    if not (isinstance(header, list) and len(header) == _HEADER_LEN):
+    if not _names_this_build(header):
         return None
-    format_, codec, key_scheme, body_digest = header
-    if (
-        format_ != FORMAT_VERSION
-        or codec != CODEC
-        or key_scheme != KEY_SCHEME
-        or policy.body_digest is None
-        or body_digest != policy.body_digest
-    ):
+    if policy.body_digest is None or header[_H_DIGEST] != policy.body_digest:
         return None
-    # A blob whose header matches this build but whose rows are the wrong shape
-    # must rebuild, not crash the resolve; the rows are untrusted too.
+    # A blob whose header matches this build but whose rows or dropped-release
+    # cell are the wrong shape must rebuild, not crash the resolve.
     try:
-        return _decode_rows(rows)
+        return ParsedListing(
+            _decode_rows(rows), _decode_zip_sdists(header[_H_ZIP_SDISTS])
+        )
     except (ValueError, TypeError):
         return None
 
@@ -177,11 +196,11 @@ def corruption_reason(blob: bytes) -> str | None:
     Distinguishes genuine corruption (garbage or truncated bytes, or a
     same-build blob whose rows are the wrong shape) from a benign miss, where
     the header names a different build or binds a different body. The read path
-    warns only on the former. The row check runs only once the header names this
-    exact build, since a foreign build may have written a shape this one never
-    did; checking it earlier would misreport version skew as corruption. This is
-    a second pass used only to gate that warning; :func:`decode` returns ``None``
-    for every miss reason alike.
+    warns only on the former. Every check past the build cells runs only once
+    the header names this exact build, since a foreign build may have written a
+    shape this one never did; checking earlier would misreport version skew as
+    corruption. This is a second pass used only to gate that warning;
+    :func:`decode` returns ``None`` for every miss reason alike.
     """
     try:
         loaded = json.loads(blob)
@@ -190,19 +209,54 @@ def corruption_reason(blob: bytes) -> str | None:
     if not (isinstance(loaded, list) and len(loaded) == _TOP_LEN):
         return "unexpected top-level shape"
     header, rows = loaded
-    if not (isinstance(header, list) and len(header) == _HEADER_LEN):
-        return "unexpected header shape"
-    format_, codec, key_scheme, _body_digest = header
-    if format_ != FORMAT_VERSION or codec != CODEC or key_scheme != KEY_SCHEME:
-        # A different-build header is benign version skew, not corruption; its
-        # rows may be a shape this build never wrote. A same-build body_digest
-        # mismatch decodes cleanly below and returns None silently.
+    if _from_another_build(header):
         return None
+    if not _names_this_build(header) or _bad_zip_sdists_cell(header):
+        return "unexpected header shape"
     try:
         _decode_rows(rows)
     except (ValueError, TypeError):
         return "unexpected row shape"
     return None
+
+
+def _names_this_build(header: object) -> bool:
+    """Whether ``header`` is this build's shape and names its codec."""
+    return (
+        isinstance(header, list)
+        and len(header) == _HEADER_LEN
+        and tuple(header[:_BUILD_CELLS]) == _BUILD_ID
+    )
+
+
+def _from_another_build(header: object) -> bool:
+    """Whether ``header`` names a build other than this one.
+
+    Read before any shape check, since another build may write a header shape
+    this one never did, and calling that corruption would warn about every
+    package a cache already holds when nab is upgraded.
+    """
+    return (
+        isinstance(header, list)
+        and len(header) >= _BUILD_CELLS
+        and tuple(header[:_BUILD_CELLS]) != _BUILD_ID
+    )
+
+
+def _bad_zip_sdists_cell(header: Sequence[object]) -> bool:
+    """Whether the header's dropped-release cell is not a list of version strings."""
+    try:
+        _decode_zip_sdists(header[_H_ZIP_SDISTS])
+    except ValueError:
+        return True
+    return False
+
+
+def _decode_zip_sdists(value: object) -> frozenset[str]:
+    """Rehydrate the header cell naming the releases the parse dropped."""
+    if not isinstance(value, list):
+        raise _BadRowError
+    return frozenset(map(_text, value))
 
 
 def _decode_rows(rows: object) -> list[WheelFile | SdistFile]:

--- a/nab-index/tests/test_index_client.py
+++ b/nab-index/tests/test_index_client.py
@@ -6,7 +6,7 @@ import json
 import sys
 
 import pytest
-from packaging.utils import parse_sdist_filename
+from packaging.utils import canonicalize_name, parse_sdist_filename
 
 from nab_index.client import (
     _parse_files,
@@ -14,6 +14,8 @@ from nab_index.client import (
     _sdist_member_top_level,
     holds_unreadable_format,
     is_readable_filename,
+    zip_sdist_version,
+    zip_sdist_versions,
 )
 
 # A version digit run past CPython's int-from-string limit.
@@ -130,6 +132,52 @@ def test_holds_unreadable_format_finds_oversized_version() -> None:
 )
 def test_holds_unreadable_format_false(data: object) -> None:
     assert not holds_unreadable_format(data)
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected"),
+    [
+        pytest.param("foo-1.0.zip", "1.0", id="canonical"),
+        pytest.param("Foo_Bar-1.0.zip", None, id="another-project"),
+        pytest.param("foo-1.0.0.zip", "1.0.0", id="version-spelled-out"),
+        pytest.param("foo-1.0RC1.zip", "1.0rc1", id="version-normalized"),
+        pytest.param("foo-1.0.tar.gz", None, id="readable-sdist"),
+        pytest.param("foo-1.5.win32.exe", None, id="installer"),
+        pytest.param("foo.zip", None, id="no-version"),
+        pytest.param("-1.0.zip", None, id="no-name"),
+        pytest.param("foo-notaversion.zip", None, id="unparseable-version"),
+        pytest.param(f"foo-{OVERSIZED}.zip", None, id="oversized-version"),
+        pytest.param("foo\x00-1.0.zip", None, id="nul-does-not-name-the-package"),
+    ],
+)
+def test_zip_sdist_version(filename: str, expected: str | None) -> None:
+    assert zip_sdist_version(filename, canonicalize_name("foo")) == expected
+
+
+def test_zip_sdist_versions_collects_every_release() -> None:
+    data = {
+        "files": [
+            {"filename": "foo-1.0.zip"},
+            {"filename": "foo-2.0.zip"},
+            {"filename": "foo-2.0-py3-none-any.whl"},
+        ]
+    }
+    assert zip_sdist_versions(data, "Foo") == frozenset({"1.0", "2.0"})
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        pytest.param(["files"], id="body-not-an-object"),
+        pytest.param({"files": [{"filename": "bar-1.0.zip"}]}, id="another-project"),
+        pytest.param(
+            {"files": [{"filename": "foo-1.0.zip", "yanked": True}]},
+            id="yanked-entry",
+        ),
+    ],
+)
+def test_zip_sdist_versions_empty(data: object) -> None:
+    assert zip_sdist_versions(data, "foo") == frozenset()
 
 
 @pytest.mark.parametrize(

--- a/nab-index/tests/test_index_local.py
+++ b/nab-index/tests/test_index_local.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, TypeVar
 
+from packaging.utils import canonicalize_name
+
 from nab_index.local_index import LocalIndexClient, _scan_pep503_directory
 
 if TYPE_CHECKING:
@@ -56,7 +58,11 @@ def test_scan_directory_without_index_html_returns_empty(tmp_path: Path) -> None
     # exercised directly here.
     package_dir = tmp_path / "foo"
     package_dir.mkdir()
-    assert _scan_pep503_directory(package_dir, "foo") == ([], False)
+    assert _scan_pep503_directory(package_dir, canonicalize_name("foo")) == (
+        [],
+        False,
+        frozenset(),
+    )
 
 
 def test_get_sdist_archive_returns_file_bytes(tmp_path: Path) -> None:

--- a/nab-index/tests/test_index_multi.py
+++ b/nab-index/tests/test_index_multi.py
@@ -46,6 +46,9 @@ class _RecordingClient:
     def served_unreadable_only(self, package: str) -> bool:
         return False
 
+    def unreadable_sdist_versions(self, package: str) -> frozenset[str]:
+        return frozenset()
+
     async def get_sdist_archive(
         self,
         package: str,

--- a/nab-index/tests/test_index_parsed_cache.py
+++ b/nab-index/tests/test_index_parsed_cache.py
@@ -33,7 +33,7 @@ from nab_index.cache import (
     is_recognized_bucket,
 )
 from nab_index.cached_client import CachedAsyncSimpleClient, ParsedCacheStats
-from nab_index.client import _parse_files
+from nab_index.client import SdistFile, WheelFile, _parse_files
 from nab_index.parsed_listing import corruption_reason, decode, encode
 
 # Derived so a bucket-version bump does not need every path updated.
@@ -129,6 +129,14 @@ class _FakeTransport:
 
 def _cache(root: Path) -> OnDiskCache:
     return OnDiskCache(root, "https://pypi.org/simple")
+
+
+def _decoded(blob: bytes | None, policy: CachePolicy) -> list[WheelFile | SdistFile]:
+    """The records ``blob`` rehydrates to, asserting it decoded at all."""
+    assert blob is not None
+    parsed = decode(blob, policy)
+    assert parsed is not None
+    return parsed.files
 
 
 class TestBodyDigestPolicy:
@@ -417,7 +425,7 @@ class TestWritePathParsedBlob:
         assert policy.body_digest == hashlib.sha256(_LISTING_BYTES).hexdigest()
         blob = cache.get_simple_parsed("pkg")
         assert blob is not None
-        decoded = decode(blob, policy)
+        decoded = _decoded(blob, policy)
         assert decoded == files
         assert decoded == _parse_files(json.loads(body), _INDEX_NORM, "pkg")
 
@@ -440,7 +448,7 @@ class TestWritePathParsedBlob:
         assert policy.body_digest == hashlib.sha256(_LISTING_BYTES).hexdigest()
         blob = cache.get_simple_parsed("pkg")
         assert blob is not None
-        assert decode(blob, policy) == files
+        assert _decoded(blob, policy) == files
 
     def test_revalidate_304_preserves_body_parsed_and_digest(
         self, tmp_path: Path
@@ -468,7 +476,7 @@ class TestWritePathParsedBlob:
         assert new_body == body
         assert policy.body_digest == digest
         assert cache.get_simple_parsed("pkg") == old_blob
-        assert decode(old_blob, policy) == files
+        assert _decoded(old_blob, policy) == files
 
     def test_revalidate_304_from_a_new_page_retires_the_blob(
         self, tmp_path: Path
@@ -627,7 +635,7 @@ class TestReadPathRebuild:
         assert result is not None
         _, policy = result
         assert policy.body_digest == digest
-        assert decode(blob, policy) == got
+        assert _decoded(blob, policy) == got
 
     def test_rebuild_on_digest_mismatch_no_warning(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
@@ -647,7 +655,7 @@ class TestReadPathRebuild:
         result = cache.get_simple("pkg")
         assert result is not None
         _, policy = result
-        assert decode(cache.get_simple_parsed("pkg"), policy) == files
+        assert _decoded(cache.get_simple_parsed("pkg"), policy) == files
 
     @pytest.mark.parametrize(
         ("field", "value"),
@@ -681,7 +689,7 @@ class TestReadPathRebuild:
         assert result is not None
         _, policy = result
         # The rebuilt blob is now well-formed and hits.
-        assert decode(cache.get_simple_parsed("pkg"), policy) == files
+        assert _decoded(cache.get_simple_parsed("pkg"), policy) == files
 
     @pytest.mark.parametrize("blob", [b"\xff\xfe not json", b"", b"\x00\x01\x02"])
     def test_garbage_blob_warns_and_reparses(
@@ -701,7 +709,7 @@ class TestReadPathRebuild:
         result = cache.get_simple("pkg")
         assert result is not None
         _, policy = result
-        assert decode(cache.get_simple_parsed("pkg"), policy) == files
+        assert _decoded(cache.get_simple_parsed("pkg"), policy) == files
 
     def test_truncated_blob_warns_and_reparses(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
@@ -742,7 +750,7 @@ class TestReadPathRebuild:
         result = cache.get_simple("pkg")
         assert result is not None
         _, policy = result
-        assert decode(cache.get_simple_parsed("pkg"), policy) == files
+        assert _decoded(cache.get_simple_parsed("pkg"), policy) == files
 
     def test_pre_c1_policy_without_digest_self_heals(self, tmp_path: Path) -> None:
         cache = _cache(tmp_path)
@@ -768,7 +776,7 @@ class TestReadPathRebuild:
         got_policy = cache.get_simple_policy("pkg")
         assert got_policy is not None
         assert got_policy.body_digest == digest
-        assert decode(cache.get_simple_parsed("pkg"), got_policy) == _PARSED
+        assert _decoded(cache.get_simple_parsed("pkg"), got_policy) == _PARSED
 
 
 class TestReadPathCorruptBody:
@@ -870,7 +878,7 @@ class TestReadPathRevalidate:
         assert result is not None
         body, policy = result
         assert body == _LISTING_V2_BYTES
-        assert decode(cache.get_simple_parsed("pkg"), policy) == got
+        assert _decoded(cache.get_simple_parsed("pkg"), policy) == got
 
     def test_stale_online_200_revalidates_without_reading_the_body(
         self, tmp_path: Path
@@ -910,7 +918,7 @@ class TestReadPathRevalidate:
         result = cache.get_simple("pkg")
         assert result is not None
         _, policy = result
-        assert decode(before, policy) == files
+        assert _decoded(before, policy) == files
 
     def test_stale_online_304_serves_the_blob_without_the_body(
         self, tmp_path: Path

--- a/nab-index/tests/test_parsed_listing_codec.py
+++ b/nab-index/tests/test_parsed_listing_codec.py
@@ -42,6 +42,7 @@ RP = sys.intern(">=3.8")
 _H_FORMAT = 0
 _H_CODEC = 1
 _H_KEY_SCHEME = 2
+_H_ZIP_SDISTS = 4
 
 # An sdist row is tag plus seven fields; the unknown-tag case relies on keeping
 # that arity so the tag check is what rejects it, not the unpack.
@@ -119,7 +120,7 @@ SAMPLE: list[WheelFile | SdistFile] = [WHEEL_FULL, SDIST_FULL, WHEEL_BARE, SDIST
 def _roundtrip(files: list[WheelFile | SdistFile]) -> list[WheelFile | SdistFile]:
     decoded = decode(encode(files, DIGEST), _policy())
     assert decoded is not None
-    return decoded
+    return decoded.files
 
 
 def test_roundtrip_preserves_records_and_order() -> None:
@@ -163,13 +164,13 @@ def test_lone_surrogate_in_field_round_trips() -> None:
     """
     record = dataclasses.replace(SDIST_FULL, requires_python=f"{RP}\ud800")
 
-    assert decode(encode([record], DIGEST), _policy()) == [record]
+    assert _roundtrip([record]) == [record]
 
 
 def test_blob_is_portable_json() -> None:
     """The wire form carries no interpreter tag, so any reader can decode it."""
     header, rows = json.loads(encode(SAMPLE, DIGEST))
-    assert header == [FORMAT_VERSION, CODEC, KEY_SCHEME, DIGEST]
+    assert header == [FORMAT_VERSION, CODEC, KEY_SCHEME, DIGEST, []]
     assert [row[0] for row in rows] == [_TAG_WHEEL, _TAG_SDIST, _TAG_WHEEL, _TAG_SDIST]
 
 
@@ -325,7 +326,7 @@ def test_absent_optional_fields_decode_as_none() -> None:
     blob = _wheel_row_with(_W_METADATA_HASH, None)
     decoded = decode(blob, _policy())
     assert decoded is not None
-    wheel = decoded[0]
+    wheel = decoded.files[0]
     assert isinstance(wheel, WheelFile)
     assert wheel.metadata_hash is None
 
@@ -340,6 +341,30 @@ def test_absent_optional_fields_decode_as_none() -> None:
 )
 def test_corruption_reason_names_the_structural_fault(blob: bytes, reason: str) -> None:
     assert corruption_reason(blob) == reason
+
+
+def test_zip_sdists_round_trip_sorted() -> None:
+    """The dropped releases ride the header, sorted so a blob is byte-stable."""
+    blob = encode(SAMPLE, DIGEST, frozenset({"2.0", "1.0"}))
+    header = json.loads(blob)[0]
+    decoded = decode(blob, _policy())
+
+    assert header[_H_ZIP_SDISTS] == ["1.0", "2.0"]
+    assert decoded is not None
+    assert decoded.zip_sdists == frozenset({"1.0", "2.0"})
+
+
+@pytest.mark.parametrize("cell", ["1.0", {"1.0": True}, [1.0], [None]])
+def test_bad_zip_sdists_cell_is_miss(cell: object) -> None:
+    """A cell JSON allows but the header does not rebuilds rather than crashes."""
+    assert decode(_tamper_header(_H_ZIP_SDISTS, cell), _policy()) is None
+
+
+def test_corruption_reason_flags_a_bad_zip_sdists_cell() -> None:
+    assert (
+        corruption_reason(_tamper_header(_H_ZIP_SDISTS, "1.0"))
+        == "unexpected header shape"
+    )
 
 
 def test_corruption_reason_flags_same_build_bad_rows() -> None:
@@ -403,12 +428,9 @@ def test_a_many_algorithm_table_defers_as_the_index_served_it() -> None:
 
 
 def test_a_rehydrated_record_defers_the_same_parse() -> None:
-    blob = encode(
-        [_deferred_wheel({"SHA256": DIGEST.upper()}, sidecar={"sha256": DIGEST})],
-        DIGEST,
+    (wheel,) = _roundtrip(
+        [_deferred_wheel({"SHA256": DIGEST.upper()}, sidecar={"sha256": DIGEST})]
     )
-
-    (wheel,) = decode(blob, _policy()) or []
 
     assert wheel.raw_hashes() == {"SHA256": DIGEST.upper()}
     assert wheel.raw_sidecar() == {"sha256": DIGEST}
@@ -426,7 +448,7 @@ def test_a_rehydrated_sdist_defers_its_hashes() -> None:
     )
     defer_hashes(sdist, {"SHA256": DIGEST.upper()})
 
-    (decoded,) = decode(encode([sdist], DIGEST), _policy()) or []
+    (decoded,) = _roundtrip([sdist])
 
     assert decoded.raw_hashes() == {"SHA256": DIGEST.upper()}
     assert decoded.hashes == ((SHA256, DIGEST),)

--- a/nab-index/tests/test_read_fresh_parsed_listing.py
+++ b/nab-index/tests/test_read_fresh_parsed_listing.py
@@ -132,6 +132,12 @@ def _warm_bound(
     return files, digest
 
 
+def _read_files(cache: OnDiskCache, *, offline: bool) -> list | None:
+    """The records the helper serves for ``pkg``, or ``None`` on a decline."""
+    parsed = read_fresh_parsed_listing(cache, "pkg", offline=offline)
+    return None if parsed is None else parsed.files
+
+
 class TestParsedBlobSize:
     def test_size_matches_written_blob(self, tmp_path: Path) -> None:
         cache = _cache(tmp_path)
@@ -148,17 +154,17 @@ class TestReadFreshParsedListing:
     def test_fresh_hit_returns_records(self, tmp_path: Path) -> None:
         cache = _cache(tmp_path)
         files, _ = _warm_bound(cache)
-        assert read_fresh_parsed_listing(cache, "pkg", offline=False) == files
+        assert _read_files(cache, offline=False) == files
 
     def test_fresh_offline_returns_records(self, tmp_path: Path) -> None:
         cache = _cache(tmp_path)
         files, _ = _warm_bound(cache)
-        assert read_fresh_parsed_listing(cache, "pkg", offline=True) == files
+        assert _read_files(cache, offline=True) == files
 
     def test_stale_offline_returns_records(self, tmp_path: Path) -> None:
         cache = _cache(tmp_path)
         files, _ = _warm_bound(cache, fresh=False)
-        assert read_fresh_parsed_listing(cache, "pkg", offline=True) == files
+        assert _read_files(cache, offline=True) == files
 
     def test_absent_policy_returns_none(self, tmp_path: Path) -> None:
         assert read_fresh_parsed_listing(_cache(tmp_path), "pkg", offline=False) is None
@@ -239,7 +245,7 @@ class TestIdenticalByConstruction:
         client = CachedAsyncSimpleClient(_FakeTransport([]), cache, _INDEX)
 
         served = _run(client.get_files("pkg"))
-        helper = read_fresh_parsed_listing(cache, "pkg", offline=False)
+        helper = _read_files(cache, offline=False)
 
         assert helper == served == files
 

--- a/nab-project/src/nab_project/fetch.py
+++ b/nab-project/src/nab_project/fetch.py
@@ -54,6 +54,8 @@ if TYPE_CHECKING:
 
     from typing_extensions import Self
 
+    from nab_index.parsed_listing import ParsedListing
+
 __all__ = [
     "DEFAULT_INDEX_NAME",
     "DEFAULT_INDEX_URL",
@@ -448,7 +450,7 @@ class FetchCoordinator:
         msg = f"Fetcher thread crashed: {self._crash_error}"
         raise RuntimeError(msg)
 
-    def _try_listing_sync(self, package: str) -> list[WheelFile | SdistFile] | None:
+    def _try_listing_sync(self, package: str) -> ParsedListing | None:
         """Read a fresh parsed listing on the caller's thread, or ``None``.
 
         ``read_fresh_parsed_listing`` never raises, so the caller's pending is
@@ -459,9 +461,9 @@ class FetchCoordinator:
         if not self._sync_listing_enabled:
             stats.declined_ineligible += 1
             return None
-        records = read_fresh_parsed_listing(self._cache, package, offline=self._offline)
-        if records is not None:
-            return records
+        parsed = read_fresh_parsed_listing(self._cache, package, offline=self._offline)
+        if parsed is not None:
+            return parsed
         policy = self._cache.get_simple_policy(package)
         if policy is None:
             stats.declined_no_policy += 1
@@ -511,13 +513,18 @@ class FetchCoordinator:
             return event
         if not speculative:
             if self._overlap_gate_admits(package):
-                records = self._try_listing_sync(package)
-                if records is not None:
+                parsed = self._try_listing_sync(package)
+                if parsed is not None:
+                    records = parsed.files
                     # Store the serving index before store_listing fires the
                     # pending, matching the async path's ordering. The tail runs
                     # on the fetcher loop, or inline when the loop is gone.
                     self.index.store_listing_index(package, self.indexes[0].name)
-                    self.index.store_listing(package, records)
+                    self.index.store_listing(
+                        package,
+                        records,
+                        unreadable_sdist_versions=parsed.zip_sdists,
+                    )
                     self._warm_sync_stats.listing_hits += 1
                     if not self._post_to_loop(self._run_listing_tail, package, records):
                         self._run_listing_tail(package, records)
@@ -1030,6 +1037,7 @@ class FetchCoordinator:
             req.package,
             files,
             unreadable_only=client.served_unreadable_only(req.package),
+            unreadable_sdist_versions=client.unreadable_sdist_versions(req.package),
         )
         logger.debug("fetched listing: %s (%d files)", req.package, len(files))
         if self._on_fetch is not None:

--- a/nab-project/tests/property_python/test_fetch_coordinator.py
+++ b/nab-project/tests/property_python/test_fetch_coordinator.py
@@ -115,6 +115,9 @@ class FakeClient:
     def served_unreadable_only(self, package: str) -> bool:
         return False
 
+    def unreadable_sdist_versions(self, package: str) -> frozenset[str]:
+        return frozenset()
+
     async def get_metadata_text(
         self,
         package: str,

--- a/nab-project/tests/property_python/test_multi_index_contract.py
+++ b/nab-project/tests/property_python/test_multi_index_contract.py
@@ -69,6 +69,9 @@ class Stub:
     def served_unreadable_only(self, package: str) -> bool:
         return False
 
+    def unreadable_sdist_versions(self, package: str) -> frozenset[str]:
+        return frozenset()
+
     async def get_metadata_text(
         self,
         package: str,

--- a/nab-project/tests/property_python/test_multi_index_pep503.py
+++ b/nab-project/tests/property_python/test_multi_index_pep503.py
@@ -75,6 +75,9 @@ class _Stub:
     def served_unreadable_only(self, package: str) -> bool:
         return False
 
+    def unreadable_sdist_versions(self, package: str) -> frozenset[str]:
+        return frozenset()
+
     async def get_metadata_text(
         self,
         package: str,

--- a/nab-project/tests/property_python/test_parsed_listing_equiv.py
+++ b/nab-project/tests/property_python/test_parsed_listing_equiv.py
@@ -201,8 +201,8 @@ def _assert_roundtrip(package: str, body: bytes) -> None:
     blob = encode(parsed, digest)
     decoded = decode(blob, policy)
     assert decoded is not None
-    assert len(decoded) == len(parsed)
-    for got, want in zip(decoded, parsed, strict=True):
+    assert len(decoded.files) == len(parsed)
+    for got, want in zip(decoded.files, parsed, strict=True):
         _assert_record_equal(got, want)
 
 
@@ -276,7 +276,11 @@ def test_blob_carries_no_interpreter_tag() -> None:
     """The wire form is portable, so a blob written anywhere decodes here."""
     blob, policy = _sample_blob()
     header, _rows = json.loads(blob)
-    assert not any(isinstance(field, list) for field in header)
+    *build, digest, zip_sdists = header
+
+    assert all(isinstance(cell, int) for cell in build)
+    assert isinstance(digest, str)
+    assert zip_sdists == []
     assert decode(blob, policy) is not None
 
 

--- a/nab-project/tests/test_cached_client.py
+++ b/nab-project/tests/test_cached_client.py
@@ -29,6 +29,7 @@ from nab_index._pep503 import json_listing
 from nab_index.cache import CachePolicy, NullCache, OfflineError, OnDiskCache
 from nab_index.cached_client import (
     CachedAsyncSimpleClient,
+    ParsedCacheStats,
     SdistArchiveHold,
     _freshness_lifetime,
     _header,
@@ -49,6 +50,7 @@ from nab_index.client import (
     _parse_sdist_filename,
 )
 from nab_index.lazy_wheel import RangeMetadataResult, RangeOutcome
+from nab_index.parsed_listing import encode as encode_parsed
 from nab_index.transport import HttpError
 from nab_provider.metadata import parse_metadata
 from nab_provider.records import (
@@ -84,6 +86,21 @@ ZIP_ONLY_LISTING = {
     ],
 }
 ZIP_ONLY_BYTES = json.dumps(ZIP_ONLY_LISTING).encode()
+
+# A release published as a wheel and a .zip sdist, so the parse keeps one file
+# and drops the other.
+WHEEL_AND_ZIP_LISTING = {
+    "meta": {"api-version": "1.0"},
+    "name": "pkg",
+    "files": [
+        *LISTING["files"],
+        {
+            "filename": "pkg-1.0.zip",
+            "url": "https://files.example.com/pkg-1.0.zip",
+        },
+    ],
+}
+WHEEL_AND_ZIP_BYTES = json.dumps(WHEEL_AND_ZIP_LISTING).encode()
 
 # A digit run just past CPython's int-from-string limit.
 OVERSIZED_DIGITS = "9" * (sys.get_int_max_str_digits() + 1)
@@ -1269,6 +1286,65 @@ class TestGetFiles:
         assert files == []
         assert not unreadable_only
         assert cache.get_negative("pkg") is not None
+
+    def test_zip_sdist_beside_a_wheel_names_its_release(self, tmp_path: Path) -> None:
+        """The wheel survives the parse, so only the version records the ``.zip``."""
+        cache = _make_cache(tmp_path)
+        transport = _FakeTransport([_FakeResponse(WHEEL_AND_ZIP_BYTES)])
+
+        files, zip_sdists = _get_files_and_zip_sdists(transport, cache, "pkg")
+
+        assert [file.filename for file in files] == ["pkg-1.0-py3-none-any.whl"]
+        assert zip_sdists == frozenset({"1.0"})
+
+    def test_readable_listing_names_no_release(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        transport = _FakeTransport([_FakeResponse(LISTING_BYTES)])
+
+        _, zip_sdists = _get_files_and_zip_sdists(transport, cache, "pkg")
+
+        assert zip_sdists == frozenset()
+
+    def test_zip_sdist_survives_a_cached_read(self, tmp_path: Path) -> None:
+        """The blob names the dropped release, so a warm read reports it too.
+
+        No record survives the parse to say the release published an sdist, so
+        a blob holding records alone would report it as never published.
+        """
+        cache = _make_cache(tmp_path)
+        transport = _FakeTransport([_FakeResponse(WHEEL_AND_ZIP_BYTES)])
+        _get_files_and_zip_sdists(transport, cache, "pkg")
+
+        stats = ParsedCacheStats()
+        offline = _FakeTransport()
+        files, zip_sdists = _get_files_and_zip_sdists(
+            offline, cache, "pkg", parsed_stats=stats
+        )
+
+        assert offline.calls == []
+        assert stats.hit == 1
+        assert [file.filename for file in files] == ["pkg-1.0-py3-none-any.whl"]
+        assert zip_sdists == frozenset({"1.0"})
+
+    def test_a_seeded_blob_names_the_dropped_release(self, tmp_path: Path) -> None:
+        """A blob already on disk answers the read, dropped releases and all."""
+        cache = _make_cache(tmp_path)
+        policy = CachePolicy(fetched_at=int(time.time()), max_age=99999, etag=None)
+        digest = cache.put_simple("pkg", WHEEL_AND_ZIP_BYTES, policy)
+        assert digest is not None
+
+        files = _parse_files(
+            json.loads(WHEEL_AND_ZIP_BYTES), "https://pypi.org/simple/", "pkg"
+        )
+        cache.put_simple_parsed("pkg", encode_parsed(files, digest, frozenset({"1.0"})))
+
+        stats = ParsedCacheStats()
+        _, zip_sdists = _get_files_and_zip_sdists(
+            _FakeTransport(), cache, "pkg", parsed_stats=stats
+        )
+
+        assert stats.hit == 1
+        assert zip_sdists == frozenset({"1.0"})
 
     def test_304_parses_the_cached_body_once(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -3918,6 +3994,34 @@ def _get_files_and_report(
         finally:
             await client.aclose()
         return files, client.served_unreadable_only(package)
+
+    return asyncio.run(go())
+
+
+def _get_files_and_zip_sdists(
+    transport: object,
+    cache: object,
+    package: str,
+    parsed_stats: ParsedCacheStats | None = None,
+) -> tuple[list, frozenset[str]]:
+    """Return ``get_files``' records and the releases dropped for their format.
+
+    Both are per-client state, so they are read while the client the call ran
+    on is still in scope.  ``parsed_stats``, when given, records whether the
+    read was served from the parsed blob.
+    """
+
+    async def go() -> tuple[list, frozenset[str]]:
+        client = CachedAsyncSimpleClient(
+            transport,  # type: ignore[arg-type]
+            cache,  # type: ignore[arg-type]
+            parsed_stats=parsed_stats,
+        )
+        try:
+            files = await client.get_files(package)
+        finally:
+            await client.aclose()
+        return files, client.unreadable_sdist_versions(package)
 
     return asyncio.run(go())
 

--- a/nab-project/tests/test_fetch.py
+++ b/nab-project/tests/test_fetch.py
@@ -1650,6 +1650,7 @@ class TestFetchCoordinator:
                 *,
                 offline_miss: bool = False,
                 unreadable_only: bool = False,
+                unreadable_sdist_versions: frozenset[str] = frozenset(),
             ) -> None:
                 serving_at_event.append(self.get_listing_index(package))
                 super().store_listing(
@@ -1657,6 +1658,7 @@ class TestFetchCoordinator:
                     data,
                     offline_miss=offline_miss,
                     unreadable_only=unreadable_only,
+                    unreadable_sdist_versions=unreadable_sdist_versions,
                 )
 
         with _coord() as coord:
@@ -2395,6 +2397,25 @@ class TestMultiIndexCoordinator:
             assert [f.filename for f in listing] == ["foo-1.0-py3-none-any.whl"]
             assert coord.index.get_listing_error("foo") is None
             assert coord.index.get_listing_index("foo") == "local"
+
+    def test_local_zip_sdist_reaches_the_store(self, tmp_path: Path) -> None:
+        """A ``.zip`` sdist leaves no record, so its release rides beside them.
+
+        The wheel keeps the listing non-empty, which is the case the
+        package-level unreadable-format flag cannot report.
+        """
+        wheelhouse = tmp_path / "wheelhouse"
+        wheelhouse.mkdir()
+        (wheelhouse / "foo-1.0-py3-none-any.whl").write_bytes(b"")
+        (wheelhouse / "foo-1.0.zip").write_bytes(b"")
+
+        with _coord(indexes=[IndexConfig("local", wheelhouse.as_uri())]) as coord:
+            coord.request_listing("foo").wait(timeout=5)
+            listing = coord.index.get_listing("foo")
+            assert listing is not None
+            assert [f.filename for f in listing] == ["foo-1.0-py3-none-any.whl"]
+            assert not coord.index.is_unreadable_only_listing("foo")
+            assert coord.index.unreadable_sdist_versions("foo") == frozenset({"1.0"})
 
     def test_local_index(self, tmp_path: Path) -> None:
         """A file:// index uses LocalIndexClient."""
@@ -3144,11 +3165,13 @@ def _warm_parsed(
     fresh: bool = True,
     blob: bool = True,
     digest_override: str | None = None,
+    zip_sdists: frozenset[str] = frozenset(),
 ) -> None:
     """Write a policy sidecar, raw body, and parsed blob for ``package``.
 
     ``fresh`` controls the freshness window; ``blob`` omits the parsed blob;
-    ``digest_override`` binds the blob to a foreign body so ``decode`` misses.
+    ``digest_override`` binds the blob to a foreign body so ``decode`` misses;
+    ``zip_sdists`` seeds the releases the blob says the parse dropped.
     """
     if body is None:
         body = json.dumps(LISTING_JSON).encode()
@@ -3160,7 +3183,7 @@ def _warm_parsed(
     digest = cache.put_simple(package, body, policy)
     if blob:
         bound = digest_override if digest_override is not None else digest
-        cache.put_simple_parsed(package, encode_parsed(list(files), bound))
+        cache.put_simple_parsed(package, encode_parsed(list(files), bound, zip_sdists))
 
 
 def _spy_submit(coord: FetchCoordinator) -> list[object]:
@@ -3620,6 +3643,29 @@ class TestWarmSyncListingPath:
             assert _listing_submits(calls) == []
             assert coord.warm_sync_stats.listing_hits == 1
 
+    def test_warm_hit_stores_the_releases_the_parse_dropped(
+        self, tmp_path: Path
+    ) -> None:
+        """The blob carries them, so an inline serve reports them as a fetch does.
+
+        Nothing else on this path reads the body a ``.zip`` sdist was listed in.
+        """
+        cache = OnDiskCache(tmp_path, _PYPI)
+        files: list[WheelFile | SdistFile] = [_sync_sdist("1.0")]
+        _warm_parsed(cache, "pkg", files, zip_sdists=frozenset({"1.0"}))
+
+        with _coord(cache_dir=tmp_path) as coord:
+            coord._prefetch_metadata_after_listing = (  # type: ignore[method-assign]
+                lambda package, records: None
+            )
+            calls = _spy_submit(coord)
+
+            coord.request_listing("pkg").wait(timeout=5)
+
+            assert _listing_submits(calls) == []
+            assert coord.warm_sync_stats.listing_hits == 1
+            assert coord.index.unreadable_sdist_versions("pkg") == frozenset({"1.0"})
+
     def test_skew_reader_never_serves_torn_pair(self, tmp_path: Path) -> None:
         """Interleaved writer/reader: every non-None probe is a bound pair."""
         cache = OnDiskCache(tmp_path, _PYPI)
@@ -3667,7 +3713,7 @@ class TestWarmSyncListingPath:
 
             assert not errors
             for value in results:
-                assert value is None or value in (files_a, files_b)
+                assert value is None or value.files in (files_a, files_b)
         finally:
             stop.set()
             coord.shutdown()

--- a/nab-project/tests/test_local_index.py
+++ b/nab-project/tests/test_local_index.py
@@ -14,8 +14,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING, TypeVar
 
 import pytest
+from packaging.utils import canonicalize_name
 
-from nab_index.client import SdistFile, WheelFile
+from nab_index.client import SdistFile, WheelFile, zip_sdist_version
 from nab_index.local_index import (
     LocalIndexClient,
     LocalIndexError,
@@ -23,7 +24,6 @@ from nab_index.local_index import (
     NonLocalArtifactError,
     UnreadableLocalIndexError,
     UnsupportedWheelError,
-    _is_zip_sdist,
     _make_record,
     _read_sdist_requires_python,
     parse_file_url,
@@ -422,13 +422,14 @@ class TestFlatWheelhouse:
         assert not client.served_unreadable_only("foo")
 
     def test_zip_sdist_check_rejects_oversized_version(self) -> None:
-        """An oversized version answers False instead of raising.
+        """An oversized version answers None instead of raising.
 
         Called directly because the filename is longer than any filesystem
         allows, so it cannot arrive from a directory scan.
         """
         oversized = "1" * (sys.get_int_max_str_digits() + 1)
-        assert not _is_zip_sdist(f"foo-{oversized}.zip", "foo")
+        name = canonicalize_name("foo")
+        assert zip_sdist_version(f"foo-{oversized}.zip", name) is None
 
     def test_zip_beside_readable_wheel_is_not_unreadable_only(
         self, tmp_path: Path
@@ -438,6 +439,26 @@ class TestFlatWheelhouse:
         client = LocalIndexClient(tmp_path.as_uri())
         assert len(run(client.get_files("foo"))) == 1
         assert not client.served_unreadable_only("foo")
+
+    def test_zip_beside_readable_wheel_names_its_release(self, tmp_path: Path) -> None:
+        """The wheel keeps the listing non-empty, so only the version is left."""
+        (tmp_path / "foo-1.0.zip").write_bytes(b"")
+        (tmp_path / "foo-1.0-py3-none-any.whl").write_bytes(b"")
+        client = LocalIndexClient(tmp_path.as_uri())
+        run(client.get_files("foo"))
+        assert client.unreadable_sdist_versions("foo") == frozenset({"1.0"})
+
+    def test_zip_of_another_package_names_no_release(self, tmp_path: Path) -> None:
+        (tmp_path / "bar-1.0.zip").write_bytes(b"")
+        (tmp_path / "foo-1.0-py3-none-any.whl").write_bytes(b"")
+        client = LocalIndexClient(tmp_path.as_uri())
+        run(client.get_files("foo"))
+        assert client.unreadable_sdist_versions("foo") == frozenset()
+
+    def test_unlisted_package_names_no_release(self, tmp_path: Path) -> None:
+        """A package the client was never asked for has nothing recorded."""
+        client = LocalIndexClient(tmp_path.as_uri())
+        assert client.unreadable_sdist_versions("foo") == frozenset()
 
     def test_filters_other_packages(self, tmp_path: Path) -> None:
         (tmp_path / "foo-1.0-py3-none-any.whl").write_bytes(b"")
@@ -808,6 +829,31 @@ class TestPep503Directory:
         client = LocalIndexClient(tmp_path.as_uri())
         assert run(client.get_files("foo")) == []
         assert client.served_unreadable_only("foo")
+
+    def test_page_zip_beside_a_wheel_names_its_release(self, tmp_path: Path) -> None:
+        """A page keeping one readable file still records the ``.zip``'s release."""
+        body = (
+            '<a href="foo-1.0.zip">foo-1.0</a>'
+            '<a href="foo-2.0-py3-none-any.whl">foo-2.0</a>'
+        )
+        package_dir = self._make_index(tmp_path, body)
+        (package_dir / "foo-2.0-py3-none-any.whl").write_bytes(b"")
+        client = LocalIndexClient(tmp_path.as_uri())
+        assert len(run(client.get_files("foo"))) == 1
+        assert not client.served_unreadable_only("foo")
+        assert client.unreadable_sdist_versions("foo") == frozenset({"1.0"})
+
+    def test_page_installer_names_no_release(self, tmp_path: Path) -> None:
+        """An ``.exe`` is unreadable but is not an sdist, so it names nothing."""
+        body = (
+            '<a href="foo-1.0.win32.exe">foo-1.0</a>'
+            '<a href="foo-2.0-py3-none-any.whl">foo-2.0</a>'
+        )
+        package_dir = self._make_index(tmp_path, body)
+        (package_dir / "foo-2.0-py3-none-any.whl").write_bytes(b"")
+        client = LocalIndexClient(tmp_path.as_uri())
+        assert len(run(client.get_files("foo"))) == 1
+        assert client.unreadable_sdist_versions("foo") == frozenset()
 
     def test_page_of_other_names_is_not_an_unreadable_listing(
         self, tmp_path: Path

--- a/nab-project/tests/test_multi_index.py
+++ b/nab-project/tests/test_multi_index.py
@@ -44,6 +44,7 @@ class FakeClient:
     def __init__(self, listing: dict[str, list[WheelFile | SdistFile]]) -> None:
         self.listing = listing
         self.unreadable: set[str] = set()
+        self.zip_sdists: dict[str, frozenset[str]] = {}
         self.get_files_calls: list[str] = []
         self.metadata_calls: list[tuple[str, str, str]] = []
         self.sdist_calls: list[tuple[str, str, str]] = []
@@ -60,6 +61,9 @@ class FakeClient:
 
     def served_unreadable_only(self, package: str) -> bool:
         return package in self.unreadable
+
+    def unreadable_sdist_versions(self, package: str) -> frozenset[str]:
+        return self.zip_sdists.get(package, frozenset())
 
     async def get_metadata_text(
         self,
@@ -189,6 +193,20 @@ class TestPresenceBased:
         assert run(client.get_files("foo")) == []
         assert client.served_unreadable_only("foo")
         assert not client.served_unreadable_only("bar")
+
+    def test_zip_sdists_collected_from_every_walked_index(self) -> None:
+        """The index serving the wheel need not be the one serving the ``.zip``."""
+        first = FakeClient({"foo": [_wheel("foo")]})
+        second = FakeClient({})
+        second.zip_sdists["foo"] = frozenset({"1.0"})
+        client = MultiIndexClient(
+            {"a": first, "b": second},
+            ["a", "b"],
+            {},
+        )
+        assert len(run(client.get_files("foo"))) == 1
+        assert client.unreadable_sdist_versions("foo") == frozenset({"1.0"})
+        assert client.unreadable_sdist_versions("bar") == frozenset()
 
     def test_route_cache_subsequent_calls(self) -> None:
         first = FakeClient({})

--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -8370,6 +8370,20 @@ class TestLadderSdistAvailability:
         " requires-python, dist-policy, or upload-time"
     )
     _ABSENT = "no PEP 658 metadata and no sdist available"
+    _DROPPED_FORMAT = (
+        "no PEP 658 metadata and the sdist is not a .tar.gz (the format nab reads)"
+    )
+
+    @staticmethod
+    def _with_zip_sdists(
+        files: list[WheelFile | SdistFile], versions: frozenset[str]
+    ) -> FakeFetchPort:
+        """Serve ``files`` for pkg, with ``versions`` also published as ``.zip``."""
+        coordinator = make_coordinator()
+        coordinator.index.store_listing(
+            "pkg", files, unreadable_sdist_versions=versions
+        )
+        return coordinator
 
     def test_upload_cutoff_filtered_sdist_names_the_filter(self) -> None:
         """A cutoff keeping the wheel and dropping the sdist names the filter."""
@@ -8444,6 +8458,74 @@ class TestLadderSdistAvailability:
             provider.get_dependencies("pkg", V("1.0"))
 
         assert self._ABSENT in str(excinfo.value)
+
+    def test_zip_sdist_names_the_format_instead_of_denying_the_sdist(self) -> None:
+        """A ``.zip`` sdist leaves no record, and must not read as absent.
+
+        The repair differs: no sdist sends the user to another release or
+        another index, while a ``.zip`` is a file nab declines to read.
+        """
+        coordinator = self._with_zip_sdists(
+            [make_wheel("1.0", has_metadata=False)], frozenset({"1.0"})
+        )
+        provider = Provider(coordinator, target=_PY312)
+
+        with pytest.raises(MetadataError) as excinfo:
+            provider.get_dependencies("pkg", V("1.0"))
+
+        assert self._DROPPED_FORMAT in str(excinfo.value)
+
+    def test_zip_sdist_of_another_release_is_reported_as_absent(self) -> None:
+        """Only this release's own ``.zip`` says anything about this release."""
+        coordinator = self._with_zip_sdists(
+            [make_wheel("1.0", has_metadata=False)], frozenset({"2.0"})
+        )
+        provider = Provider(coordinator, target=_PY312)
+
+        with pytest.raises(MetadataError) as excinfo:
+            provider.get_dependencies("pkg", V("1.0"))
+
+        assert self._ABSENT in str(excinfo.value)
+
+    def test_zip_version_matches_on_release_not_on_spelling(self) -> None:
+        """``1.0`` and ``1.0.0`` are one release, so the ``.zip`` still counts."""
+        coordinator = self._with_zip_sdists(
+            [make_wheel("1.0.0", has_metadata=False)], frozenset({"1.0"})
+        )
+        provider = Provider(coordinator, target=_PY312)
+
+        with pytest.raises(MetadataError) as excinfo:
+            provider.get_dependencies("pkg", V("1.0.0"))
+
+        assert self._DROPPED_FORMAT in str(excinfo.value)
+
+    def test_unparseable_zip_version_is_reported_as_absent(self) -> None:
+        """A blob can carry any string, so a version that will not parse is skipped."""
+        coordinator = self._with_zip_sdists(
+            [make_wheel("1.0", has_metadata=False)], frozenset({"not-a-version"})
+        )
+        provider = Provider(coordinator, target=_PY312)
+
+        with pytest.raises(MetadataError) as excinfo:
+            provider.get_dependencies("pkg", V("1.0"))
+
+        assert self._ABSENT in str(excinfo.value)
+
+    def test_filtered_tar_gz_beside_a_zip_names_the_filter(self) -> None:
+        """A filtered ``.tar.gz`` is the one the user can bring back."""
+        coordinator = self._with_zip_sdists(
+            [
+                make_wheel("1.0", has_metadata=False),
+                make_sdist("1.0", requires_python=">=3.13"),
+            ],
+            frozenset({"1.0"}),
+        )
+        provider = Provider(coordinator, target=_PY312)
+
+        with pytest.raises(MetadataError) as excinfo:
+            provider.get_dependencies("pkg", V("1.0"))
+
+        assert self._FILTERED in str(excinfo.value)
 
 
 class TestFetchVersionsNotInIndex:

--- a/nab-project/tests/test_resolve.py
+++ b/nab-project/tests/test_resolve.py
@@ -3598,6 +3598,45 @@ class TestAugmentResolutionError:
             " dist-policy, or upload-time" in diagnostics
         )
 
+    def test_zip_sdist_is_not_reported_as_never_published(self, tmp_path: Path) -> None:
+        """The diagnostics name the format, rather than reporting no sdist.
+
+        ``foo`` 1.0 publishes a sidecar-less wheel beside a ``.zip`` sdist,
+        which the listing parse drops.  Reading the report as no sdist would
+        send the user looking for a release that has one.
+        """
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "proj"\ndependencies = ["foo"]\n',
+            encoding="utf-8",
+        )
+
+        wheel = WheelFile(
+            filename="foo-1.0-py3-none-any.whl",
+            url="https://example.com/foo-1.0-py3-none-any.whl",
+            version="1.0",
+            requires_python=None,
+            has_metadata=False,
+            upload_time=None,
+        )
+        coordinator = make_coordinator()
+        coordinator.index.store_listing(
+            "foo", [wheel], unreadable_sdist_versions=frozenset({"1.0"})
+        )
+
+        with patch("nab_project.resolve.FetchCoordinator") as mock_coord_cls:
+            mock_coord_cls.return_value.__enter__ = lambda _self: coordinator
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            with pytest.raises(ResolutionError) as info:
+                _resolved(pyproject, _FAKE_TRANSPORT, python_version="3.12.0")
+
+        diagnostics = str(info.value).split("Diagnostics:")[1]
+        assert (
+            "foo: every version in range was rejected: No metadata for foo==1.0:"
+            " no PEP 658 metadata and the sdist is not a .tar.gz"
+            " (the format nab reads)" in diagnostics
+        )
+
     def test_blocker_diagnostics_render_readable_ranges(self, tmp_path: Path) -> None:
         """Blocker diagnostics render declared ranges, not the debug repr.
 

--- a/nab-provider/src/nab_provider/_provider/metadata_resolver.py
+++ b/nab-provider/src/nab_provider/_provider/metadata_resolver.py
@@ -181,11 +181,27 @@ def _ladder_failure(
             "no PEP 658 metadata and the sdist was filtered by"
             " requires-python, dist-policy, or upload-time"
         )
+    elif _index_dropped_sdist(index, normalized, version):
+        reason = (
+            "no PEP 658 metadata and the sdist is not a .tar.gz (the format nab reads)"
+        )
     else:
         reason = "no PEP 658 metadata and no sdist available"
 
     msg = f"No metadata for {package}=={version}: {reason}"
     return MetadataError(msg)
+
+
+def _released_version(version_str: str) -> Version | None:
+    """Parse a version an index reported, or ``None`` when it is not PEP 440.
+
+    A filename or a cache blob can carry anything, so a string that will not
+    parse names no release rather than failing the resolve.
+    """
+    try:
+        return intern_version(version_str)
+    except InvalidVersion:
+        return None
 
 
 def _index_published_sdist(
@@ -196,15 +212,27 @@ def _index_published_sdist(
     The ladder only sees the post-filter listing, where an sdist the filter
     dropped and one that was never published both read as absent.
     """
-    for dist in index.get_listing(normalized) or ():
-        if not isinstance(dist, SdistFile):
-            continue
-        try:
-            if intern_version(dist.version) == version:
-                return True
-        except InvalidVersion:
-            continue
-    return False
+    return any(
+        _released_version(dist.version) == version
+        for dist in index.get_listing(normalized) or ()
+        if isinstance(dist, SdistFile)
+    )
+
+
+def _index_dropped_sdist(
+    index: InMemoryIndex, normalized: str, version: Version
+) -> bool:
+    """Whether the index served ``version``'s sdist in a format nab drops.
+
+    A ``.zip`` sdist is dropped while the listing is parsed, so no record of
+    it survives for :func:`_index_published_sdist` to find.  The versions ride
+    alongside the listing instead, and are compared as parsed versions, since
+    ``1.0`` and ``1.0.0`` name one release.
+    """
+    return any(
+        _released_version(dropped) == version
+        for dropped in index.unreadable_sdist_versions(normalized)
+    )
 
 
 def _report_offline_skip(

--- a/nab-provider/src/nab_provider/provider.py
+++ b/nab-provider/src/nab_provider/provider.py
@@ -2162,13 +2162,33 @@ class Provider:
         self._package_parts[package] = result
         return result
 
-    def begin_decision_scan(self) -> None:
+    def begin_decision_scan(self) -> Callable[[str], bool] | None:
         """Open a decision scan, expiring the last one's in-flight answers.
 
         The coming scan re-reads the index, then holds any name it finds still
         in flight that way until the next call.
+
+        Hands back :meth:`listing_landed` as the queue's readiness probe, or
+        ``None`` under :attr:`DecisionOrder.STABLE`, where a scan waits for a
+        listing instead of ranking its absence and so has nothing to wait on
+        between scans.
         """
         self._scan_generation += 1
+        return None if self.settle_listings else self.listing_landed
+
+    def listing_landed(self, package: str) -> bool:
+        """Return whether ``package``'s listing has arrived.
+
+        The decision queue's readiness probe: a package whose listing is in
+        flight scores a placeholder version count, and only the arrival changes
+        it.  ``is_ready`` is not enough for an extras proxy, which reads the
+        base's ``versions_cache`` entry that ``prioritize`` fills only after
+        the arrival.
+        """
+        _, _, normalized = self.split_and_normalize(package)
+        if normalized in self.versions_cache:
+            return True
+        return self.arrived_listing(normalized) is not None
 
     def arrived_listing(self, normalized: str) -> list[DistFile] | None:
         """Return ``normalized``'s listing, or None while it is in flight.

--- a/nab-provider/src/nab_provider/store.py
+++ b/nab-provider/src/nab_provider/store.py
@@ -66,6 +66,8 @@ class InMemoryIndex:
         self._offline_listing_misses: set[str] = set()
         # Packages whose empty listing stands for a page of formats nab cannot read.
         self._unreadable_only_listings: set[str] = set()
+        # Versions an index served as an sdist in a format nab does not read.
+        self._unreadable_sdists: dict[str, frozenset[str]] = {}
 
         # Metadata text is keyed by the artifact it came from: the sidecar URL
         # for a wheel's METADATA, or None for text that stands for the version
@@ -128,6 +130,7 @@ class InMemoryIndex:
         *,
         offline_miss: bool = False,
         unreadable_only: bool = False,
+        unreadable_sdist_versions: frozenset[str] = frozenset(),
     ) -> None:
         """Cache the listing for ``package`` and unblock any waiter.
 
@@ -136,6 +139,9 @@ class InMemoryIndex:
         ``offline_miss`` marks an empty listing as an index skipped offline
         rather than one that served no files; ``unreadable_only`` marks it as
         a page of formats nab does not read.
+
+        ``unreadable_sdist_versions`` names the releases whose sdist was
+        dropped for its format; nothing in ``data`` records them.
         """
         key = f"listing:{package}"
         materialised = list(data)
@@ -145,6 +151,8 @@ class InMemoryIndex:
                 self._offline_listing_misses.add(package)
             if unreadable_only:
                 self._unreadable_only_listings.add(package)
+            if unreadable_sdist_versions:
+                self._unreadable_sdists[package] = unreadable_sdist_versions
 
     def is_offline_listing_miss(self, package: str) -> bool:
         """Whether ``package``'s empty listing is an offline cold-cache miss."""
@@ -155,6 +163,11 @@ class InMemoryIndex:
         """Whether ``package``'s empty listing held only unreadable formats."""
         with self._lock:
             return package in self._unreadable_only_listings
+
+    def unreadable_sdist_versions(self, package: str) -> frozenset[str]:
+        """Versions of ``package`` whose sdist the index served in a dropped format."""
+        with self._lock:
+            return self._unreadable_sdists.get(package, frozenset())
 
     def store_listing_error(self, package: str, error: BaseException) -> None:
         """Record a failed listing fetch and unblock any waiter.

--- a/nab-provider/tests/test_decision_scan.py
+++ b/nab-provider/tests/test_decision_scan.py
@@ -287,6 +287,63 @@ class TestOneKeyHoldsTogether:
         assert provider.prioritize("foo", rng, {})[1] == 2
 
 
+class TestTheReadinessProbe:
+    """The probe ``begin_decision_scan`` hands back for in-flight keys."""
+
+    def test_a_name_still_in_flight_denies_the_probe(self) -> None:
+        provider = Provider(_coordinator({"foo": [_wheel("foo")]}))
+
+        probe = provider.begin_decision_scan()
+
+        assert probe is not None
+        assert probe("foo") is False
+
+    def test_the_next_scan_probes_the_arrival(self) -> None:
+        provider = Provider(_coordinator({"foo": [_wheel("foo")]}))
+        provider.begin_decision_scan()
+        assert provider.is_ready("foo") is False
+
+        probe = provider.begin_decision_scan()
+
+        assert probe is not None
+        assert probe("foo") is True
+
+    def test_an_extras_proxy_lands_with_the_listing_not_the_cache(self) -> None:
+        """Why the probe is not ``is_ready``: the proxy's cache entry fills later.
+
+        A proxy's ``is_ready`` reads its base's ``versions_cache`` entry, and
+        ``prioritize`` writes that only once the listing lands, so a probe
+        reading it would hold the proxy past the arrival it waits on.
+        """
+        provider = Provider(_coordinator({"foo": [_wheel("foo")]}))
+        provider.begin_decision_scan()
+        assert provider.is_ready("foo") is False
+
+        probe = provider.begin_decision_scan()
+
+        assert probe is not None
+        assert probe("foo[socks]") is True
+        assert provider.is_ready("foo[socks]") is False
+
+    def test_a_cached_base_lands_without_the_index(self) -> None:
+        provider = Provider(_coordinator({}))
+        provider.versions_cache["foo"] = [(Version("1.0"), _wheel("foo"))]
+
+        probe = provider.begin_decision_scan()
+
+        assert probe is not None
+        assert probe("foo[socks]") is True
+
+    def test_settling_listings_offers_no_probe(self) -> None:
+        """A scan that waits for the listing has nothing to wait on between scans."""
+        provider = Provider(
+            _coordinator({"foo": [_wheel("foo")]}),
+            decision_order=DecisionOrder.STABLE,
+        )
+
+        assert provider.begin_decision_scan() is None
+
+
 class TestScanKeysShareOneView:
     """Every key a scan compares is built against one view of what has landed."""
 

--- a/nab-resolver/src/nab_resolver/decide.py
+++ b/nab-resolver/src/nab_resolver/decide.py
@@ -32,16 +32,17 @@ def choose_package_to_decide(resolver: Resolver[Any, Any]) -> Any | None:
     Prefers ``is_ready`` packages so resolution keeps making progress while
     other listings/metadata are still in flight.  ``begin_decision_scan`` marks
     the start of the scan so a provider fed by another thread can hold the
-    state behind its sort key still. The queue keeps that key across scans, so
-    one that moves without the solution or ``priority_epoch`` moving is never
-    read again.
+    state behind its sort key still, and may hand back a readiness probe that
+    lets the queue leave a still-waiting package's key alone. The queue keeps
+    that key across scans, so one that moves without the solution or
+    ``priority_epoch`` moving is never read again.
     """
     undecided = resolver.solution.undecided_packages()
     undecided.discard(ROOT)
     if not undecided:
         return None
 
-    resolver.provider.begin_decision_scan()
+    ready_probe = resolver.provider.begin_decision_scan()
 
     conflict_counts = resolver.stats.package_conflict_counts
     culprit_counts = resolver.stats.package_culprit_counts
@@ -73,6 +74,7 @@ def choose_package_to_decide(resolver: Resolver[Any, Any]) -> Any | None:
         sort_key,
         resolver.solution.take_changed_packages(),
         resolver.priority_epoch,
+        ready_probe,
     )
 
 

--- a/nab-resolver/src/nab_resolver/decision_queue.py
+++ b/nab-resolver/src/nab_resolver/decision_queue.py
@@ -29,8 +29,10 @@ class DecisionQueue(Generic[PackageType]):
     A key is re-evaluated when the partial solution reports the package's range
     or decided state as moved, when the caller passes a new ``epoch``, and on
     every scan while the package is not ready, since a listing lands without the
-    solution seeing it. Superseded heap entries stay in place until they reach
-    the top, or until a rebuild drops the ones that never do.
+    solution seeing it. A caller that supplies a readiness probe narrows that
+    last case to the scan the package becomes ready on. Superseded heap entries
+    stay in place until they reach the top, or until a rebuild drops the ones
+    that never do.
     """
 
     def __init__(self) -> None:
@@ -56,6 +58,7 @@ class DecisionQueue(Generic[PackageType]):
         sort_key: Callable[[PackageType], tuple[Any, ...]],
         changed: set[PackageType],
         epoch: int,
+        ready_probe: Callable[[PackageType], bool] | None = None,
     ) -> PackageType:
         """Return the undecided package with the smallest sort key.
 
@@ -68,9 +71,18 @@ class DecisionQueue(Generic[PackageType]):
 
         ``sort_key`` must lead with the ready penalty: a truthy first field
         keeps the package on the re-evaluate list until it clears.
+
+        ``ready_probe`` answers whether the provider state a package waits on
+        has landed. A provider that offers one promises the unready key it
+        already gave stands until the probe turns true, which lets the scan
+        keep that key instead of building it again.
         """
+        # _stale_packages overwrites the stored epoch, so compare before it
+        # runs: a new epoch re-evaluates every key, probe or not.
+        probe = ready_probe if epoch == self._epoch else None
+
         stale = self._stale_packages(undecided, changed, epoch)
-        self._refresh(undecided, stale, sort_key)
+        self._refresh(undecided, stale, sort_key, changed, probe)
         self._compact()
         return self._live_top()
 
@@ -100,12 +112,19 @@ class DecisionQueue(Generic[PackageType]):
         undecided: set[PackageType],
         stale: set[PackageType],
         sort_key: Callable[[PackageType], tuple[Any, ...]],
+        changed: set[PackageType],
+        ready_probe: Callable[[PackageType], bool] | None,
     ) -> None:
         """Re-evaluate the stale keys, pushing an entry for each one that moved.
 
         Walks ``undecided`` rather than ``stale`` so which packages are stale
         cannot change the order ``sort_key`` is called in, since a provider can
         fetch while answering one.
+
+        Given a ``ready_probe``, an unready package the solution left alone
+        reaches ``sort_key`` only once the probe reports it ready. The probe
+        runs at that package's own place in the walk, so a listing landing
+        mid-scan is still seen by the packages after it.
         """
         keys = self._keys
         heap = self._heap
@@ -114,6 +133,14 @@ class DecisionQueue(Generic[PackageType]):
 
         for package in undecided:
             if package not in stale:
+                continue
+
+            if (
+                ready_probe is not None
+                and package in unready
+                and package not in changed
+                and not ready_probe(package)
+            ):
                 continue
 
             key = sort_key(package)

--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -124,14 +124,21 @@ class ResolverProvider(Protocol[PackageType, VersionType]):
         """
         ...
 
-    def begin_decision_scan(self) -> None:
-        """Announce the start of one decision scan.
+    def begin_decision_scan(self) -> Callable[[PackageType], bool] | None:
+        """Announce the start of one decision scan, and offer a readiness probe.
 
         ``choose_package_to_decide`` builds every undecided package's sort key
         from ``prioritize`` and ``is_ready``, so both must answer from state
         that does not move until the next call.  Providers whose answers depend
-        on another thread freeze that state here; for providers with no such
-        state this is a no-op.
+        on another thread freeze that state here; providers with no such state
+        have nothing to freeze.
+
+        The probe returns whether the state a not-ready package waits on has
+        landed.  Returning one promises that the package's key holds while the
+        probe stays false and nothing else moves it, so the scan can keep the
+        key it already has; a solution change or a new ``priority_epoch`` still
+        rebuilds it.  Return ``None`` to have every not-ready key built again on
+        every scan.
         """
         ...
 
@@ -253,8 +260,9 @@ class BaseProvider(Generic[PackageType, VersionType]):
     ``from nab_resolver.resolver import BaseProvider``.
     """
 
-    def begin_decision_scan(self) -> None:
-        """Freeze nothing: no state moves between scans."""
+    def begin_decision_scan(self) -> Callable[[PackageType], bool] | None:
+        """Freeze nothing and offer no probe: no state moves between scans."""
+        return None
 
     def is_ready(self, package: PackageType) -> bool:
         """Report every package ready, since answers do not wait on a fetch."""

--- a/nab-resolver/tests/property/providers.py
+++ b/nab-resolver/tests/property/providers.py
@@ -9,7 +9,7 @@ provider implementations can be shared across files.
 from __future__ import annotations
 
 import itertools
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 
 from nab_resolver.ranges import Range
 from nab_resolver.types import Incompatibility, RangeProtocol
@@ -51,8 +51,9 @@ class FuzzProvider:
         """Return dependencies for a specific version."""
         return self._graph.get(package, {}).get(version, {})
 
-    def begin_decision_scan(self) -> None:
-        """No-op: nothing in this stub moves under a scan."""
+    def begin_decision_scan(self) -> Callable[[str], bool] | None:
+        """Offer no probe: nothing in this stub moves under a scan."""
+        return None
 
     def prioritize(
         self,

--- a/nab-resolver/tests/test_decision_queue.py
+++ b/nab-resolver/tests/test_decision_queue.py
@@ -198,13 +198,13 @@ def test_the_heap_is_rebuilt_once_superseded_entries_pile_up() -> None:
 
 
 class ConflictSensitiveProvider(FuzzProvider):
-    """A provider whose sort keys move with no assignment behind them.
+    """A provider whose sort keys move with and without the solution.
 
-    Two of the things a sort key reads sit outside the partial solution, and
-    this drives both. ``prioritize`` ranks a package by how far its culprit
-    count trails the leading one, so crediting the leading culprit moves every
-    other package's key; ``is_ready`` holds one package back for the first
-    scans, the way a listing still in flight does.
+    ``prioritize`` ranks on how far a package's culprit count trails the
+    leading one and then on how many versions its range leaves, so a key moves
+    both when crediting a culprit leaves the solution alone and when the
+    solution narrows the range. ``is_ready`` holds one package back for the
+    first scans, the way a listing still in flight does.
     """
 
     def __init__(
@@ -220,9 +220,10 @@ class ConflictSensitiveProvider(FuzzProvider):
         self._ready_scan = ready_scan
         self.scans = 0
 
-    def begin_decision_scan(self) -> None:
-        """Count the scan, which is what ``is_ready`` answers from."""
+    def begin_decision_scan(self) -> Callable[[str], bool]:
+        """Count the scan, then hand ``is_ready`` back as the readiness probe."""
         self.scans += 1
+        return self.is_ready
 
     def prioritize(
         self,
@@ -231,10 +232,17 @@ class ConflictSensitiveProvider(FuzzProvider):
         conflict_counts: Mapping[str, int],
         culprit_counts: Mapping[str, int] | None = None,
     ) -> int:
-        """Rank the package by how far its culprit count trails the leading one."""
-        del version_range, conflict_counts
+        """Rank on the culprit gap, then on how many versions the range leaves.
+
+        Scaling the gap orders the two the way a tuple would, since no package
+        in this graph has more than two versions.
+        """
         counts = culprit_counts or {}
-        return max(counts.values(), default=0) - counts.get(package, 0)
+        trailing = max(counts.values(), default=0) - counts.get(package, 0)
+        matching = super().prioritize(
+            package, version_range, conflict_counts, culprit_counts
+        )
+        return trailing * 4 + matching
 
     def is_ready(self, package: str) -> bool:
         """Report every package ready but the held-back one, until its scan."""
@@ -246,13 +254,15 @@ class RecheckingDecisionQueue(DecisionQueue[str]):
 
     The cached keys are what the resolver decides on, so a move the queue is
     never told about shows up here as a key the scan's own ``sort_key`` no
-    longer agrees with.
+    longer agrees with. Also counts the keys the readiness probe held back, so
+    a resolve that never took the skip cannot pass as a check of it.
     """
 
     def __init__(self) -> None:
-        """Start empty, with no scan yet seen holding an unready package."""
+        """Start empty, with no unready package seen and no key held back."""
         super().__init__()
         self.unready_picks = 0
+        self.held_keys = 0
 
     def pick(
         self,
@@ -260,12 +270,24 @@ class RecheckingDecisionQueue(DecisionQueue[str]):
         sort_key: Callable[[str], tuple[Any, ...]],
         changed: set[str],
         epoch: int,
+        ready_probe: Callable[[str], bool] | None = None,
     ) -> str:
         """Pick as usual, then check the cached keys against a fresh scan."""
-        picked = super().pick(undecided, sort_key, changed, epoch)
+        evaluated: set[str] = set()
+
+        def watched(package: str) -> tuple[Any, ...]:
+            """Return the package's key, recording that the scan built it."""
+            evaluated.add(package)
+            return sort_key(package)
+
+        picked = super().pick(undecided, watched, changed, epoch, ready_probe)
 
         if self._unready:
             self.unready_picks += 1
+
+        # Every unready package is stale, so one the scan never evaluated is
+        # one the probe held back.
+        self.held_keys += len(self._unready - evaluated)
 
         assert self._keys.keys() == undecided
         for package in undecided:
@@ -290,9 +312,11 @@ def test_a_resolve_that_backjumps_keeps_every_cached_key_current() -> None:
     ``a@2`` and ``d@2`` both dead-end, so the resolve backjumps and credits
     culprits, and ``c`` arrives unready. Both move sort keys of packages the
     partial solution reports as unchanged, so a queue that misses either
-    signal decides on a stale key and resolves somewhere else in silence.
+    signal decides on a stale key and resolves somewhere else in silence. The
+    provider hands back its readiness probe, so ``c``'s key is one the queue
+    keeps across scans rather than rebuilds.
     """
-    provider = ConflictSensitiveProvider(BACKJUMPING_GRAPH, unready="c", ready_scan=3)
+    provider = ConflictSensitiveProvider(BACKJUMPING_GRAPH, unready="c", ready_scan=12)
     resolver: Resolver[str, int] = Resolver(provider)
     queue = RecheckingDecisionQueue()
     resolver.decision_queue = queue
@@ -306,3 +330,106 @@ def test_a_resolve_that_backjumps_keeps_every_cached_key_current() -> None:
     assert resolver.stats.backjumps > 0
     assert resolver.priority_epoch > 0
     assert queue.unready_picks > 0
+    assert queue.held_keys > 0
+
+
+class Landings:
+    """A readiness probe over packages whose listings land on cue."""
+
+    def __init__(self) -> None:
+        """Start with nothing landed and nothing probed."""
+        self.landed: set[str] = set()
+        self.probed: list[str] = []
+
+    def probe(self, package: str) -> bool:
+        """Report whether the package's listing has landed, recording the ask."""
+        self.probed.append(package)
+        return package in self.landed
+
+
+def test_a_probe_that_stays_false_leaves_the_unready_key_unread() -> None:
+    """The saving being measured: an in-flight package's key is not rebuilt."""
+    book = KeyBook({"a": (1, 0, "a"), "b": (0, 2, "b")})
+    queue: DecisionQueue[str] = DecisionQueue()
+    landings = Landings()
+    queue.pick({"a", "b"}, book.sort_key, {"a", "b"}, 0, landings.probe)
+    book.take_read()
+
+    picked = queue.pick({"a", "b"}, book.sort_key, set(), 0, landings.probe)
+
+    assert picked == "b"
+    assert book.take_read() == set()
+    assert landings.probed == ["a"]
+
+
+def test_a_probe_turning_true_rebuilds_the_key_it_held() -> None:
+    book = KeyBook({"a": (1, 0, "a"), "b": (0, 2, "b")})
+    queue: DecisionQueue[str] = DecisionQueue()
+    landings = Landings()
+    queue.pick({"a", "b"}, book.sort_key, {"a", "b"}, 0, landings.probe)
+    queue.pick({"a", "b"}, book.sort_key, set(), 0, landings.probe)
+    book.take_read()
+
+    landings.landed.add("a")
+    book.keys["a"] = (0, 1, "a")
+
+    picked = queue.pick({"a", "b"}, book.sort_key, set(), 0, landings.probe)
+
+    assert picked == "a"
+    assert book.take_read() == {"a"}
+
+
+def test_a_changed_package_is_re_evaluated_while_its_probe_is_false() -> None:
+    """A moved range changes the key of a package still waiting on a listing."""
+    book = KeyBook({"a": (1, 0, "a"), "b": (0, 2, "b")})
+    queue: DecisionQueue[str] = DecisionQueue()
+    landings = Landings()
+    queue.pick({"a", "b"}, book.sort_key, {"a", "b"}, 0, landings.probe)
+    book.take_read()
+
+    book.keys["a"] = (1, 5, "a")
+    queue.pick({"a", "b"}, book.sort_key, {"a"}, 0, landings.probe)
+
+    assert book.take_read() == {"a"}
+    assert landings.probed == []
+
+
+def test_a_new_epoch_re_evaluates_an_unready_key_the_probe_denies() -> None:
+    """A new epoch stands for a count move the probe knows nothing about."""
+    book = KeyBook({"a": (1, 0, "a"), "b": (0, 2, "b")})
+    queue: DecisionQueue[str] = DecisionQueue()
+    landings = Landings()
+    queue.pick({"a", "b"}, book.sort_key, {"a", "b"}, 0, landings.probe)
+    book.take_read()
+
+    queue.pick({"a", "b"}, book.sort_key, set(), 1, landings.probe)
+
+    assert book.take_read() == {"a", "b"}
+    assert landings.probed == []
+
+
+def test_a_listing_landing_mid_scan_reaches_the_package_behind_it() -> None:
+    """The probe runs at the package's own place in the walk.
+
+    One readiness snapshot taken at the head of the scan would hold every
+    later arrival back a whole scan, and could pick a different package.
+    """
+    book = KeyBook({"a": (1, 0, "a"), "b": (1, 0, "b")})
+    queue: DecisionQueue[str] = DecisionQueue()
+    landings = Landings()
+    queue.pick({"a", "b"}, book.sort_key, {"a", "b"}, 0, landings.probe)
+    book.take_read()
+
+    def land_the_others(package: str) -> bool:
+        """Publish every other package's listing, then answer for this one."""
+        for other in ("a", "b"):
+            if other != package:
+                landings.landed.add(other)
+                book.keys[other] = (0, 1, other)
+        return landings.probe(package)
+
+    picked = queue.pick({"a", "b"}, book.sort_key, set(), 0, land_the_others)
+
+    _, second = landings.probed
+    assert book.take_read() == {second}
+    assert picked == second


### PR DESCRIPTION
A warm `pip:langchain-ml-course --resolution lowest` resolve builds 18,528 decision sort keys instead of 62,136 over the same 10,261 scans: 740,308 fewer Python calls, 3.5% of that run, and 2.0% to 2.7% of its instructions over three callgrind pairs.

While a listing is in flight `prioritize` scores a placeholder version count that only the arrival can change, so the scan rebuilt every waiting package's key on every pass. `begin_decision_scan` now offers the queue a probe, and a package that is not ready, was not touched by the solution and is still waiting keeps the key it has. The probe runs at each package's own place in the walk, so a listing landing mid-scan still reaches the packages behind it.

`ResolverProvider.begin_decision_scan` widens from `-> None` to returning that probe or `None`, so existing implementations stay valid and keep the behaviour they have.

Over 12 interleaved pairs CPU is down about 2%, between roughly 1% and 3%. Those runs rule out a wall slowdown above about 0.7% and put peak memory inside 0.2% either way. On a 25-tuple universal matrix, which waits on no listing, the two sides land within 350 of the same 2.0 million calls.