### PR TITLE
Document post-release literals among the markers that stop a lock

### DIFF
--- a/docs/explanation/universal.md
+++ b/docs/explanation/universal.md
@@ -201,7 +201,7 @@ operators (`<`, `<=`, `>`, `>=`) and the ones naming a region (`==`,
 into an interval is a loud error rather than a silent guess: a
 membership test (`in`, `not in`), a verbatim `===`, a non-version
 comparison, a comparison against another marker variable, or certain
-prerelease literals strictly inside the minor.
+pre- or post-release literals strictly inside the minor.
 
 To resolve a minor as one real release rather than split it, name the
 patch you deploy on:

--- a/docs/reference/lockfile.md
+++ b/docs/reference/lockfile.md
@@ -322,10 +322,17 @@ A consulted `python_full_version` marker, or on CPython an
 `implementation_version` one, that cannot be tiled into an interval is
 a loud error rather than a pin of the whole minor to one answer: a
 membership (`in` / `not in`), a verbatim `===`, a non-version string
-comparison, a comparison against another variable, or a
-prerelease-version literal strictly inside the minor on an operator that
-fixes the boundary at the literal (`<`, `>=`, `==`, `!=`, `~=`). On `<=`
-or `>` a prerelease literal lands at the next release and tiles cleanly.
+comparison, a comparison against another variable, a literal PEP 440
+refuses under the operator it is written with (`< "3.12.*"`, `~= "3"`),
+or a pre- or post-release literal strictly inside the minor on one of
+the operators below.
+
+A prerelease literal is an error on `<`, `>=`, `==`, `!=` and `~=`, and
+a literal that is only a post-release on `>=`, `==`, `!=` and `~=`.
+Every other operator lands the boundary on a real micro:
+`<= "3.12.4rc1"` and `> "3.12.4rc1"` cut at 3.12.4, and
+`< "3.12.4.post1"`, `<= "3.12.4.post1"` and `> "3.12.4.post1"` at
+3.12.5.
 
 `platform_release` and `platform_version` are never declared: they
 name one machine's kernel build, so a lock carrying the resolving

--- a/nab-provider/tests/test_target.py
+++ b/nab-provider/tests/test_target.py
@@ -1442,6 +1442,22 @@ class TestMicroBoundarySplitting:
         assert [str(point) for point in found] == ["3.12.5"]
 
     @pytest.mark.parametrize(
+        ("marker", "points"),
+        [
+            ('python_full_version > "3.12.4rc1"', ["3.12.4"]),
+            ('python_full_version > "3.12.4.post1"', ["3.12.5"]),
+        ],
+    )
+    def test_an_after_literal_pre_or_post_release_splits_above_the_literal(
+        self, marker: str, points: list[str]
+    ) -> None:
+        """``>`` puts its boundary past the literal, so it lands on a real
+        micro either way: a prerelease cuts at its own release, 3.12.4, and a
+        post release at the one after it, 3.12.5."""
+        found = micro_boundary_points(self._target(), [Marker(marker)])
+        assert [str(point) for point in found] == points
+
+    @pytest.mark.parametrize(
         "marker",
         [
             "python_full_version < python_version",
@@ -1452,7 +1468,9 @@ class TestMicroBoundarySplitting:
             'python_full_version in "3.12.4"',
             'python_full_version not in "3.12.4"',
             'python_full_version < "3.12.4rc1"',
+            'python_full_version >= "3.12.4rc1"',
             'python_full_version == "3.12.4rc1"',
+            'python_full_version != "3.12.4rc1"',
             'python_full_version ~= "3.12.4b1"',
             '"3.12.4" ~= python_full_version',
             '"3.12.4rc1" == python_full_version',


### PR DESCRIPTION
`docs/reference/lockfile.md` lists the consulted `python_full_version` markers that stop a lock, and post-release literals were missing from it. The error already names them:

    consulted marker clause python_full_version >= "3.12.4.post1" cannot tile the py312-linux_x86_64 minor interval: no micro boundary the lock can render comes from a python_full_version membership, a verbatim ===, a comparison against a variable, a pre- or post-release comparison, or a literal the operator cannot spell as a version bound

A post-release does not fold into the prerelease sentence the page already had, because the operator sets differ:

| literal inside the minor | error on | tiles cleanly on |
| --- | --- | --- |
| `3.12.4rc1` | `<`, `>=`, `==`, `!=`, `~=` | `<=` and `>`, cutting at 3.12.4 |
| `3.12.4.post1` | `>=`, `==`, `!=`, `~=` | `<`, `<=` and `>`, cutting at 3.12.5 |

A prerelease sorts just under its release and a post just over it, so `<` pushes a post-release boundary onto the next real micro while it leaves a prerelease boundary between two micros.

The page also skipped the last case in the message, a literal PEP 440 refuses under the operator it is written with (`< "3.12.*"`, `~= "3"`). `docs/explanation/universal.md` had the same prerelease-only wording and now says pre- or post-release.
