### PR TITLE
Fix build-policy docs calling build-requires-depth inert under `never`

### DIFF
--- a/docs/reference/build-policy.md
+++ b/docs/reference/build-policy.md
@@ -50,8 +50,8 @@ Static metadata only, from any source:
 
 Picks the most reproducible posture: every input to the SAT
 problem is a file read, not a sandboxed subprocess.  Use `never`
-when you want a lockdown resolve with no backend invocations at
-all.
+for a lockdown resolve; only a per-package or per-index override
+lets a backend run.
 
 ## `build-local` (default)
 
@@ -170,8 +170,12 @@ being built, pin it to wheels:
 dist-policy = "wheel-only"
 ```
 
-The setting is inert where builds cannot run: under
-`build-policy = "never"`, and for any target that declares a platform.
+`build-requires-depth` is inert only where no build can run.  A target
+that declares a platform is such a case: there an explicit non-`never`
+build policy, global or in any override, is a config error.  A global
+`build-policy = "never"` is not, since a per-package or per-index
+override can still permit a build, and the environment opened for it
+reads `build-requires-depth` from the same config.
 
 ## Overrides
 


### PR DESCRIPTION
`docs/reference/build-policy.md` calls `build-requires-depth` inert under `build-policy = "never"`. It is not, and the same page shows why: a per-package or per-index override replaces the global policy in either direction.

```toml
[tool.nab]
build-policy = "never"

[tool.nab.packages.deepspeed]
build-policy = "build-remote"
```

That build opens a build environment, which reads `build-requires-depth` from `[tool.nab]`. When a build requirement publishes no wheel the host can install, the default `0` refuses and names the requirement.

The platform case stays: a target that declares a platform forces the policy to `never` and makes an explicit non-`never` value a config error, global or in any override, so no build can run there.

The `never` section had the same gap, offering it for a resolve "with no backend invocations at all". It now names the override as what lets a backend run.
