### PR TITLE
Fix nab-index docs claiming index routes accept PEP 508 markers

### DIFF
--- a/nab-index/README.md
+++ b/nab-index/README.md
@@ -12,7 +12,7 @@ It provides:
 - A Simple-API client with JSON and HTML decoders.
 - A disk cache for project listings and file metadata responses.
 - A multi-index router (ordered named indexes plus per-package
-  overrides guarded by PEP 508 markers).
+  overrides that pin a package to one index).
 - A small VCS clone helper used by the higher-level VCS policy.
 
 ## When to use it

--- a/nab-index/src/nab_index/multi_index.py
+++ b/nab-index/src/nab_index/multi_index.py
@@ -12,11 +12,9 @@ an absent package.
 
 Per-package overrides route a package to a *named* index regardless
 of order; when an override matches, *only* that index is consulted
-(strict pin), matching uv's ``[tool.uv.sources]`` semantics.
-
-Marker evaluation for overrides happens upstream; this layer just sees
-a ``canonical_package_name -> index_name`` mapping that has already
-been resolved against the active environment.
+(strict pin), matching uv's ``[tool.uv.sources]`` semantics.  The
+index is chosen before any version is known, so a route carries no
+version scope and no marker.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
The `nab-index` README, published as the package's PyPI description, lists "per-package overrides guarded by PEP 508 markers" among the router's features. No route takes a marker: a marker in the selector and a `marker` key in the body are both refused at parse.

    packages."numpy; sys_platform == 'linux'" entry "numpy; sys_platform == 'linux'" may carry only a name and an optional version specifier; extras, markers, and URLs are not supported on the override surface

    packages.'numpy': key(s) ['marker'] are not supported

The `multi_index.py` module docstring described a mechanism that does not exist: marker evaluation upstream, leaving the router a mapping already resolved against the active environment. `index_routes_from_config` builds an `IndexRoute` per override that sets `index`, and the coordinator reduces those to `{canonical name: index name}`.

The README now says the overrides pin a package to one index, and the docstring says the index is chosen before any version is known, so a route carries no version scope and no marker. `docs/how-to/multi-index.md` already said both.
