### PR TITLE
Memoise as_term_range per range object, 269 ns per call to 107

### DIFF
--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -625,6 +625,13 @@ class Resolver(Generic[PackageType, VersionType]):
         self.fold_identity: RangeProtocol[Any] = range_type.full()
         self.term_top: RangeProtocol[Any] = ~range_type.empty()
 
+        # as_term_range's answer per supplied range object, keyed by id() with
+        # term_range_keepalive holding the keys alive. Uncapped, unlike
+        # propagate's token memo: the keys are clause and decision ranges rather
+        # than every propagation probe.
+        self.term_range_by_id: dict[int, RangeProtocol[Any]] = {}
+        self.term_range_keepalive: list[RangeProtocol[Any]] = []
+
         self.incompatibilities: list[Incompatibility[Any, Any]] = []
         self.package_to_incompatibilities: defaultdict[Any, list[int]] = defaultdict(
             list
@@ -689,8 +696,16 @@ class Resolver(Generic[PackageType, VersionType]):
         the identity :class:`~nab_resolver.types.RangeProtocol` documents
         without equalling ``full()``, such as ``full()`` minus an ``===``
         literal, passes through and reaches conflict resolution's step budget.
+
+        Memoised per supplied range object.
         """
-        return self.term_top if range_ == self.fold_identity else range_
+        key = id(range_)
+        result = self.term_range_by_id.get(key)
+        if result is None:
+            result = self.term_top if range_ == self.fold_identity else range_
+            self.term_range_by_id[key] = result
+            self.term_range_keepalive.append(range_)
+        return result
 
     def resolve(
         self,
@@ -895,6 +910,8 @@ class Resolver(Generic[PackageType, VersionType]):
         self.range_tokens.clear()
         self.range_token_by_id.clear()
         self.interned_ranges.clear()
+        self.term_range_by_id.clear()
+        self.term_range_keepalive.clear()
 
         # Re-asked here, so a hook installed since the last resolve is honoured.
         self._hint_ignoring_provider = _provider_with_inherited_hint(self.provider)

--- a/nab-resolver/tests/test_range_benchmark.py
+++ b/nab-resolver/tests/test_range_benchmark.py
@@ -70,7 +70,7 @@ SUITE_PROFILE = {
         intervals_seen=755,
         largest_range=8,
         hash_misses=64,
-        equality_calls=161,
+        equality_calls=160,
     ),
     "conflict-free-fanout": Profile(
         rounds=8,

--- a/nab-resolver/tests/test_range_contract.py
+++ b/nab-resolver/tests/test_range_contract.py
@@ -44,6 +44,9 @@ class FlaggedRange:
 
     __slots__ = ("arbitrary", "base")
 
+    # Counts every ``__eq__`` call, so a test can pin one that is skipped.
+    eq_calls: ClassVar[int] = 0
+
     def __init__(self, base: Range[int], *, arbitrary: bool = False) -> None:
         self.base = base
         self.arbitrary = arbitrary
@@ -131,6 +134,7 @@ class FlaggedRange:
 
     def __eq__(self, other: object) -> bool:
         """Equal when the interval sets and the flags both match."""
+        FlaggedRange.eq_calls += 1
         return (
             isinstance(other, FlaggedRange)
             and self.base == other.base
@@ -379,3 +383,49 @@ class TestTermTopSubstitution:
         )
         assert recorded
         assert all(constraint == resolver.term_top for constraint in recorded)
+
+
+class TestTermRangeMemo:
+    """``as_term_range`` memoises its result per supplied range object."""
+
+    def test_repeat_of_a_full_range_stays_substituted(self) -> None:
+        """A memo hit returns the substitution, not the range it keyed on."""
+        resolver = build_resolver(FlaggedProvider())
+        supplied = FlaggedRange.full()
+        assert resolver.as_term_range(supplied) is resolver.term_top
+        assert resolver.as_term_range(supplied) is resolver.term_top
+
+    def test_repeat_of_a_narrower_range_passes_through(self) -> None:
+        """A memo hit on a narrower range returns that range, not the top."""
+        resolver = build_resolver(FlaggedProvider())
+        supplied = FlaggedRange.singleton(1)
+        assert resolver.as_term_range(supplied) is supplied
+        assert resolver.as_term_range(supplied) is supplied
+
+    def test_a_repeat_makes_no_comparison(self) -> None:
+        """The memo answers a repeat without comparing the range again."""
+        resolver = build_resolver(FlaggedProvider())
+        supplied = FlaggedRange.singleton(1)
+        resolver.as_term_range(supplied)
+
+        before = FlaggedRange.eq_calls
+        resolver.as_term_range(supplied)
+
+        assert FlaggedRange.eq_calls == before
+
+    def test_the_memo_keeps_the_keyed_object_alive(self) -> None:
+        """The memo holds a reference to the object it keyed on."""
+        resolver = build_resolver(FlaggedProvider())
+        supplied = FlaggedRange.full()
+        resolver.as_term_range(supplied)
+        assert any(kept is supplied for kept in resolver.term_range_keepalive)
+
+    def test_a_new_resolution_starts_with_an_empty_memo(self) -> None:
+        """``_reset`` drops the memo, so a second solve reads none of its entries."""
+        resolver = build_resolver(FlaggedProvider())
+        resolver.as_term_range(FlaggedRange.full())
+
+        resolver._reset(None)
+
+        assert not resolver.term_range_by_id
+        assert not resolver.term_range_keepalive


### PR DESCRIPTION
`Resolver.as_term_range` compared every clause and decision range against `full()`. Memoising its answer per supplied range object takes it from 269 ns per call to 107 ns, over the call sequence a `pip:apache-airflow-311-full --resolution lowest` resolve hands it. A warm run of that scenario makes 52,746 of those calls, so about 8.5 ms of a roughly 4.1 s resolve.

Counted under `PYTHONHASHSEED=0` on the same scenario, 51,387 of those calls hit the memo: `VersionRange.__eq__` falls from 151,960 to 100,573 and the run's total calls from 28,286,280 to 28,058,535. The end-to-end run cannot resolve a change that small, but it rules out a regression above about 1.7% and puts peak memory inside about 0.25% either way.

The memo keys on `id()` and holds the keyed ranges alive, so an address is never reused under a live entry.

A resolve with no repeats pays instead. All 355 `as_term_range` calls in the 25-tuple `max-25-tuples` universal scenario miss, and it retires between about 0.02% and 0.07% more instructions across three callgrind runs.