### PR TITLE
Fix config reference's claim that only --project-* changes the resolve

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2,10 +2,10 @@
 
 `nab` exposes four subcommands: `lock`, `download`, `config`, and
 `cache`. The first two read project shape from `[tool.nab]` in the
-project's `pyproject.toml` or a project-directory `nab.toml`; the CLI
-carries runtime knobs and can override a project key for one run with a
-`--project-<key>` flag. `config` inspects the layered configuration, and
-`cache` inspects and clears the on-disk cache.
+project's `pyproject.toml` or a project-directory `nab.toml`, and their
+flags shape the resolve as well as the run; `--project-<key>` overrides
+a project key for one run. `config` inspects the layered configuration,
+and `cache` inspects and clears the on-disk cache.
 
 ## Synopsis
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -2,9 +2,9 @@
 
 The keys that decide what nab resolves live in `[tool.nab]` inside the
 project's `pyproject.toml`, or in a project-directory `nab.toml` that
-sets the same keys.  The CLI carries runtime knobs (cache directory,
-offline mode, HTTP backend), and can also override a project key for a
-single run with a `--project-<key>` flag.
+sets the same keys.  A CLI flag applies to a single run, and some change
+the resolve rather than just how the run executes; the CLI flags section
+below groups them and says which ones reach a `[tool.nab]` key.
 
 ## Top-level keys
 
@@ -885,17 +885,42 @@ nab lock --project-mode specific --python 3.13
 
 ```
 nab lock [PATH]
+  # what gets resolved
+  --python X.Y                 # resolve for this Python on this machine
+  --groups NAME ...            # fold these dependency groups into the resolve
+  --all-groups                 # fold in every group the project declares
+  --extras NAME ...            # fold these extras into the resolve
+  --all-extras                 # fold in every extra the project declares
+  --build-requirements         # lock [build-system].requires, not the dependencies
+  --no-workspace-discovery     # resolve this project alone, ignoring [tool.nab.workspace]
+  --upgrade                    # re-anchor the P<n>D window to now
+  --project-<key> VALUE        # override a project option for this run
+
+  # what comes out
   --output PATH                # output file (or "-" for stdout)
   --format FORMAT              # pylock | requirements | requirements-without-hashes
+  --no-emit-workspace          # leave workspace members out of the lockfile
+  --locked                     # verify the committed pylock is current; write nothing
+
+  # how the run executes
   --cache-dir PATH             # override on-disk cache location
   --no-cache                   # disable cache for this run
   --offline True|False         # use cache only, no network (or bare --offline / --no-offline)
-  --python X.Y                 # resolve for this Python on this machine
   --http-backend X             # urllib3 (default) | httpx (layered)
-  --locked                     # verify the committed pylock is current; write nothing
-  --upgrade                    # re-anchor the P<n>D window to now
-  --project-<key> VALUE        # override a project option for this run
 ```
