### PR TITLE
Revalidate index listings marked no-cache instead of caching them for 600s

### DIFF
--- a/docs/reference/cache.md
+++ b/docs/reference/cache.md
@@ -53,9 +53,15 @@ A listing follows a small subset of RFC 9111. The `.policy` sidecar
 records when the body was fetched and its `max-age`. A fresh entry is
 served directly; a stale one is revalidated with `If-None-Match`, and a
 `304 Not Modified` slides the window forward without refetching the body.
+A listing the index marks `no-cache` or `no-store` gets no window at
+all, so every online read revalidates it unless an `assume-fresh-seconds`
+floor (see [Configuration](configuration.md)) still covers it.
+
 Metadata and sdist records are immutable: cached once, never revalidated.
 A 404 is remembered briefly so a repeated lookup of an absent name is
-answered from cache, offline included.
+answered from cache, offline included. One the index marks `no-cache` or
+`no-store` gets no window either, so an online repeat asks the index
+again while offline still answers from the record.
 
 ## Parsed-listing accelerator
 

--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -3,8 +3,9 @@
 Drives an :class:`~nab_index.transport.AsyncHttpTransport` and consults a
 :class:`~nab_index.cache.CacheBackend` before any HTTP call. Honors a small
 subset of RFC 9111: fresh entries are served directly, stale entries are
-revalidated with ``If-None-Match``, and PEP 658 metadata + sdist PKG-INFO are
-treated as immutable (cached forever; never revalidated).
+revalidated with ``If-None-Match``, a listing the origin marks ``no-cache`` or
+``no-store`` gets no freshness window of its own, and PEP 658 metadata + sdist
+PKG-INFO are treated as immutable (cached forever; never revalidated).
 """
 
 from __future__ import annotations
@@ -101,6 +102,7 @@ _DEFAULT_MAX_AGE = 600
 _HTTP_NOT_MODIFIED = 304
 # RFC 9111 5.2: directive names are case-insensitive and the argument may be quoted.
 _MAX_AGE_RE = re.compile(r'max-age\s*=\s*"?(\d+)', re.IGNORECASE)
+_NO_REUSE_RE = re.compile(r"(?:\A|,)\s*no-(?:cache|store)\s*(?:[,=]|\Z)", re.IGNORECASE)
 _AGE_RE = re.compile(r"\A\s*(\d+)\s*\Z")
 _SECONDS_CEILING = 2**31
 _SECONDS_CEILING_DIGITS = len(str(_SECONDS_CEILING))
@@ -129,6 +131,17 @@ def _max_age_directive(cache_control: str | None) -> int | None:
     if match is None:
         return None
     return _parse_seconds(match.group(1))
+
+
+def _requires_revalidation(cache_control: str | None) -> bool:
+    """Whether Cache-Control bars reusing a stored response unvalidated.
+
+    ``no-cache`` (RFC 9111 5.2.2.4) says so directly. ``no-store`` (5.2.2.5)
+    bars storing the response at all; nab stores it anyway and revalidates on
+    every read instead. A ``no-cache`` qualified with field names reads as the
+    bare directive.
+    """
+    return cache_control is not None and _NO_REUSE_RE.search(cache_control) is not None
 
 
 def _parse_age(age: str | None) -> int:
@@ -207,9 +220,14 @@ def _freshness_lifetime(response: HttpResponse) -> int:
 
     RFC 9111 4.2.1 for a private cache: an explicit ``max-age``, else Expires
     measured from Date, else the heuristic default. 4.2.2 reserves that default
-    for a response stating no expiry at all.
+    for a response stating no expiry at all, and a response barred from
+    unvalidated reuse gets no window whatever else it states.
     """
-    max_age = _max_age_directive(_header(response, "cache-control"))
+    cache_control = _header(response, "cache-control")
+    if _requires_revalidation(cache_control):
+        return 0
+
+    max_age = _max_age_directive(cache_control)
     if max_age is not None:
         return max_age
 

--- a/nab-project/tests/test_cached_client.py
+++ b/nab-project/tests/test_cached_client.py
@@ -73,6 +73,21 @@ LISTING = {
 }
 LISTING_BYTES = json.dumps(LISTING).encode()
 
