### PR TITLE
Fix RecursionError traceback from an over-nested Simple-API listing

### DIFF
--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -10,7 +10,6 @@ treated as immutable (cached forever; never revalidated).
 from __future__ import annotations
 
 import hashlib
-import json
 import logging
 import re
 import time
@@ -34,6 +33,7 @@ from .client import (
     _listing_body,
     _parse_files,
     _verify_metadata_hash,
+    decode_listing_json,
     holds_unreadable_format,
     verify_sdist_hash,
 )
@@ -570,13 +570,14 @@ class CachedAsyncSimpleClient:
         raises there, the same as on the wire path.
         """
         try:
-            decoded: object = json.loads(body)
-        except ValueError:
+            decoded: object = decode_listing_json(body)
+        except ValueError as exc:
             logger.warning(
-                "Corrupt cached Simple-API body for %r from %s: not valid JSON; "
+                "Corrupt cached Simple-API body for %r from %s: %s; "
                 "treating as a miss and re-fetching",
                 package,
                 self._index_url,
+                exc,
             )
             return None
         return decoded
@@ -586,18 +587,16 @@ class CachedAsyncSimpleClient:
     ) -> list[WheelFile | SdistFile]:
         """Parse a Simple-API listing body served from ``page_url``.
 
-        A body that is not valid JSON raises the same
-        :class:`MalformedSimpleResponseError` as a valid-JSON body of the
-        wrong shape, not a raw decode error. ``json.loads`` raises a
-        :class:`ValueError` for every body it rejects, including non-UTF-8
-        bytes and an integer literal past CPython's conversion limit.
+        A body that will not decode raises the same
+        :class:`MalformedSimpleResponseError` as a decodable body of the
+        wrong shape, not a raw decode error.
         """
         try:
-            data = json.loads(body)
+            data = decode_listing_json(body)
         except ValueError as exc:
             msg = (
                 f"{self._index_url} served a malformed Simple-API response for "
-                f"{package!r}: body is not valid JSON"
+                f"{package!r}: {exc}"
             )
             raise MalformedSimpleResponseError(msg) from exc
         return self._parse_body(data, package, page_url=page_url)

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -59,6 +59,7 @@ __all__ = [
     "SdistHashMismatchError",
     "WheelFile",
     "WheelHashMismatchError",
+    "decode_listing_json",
     "extract_sdist_archive",
     "holds_unreadable_format",
     "is_readable_filename",
@@ -379,7 +380,7 @@ class AsyncSimpleClient:
     async def get_files(self, package: str) -> list[WheelFile | SdistFile]:
         """Fetch all distribution files for a package.
 
