### PR TITLE
Sort the lock's extras and group arrays so --locked ignores flag order

### DIFF
--- a/docs/reference/lockfile.md
+++ b/docs/reference/lockfile.md
@@ -156,7 +156,7 @@ The lock carries that name in both group arrays and gates those packages
 on it:
 
 ```toml
-dependency-groups = ["dev", "base"]
+dependency-groups = ["base", "dev"]
 default-groups = ["base"]
 
 [[packages]]
@@ -197,7 +197,7 @@ build-group = "build"
 ```
 
 ```toml
-dependency-groups = ["dev", "default", "build"]
+dependency-groups = ["build", "default", "dev"]
 default-groups = ["default"]
 
 [[packages]]
@@ -490,8 +490,11 @@ The committed pins are never seeded into the resolve, so the
 check confirms the lock still reflects those inputs rather than
 that it round-trips through itself. Only a real change to the
 locked packages fails it; volatile provenance metadata is
-ignored. `--locked` applies to a `pylock.toml` file in
-single-environment mode.
+ignored. The lock sorts the extras and groups it records, so
+listing the same names in another order, or naming that set with
+`--all-extras` or `--all-groups`, writes the same arrays.
+`--locked` applies to a `pylock.toml` file in single-environment
+mode.
 
 Some mismatches are provable from your inputs without resolving, so
 `--locked` can fail fast with the reason before it re-resolves; see the

--- a/nab-project/src/nab_project/_lockfile/pylock.py
+++ b/nab-project/src/nab_project/_lockfile/pylock.py
@@ -53,6 +53,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping, Sequence
     from collections.abc import Set as AbstractSet
 
+    from nab_provider._vendor.packaging.utils import NormalizedName
     from nab_provider.target import ResolveTarget
 
     from ..lockfile import (
@@ -307,11 +308,7 @@ def build_pylock(lock_input: LockInput, *, lock_dir: Path | None = None) -> Pylo
             if lock_input.requires_python
             else None
         ),
-        extras=(
-            tuple(canonicalize_name(e) for e in lock_input.extras)
-            if lock_input.extras
-            else None
-        ),
+        extras=_name_array(lock_input.extras),
         dependency_groups=_group_array(
             lock_input.dependency_groups,
             lock_input.base_group,
@@ -354,13 +351,21 @@ def _name_base_group(lock_input: LockInput) -> LockInput:
     return replace(lock_input, targets=targets)
 
 
+def _name_array(names: Iterable[str]) -> tuple[NormalizedName, ...] | None:
+    """Return ``names`` canonicalized, deduplicated and sorted, or ``None`` if empty.
+
+    PEP 751 gives these arrays no ordering semantics, so the order a
+    selection was typed in must not reach the file.
+    """
+    return tuple(sorted({canonicalize_name(name) for name in names})) or None
+
+
 def _group_array(
     groups: Sequence[str], *configured: str | None
-) -> tuple[str, ...] | None:
+) -> tuple[NormalizedName, ...] | None:
     """Render one of the lock's group arrays, or ``None`` when it is empty.
 
-    Every name is canonicalized here and deduplicated in order.  Which
-    arrays a ``configured`` name belongs in is the caller's decision:
+    Which arrays a ``configured`` name belongs in is the caller's decision:
     ``build-group`` joins ``dependency-groups`` alone, and ``base-group``
     joins it too, since an installer that offers only those names would
     otherwise never reach it.  ``base-group`` joins ``default-groups``
@@ -368,11 +373,7 @@ def _group_array(
     ``default-groups`` replaces the default selection rather than
     extending it.
     """
-    names = dict.fromkeys(str(canonicalize_name(group)) for group in groups)
-    for name in configured:
-        if name is not None:
-            names[str(canonicalize_name(name))] = None
-    return tuple(names) or None
+    return _name_array([*groups, *(name for name in configured if name is not None)])
 
 
 def _relativize_path(target: str | os.PathLike[str], lock_dir: Path) -> str:

--- a/nab-project/tests/test_lockfile.py
+++ b/nab-project/tests/test_lockfile.py
@@ -354,6 +354,16 @@ class TestSingleTarget:
         data = tomllib.loads(text)
         assert "my-extra" in data["extras"]
 
+    def test_extras_sorted_and_deduplicated(self) -> None:
+        """The array records which extras were selected, not how they were typed."""
+        text = write_lock(
+            LockInput(
+                targets=_one({"foo": _index_pin()}),
+                extras=("xb", "My_Extra", "my-extra"),
+            )
+        )
+        assert tomllib.loads(text)["extras"] == ["my-extra", "xb"]
+
     def test_canonicalises_package_name(self) -> None:
         text = write_lock(
             LockInput(targets=_one({"foo": _index_pin(name="Foo_Bar")})),
@@ -2057,7 +2067,7 @@ class TestDependencyGroups:
             )
         )
         data = tomllib.loads(text)
-        assert tomllib.loads(text)["default-groups"] == ["dev", "base"]
+        assert data["default-groups"] == ["base", "dev"]
         assert data["dependency-groups"] == ["base"]
 
     def test_base_group_joins_both_arrays(self) -> None:
@@ -2074,8 +2084,40 @@ class TestDependencyGroups:
             )
         )
         data = tomllib.loads(text)
-        assert data["dependency-groups"] == ["dev", "default"]
+        assert data["dependency-groups"] == ["default", "dev"]
         assert data["default-groups"] == ["default"]
+
+    def test_group_arrays_are_sorted(self) -> None:
+        """The arrays record a selection, so their order cannot follow the flags."""
+        text = write_lock(
+            LockInput(
+                targets=_one({"foo": _index_pin()}),
+                dependency_groups=("gb", "ga"),
+                default_groups=("gd", "gc"),
+            )
+        )
+        data = tomllib.loads(text)
+        assert data["dependency-groups"] == ["ga", "gb"]
+        assert data["default-groups"] == ["gc", "gd"]
+
+    def test_a_reordered_selection_writes_the_same_bytes(self) -> None:
+        """``nab lock --locked`` compares rendered text, so the bytes must match."""
+
+        def render(extras: tuple[str, ...], groups: tuple[str, ...]) -> str:
+            lock = TargetLock(
+                target=_HOST,
+                pins={"foo": _index_pin(), "bar": _index_pin(name="bar")},
+                package_gates={"bar": (("extra", "xa"), ("group", "gb"))},
+            )
+            return write_lock(
+                LockInput(
+                    targets={_HOST.label: lock},
+                    extras=extras,
+                    dependency_groups=groups,
+                )
+            )
+
+        assert render(("xb", "xa"), ("gb", "ga")) == render(("xa", "xb"), ("ga", "gb"))
 
     def test_omits_arrays_when_empty(self) -> None:
         text = write_lock(LockInput(targets=_one({"foo": _index_pin()})))

--- a/nab-project/tests/test_resolve.py
+++ b/nab-project/tests/test_resolve.py
@@ -4785,7 +4785,7 @@ class TestExtraAndGroupMembershipMarkers:
         root = self._ROOT + '[tool.nab]\ndefault-groups = ["dev", "base"]\n'
         pylock = self._lock(tmp_path, root=root + 'base-group = "base"\n')
 
-        assert pylock.default_groups == ("dev", "base")
+        assert pylock.default_groups == ("base", "dev")
         assert _pylock_selected(pylock) == {"core", "mydev"}
 
     def test_selecting_the_base_group_by_name_refuses(self, tmp_path: Path) -> None:
@@ -5563,7 +5563,7 @@ class TestBuildGroupMarkers:
         """An install that asks for no group is installing, not building."""
         pylock = self._lock(tmp_path, tool=_BOTH_GROUPS)
 
-        assert pylock.dependency_groups == ("main", "build")
+        assert pylock.dependency_groups == ("build", "main")
         assert pylock.default_groups == ("main",)
 
         assert _pylock_selected(pylock) == {"core"}
@@ -5852,7 +5852,7 @@ class TestConfiguredGroupConflictMarkers:
         """Only the project's own dependencies are a default install."""
         pylock = self._lock(tmp_path)
 
-        assert pylock.dependency_groups == ("main", "build")
+        assert pylock.dependency_groups == ("build", "main")
         assert pylock.default_groups == ("main",)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -756,7 +756,7 @@ class TestLockCommandSpecific:
         ):
             lock(pyproject, output=out)
         written = tomli.loads(out.read_text())
-        assert written["dependency-groups"] == ["main", "build"]
+        assert written["dependency-groups"] == ["build", "main"]
         assert written["default-groups"] == ["main"]
 
     def test_build_group_naming_a_declared_group_exits(

--- a/tests/test_lock_locked.py
+++ b/tests/test_lock_locked.py
@@ -244,7 +244,7 @@ def test_a_lock_offering_a_build_group_is_up_to_date(
     out = tmp_path / "pylock.toml"
     _write_lock(pyproject, out, _result({"foo": "1.0"}))
     capsys.readouterr()
-    assert tomli.loads(out.read_text())["dependency-groups"] == ["main", "build"]
+    assert tomli.loads(out.read_text())["dependency-groups"] == ["build", "main"]
 
     _run_locked(pyproject, out, _locked_mock(_result({"foo": "1.0"})))
 
@@ -538,6 +538,54 @@ def test_satisfiable_and_reproducible_falls_through_up_to_date(
     assert out.read_bytes() == before
 
 
+def test_a_reordered_selection_falls_through_up_to_date(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Flag order is no part of the selection, so the lock is still up to date."""
+    pyproject = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "proj"\ndependencies = ["foo"]\n'
+        "[project.optional-dependencies]\n"
+        'xb = ["foo"]\nxa = ["foo"]\n'
+        "[dependency-groups]\n"
+        'gb = ["foo"]\nga = ["foo"]\n',
+    )
+    out = tmp_path / "pylock.toml"
+    selection = ["--groups", "gb", "ga", "--extras", "xb", "xa"]
+    _write_lock(pyproject, out, _result({"foo": "1.0"}), *selection)
+    capsys.readouterr()
+    before = out.read_bytes()
+
+    reordered = ["--groups", "ga", "gb", "--extras", "xa", "xb"]
+    mock = _locked_mock()
+    _run_locked(pyproject, out, mock, *reordered)
+
+    assert "is up to date" in capsys.readouterr().err
+    mock.assert_called_once()
+    assert out.read_bytes() == before
+
+
+def test_all_groups_falls_through_up_to_date_on_a_listed_selection(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``--all-groups`` reaches the same names, in the order they are declared."""
+    pyproject = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "proj"\ndependencies = ["foo"]\n'
+        "[dependency-groups]\n"
+        'gb = ["foo"]\nga = ["foo"]\n',
+    )
+    out = tmp_path / "pylock.toml"
+    _write_lock(pyproject, out, _result({"foo": "1.0"}), "--groups", "ga", "gb")
+    capsys.readouterr()
+
+    mock = _locked_mock()
+    _run_locked(pyproject, out, mock, "--all-groups")
+
+    assert "is up to date" in capsys.readouterr().err
+    mock.assert_called_once()
+
+
 def test_the_base_group_named_in_default_groups_falls_through(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -554,7 +602,7 @@ def test_the_base_group_named_in_default_groups_falls_through(
     out = tmp_path / "pylock.toml"
     _write_lock(pyproject, out, _result({"foo": "1.0", "bb": "1.0"}))
     capsys.readouterr()
-    assert tomli.loads(out.read_text())["default-groups"] == ["dev", "base"]
+    assert tomli.loads(out.read_text())["default-groups"] == ["base", "dev"]
 
     mock = _locked_mock(_result({"foo": "1.0", "bb": "1.0"}))
     _run_locked(pyproject, out, mock)


### PR DESCRIPTION
`nab lock --locked` reported an up-to-date lockfile as out of date whenever the selection was listed in a different order than the run that wrote it:

```
error: --locked: lockfile pylock.toml is out of date; re-run `nab lock --groups ga gb` to update it.
```

The writer put `extras`, `dependency-groups` and `default-groups` in the file in the order the flags were typed, and `--locked` compares its rendered lock against the committed text, so the same set of names in another order is a mismatch. The pre-resolve check compares those names as sets and lets the run past, so the failure only lands after a full fresh resolve.

Two ways to hit it:

- reordering the names on `--extras` or `--groups` between the two runs
- checking a lock written from an explicit list with `--all-groups`, which takes the order the groups are declared in `pyproject.toml`

The three arrays are now sorted and deduplicated after canonicalization. PEP 751 gives none of them an ordering.

A lock committed by an earlier version with those names in another order reports out of date once, and rewriting it settles the order.
