### PR TITLE
Fix traceback from an unevaluable marker in a declared source or override

### DIFF
--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -73,7 +73,7 @@ from nab_provider._vendor.packaging.specifiers import SpecifierSet
 from nab_provider._vendor.packaging.tags import Tag
 from nab_provider._vendor.packaging.utils import canonicalize_name
 from nab_provider._vendor.packaging.version import InvalidVersion, Version
-from nab_provider.marker_holds import dependency_marker_holds
+from nab_provider.marker_holds import UnevaluableMarkerError, dependency_marker_holds
 from nab_provider.metadata import WheelMetadata
 from nab_provider.provider import (
     BuildPolicy,
@@ -2934,6 +2934,22 @@ class TestGetDependencies:
         with pytest.raises(MetadataError, match="Invalid metadata"):
             provider.get_dependencies("foo", V("1.0"))
 
+    def test_unevaluable_marker_in_metadata_drops_the_version(self) -> None:
+        """Index metadata with an undecidable marker loses only that version.
+
+        A declared source or an override stops the run instead: there the
+        marker is the user's to fix, while an index can serve another version.
+        """
+        bad_metadata = make_metadata("foo", "1.0", 'dep-a; sys_platform ~= "linux"')
+        coordinator = make_coordinator(
+            [make_wheel("1.0")], metadata_text=bad_metadata, package="foo"
+        )
+        provider = Provider(coordinator, target=_PY312)
+        with pytest.raises(MetadataError, match="cannot be evaluated"):
+            provider.get_dependencies("foo", V("1.0"))
+
+        assert provider.has_invalid_metadata("foo", V("1.0"))
+
     def test_malformed_requires_python_drops_candidate(self) -> None:
         """A version whose METADATA Requires-Python is invalid is refused.
 
@@ -3989,6 +4005,23 @@ class TestLocalSources:
         version, dist = versions[0]
         assert str(version) == "1.2.3"
         assert dist.url.startswith("file://")
+
+    def test_unevaluable_marker_names_the_marker(self, tmp_path: Path) -> None:
+        """A declared tree's undecidable marker stops the run, naming the marker."""
+
+        self._write_local(
+            tmp_path,
+            '[project]\nname = "foo"\nversion = "1.2.3"\n'
+            "dependencies = [\"dep-a; sys_platform ~= 'linux'\"]\n",
+        )
+        coordinator = make_coordinator([], package="foo")
+        provider = Provider(
+            coordinator,
+            local_sources=[LocalSource("foo", str(tmp_path))],
+            build_policy=BuildPolicy.NEVER,
+        )
+        with pytest.raises(UnevaluableMarkerError, match='sys_platform ~= "linux"'):
+            provider.get_dependencies("foo", V("1.2.3"))
 
     def test_local_source_root_requirement_skips_listing_request(
         self, tmp_path: Path
@@ -6637,6 +6670,22 @@ class TestSkipFetch:
             package_overrides=(pkg_override("foo", dependencies=()),),
         )
         assert provider.get_dependencies("foo", V("1.0")) == {}
+
+    def test_unevaluable_marker_names_the_marker(self) -> None:
+        """An override's undecidable marker stops the run, naming the marker."""
+        coordinator = make_coordinator([make_wheel("1.0")], package="foo")
+        provider = Provider(
+            coordinator,
+            target=_PY312,
+            package_overrides=(
+                pkg_override(
+                    "foo",
+                    dependencies=(Requirement('dep-a; sys_platform ~= "linux"'),),
+                ),
+            ),
+        )
+        with pytest.raises(UnevaluableMarkerError, match='sys_platform ~= "linux"'):
+            provider.get_dependencies("foo", V("1.0"))
 
     def test_prefetches_override_dependencies(self) -> None:
         # The override introduces dep-a, so its listing is background-fetched

--- a/nab-provider/src/nab_provider/_provider/metadata_resolver.py
+++ b/nab-provider/src/nab_provider/_provider/metadata_resolver.py
@@ -27,6 +27,7 @@ from ..errors import (
     UnsupportedSdistError,
 )
 from ..extra_keys import join_extra
+from ..marker_holds import evaluate_prepared
 from ..metadata import (
     DEPENDENCY_FIELDS,
     WheelMetadata,
@@ -674,7 +675,7 @@ def marker_matches_base(provider: Provider, marker: Marker, marker_id: int) -> b
     result = provider.marker_base_cache.get(marker_id)
     if result is None:
         provider.consulted_markers.add(marker)
-        result = marker.evaluate_prepared(provider.prepared_environment)
+        result = evaluate_prepared(marker, provider.prepared_environment)
         provider.marker_base_cache[marker_id] = result
     return result
 
@@ -709,7 +710,7 @@ def marker_matched_extras(
         result = per_marker.get(extra_name)
         if result is None:
             env["extra"] = extra_name
-            result = marker.evaluate_prepared(env)
+            result = evaluate_prepared(marker, env)
             per_marker[extra_name] = result
         if result:
             matched.add(extra_name)
@@ -1054,7 +1055,7 @@ def _classify_requirement_uncached(
     marker = req.marker
     if marker is None:
         return set()
-    if marker.evaluate_prepared(provider.prepared_environment):
+    if evaluate_prepared(marker, provider.prepared_environment):
         return set()
     if "extra" not in str(marker):
         return None
@@ -1062,7 +1063,7 @@ def _classify_requirement_uncached(
     matched: set[str] = set()
     for extra_name in provided_extras:
         env["extra"] = extra_name
-        if marker.evaluate_prepared(env):
+        if evaluate_prepared(marker, env):
             matched.add(extra_name)
     return matched or None
 

--- a/nab-provider/src/nab_provider/marker_holds.py
+++ b/nab-provider/src/nab_provider/marker_holds.py
@@ -11,7 +11,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from nab_provider._vendor.packaging.markers import UndefinedComparison
+from nab_provider._vendor.packaging.markers import (
+    UndefinedComparison,
+    UndefinedEnvironmentName,
+)
 from nab_provider._vendor.packaging.markersets import MarkerSet
 
 from .conflict_kind import EMPTY_MEMBERSHIP_SETS
@@ -24,29 +27,55 @@ if TYPE_CHECKING:
 
 
 class UnevaluableMarkerError(ValueError):
-    """A dependency marker parses but no comparison decides it.
+    """A dependency marker parses but nothing decides it.
 
     PEP 508 accepts any operator between a variable and a literal, and PEP 440
     gives ``~=`` a meaning only over a release with at least two components.
     So ``python_full_version ~= "3"`` is a valid marker with nothing to
     evaluate, and ``sys_platform ~= "linux"`` is one on a variable that holds
-    no version at all.  Either guess about it changes what gets locked, so the
-    run stops.
+    no version at all.  A marker that quotes its variable, ``"extra" == "gpu"``,
+    is a third: neither side names a variable to look up.  Any guess about one
+    of these changes what gets locked.
     """
+
+
+def _unevaluable(
+    marker: Marker, exc: UndefinedComparison | UndefinedEnvironmentName
+) -> UnevaluableMarkerError:
+    """Return the error for ``marker``, named in full.
+
+    The failing clause alone does not say which dependency to edit.
+    """
+    return UnevaluableMarkerError(f"marker {marker} cannot be evaluated: {exc}")
 
 
 def marker_set(marker: Marker) -> MarkerSet:
     """Return ``marker`` as a :class:`MarkerSet`.
 
     Building the set checks each clause against its operator, so a marker with
-    no meaning is caught here.  The error names the whole marker, since the
-    failing clause alone does not say which dependency to edit.
+    no meaning is caught here.
     """
     try:
         return MarkerSet.from_marker(marker)
     except UndefinedComparison as exc:
-        msg = f"marker {marker} cannot be evaluated: {exc}"
-        raise UnevaluableMarkerError(msg) from exc
+        raise _unevaluable(marker, exc) from exc
+
+
+def evaluate_prepared(
+    marker: Marker, environment: dict[str, str | AbstractSet[str]]
+) -> bool:
+    """Evaluate ``marker`` against a ``prepare_environment`` result.
+
+    A marker packaging cannot decide raises :class:`UnevaluableMarkerError`, as
+    it does through :func:`marker_set`.  ``"extra" == "gpu"`` is one: packaging
+    reads the right-hand literal as a variable name and finds none.  So
+    ``environment`` has to carry every variable a marker may name, or a gap in
+    it is reported as an unevaluable marker.
+    """
+    try:
+        return marker.evaluate_prepared(environment)
+    except (UndefinedComparison, UndefinedEnvironmentName) as exc:
+        raise _unevaluable(marker, exc) from exc
 
 
 def dependency_marker_holds(

--- a/tasks/check_engine_markersets.py
+++ b/tasks/check_engine_markersets.py
@@ -72,8 +72,8 @@ EXEMPT = {
     "nab_project._lockfile.coverage": ("Same edge as _lockfile.disjointness."),
     "nab_provider.marker_holds": (
         "Where the marker-set dependency lives so the engine does not import "
-        "it. Reached here only through target, requirements_file and "
-        "_lockfile.validate."
+        "it. Reached here through target, requirements_file, "
+        "_provider.metadata_resolver and _lockfile.validate."
     ),
     "nab_provider._vendor.packaging.markersets": "The marker-set module itself.",
 }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1682,6 +1682,63 @@ class TestLockCommandSpecific:
         )
         assert "line 3" in lines[0]
 
+    def test_local_source_unevaluable_marker_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A declared tree's undecidable marker exits 1, not a traceback."""
+        member = tmp_path / "mylocal"
+        member.mkdir()
+        (member / "pyproject.toml").write_text(
+            '[project]\nname = "mylocal"\nversion = "1.0"\n'
+            "dependencies = [\"somepkg; sys_platform ~= 'linux'\"]\n"
+        )
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\nname = "root"\nversion = "0"\n'
+            'dependencies = ["mylocal"]\n'
+            "[[tool.nab.local-sources]]\n"
+            'name = "mylocal"\n'
+            'path = "mylocal"\n',
+        )
+        with pytest.raises(SystemExit, match="1"):
+            lock(pyproject, offline=True, output=Path("-"), cache=False)
+        err = capsys.readouterr().err
+        assert 'cannot lock: marker sys_platform ~= "linux"' in err
+        assert "cannot be evaluated" in err
+        assert "Traceback" not in err
+
+    def test_local_source_constants_only_marker_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A marker with two constant operands exits 1, naming the marker.
+
+        Packaging reads the right-hand literal as a variable name and raises
+        ``UndefinedEnvironmentName``, a ``KeyError``.  The CLI's ``KeyError``
+        clause blames a missing ``[project].dependencies``, so the error must
+        not reach it.
+        """
+        member = tmp_path / "mylocal"
+        member.mkdir()
+        (member / "pyproject.toml").write_text(
+            '[project]\nname = "mylocal"\nversion = "1.0"\n'
+            'dependencies = [\'pytz>=1; "extra" == "gpu"\']\n'
+        )
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\nname = "root"\nversion = "0"\n'
+            'dependencies = ["mylocal"]\n'
+            "[[tool.nab.local-sources]]\n"
+            'name = "mylocal"\n'
+            'path = "mylocal"\n',
+        )
+        with pytest.raises(SystemExit, match="1"):
+            lock(pyproject, offline=True, output=Path("-"), cache=False)
+
+        err = capsys.readouterr().err
+        assert 'cannot lock: marker "extra" == "gpu" cannot be evaluated' in err
+        assert "[project].dependencies" not in err
+        assert "Traceback" not in err
+
     def test_local_source_naming_another_project_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:


### PR DESCRIPTION
`nab lock` fails on a marker that parses but cannot be evaluated, when it comes from a local, VCS or archive source or from a `dependencies` override. `sys_platform ~= "linux"` prints a traceback:

```
  File ".../nab_provider/_provider/metadata_resolver.py", line 677, in marker_matches_base
    result = marker.evaluate_prepared(provider.prepared_environment)
nab_provider._vendor.packaging.markers.UndefinedComparison: Undefined <Op('~=')> on 'linux' and 'linux'.
```

A marker whose operands are both constants is worse. Packaging reads the right-hand literal as a variable name and raises `UndefinedEnvironmentName`, a `KeyError`, so `pytz>=1; "extra" == "gpu"` blames a file that is correct:

```
error: /tmp/.../pyproject.toml has no [project].dependencies
```

Index metadata already handles both: `_parse_and_cache_metadata_guarded` turns the failure into a dropped version. Two branches of `get_dependencies` classify dependencies before that guard runs, and both miss it:

- a declared local, VCS or archive source, whose metadata `fetch_versions` already cached
- a complete `dependencies` override, which supplies the deps and skips the metadata fetch

Both classes now raise `UnevaluableMarkerError`, which the CLI already prints as one line:

```
error: cannot lock: marker sys_platform ~= "linux" cannot be evaluated: Undefined <Op('~=')> on 'linux' and 'linux'.
```

Stopping is right on those two routes: the marker is in the user's own project or config, and there is no other version to fall back to. Index metadata still drops the version, and the message now names the marker.