-        A body ``json.loads`` rejects becomes a
+        A body that will not decode becomes a
         :class:`MalformedSimpleResponseError`, not a raw decode error.
         """
         url = f"{self._index_url}{package}/"
@@ -393,11 +394,11 @@ class AsyncSimpleClient:
         )
 
         try:
-            data = json.loads(body)
+            data = decode_listing_json(body)
         except ValueError as exc:
             msg = (
                 f"{self._index_url} served a malformed Simple-API response for "
-                f"{package!r}: body is not valid JSON"
+                f"{package!r}: {exc}"
             )
             raise MalformedSimpleResponseError(msg) from exc
         return _parse_files(data, self._index_url, package, page_url=response.url)
@@ -413,6 +414,22 @@ class AsyncSimpleClient:
         response = await self._transport.get(url, headers=IDENTITY_HEADERS)
         raise_unless_ok(response, url)
         return response.content
+
+
+def decode_listing_json(body: bytes) -> object:
+    """Decode a Simple-API listing body, or raise ``ValueError``.
+
+    ``json.loads`` raises :class:`ValueError` for most bodies it refuses,
+    including non-UTF-8 bytes and an integer literal past CPython's
+    conversion limit. One nested past its scanner's recursion guard raises
+    :class:`RecursionError` instead.
+    """
+    try:
+        decoded: object = json.loads(body)
+    except RecursionError as exc:
+        msg = "listing is nested too deeply to decode"
+        raise ValueError(msg) from exc
+    return decoded
 
 
 def _parse_files(

--- a/nab-project/tests/test_async_transports.py
+++ b/nab-project/tests/test_async_transports.py
@@ -77,16 +77,34 @@ GZIP_BODY = gzip.compress(LISTING_BODY)
 # connection drop whose Content-Length matches the bytes that did arrive.
 TRUNCATED_GZIP_BODY = GZIP_BODY[: len(GZIP_BODY) // 2]
 
-# Nested past what ``json.loads`` will decode. The scanner's recursion guard
-# does not sit at ``sys.getrecursionlimit()``, so overshoot it rather than try
-# to compute the depth that trips it.
-_OVER_NESTED_DEPTH = 100_000
+# A listing nested deeper than any real one; _refuse_as_over_nested is what
+# makes the scanner refuse it.
+_OVER_NESTED_DEPTH = 1_000
 OVER_NESTED_BODY = (
     b'{"meta": {"api-version": "1.0"}, "name": "pkg", "files": '
     + b"[" * _OVER_NESTED_DEPTH
     + b"]" * _OVER_NESTED_DEPTH
     + b"}"
 )
+
+
+def _refuse_as_over_nested(monkeypatch: pytest.MonkeyPatch, body: bytes) -> None:
+    """Make ``json.loads`` refuse ``body`` the way it refuses an over-nested one.
+
+    The scanner's guard sits wherever the interpreter's C stack budget puts it,
+    which on 3.14 is the running thread's own stack, so no fixed depth is
+    refused everywhere the suite runs.
+    """
+    real_loads = json.loads
+
+    def loads(s: str | bytes | bytearray, **kwargs: Any) -> Any:
+        if s == body:
+            msg = "maximum recursion depth exceeded while decoding a JSON array"
+            raise RecursionError(msg)
+        return real_loads(s, **kwargs)
+
+    monkeypatch.setattr(json, "loads", loads)
+
 
 # Only the first is rejected up front; the rest raise out of urllib3's conversions.
 UNPARSEABLE_RETRY_AFTERS = [
@@ -1794,8 +1812,11 @@ class TestAsyncSimpleClient:
             asyncio.run(go())
         assert isinstance(caught.value, HttpError)
 
-    def test_get_files_over_nested_body_raises_clean(self) -> None:
+    def test_get_files_over_nested_body_raises_clean(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """A body nested past the scanner's guard must not escape raw."""
+        _refuse_as_over_nested(monkeypatch, OVER_NESTED_BODY)
         transport = self._FakeTransport(OVER_NESTED_BODY)
 
         async def go() -> list:

