### PR TITLE
Fix local-sources how-to claiming every local pin path is lock-relative

### DIFF
--- a/docs/how-to/local-sources.md
+++ b/docs/how-to/local-sources.md
@@ -63,8 +63,11 @@ the build.
 ## Lockfile shape
 
 Local pins land in the lockfile as `LocalPin` records.  The path
-is written relative to the lockfile's own directory, with POSIX
-separators, as PEP 751 requires, so a committed lockfile stays
-usable on another machine.  They do not carry a `sha256` (the
-contents are not under nab's control), so `nab download` skips
-them.
+is written with POSIX separators, relative to the lockfile's own
+directory, so a committed lockfile keeps working on another
+machine as long as the checkout moves with it.  The records carry
+no `sha256` (the contents are not under nab's control), so
+`nab download` skips them.
+
+See [Portable paths](../reference/lockfile.md) for the two cases
+where the path is not relative to the lockfile.


### PR DESCRIPTION
`docs/how-to/local-sources.md` promises that a `LocalPin` path is written relative to the lockfile's own directory, "as PEP 751 requires". Two cases contradict it:

- `nab lock --output -` has no lockfile to be relative to, so the path is written relative to the current directory.
- A target on another Windows drive has no relative form, so the absolute path is written.

PEP 751 does not require the relative form either. It reads a relative path against the lockfile, which is why nab writes one where it can.

#941 corrected the same claim on `reference/lockfile.md` and missed this page. The how-to now states the ordinary case and links to that section for the two exceptions.
