### PR TITLE
Fail on an unreadable pyproject.toml instead of calling it dynamic

### DIFF
--- a/nab-project/src/nab_project/build_backend.py
+++ b/nab-project/src/nab_project/build_backend.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 from functools import lru_cache
 from typing import TYPE_CHECKING
 
+import tomli
+
 from nab_provider._vendor.packaging.specifiers import SpecifierSet
 from nab_provider._vendor.packaging.utils import canonicalize_name
 from nab_provider._vendor.packaging.version import Version
@@ -29,8 +31,7 @@ from nab_provider.requirements_file import (
 from ._build.errors import (
     BuildBackendError as BuildBackendError,  # noqa: PLC0414  (public re-export)
 )
-from ._toml import parse_pyproject_table
-from .paths import is_absent_error, path_state
+from .paths import PathState, is_absent_error, path_state
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -59,8 +60,10 @@ def extract_static_metadata(source_dir: Path) -> WheelMetadata | None:
     ``requires_python``, ``requires_dist``, and ``provides_extra``.
 
     Raises :class:`BuildBackendError` when the file is there but cannot
-    be read.  Its contents are unknown, so it is neither "no static
-    metadata" nor a missing file; the message names the errno.
+    be read: a path that is not a regular file, an errno other than
+    absence, bytes that do not decode as UTF-8, or text that does not
+    parse as TOML.  Its contents are unknown, so it is neither "no
+    static metadata" nor a missing file; the message names the cause.
 
     Raises :class:`InvalidProjectRequirementError` when a present,
     non-dynamic field is corrupt: a structurally wrong ``dependencies`` /
@@ -83,33 +86,30 @@ def extract_static_metadata(source_dir: Path) -> WheelMetadata | None:
     as read-only.
     """
     pyproject = source_dir / "pyproject.toml"
-    if not path_state(pyproject).should_read:
+    state = path_state(pyproject)
+    if state is PathState.ABSENT:
         return None
+
+    if not state.should_read:
+        msg = f"{pyproject} exists but is not a regular file"
+        raise BuildBackendError(msg)
+
     try:
-        text = pyproject.read_text(encoding="utf-8")
+        data = tomli.loads(pyproject.read_text(encoding="utf-8"))
     except OSError as exc:
-        if not is_absent_error(exc):
-            msg = f"could not read pyproject.toml at {source_dir}: {exc}"
-            raise BuildBackendError(msg) from exc
-        # The presence check is racy: the file may vanish before the read.
-        return None
-    except UnicodeDecodeError:
-        # TOML is UTF-8, so a file that will not decode has no static metadata.
-        return None
-    project = load_static_project(text)
+        if is_absent_error(exc):
+            # The presence check is racy: the file may vanish before the read.
+            return None
+        msg = f"could not read pyproject.toml at {source_dir}: {exc}"
+        raise BuildBackendError(msg) from exc
+    except (UnicodeDecodeError, tomli.TOMLDecodeError) as exc:
+        msg = f"could not read pyproject.toml at {source_dir}: {exc}"
+        raise BuildBackendError(msg) from exc
+
+    project = static_project_from_table(data)
     if project is None:
         return None
     return _project_to_metadata(project)
-
-
-def load_static_project(text: str) -> dict | None:
-    """Return ``text``'s ``[project]`` table when it can be trusted as static.
-
-    ``None`` when the TOML does not parse, which the static reader treats
-    the same as a table it may not trust.
-    """
-    data = parse_pyproject_table(text)
-    return None if data is None else static_project_from_table(data)
 
 
 def _project_to_metadata(project: dict) -> WheelMetadata | None:

--- a/nab-project/tests/test_archive.py
+++ b/nab-project/tests/test_archive.py
@@ -1453,6 +1453,67 @@ class TestArchiveBuildPolicyLevels:
             self._extract(policy, tmp_path)
         assert "dynamic metadata" not in str(caught.value)
 
+    @pytest.mark.parametrize(
+        "policy",
+        [BuildPolicy.NEVER, BuildPolicy.BUILD_LOCAL, BuildPolicy.BUILD_REMOTE],
+    )
+    def test_unparseable_pyproject_reports_the_parse_error(
+        self, policy: BuildPolicy, tmp_path: Path
+    ) -> None:
+        """A pyproject that is not TOML is a read failure at every level.
+
+        No build policy makes the file parse, so none of them is the remedy.
+        """
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "pkg"\nversion =\n', encoding="utf-8"
+        )
+        with pytest.raises(UnsupportedSdistError) as caught:
+            self._extract(policy, tmp_path)
+
+        msg = str(caught.value)
+        assert msg.startswith(
+            f"archive source 'pkg': could not read pyproject.toml at {tmp_path}: "
+        )
+        assert "line 3" in msg
+        assert "dynamic metadata" not in msg
+
+    @pytest.mark.parametrize(
+        "policy",
+        [BuildPolicy.NEVER, BuildPolicy.BUILD_LOCAL, BuildPolicy.BUILD_REMOTE],
+    )
+    def test_non_utf8_pyproject_reports_the_decode_error(
+        self, policy: BuildPolicy, tmp_path: Path
+    ) -> None:
+        """Bytes that will not decode as UTF-8 are unread, not dynamic."""
+        (tmp_path / "pyproject.toml").write_bytes(
+            b'[project]\nname = "pkg"\nversion = "1.0"\ndescription = "\xe9"\n'
+        )
+        with pytest.raises(UnsupportedSdistError) as caught:
+            self._extract(policy, tmp_path)
+
+        msg = str(caught.value)
+        assert msg.startswith(
+            f"archive source 'pkg': could not read pyproject.toml at {tmp_path}: "
+        )
+        assert "utf-8" in msg
+        assert "dynamic metadata" not in msg
+
+    @pytest.mark.parametrize(
+        "policy",
+        [BuildPolicy.NEVER, BuildPolicy.BUILD_LOCAL, BuildPolicy.BUILD_REMOTE],
+    )
+    def test_non_regular_pyproject_reports_the_file_type(
+        self, policy: BuildPolicy, tmp_path: Path
+    ) -> None:
+        """A directory in place of pyproject.toml is unread, not dynamic."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.mkdir()
+        with pytest.raises(UnsupportedSdistError) as caught:
+            self._extract(policy, tmp_path)
+        assert str(caught.value) == (
+            f"archive source 'pkg': {pyproject} exists but is not a regular file"
+        )
+
     @pytest.mark.parametrize("policy", [BuildPolicy.NEVER, BuildPolicy.BUILD_LOCAL])
     def test_dynamic_archive_raises_below_build_remote(
         self, policy: BuildPolicy, tmp_path: Path

--- a/nab-project/tests/test_build_backend.py
+++ b/nab-project/tests/test_build_backend.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import tomli
 
 from nab_project.build_backend import (
     BuildBackendError,
@@ -99,15 +100,25 @@ class TestExtractStaticMetadata:
         ):
             extract_static_metadata(tmp_path)
 
-    def test_malformed_toml_returns_none(self, tmp_path: Path) -> None:
+    def test_malformed_toml_reports_the_parse_error(self, tmp_path: Path) -> None:
+        """Text that does not parse leaves the contents unknown."""
         _write_pyproject(tmp_path, "this is not toml [")
-        assert extract_static_metadata(tmp_path) is None
+        with pytest.raises(
+            BuildBackendError, match="could not read pyproject.toml"
+        ) as caught:
+            extract_static_metadata(tmp_path)
+        assert isinstance(caught.value.__cause__, tomli.TOMLDecodeError)
 
-    def test_non_utf8_toml_returns_none(self, tmp_path: Path) -> None:
+    def test_non_utf8_toml_reports_the_decode_error(self, tmp_path: Path) -> None:
+        """Bytes that do not decode leave the contents unknown too."""
         (tmp_path / "pyproject.toml").write_bytes(
             b'[project]\nname = "foo"\nversion = "1.0"\ndescription = "\xe9"\n'
         )
-        assert extract_static_metadata(tmp_path) is None
+        with pytest.raises(
+            BuildBackendError, match="could not read pyproject.toml"
+        ) as caught:
+            extract_static_metadata(tmp_path)
+        assert isinstance(caught.value.__cause__, UnicodeDecodeError)
 
     def test_no_project_table_returns_none(self, tmp_path: Path) -> None:
         _write_pyproject(tmp_path, '[build-system]\nrequires = ["setuptools"]\n')
@@ -369,11 +380,15 @@ class TestExtractStaticMetadata:
         ):
             extract_static_metadata(tmp_path)
 
-    def test_pyproject_is_a_directory_returns_none(self, tmp_path: Path) -> None:
-        # A directory in place of pyproject.toml is not a readable file, so
-        # the static reader bails before the read.
-        (tmp_path / "pyproject.toml").mkdir()
-        assert extract_static_metadata(tmp_path) is None
+    def test_pyproject_is_a_directory_reports_the_file_type(
+        self, tmp_path: Path
+    ) -> None:
+        """A directory in place of the file is a read failure, not absence."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.mkdir()
+        with pytest.raises(BuildBackendError) as caught:
+            extract_static_metadata(tmp_path)
+        assert str(caught.value) == f"{pyproject} exists but is not a regular file"
 
     def test_pyproject_vanishing_before_the_read_returns_none(
         self, tmp_path: Path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1612,6 +1612,40 @@ class TestLockCommandSpecific:
         assert "has dynamic metadata" in err
         assert "Traceback" not in err
 
+    def test_local_source_with_unparseable_pyproject_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A local source whose pyproject is not TOML names the parse error.
+
+        The policy bars the build, so nothing has read the file and it cannot
+        be reported as dynamic metadata.
+        """
+        member = tmp_path / "mylocal"
+        member.mkdir()
+        (member / "pyproject.toml").write_text(
+            '[project]\nname = "mylocal"\nversion =\n', encoding="utf-8"
+        )
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\nname = "root"\nversion = "0"\n'
+            'dependencies = ["mylocal"]\n'
+            "[tool.nab]\n"
+            'build-policy = "never"\n'
+            "[[tool.nab.local-sources]]\n"
+            'name = "mylocal"\n'
+            'path = "mylocal"\n',
+        )
+        with pytest.raises(SystemExit, match="1"):
+            lock(pyproject, offline=True, output=Path("-"), cache=False)
+
+        lines = capsys.readouterr().err.splitlines()
+        assert len(lines) == 1
+        assert lines[0].startswith(
+            "error: cannot lock: local source 'mylocal': could not read"
+            f" pyproject.toml at {member.resolve()}: "
+        )
+        assert "line 3" in lines[0]
+
     def test_local_source_naming_another_project_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:


### PR DESCRIPTION
A local source whose `pyproject.toml` will not parse as TOML was reported as a build-policy problem:

```
error: cannot lock: local source 'mylocal' at /tmp/demo/mylocal has dynamic metadata; building requires build-policy 'build-local' but the effective policy is 'never'
```

Nothing about the file is dynamic, and no policy is the remedy. The build path reads the same file and already named the real cause, so setting `build-policy = "build-local"` gave:

```
error: cannot lock: local source 'mylocal': could not read pyproject.toml at /tmp/demo/mylocal: Invalid value (at line 3, column 10)
```

`extract_static_metadata` returned `None` for three files whose contents it never established:

- text that does not parse as TOML
- bytes that do not decode as UTF-8
- a path that exists but is not a regular file, such as a directory

`None` is also how it reports no static metadata, so the caller could not tell the two apart and fell through to the dynamic-build gate. The build path's own reader in `_build/runner.py` raises on all three, so two readers of the same file disagreed about what it meant.

The static reader now raises the same errors, at every policy level, for local sources, VCS clones and extracted archives alike. `None` is left to mean only "no static metadata", which covers an absent file and one that vanishes between the check and the read.
