### PR TITLE
Derive a build tag only to break a rank tie, ~1% off a 25-tuple resolve

### DIFF
--- a/nab-provider/src/nab_provider/tags.py
+++ b/nab-provider/src/nab_provider/tags.py
@@ -671,6 +671,20 @@ class TagSet:
             rank_index = self._place(wheel_tags)
         return rank_index is not None
 
+    def _rank_index(self, wheel_filename: str) -> int | None:
+        """Return the rank of the most specific tag the wheel and target share.
+
+        None when the filename is not a wheel, or names no tag the target
+        accepts.
+        """
+        wheel_tags = wheel_tag_set(wheel_filename)
+        if not wheel_tags:
+            return None
+        rank_index = self._placed.get(wheel_tags, _UNPLACED)
+        if rank_index is _UNPLACED:
+            rank_index = self._place(wheel_tags)
+        return rank_index
+
     def wheel_rank(self, wheel_filename: str) -> tuple[int, tuple[int, str]] | None:
         """Return the target's install-preference key for a wheel, or None.
 
@@ -682,12 +696,7 @@ class TagSet:
         Two wheels the target's own rules cannot order return an equal,
         non-None key, so an equal, non-None pair is exactly a tie.
         """
-        wheel_tags = wheel_tag_set(wheel_filename)
-        if not wheel_tags:
-            return None
-        rank_index = self._placed.get(wheel_tags, _UNPLACED)
-        if rank_index is _UNPLACED:
-            rank_index = self._place(wheel_tags)
+        rank_index = self._rank_index(wheel_filename)
         if rank_index is None:
             return None
         return (rank_index, _build_tag_sort_key(wheel_filename))
@@ -704,20 +713,25 @@ class TagSet:
         ``wheels`` is anything carrying a ``filename``: an index
         listing's wheel or a lockfile's wheel artefact.
         """
-        best_key: tuple[int, tuple[int, str]] | None = None
         best_wheel: _WheelT | None = None
+        best_rank = 0  # ignored until best_wheel is set
+        best_build: tuple[int, str] | None = None
+
         for wheel in wheels:
-            key = self.wheel_rank(wheel.filename)
-            if key is None:
+            rank_index = self._rank_index(wheel.filename)
+            if rank_index is None:
                 continue
-            rank_index, build_key = key
-            if (
-                best_key is None
-                or rank_index < best_key[0]
-                or (rank_index == best_key[0] and build_key > best_key[1])
-            ):
-                best_key = key
-                best_wheel = wheel
+
+            if best_wheel is None or rank_index < best_rank:
+                best_wheel, best_rank, best_build = wheel, rank_index, None
+            elif rank_index == best_rank:
+                # A build tag settles nothing but a tie, so derive it only here.
+                if best_build is None:
+                    best_build = _build_tag_sort_key(best_wheel.filename)
+                build_key = _build_tag_sort_key(wheel.filename)
+                if build_key > best_build:
+                    best_wheel, best_build = wheel, build_key
+
         return best_wheel
 
     @classmethod

--- a/nab-provider/tests/test_tags.py
+++ b/nab-provider/tests/test_tags.py
@@ -913,6 +913,34 @@ class TestSelectWheel:
         assert forward is build5
         assert reverse is build5
 
+    def test_highest_build_tag_wins_among_three_at_one_rank(self) -> None:
+        """A third wheel at the same rank is weighed against the running best."""
+        spec = PlatformSpec("linux_x86_64", runs_on_libc=(2, 17))
+        build1 = _wheel("pkg-1.0-1-cp311-cp311-manylinux_2_17_x86_64.whl")
+        build5 = _wheel("pkg-1.0-5-cp311-cp311-manylinux_2_17_x86_64.whl")
+        build3 = _wheel("pkg-1.0-3-cp311-cp311-manylinux_2_17_x86_64.whl")
+        chosen = TagSet.for_spec(python_version="3.11", spec=spec).pick(
+            [build1, build5, build3]
+        )
+        assert chosen is build5
+
+    def test_better_rank_discards_the_incumbent_build_key(self) -> None:
+        """A better tag rank drops the incumbent's build key instead of carrying it.
+
+        The first two wheels tie at manylinux_2_5 and settle on build 9.
+        manylinux_2_17 then outranks both, so build 5 is weighed against
+        build 0 rather than against the discarded build 9.
+        """
+        spec = PlatformSpec("linux_x86_64", runs_on_libc=(2, 17))
+        generic9 = _wheel("pkg-1.0-9-cp311-cp311-manylinux_2_5_x86_64.whl")
+        generic1 = _wheel("pkg-1.0-1-cp311-cp311-manylinux_2_5_x86_64.whl")
+        specific0 = _wheel("pkg-1.0-0-cp311-cp311-manylinux_2_17_x86_64.whl")
+        specific5 = _wheel("pkg-1.0-5-cp311-cp311-manylinux_2_17_x86_64.whl")
+        chosen = TagSet.for_spec(python_version="3.11", spec=spec).pick(
+            [generic9, generic1, specific0, specific5]
+        )
+        assert chosen is specific5
+
     def test_build_tagged_wheel_beats_untagged_at_same_rank(self) -> None:
         """An absent build tag sorts lowest, so a tagged wheel wins."""
         spec = PlatformSpec("linux_x86_64", runs_on_libc=(2, 17))


### PR DESCRIPTION
`TagSet.pick` derived a PEP 427 build tag for every wheel it ranked, and that tag settles nothing but a tie between two wheels at the same tag rank. It now derives one only for the wheels that tie.

| workload | `_build_tag_sort_key` calls | instructions removed |
| --- | ---: | ---: |
| `max-25-tuples`, 25 Python/platform tuples | 13,784 → 50 | 43 M of 4.11 bn |
| `pip:google-bigquery-soda@lowest`, one target | 2,966 → 0 | 9.5 M of 4.37 bn |

The call counts are exact and reproduce anywhere. The instruction counts are callgrind under `PYTHONHASHSEED=0`: about 1% of the first run and 0.2% of the second. No timing run on this machine could resolve a change that size.

Which wheel `pick` returns does not change. `wheel_rank` keeps its signature and now shares its rank lookup with `pick`, so it pays one extra Python call on the tie-ambiguity check, which neither workload above reaches.