+# The same page after a second release lands on it.
+RELISTING_BYTES = json.dumps(
+    {
+        "meta": {"api-version": "1.0"},
+        "name": "pkg",
+        "files": [
+            *LISTING["files"],
+            {
+                "filename": "pkg-2.0-py3-none-any.whl",
+                "url": "https://files.example.com/pkg-2.0-py3-none-any.whl",
+            },
+        ],
+    }
+).encode()
+
 # A page whose only file is in a format nab does not read.
 ZIP_ONLY_LISTING = {
     "meta": {"api-version": "1.0"},
@@ -1027,6 +1042,56 @@ class TestFreshnessLifetime:
 
     def test_far_future_expires_clamped(self) -> None:
         assert self._lifetime({"expires": "Fri, 31 Dec 9999 23:59:59 GMT"}) == 2**31
+
+
+class TestNoReuseDirectives:
+    """A response that bars reuse gets no freshness window of its own."""
+
+    _NOW = 1_700_000_000.0
+
+    @pytest.fixture(autouse=True)
+    def _frozen_clock(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(time, "time", lambda: self._NOW)
+
+    def _lifetime(self, cache_control: str) -> int:
+        return _freshness_lifetime(
+            _FakeResponse(b"", headers={"cache-control": cache_control})
+        )
+
+    def test_no_cache_has_no_window(self) -> None:
+        assert self._lifetime("no-cache") == 0
+
+    def test_full_directive_list_has_no_window(self) -> None:
+        assert self._lifetime("no-cache,no-store,must-revalidate") == 0
+
+    def test_no_cache_outranks_max_age(self) -> None:
+        assert self._lifetime("max-age=600, no-cache") == 0
+
+    def test_no_cache_is_case_insensitive(self) -> None:
+        assert self._lifetime("public, No-Cache") == 0
+
+    def test_qualified_no_cache_reads_as_bare(self) -> None:
+        """RFC 9111 5.2.2.4 allows field names; nab revalidates either way."""
+        assert self._lifetime('no-cache="set-cookie", max-age=600') == 0
+
+    def test_no_store_has_no_window(self) -> None:
+        assert self._lifetime("no-store") == 0
+
+    def test_longer_directive_ending_in_no_cache_is_ignored(self) -> None:
+        assert self._lifetime("x-no-cache, max-age=300") == 300
+
+    def test_longer_directive_ending_in_no_store_is_ignored(self) -> None:
+        assert self._lifetime("x-no-store, max-age=300") == 300
+
+    def test_expires_is_not_consulted(self) -> None:
+        response = _FakeResponse(
+            b"",
+            headers={
+                "cache-control": "no-cache",
+                "expires": formatdate(self._NOW + 86400, usegmt=True),
+            },
+        )
+        assert _freshness_lifetime(response) == 0
 
 
 class TestParseAge:
@@ -1988,19 +2053,6 @@ class TestExpiresFreshness:
     """
 
     _NOW = 1_700_000_000.0
-    _RELISTING = json.dumps(
-        {
-            "meta": {"api-version": "1.0"},
-            "name": "pkg",
-            "files": [
-                *LISTING["files"],
-                {
-                    "filename": "pkg-2.0-py3-none-any.whl",
-                    "url": "https://files.example.com/pkg-2.0-py3-none-any.whl",
-                },
-            ],
-        }
-    ).encode()
 
     def _freeze(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(time, "time", lambda: self._NOW)
@@ -2013,7 +2065,7 @@ class TestExpiresFreshness:
         transport = _FakeTransport(
             [
                 _FakeResponse(LISTING_BYTES, headers=headers),
-                _FakeResponse(self._RELISTING, headers=headers),
+                _FakeResponse(RELISTING_BYTES, headers=headers),
             ]
         )
         assert len(_run_get_files(transport, cache, "pkg")) == 1
@@ -2131,6 +2183,140 @@ class TestExpiresFreshness:
         cached = cache.get_simple("pkg")
         assert cached is not None
         assert cached[1].max_age == 1800
+
+
+class TestNoReuseListings:
+    """A listing the origin bars from unvalidated reuse is checked every read.
+
+    RFC 9111 5.2.2.4 for ``no-cache`` and 5.2.2.5 for ``no-store``. The
+    responses here carry no max-age and no Expires, the case the heuristic
+    window would otherwise cover.
+    """
+
+    def _read_twice(
+        self, tmp_path: Path, cache_control: str
+    ) -> tuple[_FakeTransport, list]:
+        """Read pkg, then read it again once a second release has landed.
+
+        Returns the transport, so its calls can be counted, and the records the
+        second read answered with.
+        """
+        cache = _make_cache(tmp_path)
+        transport = _FakeTransport(
+            [
+                _FakeResponse(
+                    LISTING_BYTES,
+                    headers={"etag": "v1", "cache-control": cache_control},
+                ),
+                _FakeResponse(
+                    RELISTING_BYTES,
+                    headers={"etag": "v2", "cache-control": cache_control},
+                ),
+            ]
+        )
+        assert len(_run_get_files(transport, cache, "pkg")) == 1
+        return transport, _run_get_files(transport, cache, "pkg")
+
+    def test_no_cache_sees_a_release_published_between_reads(
+        self, tmp_path: Path
+    ) -> None:
+        transport, files = self._read_twice(tmp_path, "no-cache")
+
+        assert len(transport.calls) == 2
+        assert [file.filename for file in files] == [
+            "pkg-1.0-py3-none-any.whl",
+            "pkg-2.0-py3-none-any.whl",
+        ]
+
+    def test_full_directive_list_sees_it_too(self, tmp_path: Path) -> None:
+        transport, files = self._read_twice(
+            tmp_path, "no-cache,no-store,must-revalidate"
+        )
+
+        assert len(transport.calls) == 2
+        assert len(files) == 2
+
+    @pytest.mark.parametrize("cache_control", ["no-cache", "no-store"])
+    def test_listing_is_stored_and_revalidated_conditionally(
+        self, tmp_path: Path, cache_control: str
+    ) -> None:
+        """The body is still written, so the next read costs a 304, not a refetch."""
+        cache = _make_cache(tmp_path)
+        transport = _FakeTransport(
+            [
+                _FakeResponse(
+                    LISTING_BYTES,
+                    headers={"etag": "v1", "cache-control": cache_control},
+                ),
+                _FakeResponse(b"", status=304, headers={"etag": "v1"}),
+            ]
+        )
+
+        assert len(_run_get_files(transport, cache, "pkg")) == 1
+        stored = cache.get_simple("pkg")
+        assert stored is not None
+        assert stored[1].max_age == 0
+
+        assert len(_run_get_files(transport, cache, "pkg")) == 1
+        sent = transport.calls[1][1]
+        assert sent is not None
+        assert sent.get("If-None-Match") == "v1"
+
+    def test_no_store_body_replaces_the_stored_one(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        cache.put_simple("pkg", LISTING_BYTES, _stale_etag_policy())
+        transport = _FakeTransport(
+            [
+                _FakeResponse(
+                    RELISTING_BYTES, headers={"etag": "v2", "cache-control": "no-store"}
+                )
+            ]
+        )
+
+        assert len(_run_get_files(transport, cache, "pkg")) == 2
+
+        stored = cache.get_simple("pkg")
+        assert stored is not None
+        assert stored[0] == RELISTING_BYTES
+
+    def test_offline_serves_a_no_store_listing_from_disk(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        online = _FakeTransport(
+            [
+                _FakeResponse(
+                    LISTING_BYTES, headers={"etag": "v1", "cache-control": "no-store"}
+                )
+            ]
+        )
+        assert len(_run_get_files(online, cache, "pkg")) == 1
+
+        offline = _FakeTransport()
+        assert len(_run_get_files(offline, cache, "pkg", offline=True)) == 1
+        assert offline.calls == []
+
+    @pytest.mark.parametrize("cache_control", ["no-cache", "no-store"])
+    def test_404_sentinel_is_stale_at_once(
+        self, tmp_path: Path, cache_control: str
+    ) -> None:
+        cache = _make_cache(tmp_path)
+        transport = _FakeTransport(
+            [
+                _FakeResponse(
+                    b"", status=404, headers={"cache-control": cache_control}
+                ),
+                _FakeResponse(
+                    b"", status=404, headers={"cache-control": cache_control}
+                ),
+            ]
+        )
+
+        assert _run_get_files(transport, cache, "absent") == []
+        sentinel = cache.get_negative("absent")
+        assert sentinel is not None
+        assert sentinel.max_age == 0
+
+        assert _run_get_files(transport, cache, "absent") == []
+        assert len(transport.calls) == 2
 
 
 class TestRedirectedProjectPage:


### PR DESCRIPTION
A Simple listing whose `Cache-Control` says `no-cache` was served from disk for 600 seconds, so a version published between two runs stayed invisible until that window lapsed. `no-cache` carries no `max-age`, so it fell through to the heuristic default RFC 9111 4.2.2 reserves for a response stating no expiry at all.

download.pytorch.org's nightly channel sends it, and a nightly listing is where a ten-minute stale window costs the most:

    $ curl -sSI https://download.pytorch.org/whl/nightly/torch/
    cache-control: no-cache,no-store,must-revalidate

`no-cache` and `no-store` now leave a listing no freshness window, so every online read revalidates it, and a 404 sentinel recorded from such a response is stale at once.

RFC 9111 5.2.2.5 says a `no-store` response should not be stored at all. nab stores it and revalidates on each read instead, so `--offline` still serves those indexes and a warm read costs a conditional request rather than a refetch. An `assume-fresh-seconds` floor still covers an entry where one is set.

Directives match on their own boundaries, so `x-no-cache` is not `no-cache` and `no-cache="set-cookie"` reads as the bare directive.
