### PR TITLE
Cut three hot-path costs in the resolver, ~0.5% off a langchain resolve

### DIFF
--- a/nab-resolver/src/nab_resolver/decide.py
+++ b/nab-resolver/src/nab_resolver/decide.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from .incompat_index import add_incompatibility
-from .root import ROOT
 from .types import Incompatibility, IncompatibilityCause, RangeProtocol, Term
 
 if TYPE_CHECKING:
@@ -35,9 +34,12 @@ def choose_package_to_decide(resolver: Resolver[Any, Any]) -> Any | None:
     state behind its sort key still. The queue keeps that key across scans, so
     one that moves without the solution or ``priority_epoch`` moving is never
     read again.
+
+    ``ROOT`` never turns up in the undecided set: it is decided at level 1, a
+    targeted backtrack never aims lower, and conflict resolution raises rather
+    than backjumping to level 0.
     """
     undecided = resolver.solution.undecided_packages()
-    undecided.discard(ROOT)
     if not undecided:
         return None
 

--- a/nab-resolver/src/nab_resolver/decision_queue.py
+++ b/nab-resolver/src/nab_resolver/decision_queue.py
@@ -16,6 +16,7 @@ from .types import PackageType
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from collections.abc import Set as AbstractSet
 
 __all__ = ["DecisionQueue"]
 
@@ -52,7 +53,7 @@ class DecisionQueue(Generic[PackageType]):
 
     def pick(
         self,
-        undecided: set[PackageType],
+        undecided: AbstractSet[PackageType],
         sort_key: Callable[[PackageType], tuple[Any, ...]],
         changed: set[PackageType],
         epoch: int,
@@ -75,7 +76,7 @@ class DecisionQueue(Generic[PackageType]):
         return self._live_top()
 
     def _stale_packages(
-        self, undecided: set[PackageType], changed: set[PackageType], epoch: int
+        self, undecided: AbstractSet[PackageType], changed: set[PackageType], epoch: int
     ) -> set[PackageType]:
         """Return the packages this scan has to evaluate again.
 
@@ -83,13 +84,18 @@ class DecisionQueue(Generic[PackageType]):
         """
         if epoch != self._epoch:
             self._epoch = epoch
-            stale = undecided | changed
+            stale = changed | undecided
+            # Every undecided package is stale here, so only ``changed`` can
+            # name one that has left.
+            departed = changed - undecided
         elif self._unready:
             stale = changed | self._unready
+            departed = stale - undecided
         else:
             stale = changed
+            departed = stale - undecided
 
-        for package in stale - undecided:
+        for package in departed:
             self._keys.pop(package, None)
             self._unready.discard(package)
 
@@ -97,7 +103,7 @@ class DecisionQueue(Generic[PackageType]):
 
     def _refresh(
         self,
-        undecided: set[PackageType],
+        undecided: AbstractSet[PackageType],
         stale: set[PackageType],
         sort_key: Callable[[PackageType], tuple[Any, ...]],
     ) -> None:

--- a/nab-resolver/src/nab_resolver/partial_solution.py
+++ b/nab-resolver/src/nab_resolver/partial_solution.py
@@ -544,8 +544,9 @@ class PartialSolution(Generic[PackageType, VersionType]):
 
         empty_packages: list[PackageType] = []
         for package, entries in self._assignments_by_package.items():
-            decision_popped = False
+            popped = decision_popped = False
             while entries and entries[-1].decision_level > target_level:
+                popped = True
                 if entries.pop().is_decision:
                     decision_popped = True
 
@@ -555,7 +556,9 @@ class PartialSolution(Generic[PackageType, VersionType]):
                 self._negative_ranges.pop(package, None)
                 self._decided_versions.pop(package, None)
                 self._undecided.discard(package)
-            else:
+            # A package that kept every entry already holds what the rebuild
+            # would restore.
+            elif popped:
                 self._update_package_state_after_backtrack(
                     package, entries, decision_popped=decision_popped
                 )

--- a/nab-resolver/src/nab_resolver/partial_solution.py
+++ b/nab-resolver/src/nab_resolver/partial_solution.py
@@ -26,6 +26,7 @@ from .types import PackageType, RangeProtocol, VersionType
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator, Sequence
+    from collections.abc import Set as AbstractSet
     from typing import TypeAlias
 
     from .types import Incompatibility, Term
@@ -634,14 +635,15 @@ class PartialSolution(Generic[PackageType, VersionType]):
         self._changed = set()
         return changed
 
-    def undecided_packages(self) -> set[PackageType]:
+    def undecided_packages(self) -> AbstractSet[PackageType]:
         """Return packages with positive constraints but no decision yet.
 
         Packages with only negative derivations (learned exclusions) are not
-        yet known to be required.  Returns a fresh copy so callers can mutate
-        without disturbing solver state.
+        yet known to be required.  This is the live set, not a copy: callers
+        must not mutate it, and the solution must not change while one iterates
+        it.
         """
-        return set(self._undecided)
+        return self._undecided
 
     def has_positive_constraint(self, package: PackageType) -> bool:
         """Return True if the package has a positive constraint or decision."""

--- a/nab-resolver/src/nab_resolver/partial_solution.py
+++ b/nab-resolver/src/nab_resolver/partial_solution.py
@@ -523,9 +523,9 @@ class PartialSolution(Generic[PackageType, VersionType]):
         """Remove all assignments above target_level.
 
         Non-chronological backjumping: skips past irrelevant decision levels
