### PR TITLE
Stop a floating VCS ref resolving against the invoking checkout's config

### DIFF
--- a/nab-index/src/nab_index/vcs.py
+++ b/nab-index/src/nab_index/vcs.py
@@ -204,16 +204,26 @@ def _resolve_sha(
     # companion refs/tags/<name>^{} line, so without it an annotated tag
     # would resolve to the tag object rather than the commit it points at.
     ls_remote_args = ["git", "ls-remote", request.repo_url, target, f"{target}^{{}}"]
+
+    # Resolve from a scratch directory: git finds its repository by walking up
+    # from the working directory, so a ``url.<base>.insteadOf`` rewrite in the
+    # checkout nab was invoked from would resolve the ref at one repository
+    # while the clone fetches the commit from another.
     try:
-        proc = subprocess.run(  # noqa: S603 - URL admission upstream
-            ls_remote_args,
-            check=True,
-            capture_output=True,
-            env=_git_env(),
-            timeout=_LS_REMOTE_TIMEOUT_SECONDS,
-        )
+        with tempfile.TemporaryDirectory(
+            prefix="nab-ls-remote-",
+            ignore_cleanup_errors=True,
+        ) as scratch:
+            proc = subprocess.run(  # noqa: S603 - URL admission upstream
+                ls_remote_args,
+                check=True,
+                capture_output=True,
+                cwd=scratch,
+                env=_git_env(Path(scratch)),
+                timeout=_LS_REMOTE_TIMEOUT_SECONDS,
+            )
     except (
-        FileNotFoundError,
+        OSError,
         subprocess.CalledProcessError,
         subprocess.TimeoutExpired,
     ) as exc:
@@ -264,7 +274,7 @@ def _shallow_clone(repo_url: str, sha: str, dest: Path) -> None:
     :func:`tempfile.mkdtemp`, so it already exists.
     """
     dest.mkdir(parents=True, exist_ok=True)
-    env = _git_env()
+    env = _git_env(dest)
 
     init_args = ["git", "init", "--quiet"]
     fetch_args = ["git", "fetch", "--quiet", "--depth", "1", repo_url, sha]
@@ -308,17 +318,21 @@ def _shallow_clone(repo_url: str, sha: str, dest: Path) -> None:
         raise VcsCloneError(msg) from exc
 
 
-def _git_env() -> dict[str, str]:
-    """Return an environment for git subprocesses.
+def _git_env(cwd: Path) -> dict[str, str]:
+    """Return an environment for a git subprocess running in ``cwd``.
 
     Disables interactive prompts and any auto-detected user config so
-    the clone fails fast on unauthenticated repos rather than hanging,
-    and drops the inherited repo-selection variables so every call acts
-    on the directory nab passes as ``cwd``.
+    the clone fails fast on unauthenticated repos rather than hanging.
+    Drops the inherited repo-selection variables and confines repository
+    discovery to ``cwd``, so no surrounding checkout is found.
     """
     env = dict(os.environ)
     for name in _REPO_SELECTION_VARS:
         env.pop(name, None)
+
+    # git stops the walk before a ceiling directory, so naming the parent
+    # leaves ``cwd`` as the only place it can find a repository.
+    env["GIT_CEILING_DIRECTORIES"] = str(cwd.resolve().parent)
 
     env["GIT_TERMINAL_PROMPT"] = "0"
     env.setdefault("GIT_CONFIG_GLOBAL", "/dev/null")

--- a/nab-project/tests/test_vcs.py
+++ b/nab-project/tests/test_vcs.py
@@ -6,7 +6,9 @@ here; integration tests live alongside the runner.
 
 from __future__ import annotations
 
+import shutil
 import subprocess
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -270,6 +272,25 @@ class TestResolveSha:
             raise FileNotFoundError("git not on PATH")
 
         monkeypatch.setattr(subprocess, "run", boom)
+        req = VcsRequest("git", "https://x", "main", "")
+        with pytest.raises(VcsCloneError):
+            _resolve_sha(req, require_pin=False)
+
+    def test_unusable_scratch_directory_raises(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A scratch directory nab cannot create surfaces as a clone error.
+
+        The temporary root is a regular file, so ``mkdtemp`` fails with a
+        ``NotADirectoryError`` rather than the ``FileNotFoundError`` a
+        missing ``git`` binary raises.
+        """
+        not_a_directory = tmp_path / "tmp"
+        not_a_directory.write_text("")
+        monkeypatch.setattr(tempfile, "tempdir", str(not_a_directory))
+
         req = VcsRequest("git", "https://x", "main", "")
         with pytest.raises(VcsCloneError):
             _resolve_sha(req, require_pin=False)
@@ -739,6 +760,98 @@ class TestAmbientGitEnvironment:
         assert "could not be marked complete" in message
         assert "failed to clone" not in message
         assert list((tmp_path / "vcs").rglob("*.tmp")) == []
+
+
+class TestAmbientGitRepository:
+    """A checkout nab is invoked from must not configure nab's git calls."""
+
+    def _run_git(self, args: list[str], cwd: Path) -> str:
+        """Run git with ``args`` in ``cwd`` and return its stripped stdout."""
+        git = shutil.which("git")
+        assert git is not None
+        proc = subprocess.run(  # noqa: S603 - git is a runtime dep
+            [git, *args],
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return proc.stdout.strip()
+
+    def _commit_repo(self, path: Path, content: str) -> str:
+        """Create a one-commit repo on ``main`` at ``path``, returning its SHA."""
+        path.mkdir()
+        self._run_git(["init", "--quiet", "-b", "main"], path)
+        (path / "f.txt").write_text(content)
+        self._run_git(["add", "f.txt"], path)
+        self._run_git(
+            [
+                "-c",
+                "user.name=nab tests",
+                "-c",
+                "user.email=tests@example.invalid",
+                "commit",
+                "--quiet",
+                "--no-gpg-sign",
+                "-m",
+                content,
+            ],
+            path,
+        )
+        return self._run_git(["rev-parse", "HEAD"], path)
+
+    def _rewriting_checkout(self, tmp_path: Path) -> tuple[Path, str, str]:
+        """Build an origin, a diverged mirror, and a checkout that swaps them.
+
+        The checkout's local config rewrites the origin's URL to the
+        mirror's, so any git command that reads that config answers from
+        the wrong repository.  Returns the checkout, the origin's URL,
+        and the SHA the origin's ``main`` names.
+        """
+        origin_sha = self._commit_repo(tmp_path / "origin", "origin")
+        mirror_sha = self._commit_repo(tmp_path / "mirror", "mirror")
+        assert origin_sha != mirror_sha
+
+        origin_url = (tmp_path / "origin").as_uri()
+        mirror_url = (tmp_path / "mirror").as_uri()
+
+        work = tmp_path / "work"
+        work.mkdir()
+        self._run_git(["init", "--quiet"], work)
+        self._run_git(
+            ["config", "--local", f"url.{mirror_url}.insteadOf", origin_url],
+            work,
+        )
+        return work, origin_url, origin_sha
+
+    def test_ls_remote_ignores_a_rewrite_in_the_invoking_checkout(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The rewrite in the current directory's checkout does not apply."""
+        work, origin_url, origin_sha = self._rewriting_checkout(tmp_path)
+        monkeypatch.chdir(work)
+
+        req = VcsRequest("git", origin_url, "main", "")
+
+        assert _resolve_sha(req, require_pin=False) == origin_sha
+
+    def test_ls_remote_ignores_a_rewrite_around_the_temporary_directory(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A scratch directory inside the checkout does not expose the rewrite."""
+        work, origin_url, origin_sha = self._rewriting_checkout(tmp_path)
+        scratch_root = work / "tmp"
+        scratch_root.mkdir()
+        monkeypatch.setattr(tempfile, "tempdir", str(scratch_root))
+        monkeypatch.chdir(work)
+
+        req = VcsRequest("git", origin_url, "main", "")
+
+        assert _resolve_sha(req, require_pin=False) == origin_sha
 
 
 class TestOfflineClone:


### PR DESCRIPTION
A `url.<base>.insteadOf` rewrite in the checkout nab was invoked from sent a floating VCS ref's lookup to one repository while the clone fetched the commit from another. `nab lock` resolves such a ref with `git ls-remote` when `vcs.require-pin` is false, and that call ran with no working directory of its own, so git walked up from the invoking directory and read that checkout's config.

Two repositories and a checkout that rewrites one to the other reproduce it. When the rewrite target holds commits the real repository does not, the fetch fails against the real repository, naming a commit it has never had:

    fatal: remote error: upload-pack: not our ref 6a7c65bfe6c25a2b72d6eaaa7fc47097be0b88be

When the target is a stale mirror instead, the fetch succeeds and the lock pins the mirror's `main` rather than the tip at the URL in the project file.

`ls-remote` was the last git call still exposed to this. nab already points `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` at `/dev/null` and drops the inherited `GIT_DIR` family, and the clone reads its own config because `git init` runs there first.

It now runs in a fresh temporary directory with `GIT_CEILING_DIRECTORIES` naming that directory's parent, so the discovery walk has nowhere to land. Creating the directory can fail with more than the `FileNotFoundError` a missing `git` raises, so the error path catches `OSError`.
