### PR TITLE
Pin each re-lock diff counter to a distinct count in tests

### DIFF
--- a/nab-project/tests/test_lockfile_locked.py
+++ b/nab-project/tests/test_lockfile_locked.py
@@ -481,11 +481,32 @@ class TestSummarizeLock:
         lock_input = _lock_input({"foo": _pin("foo", "1.0")})
         assert summarize_lock(lock_input, {"foo": Version("1.0")}) == "1 packages"
 
-    def test_added_upgraded_and_removed(self) -> None:
-        lock_input = _lock_input({"foo": _pin("foo", "2.0"), "baz": _pin("baz", "1.0")})
-        prior = {"foo": Version("1.0"), "bar": Version("1.0")}
+    def test_each_change_kind_reports_its_own_count(self) -> None:
+        """Each kind gets a distinct count, so a swapped label changes the summary."""
+        lock_input = _lock_input(
+            {
+                "added1": _pin("added1", "1.0"),
+                "added2": _pin("added2", "1.0"),
+                "added3": _pin("added3", "1.0"),
+                "upgraded1": _pin("upgraded1", "2.0"),
+                "upgraded2": _pin("upgraded2", "2.0"),
+                "downgraded1": _pin("downgraded1", "1.0"),
+                "unchanged": _pin("unchanged", "1.0"),
+            }
+        )
+        prior = {
+            "upgraded1": Version("1.0"),
+            "upgraded2": Version("1.0"),
+            "downgraded1": Version("2.0"),
+            "unchanged": Version("1.0"),
+            "removed1": Version("1.0"),
+            "removed2": Version("1.0"),
+            "removed3": Version("1.0"),
+            "removed4": Version("1.0"),
+        }
+
         assert summarize_lock(lock_input, prior) == (
-            "2 packages: 1 added, 1 upgraded, 1 removed"
+            "7 packages: 3 added, 2 upgraded, 1 downgraded, 4 removed"
         )
 
     def test_downgrade_is_reported(self) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3533,21 +3533,27 @@ class TestRelockDiffSummary:
     def test_relock_reports_added_upgraded_removed(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
+        """Each kind gets a distinct count, so a swapped label changes the line."""
         out = tmp_path / "pylock.toml"
-        _emit(
-            _stub_lock_input({"foo": V("1.0"), "bar": V("1.0")}),
-            format="pylock",
-            output=out,
-        )
+        prior = {
+            "upgraded": V("1.0"),
+            "removed1": V("1.0"),
+            "removed2": V("1.0"),
+            "removed3": V("1.0"),
+        }
+        _emit(_stub_lock_input(prior), format="pylock", output=out)
         capsys.readouterr()
-        # foo upgraded 1.0 -> 2.0, bar removed, baz added.
+
         _emit(
-            _stub_lock_input({"foo": V("2.0"), "baz": V("1.0")}),
+            _stub_lock_input(
+                {"upgraded": V("2.0"), "added1": V("1.0"), "added2": V("1.0")}
+            ),
             format="pylock",
             output=out,
         )
+
         err = capsys.readouterr().err.strip()
-        assert err.endswith("(2 packages: 1 added, 1 upgraded, 1 removed)")
+        assert err.endswith("(3 packages: 2 added, 1 upgraded, 3 removed)")
 
     def test_relock_reports_downgrade(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
Every test of the `nab lock` re-lock summary used one package per kind:

    2 packages: 1 added, 1 upgraded, 1 removed

Swap the added, upgraded and removed counters for each other and the line comes out identical, so both tests still pass. Only downgraded was pinned, by its own separate test.

Each kind now gets its own count:

- `summarize_lock`: 3 added, 2 upgraded, 1 downgraded, 4 removed, plus one unchanged pin
- the stderr line from a re-lock: 2 added, 1 upgraded, 3 removed