-        directly to the cause of the conflict.  Relies on
-        ``Assignment.accumulated_range`` already being cumulative, so each
-        package's surviving state can be rebuilt without re-intersecting.
+        directly to the cause of the conflict.  A package that loses entries is
+        rebuilt from its last survivor, which already carries that package's
+        ``cum_positive`` and ``cum_negative``.
         See: https://github.com/dart-lang/pub/blob/master/doc/solver.md#conflict-resolution
         """
         self._contradiction_epoch += 1
@@ -544,8 +544,10 @@ class PartialSolution(Generic[PackageType, VersionType]):
 
         empty_packages: list[PackageType] = []
         for package, entries in self._assignments_by_package.items():
+            decision_popped = False
             while entries and entries[-1].decision_level > target_level:
-                entries.pop()
+                if entries.pop().is_decision:
+                    decision_popped = True
 
             if not entries:
                 empty_packages.append(package)
@@ -554,7 +556,9 @@ class PartialSolution(Generic[PackageType, VersionType]):
                 self._decided_versions.pop(package, None)
                 self._undecided.discard(package)
             else:
-                self._update_package_state_after_backtrack(package, entries)
+                self._update_package_state_after_backtrack(
+                    package, entries, decision_popped=decision_popped
+                )
 
         for package in empty_packages:
             del self._assignments_by_package[package]
@@ -563,26 +567,20 @@ class PartialSolution(Generic[PackageType, VersionType]):
         self,
         package: PackageType,
         entries: list[Assignment[PackageType, VersionType]],
+        *,
+        decision_popped: bool,
     ) -> None:
-        """Recompute positive/negative/decided state for a package.
+        """Restore a package's state from its last surviving entry.
 
-        Each ``Assignment.accumulated_range`` is already cumulative, so the
-        latest entry of each kind is enough to rebuild state.  Trail levels
-        never decrease, so popping a decision pops every later entry for the
-        same package; a surviving decision is always the current one.
+        ``decide`` and ``derive`` stamp each entry with the package's positive
+        and negative ranges as of that entry, and a backtrack keeps a prefix of
+        the entries, so the last survivor already carries both.  A package holds
+        at most one decision at a time, so its decided version stands unless the
+        pop reached the decision itself.
         """
-        last_pos: RangeProtocol[VersionType] | None = None
-        last_neg: RangeProtocol[VersionType] | None = None
-        last_decision_version: VersionType | None = None
-
-        for assignment in entries:
-            if assignment.is_decision:
-                last_pos = assignment.accumulated_range
-                last_decision_version = assignment.version
-            elif assignment.positive:
-                last_pos = assignment.accumulated_range
-            else:
-                last_neg = assignment.accumulated_range
+        tail = entries[-1]
+        last_pos = tail.cum_positive
+        last_neg = tail.cum_negative
 
         if last_pos is None:
             self._positive_ranges.pop(package, None)
@@ -594,12 +592,10 @@ class PartialSolution(Generic[PackageType, VersionType]):
         else:
             self._negative_ranges[package] = last_neg
 
-        if last_decision_version is None:
+        if decision_popped:
             self._decided_versions.pop(package, None)
-        else:
-            self._decided_versions[package] = last_decision_version
 
-        if last_pos is not None and last_decision_version is None:
+        if last_pos is not None and package not in self._decided_versions:
             self._undecided.add(package)
         else:
             self._undecided.discard(package)

--- a/nab-resolver/tests/test_decision_queue.py
+++ b/nab-resolver/tests/test_decision_queue.py
@@ -20,6 +20,7 @@ marks a package whose listing has not settled.
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
+from collections.abc import Set as AbstractSet
 from typing import Any
 
 from nab_resolver.decision_queue import DecisionQueue
@@ -256,7 +257,7 @@ class RecheckingDecisionQueue(DecisionQueue[str]):
 
     def pick(
         self,
-        undecided: set[str],
+        undecided: AbstractSet[str],
         sort_key: Callable[[str], tuple[Any, ...]],
         changed: set[str],
         epoch: int,


### PR DESCRIPTION
A `pip:langchain-ml-course --resolution lowest` resolve stops copying 535,953 package names and stops walking 25,321 trail entries. Nine callgrind pairs put the branch lighter in every one; the middle estimate is 121 million instructions of 23.7 billion, 0.5%, and the run puts the size between 0.1% and 2%.

- `PartialSolution.undecided_packages` hands the decision scan the live set instead of a fresh copy, over 10,262 scans at a median of 53 packages each. `decide.py`, its one caller, only reads it.
- A backtracked package is restored from its last surviving trail entry, which already carries that package's cumulative positive and negative ranges.
- A package whose trail did not shrink is skipped: the run's 184 backtracks make 2,809 rebuild calls instead of 11,479.

Iterating the live set changes the order the scan asks the provider about packages, so a different listing can be fetched first. The pick cannot change, because the sort key ends in a value unique per package.

`max-25-tuples`, a 25-target lock that never backtracks, moves by 236 Python calls of 2.01 million.

Twelve timed runs of each side put CPU about 1% lower and rule out a wall regression above about 2%.