### PR TITLE
Reuse version_dists' wheels in pick_dist, 20M instructions off max-25-tuples

### DIFF
--- a/nab-provider/src/nab_provider/_provider/metadata_resolver.py
+++ b/nab-provider/src/nab_provider/_provider/metadata_resolver.py
@@ -376,11 +376,14 @@ def version_dists(
     picked: dict[Version, DistFile] = {}
     sibling_wheels: dict[Version, list[WheelFile]] = {}
     for version, dists in grouped.items():
-        picked[version] = pick_dist(dists, provider.wheel_tags, provider.target)
+        # Selected before the pick, which reuses them rather than selecting again.
+        wheels: list[WheelFile] | None = None
         if len(dists) > 1:
             wheels = [d for d in dists if isinstance(d, WheelFile)]
             if len(wheels) > 1:
                 sibling_wheels[version] = wheels
+
+        picked[version] = pick_dist(dists, provider.wheel_tags, provider.target, wheels)
 
     indexed = VersionDists(picked, sibling_wheels)
     if cacheable:
@@ -392,10 +395,13 @@ def pick_dist(
     dists: Sequence[DistFile],
     tags: TagSet | None,
     target: ResolveTarget | None = None,
+    wheels: list[WheelFile] | None = None,
 ) -> DistFile:
     """Pick the dist of one version whose metadata answers for the target.
 
     ``dists`` are the artifacts of a single version, and must be non-empty.
+    ``wheels`` is those dists' wheels in listing order, for a caller that
+    already holds them; they are selected from ``dists`` otherwise.
 
     Sibling wheels of one version can declare different dependencies, so
     the wheel the ``tags`` rank most specific wins: :pep:`425` is what an
@@ -418,7 +424,8 @@ def pick_dist(
     if len(dists) == 1:
         return dists[0]
 
-    wheels = [d for d in dists if isinstance(d, WheelFile)]
+    if wheels is None:
+        wheels = [d for d in dists if isinstance(d, WheelFile)]
     if not wheels:
         return dists[0]
 


### PR DESCRIPTION
`version_dists` selects each version's wheels to find its sibling wheels, then `pick_dist` selects the same wheels out of the same dists again. On a `max-25-tuples` run (dask on 5 Pythons by 5 platforms) that second pass runs on 13,499 of the loop's 16,210 picks, over 27,023 dists. `pick_dist` now takes the list the loop already holds.

| workload | base | branch | change |
| --- | ---: | ---: | ---: |
| `max-25-tuples` | 4,106,787,665 | 4,086,324,559 | -20,463,106 (-0.50%) |
| `max-25-tuples` repeat | 4,106,006,106 | 4,085,385,197 | -20,620,909 (-0.50%) |
| `pip:google-bigquery-soda@lowest` | 4,225,401,145 | 4,221,421,721 | -3,979,424 (-0.09%) |

Instructions under callgrind with `PYTHONHASHSEED=0`. Soda repeats the selection on 2,696 of its 3,601 picks, so it wins less.

`sibling_wheels` now holds the same list the pick is handed; `pick_dist` rebinds rather than mutates it. The 2,711 `max-25-tuples` picks on a version publishing one dist pay for an argument they never read. The timing run could not resolve anything under about 8%, so it rules out a wall regression above that.