### PR TITLE
Share the version index across a matrix's targets, 2.6% off max-25-tuples

### DIFF
--- a/nab-project/src/nab_project/resolve.py
+++ b/nab-project/src/nab_project/resolve.py
@@ -285,7 +285,8 @@ def resolve_with_coordinator(  # noqa: PLR0913 - the knobs of a bare resolve
             ),
             progress=progress,
             listing_filter_cache=ListingFilterCache(
-                len({target.python_full_version for target in targets})
+                pythons=len({target.python_full_version for target in targets}),
+                targets=len(targets),
             ),
         )
 

--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -72,7 +72,7 @@ from nab_provider._vendor.packaging.specifiers import SpecifierSet
 from nab_provider._vendor.packaging.tags import Tag
 from nab_provider._vendor.packaging.utils import canonicalize_name
 from nab_provider._vendor.packaging.version import InvalidVersion, Version
-from nab_provider.marker_holds import dependency_marker_holds
+from nab_provider.marker_holds import UnevaluableMarkerError, dependency_marker_holds
 from nab_provider.metadata import WheelMetadata
 from nab_provider.provider import (
     BuildPolicy,
@@ -2720,6 +2720,22 @@ class TestGetDependencies:
         with pytest.raises(MetadataError, match="Invalid metadata"):
             provider.get_dependencies("foo", V("1.0"))
 
+    def test_unevaluable_marker_in_metadata_drops_the_version(self) -> None:
+        """Index metadata with an undecidable marker loses only that version.
+
+        A declared source or an override stops the run instead: there the
+        marker is the user's to fix, while an index can serve another version.
+        """
+        bad_metadata = make_metadata("foo", "1.0", 'dep-a; sys_platform ~= "linux"')
+        coordinator = make_coordinator(
+            [make_wheel("1.0")], metadata_text=bad_metadata, package="foo"
+        )
+        provider = Provider(coordinator, target=_PY312)
+        with pytest.raises(MetadataError, match="cannot be evaluated"):
+            provider.get_dependencies("foo", V("1.0"))
+
+        assert provider.has_invalid_metadata("foo", V("1.0"))
+
     def test_malformed_requires_python_drops_candidate(self) -> None:
         """A version whose METADATA Requires-Python is invalid is refused.
 
@@ -3775,6 +3791,23 @@ class TestLocalSources:
         version, dist = versions[0]
         assert str(version) == "1.2.3"
         assert dist.url.startswith("file://")
+
+    def test_unevaluable_marker_names_the_marker(self, tmp_path: Path) -> None:
+        """A declared tree's undecidable marker stops the run, naming the marker."""
+
+        self._write_local(
+            tmp_path,
+            '[project]\nname = "foo"\nversion = "1.2.3"\n'
+            "dependencies = [\"dep-a; sys_platform ~= 'linux'\"]\n",
+        )
+        coordinator = make_coordinator([], package="foo")
+        provider = Provider(
+            coordinator,
+            local_sources=[LocalSource("foo", str(tmp_path))],
+            build_policy=BuildPolicy.NEVER,
+        )
+        with pytest.raises(UnevaluableMarkerError, match='sys_platform ~= "linux"'):
+            provider.get_dependencies("foo", V("1.2.3"))
 
     def test_local_source_root_requirement_skips_listing_request(
         self, tmp_path: Path
@@ -6373,6 +6406,22 @@ class TestSkipFetch:
             package_overrides=(pkg_override("foo", dependencies=()),),
         )
         assert provider.get_dependencies("foo", V("1.0")) == {}
+
+    def test_unevaluable_marker_names_the_marker(self) -> None:
+        """An override's undecidable marker stops the run, naming the marker."""
+        coordinator = make_coordinator([make_wheel("1.0")], package="foo")
+        provider = Provider(
+            coordinator,
+            target=_PY312,
+            package_overrides=(
+                pkg_override(
+                    "foo",
+                    dependencies=(Requirement('dep-a; sys_platform ~= "linux"'),),
+                ),
+            ),
+        )
+        with pytest.raises(UnevaluableMarkerError, match='sys_platform ~= "linux"'):
+            provider.get_dependencies("foo", V("1.0"))
 
     def test_prefetches_override_dependencies(self) -> None:
         # The override introduces dep-a, so its listing is background-fetched

--- a/nab-provider/src/nab_provider/_provider/listing.py
+++ b/nab-provider/src/nab_provider/_provider/listing.py
@@ -299,6 +299,10 @@ def filter_distributions(
     base = base_distributions(provider, normalized, files)
     result = _apply_wheel_tags(provider, normalized, base)
 
+    if len(result) == len(base):
+        # The tag pass only drops, so an equal length means an equal list.
+        provider.untrimmed_listings.add(normalized)
+
     if not result and len(base) < len(files):
         # The base pass (dist-policy, requires-python, upload cutoff) dropped a
         # file, so an empty result is not the tag pass alone.

--- a/nab-provider/src/nab_provider/_provider/metadata_resolver.py
+++ b/nab-provider/src/nab_provider/_provider/metadata_resolver.py
@@ -27,6 +27,7 @@ from ..errors import (
     UnsupportedSdistError,
 )
 from ..extra_keys import join_extra
+from ..marker_holds import evaluate_prepared
 from ..metadata import (
     DEPENDENCY_FIELDS,
     WheelMetadata,
@@ -661,7 +662,7 @@ def marker_matches_base(provider: Provider, marker: Marker, marker_id: int) -> b
     result = provider.marker_base_cache.get(marker_id)
     if result is None:
         provider.consulted_markers.add(marker)
-        result = marker.evaluate_prepared(provider.prepared_environment)
+        result = evaluate_prepared(marker, provider.prepared_environment)
         provider.marker_base_cache[marker_id] = result
     return result
 
@@ -696,7 +697,7 @@ def marker_matched_extras(
         result = per_marker.get(extra_name)
         if result is None:
             env["extra"] = extra_name
-            result = marker.evaluate_prepared(env)
+            result = evaluate_prepared(marker, env)
             per_marker[extra_name] = result
         if result:
             matched.add(extra_name)
@@ -1041,7 +1042,7 @@ def _classify_requirement_uncached(
     marker = req.marker
     if marker is None:
         return set()
-    if marker.evaluate_prepared(provider.prepared_environment):
+    if evaluate_prepared(marker, provider.prepared_environment):
         return set()
     if "extra" not in str(marker):
         return None
@@ -1049,7 +1050,7 @@ def _classify_requirement_uncached(
     matched: set[str] = set()
     for extra_name in provided_extras:
         env["extra"] = extra_name
-        if marker.evaluate_prepared(env):
+        if evaluate_prepared(marker, env):
             matched.add(extra_name)
     return matched or None
 

--- a/nab-provider/src/nab_provider/_provider/metadata_resolver.py
+++ b/nab-provider/src/nab_provider/_provider/metadata_resolver.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
+from functools import partial
 from typing import TYPE_CHECKING, Literal, NamedTuple, TypeGuard
 from urllib.parse import urlsplit
 
@@ -357,6 +358,8 @@ def version_dists(
 
     Only the provider's own cached listing is memoised: another listing under
     the same name is a different set of artifacts, so it is indexed fresh.
+    The half of the index no wheel tag reads is shared with this Python's
+    other targets when :func:`_shared_index` offers it.
     """
     cacheable = version_list is provider.versions_cache.get(normalized)
     if cacheable:
@@ -364,23 +367,70 @@ def version_dists(
         if cached is not None:
             return cached
 
+    shared = _shared_index(provider, normalized, version_list) if cacheable else None
+    grouped, sibling_wheels = (
+        shared if shared is not None else _group_versions(version_list)
+    )
+
+    tags = provider.wheel_tags
+    target = provider.target
+    indexed = VersionDists(
+        {v: pick_dist(dists, tags, target) for v, dists in grouped.items()},
+        sibling_wheels,
+    )
+
+    if cacheable:
+        provider.version_dists_cache[normalized] = indexed
+    return indexed
+
+
+def _shared_index(
+    provider: Provider,
+    normalized: str,
+    version_list: Sequence[tuple[Version, DistFile]],
+) -> tuple[dict[Version, list[DistFile]], dict[Version, list[WheelFile]]] | None:
+    """Return the shared version groups and sibling wheels, or None.
+
+    Neither half reads a wheel tag, so the targets of one Python can share
+    both.  They are indexing the same listing only when the tag pass left
+    this one whole, which makes it the base list
+    :class:`~nab_provider.provider.ListingFilterCache` already keys by
+    (package, Python).  Every one of those targets then holds the result, so
+    callers must not mutate it.
+
+    A resolve with one target per Python has no second target to share with,
+    so it takes the unshared path rather than storing an entry nothing will
+    read.
+    """
+    cache = provider.listing_filter_cache
+    if (
+        cache is None
+        or not cache.shares_targets
+        or normalized not in provider.untrimmed_listings
+    ):
+        return None
+
+    return cache.indexed(
+        normalized, provider.python_version, partial(_group_versions, version_list)
+    )
+
+
+def _group_versions(
+    version_list: Sequence[tuple[Version, DistFile]],
+) -> tuple[dict[Version, list[DistFile]], dict[Version, list[WheelFile]]]:
+    """Return ``version_list``'s dists grouped by version, and its sibling wheels."""
     grouped: dict[Version, list[DistFile]] = {}
     for version, dist in version_list:
         grouped.setdefault(version, []).append(dist)
 
-    picked: dict[Version, DistFile] = {}
     sibling_wheels: dict[Version, list[WheelFile]] = {}
     for version, dists in grouped.items():
-        picked[version] = pick_dist(dists, provider.wheel_tags, provider.target)
         if len(dists) > 1:
             wheels = [d for d in dists if isinstance(d, WheelFile)]
             if len(wheels) > 1:
                 sibling_wheels[version] = wheels
 
-    indexed = VersionDists(picked, sibling_wheels)
-    if cacheable:
-        provider.version_dists_cache[normalized] = indexed
-    return indexed
+    return grouped, sibling_wheels
 
 
 def pick_dist(

--- a/nab-provider/src/nab_provider/marker_holds.py
+++ b/nab-provider/src/nab_provider/marker_holds.py
@@ -35,18 +35,38 @@ class UnevaluableMarkerError(ValueError):
     """
 
 
+def _unevaluable(marker: Marker, exc: UndefinedComparison) -> UnevaluableMarkerError:
+    """Return the error for ``marker``, named in full.
+
+    The failing clause alone does not say which dependency to edit.
+    """
+    return UnevaluableMarkerError(f"marker {marker} cannot be evaluated: {exc}")
+
+
 def marker_set(marker: Marker) -> MarkerSet:
     """Return ``marker`` as a :class:`MarkerSet`.
 
     Building the set checks each clause against its operator, so a marker with
-    no meaning is caught here.  The error names the whole marker, since the
-    failing clause alone does not say which dependency to edit.
+    no meaning is caught here.
     """
     try:
         return MarkerSet.from_marker(marker)
     except UndefinedComparison as exc:
-        msg = f"marker {marker} cannot be evaluated: {exc}"
-        raise UnevaluableMarkerError(msg) from exc
+        raise _unevaluable(marker, exc) from exc
+
+
+def evaluate_prepared(
+    marker: Marker, environment: dict[str, str | AbstractSet[str]]
+) -> bool:
+    """Evaluate ``marker`` against a ``prepare_environment`` result.
+
+    A clause no comparison decides raises :class:`UnevaluableMarkerError`, as
+    it does through :func:`marker_set`.
+    """
+    try:
+        return marker.evaluate_prepared(environment)
+    except UndefinedComparison as exc:
+        raise _unevaluable(marker, exc) from exc
 
 
 def dependency_marker_holds(

--- a/nab-provider/src/nab_provider/provider.py
+++ b/nab-provider/src/nab_provider/provider.py
@@ -114,6 +114,7 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 _PreparedT = TypeVar("_PreparedT")
+_IndexT = TypeVar("_IndexT")
 
 
 @dataclass
@@ -188,18 +189,29 @@ class ListingFilterCache:
     since materialising the intermediate list would cost it a pass it does
     not get back.
 
+    :meth:`indexed` shares along the other axis: grouping a listing's
+    dists by version reads no wheel tags, so the targets of one Python
+    share the groups whenever the tag pass left the listing whole.  That
+    needs a second target on some Python, which :attr:`shares_targets`
+    records; without one the entry would be held for the whole resolve
+    and read by nobody.
+
     One instance is only valid across providers that share a coordinator
     and a policy config, as the targets of one resolve do.
     """
 
-    def __init__(self, pythons: int = 1) -> None:
-        """Create an empty cache for a resolve over ``pythons`` Python releases."""
+    def __init__(self, pythons: int = 1, targets: int = 1) -> None:
+        """Create an empty cache for ``targets`` targets over ``pythons`` Pythons."""
         self.shares_pythons = pythons > 1
+        # By pigeonhole this is "some Python has two targets", the only
+        # shape in which a second target reads what :meth:`indexed` stores.
+        self.shares_targets = targets > pythons
         self._entries: dict[
             tuple[str, str | None],
             tuple[list[tuple[Version, DistFile]], tuple[int, ...]],
         ] = {}
         self._prepared: dict[str, tuple[object, tuple[int, ...]]] = {}
+        self._indexes: dict[tuple[str, str | None], object] = {}
 
     def filtered(
         self,
@@ -248,6 +260,28 @@ class ListingFilterCache:
         result = compute()
 
         self._prepared[package] = (result, _since(before, stats))
+        return result
+
+    def indexed(
+        self,
+        package: str,
+        python_version: str | None,
+        compute: Callable[[], _IndexT],
+    ) -> _IndexT:
+        """Return the tag-invariant version index, running ``compute`` once.
+
+        Keyed like :meth:`filtered`, since the caller only offers a listing
+        the wheel-tag pass left equal to that base list.  ``compute`` raises
+        no counters, so a hit has nothing to replay, and the result is
+        shared, so the caller must treat it as read-only.
+        """
+        key = (package, python_version)
+        entry = self._indexes.get(key)
+        if entry is not None:
+            return cast("_IndexT", entry)
+
+        result = compute()
+        self._indexes[key] = result
         return result
 
 
@@ -558,6 +592,9 @@ class Provider:
         self.root_requirements = root_requirements or {}
         self.constraints: Mapping[str, VersionRange] = constraints or {}
         self.versions_cache: dict[str, list[tuple[Version, DistFile]]] = {}
+        # Canonical names whose ``versions_cache`` listing the wheel-tag pass
+        # left whole, so it is still the pre-tag list.
+        self.untrimmed_listings: set[str] = set()
         self.deps_cache: dict[tuple[str, Version], dict[str, VersionRange]] = {}
         # Metadata the pipelined scan prefetched, as ``(version string, sidecar
         # URL)``, decoded on the first read of that candidate.  A candidate the

--- a/nab-provider/tests/test_provider_declared_target.py
+++ b/nab-provider/tests/test_provider_declared_target.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Any, cast
 import pytest
 
 from nab_provider._provider import listing as listing_mod
+from nab_provider._provider import metadata_resolver as metadata_mod
 from nab_provider._vendor.packaging.ranges import VersionRange
 from nab_provider._vendor.packaging.requirements import Requirement
 from nab_provider._vendor.packaging.version import Version
@@ -461,7 +462,9 @@ class TestStrategyChoiceVersion:
         assert chosen == Version("3.0")
 
 
-def _platform_wheel(version: str, tag: str, *, package: str = "pkg") -> WheelFile:
+def _platform_wheel(
+    version: str, tag: str, *, package: str = "pkg", has_metadata: bool = True
+) -> WheelFile:
     """Build a wheel with an explicit ``cpXY-cpXY-<platform>`` tag."""
     filename = f"{package}-{version}-{tag}.whl"
     return WheelFile(
@@ -469,7 +472,7 @@ def _platform_wheel(version: str, tag: str, *, package: str = "pkg") -> WheelFil
         url=f"https://example.com/{filename}",
         version=version,
         requires_python=None,
-        has_metadata=True,
+        has_metadata=has_metadata,
         upload_time=None,
     )
 
@@ -811,6 +814,142 @@ class TestEqualVersionCanonicalization:
         assert windows.fetch_versions("pkg") == []
         assert windows.stats.excluded_by_wheel_tags == 2
         assert windows.stats.excluded_versions_no_compatible_wheel == 1
+
+
+class TestVersionIndexSharedAcrossTargets:
+    """A matrix shares the half of the version index no target's tags change."""
+
+    @staticmethod
+    def _providers(
+        files: Sequence[WheelFile | SdistFile],
+        cache: ListingFilterCache,
+        targets: Sequence[ResolveTarget],
+    ) -> list[Provider]:
+        """One provider per target, over one listing and one filter cache."""
+        coordinator = _index_with_files(files)
+        return [
+            Provider(coordinator, target, listing_filter_cache=cache)
+            for target in targets
+        ]
+
+    @classmethod
+    def _platform_providers(
+        cls, files: Sequence[WheelFile | SdistFile], cache: ListingFilterCache
+    ) -> list[Provider]:
+        """A linux and a windows 3.11 target over one listing and one cache."""
+        return cls._providers(
+            files,
+            cache,
+            [
+                _linux_target(PlatformSpec("linux_x86_64")),
+                _linux_target(PlatformSpec("windows_amd64")),
+            ],
+        )
+
+    @staticmethod
+    def _indexed(provider: Provider) -> metadata_mod.VersionDists:
+        """Index ``pkg``'s listing for ``provider``, as the metadata path does."""
+        return metadata_mod.version_dists(
+            provider, "pkg", provider.fetch_versions("pkg")
+        )
+
+    @staticmethod
+    def _two_universal_wheels() -> list[WheelFile | SdistFile]:
+        """One version publishing two wheels every target installs."""
+        return [
+            _platform_wheel("1.0", "py3-none-any"),
+            _platform_wheel("1.0", "py2.py3-none-any"),
+        ]
+
+    def test_targets_keeping_the_whole_listing_share_one_index(self) -> None:
+        """Both targets accept both wheels, so both index the same base list.
+
+        The sibling wheels come back as one object, so the second target
+        of this Python does not walk the listing again.
+        """
+        linux, windows = self._platform_providers(
+            self._two_universal_wheels(), ListingFilterCache(targets=2)
+        )
+
+        linux_index = self._indexed(linux)
+        windows_index = self._indexed(windows)
+
+        assert linux_index.sibling_wheels is windows_index.sibling_wheels
+        assert len(linux_index.sibling_wheels[Version("1.0")]) == 2
+
+        assert set(linux_index.picked) == {Version("1.0")}
+        assert set(windows_index.picked) == {Version("1.0")}
+
+    def test_a_trimmed_target_indexes_its_own_listing(self) -> None:
+        """Windows refuses the manylinux wheel, so 2.0 is not one of its versions.
+
+        Linux indexes first and fills the shared entry.  Windows shares
+        the Python and the package, so keying on those alone would hand
+        it a version its tags dropped.
+        """
+        files = [
+            _platform_wheel("1.0", "py3-none-any"),
+            _platform_wheel("2.0", "cp311-cp311-manylinux_2_17_x86_64"),
+        ]
+        linux, windows = self._platform_providers(files, ListingFilterCache(targets=2))
+
+        linux_index = self._indexed(linux)
+        windows_index = self._indexed(windows)
+
+        assert set(linux_index.picked) == {Version("1.0"), Version("2.0")}
+        assert set(windows_index.picked) == {Version("1.0")}
+
+    def test_the_pick_is_rebuilt_per_target_off_the_shared_groups(self) -> None:
+        """Two targets read one set of groups and still pick different wheels.
+
+        Neither loses a file to the tag pass, so both take the shared
+        groups.  The faithful target ranks by wheel tags and takes the
+        manylinux wheel; the overlay target moved off its tag axis, so it
+        takes the wheel that carries metadata.
+        """
+        files = [
+            _platform_wheel("1.0", "py3-none-any"),
+            _platform_wheel(
+                "1.0", "cp311-cp311-manylinux_2_17_x86_64", has_metadata=False
+            ),
+        ]
+        faithful_target = _linux_target(PlatformSpec("linux_x86_64"))
+        overlay_target = faithful_target.with_marker_overrides(
+            {"platform_machine": "aarch64"}
+        )
+        faithful, overlay = self._providers(
+            files, ListingFilterCache(targets=2), [faithful_target, overlay_target]
+        )
+
+        faithful_index = self._indexed(faithful)
+        overlay_index = self._indexed(overlay)
+
+        assert faithful_index.sibling_wheels is overlay_index.sibling_wheels
+        assert len(faithful_index.sibling_wheels[Version("1.0")]) == 2
+
+        faithful_pick = faithful_index.picked[Version("1.0")]
+        overlay_pick = overlay_index.picked[Version("1.0")]
+        assert faithful_pick.filename.endswith("manylinux_2_17_x86_64.whl")
+        assert overlay_pick.filename.endswith("py3-none-any.whl")
+
+    def test_one_target_per_python_shares_nothing(self) -> None:
+        """A cache built for a one-target resolve hands out no shared index.
+
+        The second provider is that same target under another conflict
+        fork, and it groups the listing again rather than reading what
+        the first one built.
+        """
+        first, second = self._providers(
+            self._two_universal_wheels(),
+            ListingFilterCache(),
+            [_linux_target(PlatformSpec("linux_x86_64"))] * 2,
+        )
+
+        first_index = self._indexed(first)
+        second_index = self._indexed(second)
+
+        assert first_index.sibling_wheels == second_index.sibling_wheels
+        assert first_index.sibling_wheels is not second_index.sibling_wheels
 
 
 class TestListingFilterSharedAcrossPythons:

--- a/tasks/check_engine_markersets.py
+++ b/tasks/check_engine_markersets.py
@@ -72,8 +72,8 @@ EXEMPT = {
     "nab_project._lockfile.coverage": ("Same edge as _lockfile.disjointness."),
     "nab_provider.marker_holds": (
         "Where the marker-set dependency lives so the engine does not import "
-        "it. Reached here only through target, requirements_file and "
-        "_lockfile.validate."
+        "it. Reached here through target, requirements_file, "
+        "_provider.metadata_resolver and _lockfile.validate."
     ),
     "nab_provider._vendor.packaging.markersets": "The marker-set module itself.",
 }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1612,6 +1612,31 @@ class TestLockCommandSpecific:
         assert "has dynamic metadata" in err
         assert "Traceback" not in err
 
+    def test_local_source_unevaluable_marker_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A declared tree's undecidable marker exits 1, not a traceback."""
+        member = tmp_path / "mylocal"
+        member.mkdir()
+        (member / "pyproject.toml").write_text(
+            '[project]\nname = "mylocal"\nversion = "1.0"\n'
+            "dependencies = [\"somepkg; sys_platform ~= 'linux'\"]\n"
+        )
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\nname = "root"\nversion = "0"\n'
+            'dependencies = ["mylocal"]\n'
+            "[[tool.nab.local-sources]]\n"
+            'name = "mylocal"\n'
+            'path = "mylocal"\n',
+        )
+        with pytest.raises(SystemExit, match="1"):
+            lock(pyproject, offline=True, output=Path("-"), cache=False)
+        err = capsys.readouterr().err
+        assert 'cannot lock: marker sys_platform ~= "linux"' in err
+        assert "cannot be evaluated" in err
+        assert "Traceback" not in err
+
     def test_local_source_naming_another_project_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:


### PR DESCRIPTION
`max-25-tuples` (dask over 5 Pythons and 5 platforms, 285 decisions) loses 54,141,532 instructions of 2,113,132,552, 2.56%, under callgrind with `PYTHONHASHSEED=0`. A second run of the same comparison gives 54,030,438, and two runs of the base itself differ by 105,986.

Stacked on #1019, so the diff and every number here are against that branch.

`version_dists` groups a package's listing by version, builds the sibling-wheel map, then picks one dist per version for the target. Only the pick reads wheel tags, so every target of one Python was rebuilding the same two dicts. The branch builds them once per (package, Python) and shares them, keyed the way the listing cache already keys that pre-tag list; a target whose listing the tag pass trimmed is indexing a different list and still builds its own.

| scenario | targets | base instructions | change |
| --- | ---: | ---: | ---: |
| `max-25-tuples` | 25 | 2,113,132,552 | -54,141,532 (-2.56%) |
| `scientific-python-multi` | 12 | 5,070,207,544 | -9,958,924 (-0.20%) |
| `numpy-wide-python-diverge` | 5, one per Python | 2,190,984,554 | +362,378 (+0.02%) |
| `pip:google-bigquery-soda@lowest` | 1 | 4,542,988,117 | +305,478 (+0.007%) |

How much it wins depends on how much the tag pass trims. On `max-25-tuples` the 260 listings that reach the grouping carry 29,734 entries, and the branch walks 76 of them, 6,794 entries: 51 built once per (package, Python), 25 by targets the tag pass trimmed.

`scientific-python-multi` is numpy, scipy, pandas, matplotlib and scikit-learn, whose wheels are mostly platform-specific, so most of its targets index a trimmed listing and it still walks 15,053 of its 21,035 entries. Its two runs give -9,958,924 and -11,649,028 against a base spread of 1,428,559, so that win is between about 10.0 and 11.6 million.

A resolve with nothing to share pays for one extra pass over the groups, and for the set recording which listings came through the tag pass whole. `numpy-wide-python-diverge` repeats at +399,234 against a base spread of 153,661, so its 0.02% is a real cost rather than drift; the canary row is a single comparison.

Peak memory on that path is inside about 0.02% either way: +2,663 traced bytes of 27.1 MB, against two base runs differing by 4,578, with 42 more live blocks at exit and the same GC collection counts.

Both matrices emit a lock byte-identical to the base's and reach the same decisions, 285 and 234.

The clock cannot see a change this size. Twelve runs of `universal_scenarios.py --scenario max-25-tuples` on the base and twelve on the branch rule out a wall regression above about 3.7% and a peak-RSS regression above about 5.0% locally.
