### PR TITLE
Cover nab download's summary counts, which no test asserted

### DIFF
--- a/nab-project/tests/test_build_runner.py
+++ b/nab-project/tests/test_build_runner.py
@@ -1964,7 +1964,7 @@ class TestResolveAndDownload:
         monkeypatch.setattr("nab_project.resolve.resolve_for_targets", fake_resolve)
         monkeypatch.setattr(
             "nab_project._build.env.download_lock",
-            lambda *_a, **_k: MagicMock(written=[], skipped=[]),
+            lambda *_a, **_k: DownloadResult(written=(), skipped=()),
         )
         wheel_dir = tmp_path / "wheels"
         wheel_dir.mkdir()
@@ -2062,7 +2062,7 @@ class TestResolveAndDownload:
         monkeypatch.setattr("nab_project.resolve.resolve_for_targets", fake_resolve)
         monkeypatch.setattr(
             "nab_project._build.env.download_lock",
-            lambda *_a, **_k: MagicMock(written=[], skipped=[]),
+            lambda *_a, **_k: DownloadResult(written=(), skipped=()),
         )
         wheel_dir = tmp_path / "wheels"
         wheel_dir.mkdir()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -61,7 +61,7 @@ from nab_index.urllib3_async_transport import Urllib3AsyncTransport
 from nab_project._testing.coordinator_fake import make_coordinator
 from nab_project.config import ConfigError, read_pyproject_config
 from nab_project.config_sources import SourceRoots
-from nab_project.download import DownloadError
+from nab_project.download import DownloadError, DownloadResult
 from nab_project.fetch import FetchCoordinator
 from nab_project.lockfile import (
     ArchivePin,
@@ -1966,7 +1966,7 @@ class TestPythonFlag:
             ) as mock_resolve,
             patch(
                 "nab._download.download_lock",
-                return_value=MagicMock(written=(out / "x.whl",), skipped=()),
+                return_value=DownloadResult(written=(out / "x.whl",), skipped=()),
             ),
         ):
             download(pyproject, output=out, python="3.11")
@@ -5644,7 +5644,7 @@ class TestProgressReachesTheResolve:
             ["nab", "download", str(pyproject), "--output", str(tmp_path / "vendor")],
             patch(
                 "nab._download.download_lock",
-                return_value=MagicMock(written=(), skipped=()),
+                return_value=DownloadResult(written=(), skipped=()),
             ),
         )
 
@@ -5691,7 +5691,7 @@ class TestProgressReachesTheResolve:
             ],
             patch(
                 "nab._download.download_lock",
-                return_value=MagicMock(written=(), skipped=()),
+                return_value=DownloadResult(written=(), skipped=()),
             ),
         )
 
@@ -5801,7 +5801,7 @@ class TestDownloadCommand:
     def test_invokes_download_lock(self, tmp_path: Path) -> None:
         pyproject = _make_pyproject(tmp_path)
         out = tmp_path / "vendor"
