### PR TITLE
Read each consulted marker text once when declaring environments

### DIFF
--- a/nab-project/src/nab_project/resolve.py
+++ b/nab-project/src/nab_project/resolve.py
@@ -409,10 +409,11 @@ def _declared_environments(
     target's resolve read (see
     :func:`~nab_provider.target.environment_declaration`).
     """
+    # A matrix consults the same marker on every target it expands to.
+    texts = {str(marker) for markers in consulted.values() for marker in markers}
     variables: set[str] = set()
-    for markers in consulted.values():
-        for marker in markers:
-            variables |= marker_variables(str(marker))
+    for text in texts:
+        variables |= marker_variables(text)
 
     unboundable = sorted(variables & UNBOUNDABLE_MARKER_VARIABLES)
     if unboundable:

--- a/nab-project/tests/test_resolve_targets.py
+++ b/nab-project/tests/test_resolve_targets.py
@@ -22,6 +22,7 @@ from nab_index import vcs as vcs_mod
 from nab_index.cache import ARCHIVE_BUCKET, VCS_BUCKET
 from nab_index.client import SdistFile, WheelFile
 from nab_index.multi_index import IndexConfig
+from nab_project import resolve as resolve_mod
 from nab_project._resolve import engine as engine_mod
 from nab_project._resolve.engine import _EngineSettings, _resolve_one_target, _run_pass
 from nab_project._testing.coordinator_fake import FakeFetchPort, make_coordinator
@@ -61,6 +62,7 @@ from nab_project.resolve import (
     resolve_with_coordinator,
 )
 from nab_provider._provider import listing as listing_mod
+from nab_provider._vendor.packaging.markers import Marker
 from nab_provider._vendor.packaging.ranges import VersionRange
 from nab_provider._vendor.packaging.requirements import Requirement
 from nab_provider._vendor.packaging.version import Version
@@ -2024,6 +2026,40 @@ class TestBuildLockInput:
         assert len(merged.targets) == 2
         versions = {lock.pins["pkg"].version for lock in merged.targets.values()}
         assert versions == {"1.0", "2.0"}
+
+    def test_a_marker_consulted_on_every_target_is_read_once(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Declaring environments calls marker_variables once per distinct text."""
+        linux, windows = _linux_311(), _windows_311()
+        marker = Marker('platform_system == "Linux"')
+        results = [
+            TargetResult(
+                target=target,
+                success=True,
+                pins={"pkg": Version("1.0")},
+                consulted=frozenset({marker}),
+                lock=TargetLock(
+                    target=target,
+                    pins={"pkg": IndexPin(name="pkg", version="1.0", index="pypi")},
+                ),
+            )
+            for target in (linux, windows)
+        ]
+
+        texts: list[str] = []
+        real_marker_variables = resolve_mod.marker_variables
+
+        def spy_marker_variables(text: str) -> frozenset[str]:
+            texts.append(text)
+            return real_marker_variables(text)
+
+        monkeypatch.setattr(resolve_mod, "marker_variables", spy_marker_variables)
+        build_lock_input(
+            ResolveResult(targets=(linux, windows), target_results=results)
+        )
+
+        assert texts == ['platform_system == "Linux"']
 
     def test_a_double_quote_in_a_consulted_marker_value_still_locks(self) -> None:
         """A marker value carrying a double quote still locks.


### PR DESCRIPTION
About 460,000 instructions come off a universal `max-25-tuples` lock, of the 3.13 billion it costs, measured by replaying that lock's own arguments to the changed function under callgrind (`PYTHONHASHSEED=0`).

`_declared_environments` calls `marker_variables` 955 times there to read 41 distinct marker texts, because a matrix consults the same marker on every target it expands to. Collecting the texts into a set first takes those 955 calls to 41, of the 1,910 the whole lock makes. They are memo lookups rather than parses, since `marker_variables` is memoised, which is why the saving is this size.

Counting the whole lock instead puts the change anywhere from 2.9 million instructions lower to 0.6 million higher across four repeats, so an end-to-end count cannot resolve it.

The variable names feed only the warning about markers a lock cannot declare, and the emitted lock is byte-identical at 24,160 bytes.