+
+What each flag in the first group does to `[tool.nab]`:
+
+* `--project-<key>` replaces the key it names.
+* `--python` overrides `[tool.nab.environment].python`.
+* `--build-requirements` clears `conflicts`, `default-groups`,
+  `base-group` and `build-group` for the run.
+* `--no-workspace-discovery` skips `[tool.nab.workspace]`, the project's
+  own table included.
+* `--upgrade` re-anchors a relative `uploaded-prior-to` window without
+  changing its value.
+* `--groups`, `--all-groups`, `--extras` and `--all-extras` add to the
+  selection rather than replacing a key.
 
 A project option can be overridden for a single run with a
 `--project-<key>` flag (for example `--project-resolution`,
@@ -908,10 +933,6 @@ it prints a notice and is recorded in the lockfile.
 `--project-dist-policy` takes a bare policy, so it replaces the whole
 `dist-policy` value and resets `trust-unverified-deps`; set the table form
 in a file to keep that flag.
-
-The CLI carries knobs about *how this run executes*; the one exception
-is a `--project-*` flag, which overrides a *what-gets-resolved* key for
-the single run.
 
 ## Layered configuration sources
 

--- a/nab-project/src/nab_project/config.py
+++ b/nab-project/src/nab_project/config.py
@@ -1,8 +1,8 @@
 """Read ``[tool.nab]`` from a ``pyproject.toml`` into a typed config.
 
-The CLI is intentionally narrow: anything that defines *what* gets
-resolved lives in ``[tool.nab]``; anything about *how this run executes*
-lives on the CLI.  This module owns the project side.
+``[tool.nab]`` holds the keys that decide what a project resolves; a CLI
+run can override one of them by name under the ``--project-`` prefix.
+This module owns the project side.
 """
 
 from __future__ import annotations

--- a/tests/test_cli_docs.py
+++ b/tests/test_cli_docs.py
@@ -1,6 +1,7 @@
 """Check the published CLI pages against what the CLI does.
 
-The reference page lists each subcommand's flags, env vars and statuses; the
+The CLI reference lists each subcommand's flags, env vars and statuses; the
+config reference groups the ``nab lock`` flags by what they decide; the
 conflicts page quotes refusal lines verbatim.
 
 These tests read ``docs/``, which the umbrella sdist does not ship, so the
@@ -27,6 +28,7 @@ from nab_project.config_sources import OPTIONS
 
 _DOCS = Path(__file__).resolve().parents[1] / "docs"
 _CLI_REFERENCE = _DOCS / "reference" / "cli.md"
+_CONFIG_REFERENCE = _DOCS / "reference" / "configuration.md"
 _CONFLICTS_DOC = _DOCS / "explanation" / "conflicts.md"
 
 _SUBCOMMANDS = ("lock", "download", "config", "cache")
@@ -36,9 +38,47 @@ def _reference_text() -> str:
     return _CLI_REFERENCE.read_text(encoding="utf-8")
 
 
+def _section(text: str, heading: str) -> str:
+    """The body of ``text`` under ``heading``, up to the next ``##``."""
+    return text.partition(f"\n{heading}\n")[2].partition("\n## ")[0]
+
+
 def _reference_section(heading: str) -> str:
-    """The reference body under ``heading``, up to the next ``##``."""
-    return _reference_text().partition(f"\n{heading}\n")[2].partition("\n## ")[0]
+    """The CLI reference body under ``heading``."""
+    return _section(_reference_text(), heading)
+
+
+def _config_reference_section(heading: str) -> str:
+    """The config reference body under ``heading``."""
+    return _section(_CONFIG_REFERENCE.read_text(encoding="utf-8"), heading)
+
+
+def _config_reference_flag_block() -> str:
+    """The fenced ``nab lock`` block that opens the config reference's CLI flags."""
+    block = re.search(
+        r"```\n(.*?)```", _config_reference_section("## CLI flags"), re.DOTALL
+    )
+    if block is None:
+        msg = "no fenced flag block under the config reference's CLI flags heading"
+        raise AssertionError(msg)
+
+    return block.group(1)
+
+
+def _config_reference_flag_prose() -> str:
+    """The config reference's CLI-flags prose, everything after the fenced block."""
+    return _config_reference_section("## CLI flags").rpartition("```")[2]
+
+
+def _resolve_group_lines() -> str:
+    """The ``# what gets resolved`` lines of the config reference's flag block."""
+    block = _config_reference_flag_block()
+    header = "  # what gets resolved\n"
+    if header not in block:
+        msg = "no 'what gets resolved' group in the config reference's flag block"
+        raise AssertionError(msg)
+
+    return block.partition(header)[2].partition("\n\n")[0]
 
 
 def _write(path: Path, body: str) -> Path:
@@ -62,12 +102,38 @@ def _run_config(args: list[str]) -> str:
     return buf.getvalue()
 
 
-def _names_flag(text: str, flag: str) -> bool:
-    """Whether ``text`` names ``flag``, its ``--no-`` form, or a covering wildcard."""
+def _flag_forms(flag: str) -> list[str]:
+    """The spellings a page may use for ``flag``: itself, ``--no-``, a wildcard."""
     forms = [flag, f"--no-{flag.removeprefix('--')}"]
     if flag.startswith("--project-"):
-        forms.append("--project-*")
-    return any(re.search(rf"`{re.escape(form)}(?![\w-])", text) for form in forms)
+        forms += ["--project-*", "--project-<key>"]
+    return forms
+
+
+def _spells_flag(text: str, flag: str, *, left: str) -> bool:
+    """Whether ``text`` names ``flag`` in any of its forms, preceded by ``left``.
+
+    ``left`` is what the page puts to a flag's left: a backtick in prose, a
+    non-word boundary inside a fenced block.
+    """
+    return any(
+        re.search(rf"{left}{re.escape(form)}(?![\w-])", text)
+        for form in _flag_forms(flag)
+    )
+
+
+def _keyword_flags(command: Callable[..., None]) -> list[str]:
+    """The flags ``command`` accepts, one per keyword-only parameter."""
+    return [
+        "--" + name.replace("_", "-")
+        for name, param in inspect.signature(command).parameters.items()
+        if param.kind is inspect.Parameter.KEYWORD_ONLY
+    ]
+
+
+def _block_flags(block: str) -> list[str]:
+    """The flags a fenced usage ``block`` declares, one per line."""
+    return re.findall(r"(?m)^\s+(--[\w<>-]+)", block)
 
 
 def _doc_paragraph(text: str, needle: str) -> str:
@@ -121,11 +187,40 @@ class TestCliReferenceFlagCoverage:
         # Flags shared by both commands are documented once, in their own section.
         scope = _reference_section(heading) + _reference_section("## Runtime flags")
 
-        for name, param in inspect.signature(command).parameters.items():
-            if param.kind is not inspect.Parameter.KEYWORD_ONLY:
-                continue
-            flag = "--" + name.replace("_", "-")
-            assert _names_flag(scope, flag), f"{heading} omits {flag}"
+        for flag in _keyword_flags(command):
+            assert _spells_flag(scope, flag, left="`"), f"{heading} omits {flag}"
+
+
+class TestConfigReferenceCliFlags:
+    """The config reference's CLI flags section matches the ``nab lock`` surface.
+
+    The section lists the flags in groups, then says what each flag of the
+    first group does to ``[tool.nab]``.  These check both halves against the
+    ``lock`` signature.
+    """
+
+    def test_block_lists_every_lock_flag(self) -> None:
+        block = _config_reference_flag_block()
+
+        for flag in _keyword_flags(lock):
+            assert _spells_flag(block, flag, left=r"(?<![\w-])"), (
+                f"the CLI flags block omits {flag}"
+            )
+
+    def test_block_lists_only_flags_lock_accepts(self) -> None:
+        accepted = {form for flag in _keyword_flags(lock) for form in _flag_forms(flag)}
+
+        for flag in _block_flags(_config_reference_flag_block()):
+            assert flag in accepted, f"the CLI flags block still lists {flag}"
+
+    def test_prose_places_every_resolve_flag(self) -> None:
+        """The prose says what each flag of the first group does to ``[tool.nab]``."""
+        prose = _config_reference_flag_prose()
+
+        for flag in _block_flags(_resolve_group_lines()):
+            assert _spells_flag(prose, flag, left="`"), (
+                f"the section never says what {flag} does to [tool.nab]"
+            )
 
 
 class TestCliReferenceSelectionShape:


### PR DESCRIPTION
`docs/reference/configuration.md` ended its CLI flags section by saying the CLI carries knobs about how a run executes, with a `--project-*` flag as "the one exception". Several `nab lock` flags are not that: `--python`, `--groups`, `--all-groups`, `--extras`, `--all-extras`, `--build-requirements` and `--no-workspace-discovery` all change what gets resolved.

Six of those were missing from the flag block above the claim, along with `--no-emit-workspace`, so a reader looking for where a resolve input comes from found only `[tool.nab]`. The block now lists every flag `lock` accepts, in three groups: what gets resolved, what comes out, and how the run executes.

Prose under the block says what each flag in the first group does to `[tool.nab]`:

* `--project-<key>` replaces the key it names
* `--python` overrides `[tool.nab.environment].python`
* `--build-requirements` clears `conflicts`, `default-groups`, `base-group` and `build-group` for the run
* `--no-workspace-discovery` skips `[tool.nab.workspace]`, the project's own table included
* `--upgrade` re-anchors a relative `uploaded-prior-to` window without changing its value
* the group and extra flags add to the selection rather than replacing a key

The CLI reference's opening paragraph and `nab_project/config.py`'s module docstring drew the same line and now say the lock flags shape the resolve as well as the run. Tests read the section back and check it against the `lock` signature: every flag listed, nothing listed that `lock` does not accept, and the prose bullets covering exactly the first group, so moving a flag between groups turns one red.