### PR TITLE
Fix RecursionError crash on an sdist of chained link members

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -758,8 +758,9 @@ def extract_sdist_archive(
     """Extract a .tar.gz sdist into ``target_dir`` and return the source root.
 
     Anything the extractor cannot read raises :class:`ValueError`: a corrupt or
-    truncated stream, a tar that will not open, and a member the tar ``data``
-    filter (:pep:`706`) refuses.  The filter refuses any member that would write
+    truncated stream, a tar that will not open, a chain of link members long
+    enough to exhaust the stack, and a member the tar ``data`` filter
+    (:pep:`706`) refuses.  The filter refuses any member that would write
     outside ``target_dir`` (absolute paths, ``..``, escaping links), is a special
     file (device node, FIFO), or is a hard link whose target the archive does not
     carry.  A lone top-level directory that wraps every member is the source
@@ -786,10 +787,11 @@ def extract_sdist_archive(
     except KeyError as exc:
         msg = f"broken link in sdist member: {exc}"
         raise ValueError(msg) from exc
-    except (tarfile.TarError, OSError, EOFError, zlib.error) as exc:
+    except (tarfile.TarError, OSError, EOFError, zlib.error, RecursionError) as exc:
         # gzip raises BadGzipFile (an OSError) on a bad header, a bare EOFError on
         # a truncated stream, and zlib.error on a corrupt deflate block; none of
-        # them is a TarError.
+        # them is a TarError.  RecursionError comes from tarfile recursing once
+        # per link to resolve a chain of link members.
         msg = f"unreadable sdist archive: {exc}"
         raise ValueError(msg) from exc
 

--- a/nab-project/tests/test_archive.py
+++ b/nab-project/tests/test_archive.py
@@ -15,8 +15,10 @@ import hashlib
 import inspect
 import io
 import os
+import sys
 import tarfile
 import textwrap
+import traceback
 import zlib
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn
@@ -1294,6 +1296,49 @@ class TestExtractArchive:
         out.mkdir()
         with pytest.raises(ValueError, match="broken link in sdist member"):
             extract_sdist_archive(buf.getvalue(), out)
+
+    @requires_data_filter
+    def test_chained_link_members_raise_value_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A chain of link members is an unreadable archive, not a crash.
+
+        tarfile recurses once per link either way: it copies a link's target
+        when it cannot create the link, and it resolves the destination through
+        the links it did create.  A long enough chain runs out of stack.
+        Refusing os.symlink, as a Windows host without the privilege does, pins
+        this to the copying path.
+        """
+
+        def refuse_symlink(*_args: object, **_kwargs: object) -> NoReturn:
+            raise OSError(errno.EPERM, "symbolic link privilege not held")
+
+        monkeypatch.setattr(os, "symlink", refuse_symlink)
+
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            directory = tarfile.TarInfo("foo-1.0.0")
+            directory.type = tarfile.DIRTYPE
+            tar.addfile(directory)
+
+            for index in range(200):
+                link = tarfile.TarInfo(f"foo-1.0.0/link{index}")
+                link.type = tarfile.SYMTYPE
+                link.linkname = f"link{index - 1}" if index else "absent"
+                tar.addfile(link)
+
+        out = tmp_path / "out"
+        out.mkdir()
+
+        original = sys.getrecursionlimit()
+        try:
+            # Just above the current depth, so the chain overruns the limit
+            # whatever this interpreter starts with.
+            sys.setrecursionlimit(len(traceback.extract_stack()) + 100)
+            with pytest.raises(ValueError, match="unreadable sdist archive"):
+                extract_sdist_archive(buf.getvalue(), out)
+        finally:
+            sys.setrecursionlimit(original)
 
     @requires_data_filter
     @pytest.mark.parametrize(


### PR DESCRIPTION
`nab lock` ends on a raw traceback when an sdist it extracts is a tar whose members are a chain of links:

    RecursionError: maximum recursion depth exceeded

tarfile recurses per link on both routes it can take:

- it copies a link's target when the host refuses to create the link, recursing back into member extraction
- it resolves the destination through the links it did create, recursing inside `os.path.realpath` in the data filter

Either way that is a frame or two per link, so a chain of about a thousand members overruns the default limit.

`extract_sdist_archive` turns every other unreadable archive into a `ValueError`, and its three callers rely on that: a PyPI sdist that will not open is skipped and the resolve moves on, while a declared source or a build requirement ends the resolve with a message rather than a traceback.

`RecursionError` now joins the exceptions extraction normalises, next to a truncated stream, a bad gzip header and a corrupt deflate block.
