### PR TITLE
Fix raw traceback from a symlink loop in a project path

### DIFF
--- a/nab-project/src/nab_project/config.py
+++ b/nab-project/src/nab_project/config.py
@@ -80,7 +80,7 @@ from .config_sources import (
     resolve_config,
 )
 from .fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL, IndexRoute
-from .paths import resolve_path
+from .paths import realpath, resolve_path
 from .workspace import (
     WorkspaceConfig,
     discover_workspace_root,
@@ -657,11 +657,11 @@ def read_pyproject_config(
     """
     if anchor is None:
         anchor = datetime.now(timezone.utc)
-    pyproject_dir = path.parent.resolve()
+    pyproject_dir = realpath(path.parent)
     _reject_unknown_pyproject_keys(path)
     project_requires_python = _read_project_requires_python(path)
     # Point the pyproject root at ``pyproject_dir / path.name`` (not
-    # ``path.resolve()``) so the registry's declaring directory is the
+    # ``realpath(path)``) so the registry's declaring directory is the
     # symlink's own directory, matching the historical local-sources base
     # and the project-dir nab.toml lookup.  ``open`` still follows the
     # symlink, so the same file is read.
@@ -893,7 +893,7 @@ def _apply_workspace_discovery(
     if config.workspace is not None:
         discovered = workspace_local_sources(
             config.workspace.members,
-            root_dir=path.parent.resolve(),
+            root_dir=realpath(path.parent),
             declared_in=declared_in,
         )
     else:

--- a/nab-project/src/nab_project/paths.py
+++ b/nab-project/src/nab_project/paths.py
@@ -91,8 +91,8 @@ def realpath(path: Path) -> Path:
     """Resolve ``path``, leaving a symlink loop along it unresolved.
 
     :meth:`Path.resolve` raises ``RuntimeError`` on a loop below Python
-    3.13.  A loop is filesystem state, so it is left for the read to
-    report by errno.
+    3.13.  A loop is filesystem state, so it is left for the stat or the
+    read to report.
     """
     return Path(os.path.realpath(path))
 

--- a/nab-project/src/nab_project/paths.py
+++ b/nab-project/src/nab_project/paths.py
@@ -3,18 +3,17 @@
 from __future__ import annotations
 
 import errno
+import os
 import stat
 from enum import Enum
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from pathlib import Path
+from pathlib import Path
 
 __all__ = [
     "PathState",
     "is_absent_error",
     "is_usable_path_name",
     "path_state",
+    "realpath",
     "resolve_path",
 ]
 
@@ -88,6 +87,16 @@ def is_usable_path_name(entry: str) -> bool:
     return "\x00" not in entry
 
 
+def realpath(path: Path) -> Path:
+    """Resolve ``path``, leaving a symlink loop along it unresolved.
+
+    :meth:`Path.resolve` raises ``RuntimeError`` on a loop below Python
+    3.13.  A loop is filesystem state, so it is left for the read to
+    report by errno.
+    """
+    return Path(os.path.realpath(path))
+
+
 def resolve_path(base: Path, entry: str) -> Path | None:
     """Resolve ``entry`` against ``base``, or ``None`` for an unusable name.
 
@@ -96,6 +105,6 @@ def resolve_path(base: Path, entry: str) -> Path | None:
     if not is_usable_path_name(entry):
         return None
     try:
-        return (base / entry).resolve()
+        return realpath(base / entry)
     except ValueError:
         return None

--- a/nab-project/src/nab_project/workspace.py
+++ b/nab-project/src/nab_project/workspace.py
@@ -29,7 +29,7 @@ from nab_provider._vendor.packaging.utils import canonicalize_name
 from nab_provider.policy import LocalSource
 
 from ._toml import tool_nab_section
-from .paths import PathState, path_state, resolve_path
+from .paths import PathState, path_state, realpath, resolve_path
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -117,7 +117,7 @@ def discover_workspace_root(member_pyproject: Path) -> Path | None:
     errors during the walk are swallowed: a malformed sibling should not
     prevent discovery from finding a valid root above it.
     """
-    start_dir = member_pyproject.resolve().parent
+    start_dir = realpath(member_pyproject).parent
     for parent in (start_dir, *start_dir.parents):
         for candidate in (parent / "pyproject.toml", parent / _PROJECT_TOML):
             try:

--- a/nab-project/tests/test_config.py
+++ b/nab-project/tests/test_config.py
@@ -330,6 +330,12 @@ class TestTopLevelKeys:
         ):
             read_pyproject_config(path)
 
+    def test_symlink_loop_in_the_path_rejected(self, tmp_path: Path) -> None:
+        """A loop reaches the read, so the error names the errno."""
+        (tmp_path / "loop").symlink_to("loop")
+        with pytest.raises(ConfigError, match="cannot read"):
+            read_pyproject_config(tmp_path / "loop" / "pyproject.toml")
+
     @pytest.mark.parametrize("user_key", ["offline = true", 'cache-dir = "x"'])
     def test_user_scope_key_in_pyproject_rejected(
         self, tmp_path: Path, user_key: str
@@ -2819,6 +2825,16 @@ class TestLocalSources:
         )
         with pytest.raises(ConfigError, match="escapes the source tree"):
             read_pyproject_config(path)
+
+    def test_path_through_a_symlink_loop_parses(self, tmp_path: Path) -> None:
+        """A loop is a bad tree, not a bad config, so parsing accepts it."""
+        (tmp_path / "loop").symlink_to("loop")
+        path = write(
+            tmp_path,
+            '[[tool.nab.local-sources]]\nname = "x"\npath = "loop"\n',
+        )
+        srcs = read_pyproject_config(path).local_sources
+        assert srcs[0].path == str(tmp_path.resolve() / "loop")
 
     def test_unknown_key_rejected(self, tmp_path: Path) -> None:
         path = write(

--- a/nab-project/tests/test_paths.py
+++ b/nab-project/tests/test_paths.py
@@ -11,7 +11,8 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
-from nab_project.paths import PathState, path_state, resolve_path
+from nab_project import paths
+from nab_project.paths import PathState, path_state, realpath, resolve_path
 
 
 def _fake_stat(mode: int) -> os.stat_result:
@@ -85,6 +86,19 @@ class TestDenyAccessFixture:
         assert state is PathState.UNREADABLE
 
 
+class TestRealpath:
+    def test_follows_links(self, tmp_path: Path) -> None:
+        base = tmp_path.resolve()
+        (base / "real").mkdir()
+        (base / "link").symlink_to("real", target_is_directory=True)
+        assert realpath(base / "link") == base / "real"
+
+    def test_symlink_loop_is_left_unresolved(self, tmp_path: Path) -> None:
+        base = tmp_path.resolve()
+        (base / "loop").symlink_to("loop")
+        assert realpath(base / "loop") == base / "loop"
+
+
 class TestResolvePath:
     def test_normalises_against_base(self, tmp_path: Path) -> None:
         base = tmp_path.resolve()
@@ -95,8 +109,8 @@ class TestResolvePath:
         assert resolve_path(tmp_path, "pk\x00g") is None
 
     def test_unencodable_name(self, tmp_path: Path) -> None:
-        # A lone surrogate only fails the encode on POSIX, so the resolve is
-        # mocked to reach the arm on every platform.
+        # A lone surrogate only fails the encode on POSIX, so ``realpath``
+        # is mocked to reach the branch on every platform.
         broken = UnicodeEncodeError("utf-8", "\ud800", 0, 1, "surrogates not allowed")
-        with patch.object(Path, "resolve", side_effect=broken):
+        with patch.object(paths, "realpath", side_effect=broken):
             assert resolve_path(tmp_path, "pkg") is None

--- a/nab-project/tests/test_workspace.py
+++ b/nab-project/tests/test_workspace.py
@@ -323,7 +323,11 @@ class TestReadWorkspaceMembers:
             read_workspace_members(root)
 
     def test_member_through_a_symlink_loop_raises(self, tmp_path: Path) -> None:
-        """A loop reaches the member read, so the error names the errno."""
+        """A loop below a member is reported against the member's path.
+
+        Whether the loop stats as unreadable or as absent varies by
+        platform, so only the path is asserted.
+        """
         root = _write(
             tmp_path / "pyproject.toml",
             '[project]\nname = "ws"\nversion = "0"\n'
@@ -333,8 +337,7 @@ class TestReadWorkspaceMembers:
         (tmp_path / "loop").symlink_to("loop")
         member_pyproject = tmp_path.resolve() / "loop" / "pyproject.toml"
         with pytest.raises(
-            WorkspaceDiscoveryError,
-            match=re.escape(f"cannot read {member_pyproject}"),
+            WorkspaceDiscoveryError, match=re.escape(str(member_pyproject))
         ):
             read_workspace_members(root)
 

--- a/nab-project/tests/test_workspace.py
+++ b/nab-project/tests/test_workspace.py
@@ -172,6 +172,17 @@ class TestDiscoverWorkspaceRoot:
         )
         assert discover_workspace_root(member) == (root / "pyproject.toml")
 
+    def test_symlink_loop_below_the_root_still_finds_it(self, tmp_path: Path) -> None:
+        """The walk starts inside the loop, so it still reaches the root above."""
+        root = _write(
+            tmp_path / "pyproject.toml",
+            '[project]\nname = "ws"\nversion = "0"\n'
+            "[tool.nab.workspace]\nmembers = []\n",
+        )
+        (tmp_path / "loop").symlink_to("loop")
+        member = tmp_path / "loop" / "pyproject.toml"
+        assert discover_workspace_root(member) == root.resolve()
+
     def test_walks_past_non_table_tool_nab(self, tmp_path: Path) -> None:
         _write(
             tmp_path / "outer" / "pyproject.toml",
@@ -308,6 +319,22 @@ class TestReadWorkspaceMembers:
         )
         with pytest.raises(
             WorkspaceDiscoveryError, match="is not a usable filesystem path"
+        ):
+            read_workspace_members(root)
+
+    def test_member_through_a_symlink_loop_raises(self, tmp_path: Path) -> None:
+        """A loop reaches the member read, so the error names the errno."""
+        root = _write(
+            tmp_path / "pyproject.toml",
+            '[project]\nname = "ws"\nversion = "0"\n'
+            "[tool.nab.workspace]\n"
+            'members = ["loop"]\n',
+        )
+        (tmp_path / "loop").symlink_to("loop")
+        member_pyproject = tmp_path.resolve() / "loop" / "pyproject.toml"
+        with pytest.raises(
+            WorkspaceDiscoveryError,
+            match=re.escape(f"cannot read {member_pyproject}"),
         ):
             read_workspace_members(root)
 

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -52,7 +52,7 @@ from nab_project.config_sources import (
     resolve_config,
 )
 from nab_project.lockfile import MissingHashError, MissingSdistError
-from nab_project.paths import PathState, path_state
+from nab_project.paths import PathState, path_state, realpath
 from nab_project.resolve import resolve_for_targets
 from nab_project.workspace import WorkspaceDiscoveryError
 from nab_provider.errors import (
@@ -272,7 +272,7 @@ def _config_search_roots(pyproject: Path) -> SourceRoots:
     """
     base = os.environ.get("XDG_CONFIG_HOME")
     user_dir = Path(base) if base else Path.home() / ".config"
-    project_dir = pyproject.parent.resolve()
+    project_dir = realpath(pyproject.parent)
     return SourceRoots(
         system_toml=Path("/etc/nab/nab.toml"),
         user_toml=user_dir / "nab" / "nab.toml",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3938,11 +3938,12 @@ class TestConfigErrors:
     def test_symlink_loop_in_the_path_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        """A loop is left to the pyproject read, which names the errno."""
+        """A loop in the project path exits 1 naming the path, rather than raising."""
         (tmp_path / "loop").symlink_to("loop")
+        pyproject = tmp_path / "loop" / "pyproject.toml"
         with pytest.raises(SystemExit, match="1"):
-            lock(tmp_path / "loop" / "pyproject.toml")
-        assert "cannot read" in capsys.readouterr().err
+            lock(pyproject)
+        assert str(pyproject) in capsys.readouterr().err
 
 
 class TestCliDocstringCommandModules:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3935,6 +3935,15 @@ class TestConfigErrors:
             lock(member)
         assert "workspace discovery error" in capsys.readouterr().err
 
+    def test_symlink_loop_in_the_path_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A loop is left to the pyproject read, which names the errno."""
+        (tmp_path / "loop").symlink_to("loop")
+        with pytest.raises(SystemExit, match="1"):
+            lock(tmp_path / "loop" / "pyproject.toml")
+        assert "cannot read" in capsys.readouterr().err
+
 
 class TestCliDocstringCommandModules:
     """``nab.cli``'s docstring names every module that registers a subcommand."""


### PR DESCRIPTION
On Python 3.10 to 3.12, a project path that runs through a symlink loop crashes `nab` with a traceback instead of an error message:

    RuntimeError: Symlink loop from '/tmp/demo/loop'

Three places reach it:

- the directory holding the pyproject file
- a `path` under `[[tool.nab.local-sources]]`
- an entry in `[tool.nab.workspace].members`

`Path.resolve()` turns ELOOP into a `RuntimeError` below 3.13, and returns the unresolved path from 3.13 on. The five `Path.resolve()` calls along the config read now go through one `realpath` helper that leaves the loop in the path on every version, so whatever opens it reports the errno:

    error: in [tool.nab]: cannot read loop/pyproject.toml: [Errno 40] Too many levels of symbolic links: 'loop/pyproject.toml'

A local source pointing through a loop still parses, since a broken tree is not a broken config. The error comes later, when the source is read, and names the same errno.
