### PR TITLE
Tally tag-excluded wheels once per version, 2% fewer instructions

### DIFF
--- a/nab-provider/src/nab_provider/_provider/listing.py
+++ b/nab-provider/src/nab_provider/_provider/listing.py
@@ -633,11 +633,27 @@ def _apply_wheel_tags(
 
     result: list[tuple[Version, DistFile]] = []
     tag_rejected_versions: set[Version] = set()
+    run_version: Version | None = None
+    run_length = 0
+
     for version, dist in base:
-        if excluded_by_wheel_tags(provider, normalized, version, dist, tags):
-            tag_rejected_versions.add(version)
+        if not excluded_by_wheel_tags(dist, tags):
+            result.append((version, dist))
             continue
-        result.append((version, dist))
+
+        # ``base`` is sorted by version, so a version's rejected wheels arrive
+        # together and fold into one tally update.  Identity is enough for the
+        # boundary: a split run tallies twice and the counts still add up.
+        if version is not run_version:
+            if run_version is not None:
+                _tally_tag_exclusions(provider, normalized, run_version, run_length)
+            tag_rejected_versions.add(version)
+            run_version = version
+            run_length = 0
+        run_length += 1
+
+    if run_version is not None:
+        _tally_tag_exclusions(provider, normalized, run_version, run_length)
 
     if tag_rejected_versions:
         # A version whose every wheel the target refused, and which ships no
@@ -692,27 +708,30 @@ def python_or_time_cause(
     return cause
 
 
-def excluded_by_wheel_tags(
-    provider: Provider,
-    normalized: str,
-    version: Version,
-    dist: DistFile,
-    tags: TagSet,
-) -> bool:
+def excluded_by_wheel_tags(dist: DistFile, tags: TagSet) -> bool:
     """Return True when ``dist`` is a wheel the target cannot install.
 
     An sdist is never excluded here: it carries no tags, and building it
-    produces a wheel for whatever machine runs the build.  Tallied per
-    ``(package, version)`` for the lock's omitted-wheel count.
+    produces a wheel for whatever machine runs the build.
     """
-    if not isinstance(dist, WheelFile) or tags.accepts(dist.filename):
-        return False
-    provider.stats.excluded_by_wheel_tags += 1
+    return isinstance(dist, WheelFile) and not tags.accepts(dist.filename)
+
+
+def _tally_tag_exclusions(
+    provider: Provider,
+    normalized: str,
+    version: Version,
+    count: int,
+) -> None:
+    """Add one version's ``count`` tag-rejected wheels to the diagnostic tallies.
+
+    The per-``(package, version)`` count feeds the lock's omitted-wheel count.
+    """
+    provider.stats.excluded_by_wheel_tags += count
     key = (normalized, version)
     provider.tag_excluded_wheels_by_version[key] = (
-        provider.tag_excluded_wheels_by_version.get(key, 0) + 1
+        provider.tag_excluded_wheels_by_version.get(key, 0) + count
     )
-    return True
 
 
 def parsed_version(raw: str) -> Version | None:

--- a/nab-provider/src/nab_provider/_provider/listing_diagnosis.py
+++ b/nab-provider/src/nab_provider/_provider/listing_diagnosis.py
@@ -385,7 +385,7 @@ def walk_listing(provider: Provider, normalized: str) -> ListingDiagnosis | None
     dropped, survivors, sdist_install = _shared_base_pass(
         provider, normalized, files, policy
     )
-    tag_dropped, kept = _tag_pass(provider, normalized, survivors, sdist_install)
+    tag_dropped, kept = _tag_pass(provider, survivors, sdist_install)
 
     filtered = provider.versions_cache.get(normalized) or []
     return ListingDiagnosis(
@@ -478,7 +478,6 @@ def _base_pass(
 
 def _tag_pass(
     provider: Provider,
-    normalized: str,
     survivors: Sequence[tuple[Version, DistFile]],
     sdist_install: set[Version],
 ) -> tuple[list[DroppedFile], set[Version]]:
@@ -500,9 +499,7 @@ def _tag_pass(
             )
             continue
 
-        if tags is not None and _listing.excluded_by_wheel_tags(
-            provider, normalized, version, dist, tags
-        ):
+        if tags is not None and _listing.excluded_by_wheel_tags(dist, tags):
             dropped.append(DroppedFile(dist, version, DropCause.WHEEL_TAGS))
             continue
 

--- a/nab-provider/tests/test_provider_declared_target.py
+++ b/nab-provider/tests/test_provider_declared_target.py
@@ -698,6 +698,24 @@ class TestPerVersionPruneCounter:
         assert provider.tag_excluded_wheel_count("pkg", Version("2.0")) == 1
         assert provider.stats.excluded_by_wheel_tags == 2
 
+    def test_count_sums_every_wheel_one_version_loses(self) -> None:
+        """A version's several lost wheels add up in its count and in the total."""
+        wheels = [
+            _platform_wheel("1.0", "cp311-cp311-win_amd64"),
+            _platform_wheel("1.0", "cp311-cp311-macosx_11_0_arm64"),
+            _platform_wheel("1.0", "cp311-cp311-manylinux_2_17_x86_64"),
+            _platform_wheel("2.0", "cp311-cp311-win_amd64"),
+        ]
+        provider = Provider(
+            _index_with_files(wheels),
+            _linux_target(PlatformSpec("linux_x86_64")),
+        )
+        provider.filter_distributions("pkg", wheels)
+
+        assert provider.tag_excluded_wheel_count("pkg", Version("1.0")) == 2
+        assert provider.tag_excluded_wheel_count("pkg", Version("2.0")) == 1
+        assert provider.stats.excluded_by_wheel_tags == 3
+
     def test_no_prune_leaves_zero(self) -> None:
         """A version whose every wheel the target keeps has a zero count."""
         wheels = [_platform_wheel("1.0", "py3-none-any")]


### PR DESCRIPTION
Tallying a version's tag-excluded wheels once instead of once per wheel takes about 88 million instructions off a warm `pip:google-bigquery-soda --resolution lowest` resolve, 2.0% of a 4.37 billion base run, counted with callgrind under `PYTHONHASHSEED=0`.

Dropping a wheel bumped the resolve-wide counter, read and rewrote the `(package, version)` tally, and added the version to a set: three `Version.__hash__` calls per wheel. The drops arrive grouped by version, because the list is sorted and `_canonicalize_equal_versions` has already collapsed each release onto one `Version`, so the loop now counts a version's run of drops and applies it in one update. That resolve folds 22,007 updates into 919, and the saving scales with how many wheels a target refuses.

Call counts on the same workload:

| | base | branch |
| --- | --- | --- |
| `Version.__hash__` | 137,503 | 74,239 |
| `dict.get` | 168,608 | 147,520 |
| `set.add` | 32,529 | 11,441 |
| `_tally_tag_exclusions` | 0 | 919 |

`excluded_by_wheel_tags` is now a two-argument predicate with no side effect; the counters move to `_tally_tag_exclusions`.