### PR TITLE
Stop rebuilding the lock's marker sets, 83 builds down to 56

### DIFF
--- a/nab-project/src/nab_project/_lockfile/coverage.py
+++ b/nab-project/src/nab_project/_lockfile/coverage.py
@@ -74,6 +74,7 @@ def validate_marker_coverage(
     *,
     environments: Sequence[Marker],
     store: DecisionStore | None = None,
+    environment_sets: Sequence[MarkerSet] | None = None,
 ) -> None:
     """Confirm the emitted rows cover every target the resolve ran.
 
@@ -83,15 +84,16 @@ def validate_marker_coverage(
 
     An empty ``environments`` returns early: an omitted field declares
     support for every environment, so it must not be read as the empty set.
+
+    ``environment_sets`` are ``environments`` already built as sets; they are
+    built here when omitted.
     """
     if not environments:
         return
 
-    covered = reduce(
-        MarkerSet.union,
-        (MarkerSet.from_marker(marker) for marker in environments),
-        MarkerSet.empty(),
-    )
+    if environment_sets is None:
+        environment_sets = [MarkerSet.from_marker(marker) for marker in environments]
+    covered = reduce(MarkerSet.union, environment_sets, MarkerSet.empty())
     covered = _project_implementation_version(covered, environments, targets)
 
     for pins, references in _references_by_pins(targets).items():

--- a/nab-project/src/nab_project/_lockfile/pylock.py
+++ b/nab-project/src/nab_project/_lockfile/pylock.py
@@ -606,14 +606,15 @@ def _finalize_marker(
     if raw is None:
         return None
     try:
-        simplified = MarkerSet.from_marker(raw).simplify(within=within, store=store)
+        source = MarkerSet.from_marker(raw)
+        simplified = source.simplify(within=within, store=store)
         text = simplified.to_marker_string(store=store)
         rebuilt = None if text is None else _parsed_marker(text)
         emitted = (
             MarkerSet.full() if rebuilt is None else MarkerSet.from_marker(rebuilt)
         )
         shown = "no marker" if rebuilt is None else str(rebuilt)
-        sound = _sound_within_universe(raw, emitted, within, store)
+        sound = source.equivalent_within(emitted, within, store=store)
     except (IntractableMarkerSet, UnserializableMarkerSet):
         return raw
     if not sound:
@@ -644,21 +645,6 @@ def _finalize_cached(
     if key not in memo:
         memo[key] = _finalize_marker(raw, within, name, store)
     return memo[key]
-
-
-def _sound_within_universe(
-    raw: Marker,
-    emitted: MarkerSet,
-    within: MarkerSet,
-    store: DecisionStore | None = None,
-) -> bool:
-    """Whether ``emitted`` and ``raw`` agree on every environment in ``within``.
-
-    ``emitted`` is what the lock ships: the reparsed marker bytes, or
-    :meth:`MarkerSet.full` when no marker field is emitted.  Decided per universe
-    row, under the same budget as the operator it checks.
-    """
-    return MarkerSet.from_marker(raw).equivalent_within(emitted, within, store=store)
 
 
 def _build_packages(

--- a/nab-project/src/nab_project/_lockfile/pylock.py
+++ b/nab-project/src/nab_project/_lockfile/pylock.py
@@ -281,7 +281,11 @@ def build_pylock(lock_input: LockInput, *, lock_dir: Path | None = None) -> Pylo
     base = (lock_dir if lock_dir is not None else Path.cwd()).resolve()
     exclusion_groups = conflict_exclusion_groups(lock_input.conflicts)
     store = DecisionStore()
-    universe = _emission_universe(lock_input, store)
+    # The universe and the coverage gate share these rows, so build them once.
+    environment_rows = [
+        MarkerSet.from_marker(marker) for marker in lock_input.environments
+    ]
+    universe = _emission_universe(lock_input, store, rows=environment_rows)
     package_records = _build_packages(
         lock_input, base, exclusion_groups, universe, store
     )
@@ -298,6 +302,7 @@ def build_pylock(lock_input: LockInput, *, lock_dir: Path | None = None) -> Pylo
         [lock.target for lock in lock_input.targets.values()],
         environments=lock_input.environments,
         store=store,
+        environment_sets=environment_rows,
     )
     tool: dict[str, Any] | None = (
         {"nab": lock_input.provenance.to_block()}
@@ -545,7 +550,9 @@ def _sdist_to_package(sdist: SdistArtifact, *, lock_dir: Path) -> PackageSdist:
 
 
 def _emission_universe(
-    lock_input: LockInput, store: DecisionStore | None = None
+    lock_input: LockInput,
+    store: DecisionStore | None = None,
+    rows: Sequence[MarkerSet] | None = None,
 ) -> MarkerSet:
     """Return the environment universe simplification must agree over.
 
@@ -559,10 +566,14 @@ def _emission_universe(
     every environment is sound inside an empty one too.  A union is empty
     exactly when every row is, so rows are tested one at a time rather than as a
     whole-matrix product, and a row too wide to decide counts as inhabited.
+
+    ``rows`` are ``lock_input.environments`` already built as sets; they are
+    built here when omitted.
     """
     if not lock_input.environments:
         return MarkerSet.full()
-    rows = [MarkerSet.from_marker(m) for m in lock_input.environments]
+    if rows is None:
+        rows = [MarkerSet.from_marker(m) for m in lock_input.environments]
     try:
         uninhabited = all(row.is_empty(store=store) for row in rows)
     except IntractableMarkerSet:

--- a/nab-project/tests/test_pylock.py
+++ b/nab-project/tests/test_pylock.py
@@ -858,9 +858,15 @@ class TestEmissionStore:
             *,
             environments: Sequence[Marker],
             store: DecisionStore | None = None,
+            environment_sets: Sequence[MarkerSet] | None = None,
         ) -> None:
             seen.append(store)
-            real_coverage(targets, environments=environments, store=store)
+            real_coverage(
+                targets,
+                environments=environments,
+                store=store,
+                environment_sets=environment_sets,
+            )
 
         monkeypatch.setattr(MarkerSet, "simplify", recording_simplify)
         monkeypatch.setattr(MarkerSet, "equivalent_within", recording_equivalent)


### PR DESCRIPTION
Emitting the lock for the 25-environment `max-25-tuples` universal scenario builds 83 `MarkerSet`s over 54 distinct marker texts, and 27 of those rebuild a set already in hand. This brings it to 56 builds over the same 54 texts.

The 27 come from two places:

- the 25 `environments` rows, built by `_emission_universe` and built again by `validate_marker_coverage`. `build_pylock` now builds them once and hands them to both.
- the 2 sets the soundness check reparsed from markers `_finalize_marker` had already parsed. It now keeps the one it has, and `_sound_within_universe` goes with it.

A lock declaring fewer environments saves proportionally less.

`MarkerSet` is immutable, so a shared row is the same set each consumer built for itself. Emitted locks are byte-identical.