### PR TITLE
Fix build-env cleanup deleting the wrong module's cached bytecode

### DIFF
--- a/nab-project/src/nab_project/_build/env.py
+++ b/nab-project/src/nab_project/_build/env.py
@@ -22,6 +22,7 @@ from ``build.env.IsolatedEnv``.
 
 from __future__ import annotations
 
+import glob
 import json
 import logging
 import os
@@ -695,6 +696,9 @@ def _remove_files(entries: list[tuple[Path, Path]]) -> None:
     run in this venv, so a removed package has usually been imported,
     and the ``__pycache__`` that import wrote would keep its directory
     importable as a namespace package.
+
+    A wheel member's name can hold glob syntax, so the stem is escaped
+    before the cache is searched for it.
     """
     directories: set[Path] = set()
     roots: set[Path] = set()
@@ -705,7 +709,7 @@ def _remove_files(entries: list[tuple[Path, Path]]) -> None:
 
         if target.suffix == ".py":
             cache = target.parent / "__pycache__"
-            for compiled in cache.glob(f"{target.stem}.*.pyc"):
+            for compiled in cache.glob(f"{glob.escape(target.stem)}.*.pyc"):
                 compiled.unlink()
             directories.add(cache)
 

--- a/nab-project/tests/test_build_runner.py
+++ b/nab-project/tests/test_build_runner.py
@@ -47,6 +47,7 @@ from nab_project._build.env import (
     NabBuildEnv,
     _FastSchemeDictionaryDestination,
     _PendingBuild,
+    _remove_files,
     _venv_scheme_paths,
 )
 from nab_project._build.runner import (
@@ -3754,6 +3755,61 @@ class TestBuildEnvFollowUpInstall:
         env.install(["probefoo<2"])
 
         assert not (site / "probebar").exists()
+
+    def test_bytecode_of_a_module_named_like_a_pattern_goes_with_it(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Glob syntax in a wheel member name does not strand its bytecode."""
+        env, scheme, site = self._env(tmp_path, monkeypatch)
+
+        kept = tmp_path / "probefoo-1.0-py3-none-any.whl"
+        _make_installable_wheel(kept, "probefoo", "1.0")
+        dropped = tmp_path / "probebar-1.0-py3-none-any.whl"
+        _make_installable_wheel(
+            dropped, "probebar", "1.0", package_files={"mod[1].py": b""}
+        )
+        env._install_wheels([kept, dropped], scheme)
+
+        compiled = Path(cache_from_source(str(site / "probebar" / "mod[1].py")))
+        compiled.parent.mkdir()
+        compiled.write_bytes(b"")
+
+        monkeypatch.setattr(env, "_resolve_and_download", lambda *_a, **_k: [kept])
+
+        env.install(["probefoo<2"])
+
+        assert not (site / "probebar").exists()
+
+
+# Windows rejects ``*`` and ``?`` in a filename, leaving the bracket stem.
+_GLOB_PATTERN_STEMS = ["mod[1]"]
+if sys.platform != "win32":
+    _GLOB_PATTERN_STEMS += ["mod*", "mod?", "mod**"]
+
+
+class TestRemoveFilesNameEscaping:
+    """An installed file's name is matched literally, not as glob syntax."""
+
+    @pytest.mark.parametrize("stem", _GLOB_PATTERN_STEMS)
+    def test_a_module_named_like_a_pattern_takes_only_its_own_bytecode(
+        self, tmp_path: Path, stem: str
+    ) -> None:
+        """``mod1`` is the neighbour an unescaped ``mod[1]`` would match."""
+        package = tmp_path / "pkg"
+        package.mkdir()
+        (package / f"{stem}.py").write_bytes(b"")
+        (package / "mod1.py").write_bytes(b"")
+
+        removed = Path(cache_from_source(str(package / f"{stem}.py")))
+        kept = Path(cache_from_source(str(package / "mod1.py")))
+        removed.parent.mkdir()
+        removed.write_bytes(b"")
+        kept.write_bytes(b"")
+
+        _remove_files([(tmp_path, Path(f"pkg/{stem}.py"))])
+
+        assert not removed.exists()
+        assert kept.is_file()
 
 
 class TestVenvSchemeProbeErrors:


### PR DESCRIPTION
A build dependency shipping a `.py` file whose name contains glob syntax makes the build env's cleanup delete a different module's bytecode. The name goes into a `__pycache__` glob unescaped:

- `mod[1].py` searches for `mod[1].*.pyc`, so the neighbour `mod1` loses its `mod1.cpython-312.pyc` and `mod[1]` keeps its own.
- `mod*.py` reaches every neighbour whose name starts with `mod`, and `mod?.py` every one named `mod` plus a character.
- `mod**.py` builds a pattern `pathlib` rejects on Python 3.12 and older, and `ValueError` is not an `OSError`, so it leaves `run_build_backend` unwrapped:

```
ValueError: Invalid pattern: '**' can only be an entire path component
```

Cleanup runs when a backend's `get_requires_for_build_wheel` asks for extra requirements: the inner resolve produces the whole build env, so the previous install comes out before the new one goes in. The removal exists to stop a `.pyc` being stranded, since `__pycache__` then never empties and the package directory survives, importable as a namespace package for the rest of the build.

The stem now goes through `glob.escape`.
