### PR TITLE
Restrict the coverage gate to each group's pins, ~7% off a 25-target lock

### DIFF
--- a/nab-project/src/nab_project/_lockfile/coverage.py
+++ b/nab-project/src/nab_project/_lockfile/coverage.py
@@ -95,18 +95,28 @@ def validate_marker_coverage(
     covered = _project_implementation_version(covered, environments, targets)
 
     for pins, references in _references_by_pins(targets).items():
+        env = dict(pins)
+
         # Complementing the whole matrix carries every row's atoms on every
         # axis at once and overruns the cell budget.  Restricting first leaves
         # a single-platform residual denoting the same set.
-        covered_here = covered.restrict(dict(pins))
+        covered_here = covered.restrict(env)
+
+        # Restricting the question too is sound: a group's pins are a subset
+        # of every reference's own == clauses at the same values, since both
+        # read the target's marker_env and the reference only ever adds the
+        # python axes _reference_pins leaves open.  So this drops conjuncts
+        # the reference already fixes rather than narrowing what is asked.
         asked = reduce(
             MarkerSet.union,
             (MarkerSet.from_marker(marker) for marker in references),
             MarkerSet.empty(),
-        )
+        ).restrict(env)
+
         witness = (asked & ~covered_here).witness(store=store)
         if witness is not None:
-            raise CoverageError(_coverage_message(witness))
+            # The residual carries no pins, so env restores them for the message.
+            raise CoverageError(_coverage_message({**env, **witness}))
 
 
 def _references_by_pins(


### PR DESCRIPTION
A warm `max-25-tuples` lock (25 targets) drops about 7% of its instructions, and a `scientific-python-multi` lock (12 targets) about 1.7%. Those are callgrind counts under `PYTHONHASHSEED=0`. The emit-time coverage gate runs once per lock, and one call over the inputs `max-25-tuples` hands it goes from about 301 million instructions to about 84 million.

`_references_by_pins` groups the targets by the platform axes their references pin: on `max-25-tuples`, five groups of five, each reference conjoining the group's six pins with one `python_version` clause. `covered` was restricted to a group's pins and `asked` was not, so the difference reached `witness` with all seven axes live. Restricting `asked` the same way leaves live only the axes no reference pins, and `env` puts the pins back into the message the error renders.

Locally the same lock runs between about 3% and 8% faster, and the run puts peak memory inside about 0.6% either way.

The emitted lock hashes the same before and after on `max-25-tuples`, `scientific-python-multi` and `transformers-cpu-multi-python`.