### PR TITLE
Test the progress counters past their first call

### DIFF
--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -402,20 +402,47 @@ def test_progress_renders_counter_line() -> None:
     assert "Resolving... 1 fetched, 0 pinned" in out
 
 
-def test_progress_pin_updates_line() -> None:
-    times = iter([0.0, 10.0])
+def test_progress_pin_replaces_the_count() -> None:
+    times = iter([0.0, 10.0, 20.0])
     reporter, err = _enabled_reporter(clock=lambda: next(times), min_interval=1.0)
     reporter.on_fetch()
     reporter.on_pin(4)
-    assert "1 fetched, 4 pinned" in err.getvalue()
+    assert err.getvalue().endswith("1 fetched, 4 pinned")
+
+    reporter.on_pin(2)
+    assert err.getvalue().endswith("1 fetched, 2 pinned")
+
+
+def test_progress_fetch_counts_every_call() -> None:
+    times = iter([0.0, 10.0])
+    reporter, err = _enabled_reporter(clock=lambda: next(times), min_interval=1.0)
+    reporter.on_fetch()
+    reporter.on_fetch()
+    assert err.getvalue().endswith("2 fetched, 0 pinned")
 
 
 def test_progress_throttle_skips_rapid_repaint() -> None:
-    reporter, err = _enabled_reporter(clock=lambda: 5.0, min_interval=1.0)
+    times = iter([5.0, 5.5, 7.0])
+    reporter, err = _enabled_reporter(clock=lambda: next(times), min_interval=1.0)
     reporter.on_fetch()
     first = err.getvalue()
     reporter.on_fetch()
     assert err.getvalue() == first
+
+    reporter.on_fetch()
+    assert err.getvalue().endswith("3 fetched, 0 pinned")
+
+
+def test_progress_throttled_pin_shows_on_next_repaint() -> None:
+    times = iter([5.0, 5.5, 7.0])
+    reporter, err = _enabled_reporter(clock=lambda: next(times), min_interval=1.0)
+    reporter.on_fetch()
+    first = err.getvalue()
+    reporter.on_pin(5)
+    assert err.getvalue() == first
+
+    reporter.on_fetch()
+    assert err.getvalue().endswith("2 fetched, 5 pinned")
 
 
 def test_progress_colour_dims_the_line() -> None:


### PR DESCRIPTION
No `ProgressReporter` test painted a line past a counter's first call, and from zero a counter that adds and one that replaces paint the same thing. The reporter does one of each: `on_fetch()` adds one per listing, while `on_pin(decided)` takes the resolver's current decision level, which falls on a backjump, so it has to replace. An `on_pin` that added, or an `on_fetch` stuck at 1, passed every old assertion.

The throttle window had the same hole: `test_progress_throttle_skips_rapid_repaint` froze the clock, confirmed the second `on_fetch()` painted nothing, and stopped there. A call arriving inside the window was never seen to reach the line afterwards.

Now covered:

- `on_pin(4)` then `on_pin(2)` paints `2 pinned`, not `6`
- two `on_fetch()` calls paint `2 fetched`
- both throttle tests step the clock past the window and assert the skipped call's count shows up on the next paint

The counter assertions also moved from `in` to `endswith`, so they read the line painted last rather than any line still in the buffer.
