### PR TITLE
Document `python_full_version` on a split minor's pylock markers

### DIFF
--- a/docs/explanation/universal.md
+++ b/docs/explanation/universal.md
@@ -235,17 +235,17 @@ accepts `ppXY-pypyXY_pp73` wheel tags instead of `cpXY`. Labels use the
 `pp` interpreter prefix (`pp311-linux_x86_64`).
 
 A CPython-only matrix leaves the axis open: its lockfile markers carry
-`python_version`, `sys_platform` and `platform_machine` only. Any other
-matrix, whether it names two implementations or one non-CPython one,
-puts `implementation_name` on every target's marker and on the
-`environments` entry it declares. The CPython and PyPy entries for one
-`(python, platform)` point stay mutually exclusive, and a PyPy-only
-lock refuses CPython. PyPy's `implementation_version` is modelled as
-the Python level, not PyPy's own release, so the rare marker comparing
-`implementation_version` against a PyPy version misevaluates during the
-resolve. The lockfile does not carry that synthetic value: a non-CPython
-`environments` entry leaves `implementation_version` open, so a real PyPy
-still accepts the lock (a dep gated on the axis may be missed at install).
+no `implementation_name`. Any other matrix, whether it names two
+implementations or one non-CPython one, puts `implementation_name` on
+every target's marker and on the `environments` entry it declares. The
+CPython and PyPy entries for one `(python, platform)` point stay
+mutually exclusive, and a PyPy-only lock refuses CPython. PyPy's
+`implementation_version` is modelled as the Python level, not PyPy's
+own release, so the rare marker comparing `implementation_version`
+against a PyPy version misevaluates during the resolve. The lockfile
+does not carry that synthetic value: a non-CPython `environments` entry
+leaves `implementation_version` open, so a real PyPy still accepts the
+lock (a dep gated on the axis may be missed at install).
 
 ## Resolution axes
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -151,7 +151,9 @@ all three formats:
 * `pylock` produces one PEP 751 file with per-tuple `Package`
   entries gated by markers (`python_version`, `sys_platform`,
   `platform_machine`, plus `implementation_name` when the matrix
-  declares a non-CPython implementation or more than one). Versions
+  declares a non-CPython implementation or more than one). A slice
+  of a split minor adds its `python_full_version` bounds (see
+  [Universal resolution](../explanation/universal.md)). Versions
   agreed across every tuple appear once without a marker; divergent
   versions appear once per `(version, source)` group with the
   matching tuples disjoined.

--- a/docs/reference/formats.md
+++ b/docs/reference/formats.md
@@ -56,7 +56,10 @@ all three formats:
 * `pylock` produces one PEP 751 file with per-tuple `Package`
   entries gated by markers (`python_version`, `sys_platform`,
   `platform_machine`, plus `implementation_name` when the matrix
-  declares a non-CPython implementation or more than one). Versions
+  declares a non-CPython implementation or more than one). A minor
+  split into micro slices contributes one tuple per slice, and each
+  slice's markers name its `python_full_version` bounds as well (see
+  [Universal resolution](../explanation/universal.md)). Versions
   agreed across every tuple appear once without a marker; divergent
   versions appear once per `(version, source)` group with the
   matching tuples disjoined.

--- a/docs/reference/lockfile.md
+++ b/docs/reference/lockfile.md
@@ -357,13 +357,14 @@ whose pinned version is identical across every target appear once with
 no marker; packages that diverge appear as multiple `Package` entries
 with PEP 508 markers built from each target's `python_version`,
 `sys_platform` and `platform_machine`, plus `implementation_name` on
-the same terms as the `environments` declarations above. Each such
-marker is emitted in its shortest form equivalent over the lock's
-declared environments, and the emitted bytes are checked against the
-original over those environments before the lock is written, one
-declared environment at a time so that a matrix spanning many platforms
-stays decidable. A marker whose shortening or check runs out of budget
-is emitted unsimplified, as is one that selects nothing inside the
+the same terms as the `environments` declarations above. A slice of a
+split minor adds its `python_full_version` bounds. Each such marker is
+emitted in its shortest form equivalent over the lock's declared
+environments, and the emitted bytes are checked against the original
+over those environments before the lock is written, one declared
+environment at a time so that a matrix spanning many platforms stays
+decidable. A marker whose shortening or check runs out of budget is
+emitted unsimplified, as is one that selects nothing inside the
 declared environments.
 
 `environments` carries a declaration per target, built the same way a