-        download_result = MagicMock(written=(out / "x.whl",), skipped=())
+        download_result = DownloadResult(written=(out / "x.whl",), skipped=())
         with (
             patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()),
             patch(
@@ -5818,7 +5818,7 @@ class TestDownloadCommand:
         """``--offline`` must reach the download, not just the resolve."""
         pyproject = _make_pyproject(tmp_path)
         out = tmp_path / "vendor"
-        download_result = MagicMock(written=(), skipped=())
+        download_result = DownloadResult(written=(), skipped=())
         with (
             patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()),
             patch(
@@ -5832,7 +5832,7 @@ class TestDownloadCommand:
         """``--http-backend`` must reach the download, not just the resolve."""
         pyproject = _make_pyproject(tmp_path)
         out = tmp_path / "vendor"
-        download_result = MagicMock(written=(), skipped=())
+        download_result = DownloadResult(written=(), skipped=())
 
         resolve_transport = MagicMock(name="resolve_transport")
         fetch_transport = MagicMock(name="fetch_transport")
@@ -5898,6 +5898,36 @@ class TestDownloadCommand:
 
         assert transport.peak == 2
 
+    def test_summary_counts_swap_on_a_second_download(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A second download into the same directory swaps the two counts."""
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "vendor"
+        result, payloads = _fetchable_resolve_result(3)
+
+        def run() -> str:
+            """Download into ``out`` and return what the run wrote to stderr."""
+            with (
+                patch("nab.cli.resolve_for_targets", return_value=result),
+                patch(
+                    "nab.cli._make_transport",
+                    return_value=_ConcurrencyProbeTransport(payloads),
+                ),
+            ):
+                download(pyproject, output=out)
+            return capsys.readouterr().err
+
+        first = run()
+        second = run()
+
+        assert first.splitlines() == [
+            f"Downloaded 3 files, 0 already present, into {out}"
+        ]
+        assert second.splitlines() == [
+            f"Downloaded 0 files, 3 already present, into {out}"
+        ]
+
     def test_project_override_uses_download_wording(
         self,
         tmp_path: Path,
@@ -5907,7 +5937,7 @@ class TestDownloadCommand:
         """A CLI PROJECT override on ``nab download`` uses the no-lock wording."""
         pyproject = _make_pyproject(tmp_path)
         out = tmp_path / "vendor"
-        download_result = MagicMock(written=(out / "x.whl",), skipped=())
+        download_result = DownloadResult(written=(out / "x.whl",), skipped=())
         monkeypatch.setattr(
             "nab.cli._config_search_roots",
             lambda p: SourceRoots(project_dir=p.parent, pyproject=p),
@@ -5940,7 +5970,7 @@ class TestDownloadCommand:
         """Universal mode re-resolves the matrix and downloads the union."""
         pyproject = _universal_pyproject(tmp_path)
         out = tmp_path / "vendor"
-        download_result = MagicMock(written=(out / "foo.whl",), skipped=())
+        download_result = DownloadResult(written=(out / "foo.whl",), skipped=())
         with (
             patch(
                 "nab.cli.resolve_for_targets",
@@ -6128,7 +6158,7 @@ class TestDownloadCommand:
             '[project]\nname = "x"\nversion = "0"\ndependencies = ["foo"]\n'
             "[project.optional-dependencies]\ncpu = []\ngpu = []\n",
         )
-        download_result = MagicMock(written=(), skipped=())
+        download_result = DownloadResult(written=(), skipped=())
         with (
             patch(
                 "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
@@ -6144,7 +6174,7 @@ class TestDownloadCommand:
             '[project]\nname = "x"\nversion = "0"\ndependencies = ["foo"]\n'
             "[dependency-groups]\ndev = []\n",
         )
-        download_result = MagicMock(written=(), skipped=())
+        download_result = DownloadResult(written=(), skipped=())
         with (
             patch(
                 "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
@@ -6160,7 +6190,7 @@ class TestDownloadCommand:
             '[project]\nname = "x"\nversion = "0"\ndependencies = ["foo"]\n'
             "[project.optional-dependencies]\ncpu = []\ngpu = []\n",
         )
-        download_result = MagicMock(written=(), skipped=())
+        download_result = DownloadResult(written=(), skipped=())
         with (
             patch(
                 "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
@@ -6176,7 +6206,7 @@ class TestDownloadCommand:
             '[project]\nname = "x"\nversion = "0"\ndependencies = ["foo"]\n'
             "[dependency-groups]\ndev = []\ntest = []\n",
         )
-        download_result = MagicMock(written=(), skipped=())
+        download_result = DownloadResult(written=(), skipped=())
         with (
             patch(
                 "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
@@ -6188,7 +6218,7 @@ class TestDownloadCommand:
 
     def test_universal_forwards_selection(self, tmp_path: Path) -> None:
         pyproject = _universal_pyproject(tmp_path)
-        download_result = MagicMock(written=(), skipped=())
+        download_result = DownloadResult(written=(), skipped=())
         with (
             patch(
                 "nab.cli.resolve_for_targets",

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -26,7 +26,7 @@ from contextlib import (
 )
 from datetime import datetime, timezone
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -38,6 +38,7 @@ from nab._lock import lock
 from nab.cli import app, effective_config
 from nab_project.config import NabProjectConfig
 from nab_project.config_sources import OPTIONS, OptionSpec, Scope, SourceRoots
+from nab_project.download import DownloadResult
 from nab_project.lockfile import (
     IndexPin,
     SdistArtifact,
@@ -1143,7 +1144,7 @@ class TestDownloadLadder:
     def _resolve_kwargs(
         self, proj: Path, out: Path, *, offline: bool | None = None
     ) -> Mapping[str, object]:
-        download_result = MagicMock(written=(), skipped=())
+        download_result = DownloadResult(written=(), skipped=())
         with (
             patch(
                 "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()


### PR DESCRIPTION
No test read `nab download`'s completion summary, so swapping `written` and `skipped` in `src/nab/_download.py` ships with the suite green.

Two things hid it:

- Sixteen call sites across the CLI and build-env tests stood a `MagicMock` in for the real `DownloadResult`, and a `MagicMock` answers to any attribute name.
- Every one of them set `skipped` empty, so the already-present half of the line was always `0`. `download_lock` has skip coverage in `nab-project/tests/test_download.py`; the CLI line printing its counts did not.

The new test downloads three wheels into one output directory twice, through the real `download_lock`, and asserts the whole line each run prints:

    Downloaded 3 files, 0 already present, into <out>
    Downloaded 0 files, 3 already present, into <out>

The counts differ between the runs, so a swap fails. The sixteen stand-ins become real `DownloadResult` objects.
