### PR TITLE
Fix docs: a matrix reads metadata per wheel, not once per package

### DIFF
--- a/docs/explanation/universal.md
+++ b/docs/explanation/universal.md
@@ -22,10 +22,16 @@ targets one at a time, each on the same engine and the same
 single-environment resolve a project without a matrix runs once for the
 host.
 
-The targets share one fetcher, so each package's metadata is fetched at
-most once across the whole matrix. After a target resolves, its pins
-flow forward as preferences for the next, giving best-effort alignment
-across targets.
+The targets share one fetcher, so a package's listing is read once for
+the whole matrix rather than once per target. Metadata is shared per
+wheel rather than per package, so a release publishing one wheel per
+interpreter or per platform costs one read for each wheel the matrix
+picks (see Where a version's metadata comes from below). An sdist's
+`PKG-INFO` stands for the whole version, so one read serves every
+target that picks it.
+
+After a target resolves, its pins flow forward as preferences for the
+next, giving best-effort alignment across targets.
 
 The lock a matrix produces is the lock a single environment produces,
 with more environments in it: the same shape, the same

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -717,9 +717,11 @@ the cached tree was not checked against downloads the archive again.
 
 Universal resolution resolves one target per declared
 `(python, platform, implementation)` point, on the same engine a
-single-environment resolve uses, sharing one fetcher so metadata is
-fetched at most once per package.  The multi-target lockfile format it
-produces is experimental and may change without notice.
+single-environment resolve uses.  The targets share one fetcher: a
+package's listing is read once for the whole matrix, a version's wheel
+metadata once per wheel the targets pick, and an sdist's PKG-INFO once
+for the version.  The multi-target lockfile format it produces is
+experimental and may change without notice.
 
 ```toml
 [tool.nab]

--- a/nab-project/src/nab_project/resolve.py
+++ b/nab-project/src/nab_project/resolve.py
@@ -4,8 +4,9 @@
 :class:`~nab_provider.target.ResolveTarget` per environment, whether
 ``[tool.nab.matrix]`` declares many or a bare project declares none (the
 host is the target).  Each gets a single-environment resolve against a
-shared :class:`~nab_project.fetch.FetchCoordinator`, so metadata is
-fetched once across them.
+shared :class:`~nab_project.fetch.FetchCoordinator`, so a package's
+listing is read once across them, a version's wheel metadata once per
+wheel they pick, and an sdist's ``PKG-INFO`` once for the version.
 
 A declared conflict, matrix or not, is where a resolve produces more than
 one result for an environment.  Directly co-selecting two members of an

--- a/nab-project/tests/test_resolve_targets.py
+++ b/nab-project/tests/test_resolve_targets.py
@@ -1050,6 +1050,77 @@ class TestMatrixPerTargetWheelDivergence:
         }
 
 
+class TestMatrixMetadataReadGranularity:
+    """Which metadata a matrix reads per wheel, and which per version.
+
+    A wheel's metadata comes from its own sidecar, so a matrix asks for one
+    URL per wheel its targets pick between them.  An sdist's ``PKG-INFO``
+    stands for the version, so one read serves the whole matrix.  Collapsing
+    repeat requests for one URL is the coordinator's job, covered by
+    ``property_python/test_fetch_coordinator.py``.
+    """
+
+    def _wheel(self, tag: str) -> WheelFile:
+        """A ``pkg`` 1.0 wheel tagged ``tag``, advertising a sidecar."""
+        return WheelFile(
+            filename=f"pkg-1.0-{tag}.whl",
+            url=f"https://example.com/pkg-1.0-{tag}.whl",
+            version="1.0",
+            requires_python=None,
+            has_metadata=True,
+            upload_time=None,
+        )
+
+    def _resolve_three_targets(self, coordinator: FakeFetchPort) -> None:
+        """Resolve ``pkg`` for 3.11 through 3.13 on one platform, and expect success."""
+        targets = Matrix(
+            python=">=3.11,<3.14", platforms=(PlatformSpec("linux_x86_64"),)
+        ).expand()
+        assert len(targets) == 3
+
+        result = resolve_with_coordinator(
+            coordinator, targets, _reqs("pkg"), config=_no_build()
+        )
+        assert result.success
+
+    def _metadata_urls(self, wheels: list[WheelFile]) -> set[str]:
+        """The distinct sidecar URLs the three targets ask for, given ``wheels``."""
+        coordinator = make_coordinator(listings={"pkg": wheels}, auto_metadata=True)
+        self._resolve_three_targets(coordinator)
+
+        calls = coordinator.calls_to("request_metadata")
+        return {url for _package, _version, url, _hash in calls}
+
+    def test_two_wheels_across_three_targets_name_two_urls(self) -> None:
+        """3.11 picks its own wheel; 3.12 and 3.13 both pick the universal one."""
+        universal = self._wheel("py3-none-any")
+        for_311 = self._wheel("cp311-cp311-manylinux_2_17_x86_64")
+
+        urls = self._metadata_urls([universal, for_311])
+
+        assert urls == {universal.metadata_url, for_311.metadata_url}
+
+    def test_a_wheel_per_interpreter_is_a_url_per_target(self) -> None:
+        """Nothing is shared when every target ranks a different wheel first."""
+        wheels = [
+            self._wheel(f"cp3{minor}-cp3{minor}-manylinux_2_17_x86_64")
+            for minor in (11, 12, 13)
+        ]
+
+        assert self._metadata_urls(wheels) == {wheel.metadata_url for wheel in wheels}
+
+    def test_an_sdist_is_read_once_for_the_whole_matrix(self) -> None:
+        """No wheel to pick, so all three targets read the one PKG-INFO."""
+        coordinator = make_coordinator(
+            listings={"pkg": [_make_sdist("1.0", package="pkg")]},
+            sdist_pkg_info="Metadata-Version: 2.2\nName: pkg\nVersion: 1.0\n",
+        )
+
+        self._resolve_three_targets(coordinator)
+
+        assert len(coordinator.calls_to("request_sdist")) == 1
+
+
 _FORTY_SHA = "0123456789abcdef0123456789abcdef01234567"
 
 


### PR DESCRIPTION
`docs/explanation/universal.md` claimed the targets in a matrix share one fetcher, so "each package's metadata is fetched at most once across the whole matrix". It is once per wheel: every wheel has its own metadata URL, and the fetcher collapses repeat requests only for the same URL.

So a release publishing one wheel per interpreter or per platform costs one read for each wheel the matrix picks. A 3.11 to 3.13 matrix over such a release reads three, not one.

What is actually shared:

| Read | Once per |
| --- | --- |
| package listing | package |
| wheel metadata | wheel URL |
| sdist `PKG-INFO` | version |

The same claim sat in the configuration reference's universal-mode section and in the `nab_project.resolve` module docstring. All three now agree, and the universal page points at its own "Where a version's metadata comes from" section for why the granularity is per wheel.

The new tests count the distinct metadata URLs a three-target matrix asks for: two for a universal wheel alongside a cp311 one, and three for a wheel per interpreter. A version shipping only an sdist gets a single `PKG-INFO` read for the whole matrix.