--- a/nab-project/tests/test_async_transports.py
+++ b/nab-project/tests/test_async_transports.py
@@ -77,6 +77,17 @@ GZIP_BODY = gzip.compress(LISTING_BODY)
 # connection drop whose Content-Length matches the bytes that did arrive.
 TRUNCATED_GZIP_BODY = GZIP_BODY[: len(GZIP_BODY) // 2]
 
+# Nested past what ``json.loads`` will decode. The scanner's recursion guard
+# does not sit at ``sys.getrecursionlimit()``, so overshoot it rather than try
+# to compute the depth that trips it.
+_OVER_NESTED_DEPTH = 100_000
+OVER_NESTED_BODY = (
+    b'{"meta": {"api-version": "1.0"}, "name": "pkg", "files": '
+    + b"[" * _OVER_NESTED_DEPTH
+    + b"]" * _OVER_NESTED_DEPTH
+    + b"}"
+)
+
 # Only the first is rejected up front; the rest raise out of urllib3's conversions.
 UNPARSEABLE_RETRY_AFTERS = [
     pytest.param("soon", id="not-a-date"),
@@ -1782,6 +1793,25 @@ class TestAsyncSimpleClient:
         ) as caught:
             asyncio.run(go())
         assert isinstance(caught.value, HttpError)
+
+    def test_get_files_over_nested_body_raises_clean(self) -> None:
+        """A body nested past the scanner's guard must not escape raw."""
+        transport = self._FakeTransport(OVER_NESTED_BODY)
+
+        async def go() -> list:
+            async with AsyncSimpleClient(transport, "https://pypi.org/simple/") as c:
+                return await c.get_files("pkg")
+
+        with pytest.raises(
+            MalformedSimpleResponseError,
+            match="malformed Simple-API.+'pkg': listing is nested too deeply",
+        ) as caught:
+            asyncio.run(go())
+        assert isinstance(caught.value, HttpError)
+
+        decode_error = caught.value.__cause__
+        assert isinstance(decode_error, ValueError)
+        assert isinstance(decode_error.__cause__, RecursionError)
 
     def test_get_files_404_returns_empty(self) -> None:
         transport = self._FakeTransport(b"not found", status=404)

--- a/nab-project/tests/test_cached_client.py
+++ b/nab-project/tests/test_cached_client.py
@@ -88,6 +88,17 @@ ZIP_ONLY_BYTES = json.dumps(ZIP_ONLY_LISTING).encode()
 # A digit run just past CPython's int-from-string limit.
 OVERSIZED_DIGITS = "9" * (sys.get_int_max_str_digits() + 1)
 
+# Nested past what ``json.loads`` will decode. The scanner's recursion guard
+# does not sit at ``sys.getrecursionlimit()``, so overshoot it rather than try
+# to compute the depth that trips it.
+_OVER_NESTED_DEPTH = 100_000
+OVER_NESTED_BYTES = (
+    b'{"meta": {"api-version": "1.0"}, "name": "pkg", "files": '
+    + b"[" * _OVER_NESTED_DEPTH
+    + b"]" * _OVER_NESTED_DEPTH
+    + b"}"
+)
+
 
 class _FakeResponse:
     def __init__(
@@ -4468,6 +4479,51 @@ class TestOversizedListingInt:
         assert healed is not None
         assert healed[0] == LISTING_BYTES
         assert len(_cached_warnings(caplog)) == 1
+
+
+class TestOverNestedListingBody:
+    """A listing nested past the JSON scanner's guard reads as undecodable.
+
+    ``json.loads`` refuses it with :class:`RecursionError` rather than the
+    :class:`ValueError` a malformed body normally raises.
+    """
+
+    def test_wire_body_raises_clean_and_skips_cache(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        transport = _FakeTransport([_FakeResponse(OVER_NESTED_BYTES, status=200)])
+
+        with pytest.raises(
+            MalformedSimpleResponseError,
+            match="malformed Simple-API.+'pkg': listing is nested too deeply",
+        ) as caught:
+            _run_get_files(transport, cache, "pkg")
+
+        assert isinstance(caught.value, HttpError)
+
+        decode_error = caught.value.__cause__
+        assert isinstance(decode_error, ValueError)
+        assert isinstance(decode_error.__cause__, RecursionError)
+
+        assert cache.get_simple("pkg") is None
+
+    def test_cached_body_self_heals_online(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        cache = _make_cache(tmp_path)
+        cache.put_simple("pkg", OVER_NESTED_BYTES, _fresh_policy())
+        transport = _FakeTransport([_FakeResponse(LISTING_BYTES, status=200)])
+
+        with caplog.at_level(logging.WARNING, logger="nab_index.cached_client"):
+            files = _run_get_files(transport, cache, "pkg")
+
+        assert len(files) == 1
+        healed = cache.get_simple("pkg")
+        assert healed is not None
+        assert healed[0] == LISTING_BYTES
+
+        warnings = _cached_warnings(caplog)
+        assert len(warnings) == 1
+        assert "nested too deeply to decode" in warnings[0].getMessage()
 
 
 class TestModuleDocstring:

--- a/nab-project/tests/test_cached_client.py
+++ b/nab-project/tests/test_cached_client.py
@@ -88,16 +88,33 @@ ZIP_ONLY_BYTES = json.dumps(ZIP_ONLY_LISTING).encode()
 # A digit run just past CPython's int-from-string limit.
 OVERSIZED_DIGITS = "9" * (sys.get_int_max_str_digits() + 1)
 
-# Nested past what ``json.loads`` will decode. The scanner's recursion guard
-# does not sit at ``sys.getrecursionlimit()``, so overshoot it rather than try
-# to compute the depth that trips it.
-_OVER_NESTED_DEPTH = 100_000
+# A listing nested deeper than any real one; _refuse_as_over_nested is what
+# makes the scanner refuse it.
+_OVER_NESTED_DEPTH = 1_000
 OVER_NESTED_BYTES = (
     b'{"meta": {"api-version": "1.0"}, "name": "pkg", "files": '
     + b"[" * _OVER_NESTED_DEPTH
     + b"]" * _OVER_NESTED_DEPTH
     + b"}"
 )
+
+
+def _refuse_as_over_nested(monkeypatch: pytest.MonkeyPatch, body: bytes) -> None:
+    """Make ``json.loads`` refuse ``body`` the way it refuses an over-nested one.
+
+    The scanner's guard sits wherever the interpreter's C stack budget puts it,
+    which on 3.14 is the running thread's own stack, so no fixed depth is
+    refused everywhere the suite runs.
+    """
+    real_loads = json.loads
+
+    def loads(s: str | bytes | bytearray, **kwargs: Any) -> Any:
+        if s == body:
+            msg = "maximum recursion depth exceeded while decoding a JSON array"
+            raise RecursionError(msg)
+        return real_loads(s, **kwargs)
+
+    monkeypatch.setattr(json, "loads", loads)
 
 
 class _FakeResponse:
@@ -4488,7 +4505,10 @@ class TestOverNestedListingBody:
     :class:`ValueError` a malformed body normally raises.
     """
 
-    def test_wire_body_raises_clean_and_skips_cache(self, tmp_path: Path) -> None:
+    def test_wire_body_raises_clean_and_skips_cache(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _refuse_as_over_nested(monkeypatch, OVER_NESTED_BYTES)
         cache = _make_cache(tmp_path)
         transport = _FakeTransport([_FakeResponse(OVER_NESTED_BYTES, status=200)])
 
@@ -4507,8 +4527,12 @@ class TestOverNestedListingBody:
         assert cache.get_simple("pkg") is None
 
     def test_cached_body_self_heals_online(
-        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        _refuse_as_over_nested(monkeypatch, OVER_NESTED_BYTES)
         cache = _make_cache(tmp_path)
         cache.put_simple("pkg", OVER_NESTED_BYTES, _fresh_policy())
         transport = _FakeTransport([_FakeResponse(LISTING_BYTES, status=200)])

--- a/nab-provider/src/nab_provider/errors.py
+++ b/nab-provider/src/nab_provider/errors.py
@@ -134,8 +134,8 @@ class UnserveableUrlError(HttpError):
 class MalformedSimpleResponseError(HttpError):
     """The index served a 200 response that is not a usable Simple-API body.
 
-    Covers a listing that is neither valid JSON nor decodable HTML, and a
-    PEP 658 metadata sidecar that is not valid UTF-8.
+    Covers a listing body that neither the JSON nor the HTML decoder will
+    take, and a PEP 658 metadata sidecar that is not valid UTF-8.
     """
 
 


### PR DESCRIPTION
`nab lock` against an index whose JSON listing is nested past CPython's decoder guard crashes with a traceback instead of nab's own error:

    RecursionError: maximum recursion depth exceeded while decoding a JSON array from a unicode string

`json.loads` raises `RecursionError` for that body, not the `ValueError` it raises for everything else it refuses, and both listing decoders caught only `ValueError`:

- On the wire nothing raises `MalformedSimpleResponseError`, so no CLI handler catches what escapes instead.
- The cached path treats an undecodable body as a miss and re-fetches, so a cache entry nested that deep crashed on every run instead of being replaced.

Both paths now decode through one `decode_listing_json`, which raises the `ValueError` the existing handlers already catch. The error and the cached-body warning now quote the decoder's own reason, since this body is well-formed JSON and `body is not valid JSON` named a syntax error that is not there:

    error: cannot lock: https://pypi.org/simple/ served a malformed Simple-API response for 'pkg': listing is nested too deeply to decode