--- a/nab-project/tests/test_lockfile.py
+++ b/nab-project/tests/test_lockfile.py
@@ -392,6 +392,36 @@ class TestPerTargetMarkerSimplification:
         assert any('python_version == "3.10"' in m for m in markers)
         assert any('python_version == "3.11"' in m for m in markers)
 
+    def test_micro_slice_pin_gated_on_python_full_version(self) -> None:
+        """A pin held by only one slice of a split minor names the slice bounds.
+
+        The slices agree on every other axis, so shortening against the
+        declared environments leaves the micro bounds as the whole marker.
+        """
+        consulted = [Marker('python_full_version < "3.10.4"')]
+        minor = _target("3.10")
+        lower, upper = slices_from_points(
+            minor, micro_boundary_points(minor, consulted)
+        )
+
+        text = write_lock(
+            LockInput(
+                targets=_targets(
+                    (lower, {"foo": _index_pin(), "bar": _index_pin("bar")}),
+                    (upper, {"foo": _index_pin()}),
+                ),
+                environments=[
+                    Marker(environment_declaration(target, consulted))
+                    for target in (lower, upper)
+                ],
+            )
+        )
+        data = tomllib.loads(text)
+
+        markers = {p["name"]: p.get("marker") for p in data["packages"]}
+        assert markers["foo"] is None
+        assert markers["bar"] == 'python_full_version < "3.10.4"'
+
     def test_three_targets_two_groups(self) -> None:
         # 3.10 + 3.11 share v1.0; 3.12 has v2.0 -> two groups
         text = write_lock(

--- a/nab-provider/src/nab_provider/target.py
+++ b/nab-provider/src/nab_provider/target.py
@@ -994,10 +994,11 @@ class ResolveTarget:
 
         Combines ``python_version``, ``sys_platform`` and
         ``platform_machine``, plus ``implementation_name`` when
-        :attr:`declares_implementation` and the :attr:`micro_clauses`
-        bounds on a slice of a split minor.  It carries no conflict-fork
-        ``selection``, so it selects this target's platform/Python point,
-        not which extras or groups are active.
+        :attr:`declares_implementation`, then every clause in
+        :attr:`micro_clauses`, which bound a slice of a split minor.  It
+        carries no conflict-fork ``selection``, so it selects this
+        target's platform/Python point, not which extras or groups are
+        active.
         """
         env = self.marker_env
         marker = (

--- a/nab-provider/src/nab_provider/target.py
+++ b/nab-provider/src/nab_provider/target.py
@@ -987,7 +987,8 @@ class ResolveTarget:
 
         Combines ``python_version``, ``sys_platform`` and
         ``platform_machine``, plus ``implementation_name`` when
-        :attr:`declares_implementation`.  It carries no conflict-fork
+        :attr:`declares_implementation` and the :attr:`micro_clauses`
+        bounds on a slice of a split minor.  It carries no conflict-fork
         ``selection``, so it selects this target's platform/Python point,
         not which extras or groups are active.
         """


### PR DESCRIPTION
When a `python_full_version` marker splits a minor, `nab lock --format pylock` gates a package pinned on only one slice with that slice's bounds. Four places named the per-package marker variables as a closed set: `python_version`, `sys_platform`, `platform_machine`, and `implementation_name` where the matrix declares one. A reader of such a lock had nowhere to place the extra clause.

`ResolveTarget.environment_marker_string` appends every clause of `micro_clauses` after the optional `implementation_name` one, and the four now say so:

* `reference/formats.md`, the `pylock` bullet under Universal output
* `reference/lockfile.md`, the universal-mode paragraph on per-package markers
* `explanation/universal.md`, whose sentence on a CPython-only matrix closed the list only to make its point about `implementation_name`
* the `environment_marker_string` docstring

A new lockfile test splits a 3.10 target at 3.10.4, pins one package on the lower slice alone, and asserts its emitted marker is `python_full_version < "3.10.4"`.