### PR TITLE
Memoise version parses when partitioning a marker axis, ~3.5% off a lock

### DIFF
--- a/nab-provider/src/nab_provider/_vendor/packaging/_markersets.py
+++ b/nab-provider/src/nab_provider/_vendor/packaging/_markersets.py
@@ -687,21 +687,23 @@ class _Decision(NamedTuple):
 
 
 class Memo:
-    """The emptiness verdicts, partitions and atom truths a decision re-reads.
+    """The verdicts, partitions, atom truths and version parses a decision re-reads.
 
     A run over related trees decides the same tree shape more than once. Within one
-    decision, one axis is re-partitioned for overlapping atom sets and one atom
-    re-read on one point across those partitions. All three are memoised here. One
-    decision makes its own unless the caller passes one to share; see
+    decision, one axis is re-partitioned for overlapping atom sets, one atom re-read
+    on one point across those partitions, and the literals those partitions share
+    parsed as versions once per partition. All four are memoised here. One decision
+    makes its own unless the caller passes one to share; see
     :class:`~packaging.markersets.DecisionStore` for the sharing contract.
     """
 
-    __slots__ = ("decisions", "partitions", "truths")
+    __slots__ = ("decisions", "partitions", "truths", "versions")
 
     def __init__(self) -> None:
         self.decisions: dict[tuple, _Decision] = {}
         self.partitions: dict[tuple, list[Cell]] = {}
         self.truths: dict[tuple[Atom, str], bool] = {}
+        self.versions: dict[str, Version | None] = {}
 
 
 def _truth(atom: Atom, point: object, memo: Memo) -> bool:
@@ -713,6 +715,26 @@ def _truth(atom: Atom, point: object, memo: Memo) -> bool:
     if hit is None:
         hit = memo.truths[key] = atom.holds(point)
     return hit
+
+
+def _pooled_version(text: str, memo: Memo) -> Version | None:
+    """Return ``text`` parsed as a version, or None, memoised for the operation's span.
+
+    Distinct atom subsets of one axis re-derive their candidate pools from
+    overlapping literals, so the parse is shared rather than repeated per subset.
+
+    Keyed on text alone where :func:`_apply` also keys on the int-string limit.
+    Every text pooled here is an axis literal, a substring of one, or a neighbour
+    minted from one, and the parse-limit guards bound each of those ahead of its
+    read, so a hit is never a parse the current limit forbids.
+    """
+    versions = memo.versions
+    if text not in versions:
+        try:
+            versions[text] = Version(text)
+        except InvalidVersion:
+            versions[text] = None
+    return versions[text]
 
 
 def _substring_cost(text: str) -> int:
@@ -812,7 +834,7 @@ def _equal_twins(version: Version) -> list[str]:
     return [version.public, str(padded)]
 
 
-def _between(vlow: Version, low: str, vhigh: Version) -> str | None:
+def _between(vlow: Version, low: str, vhigh: Version, memo: Memo) -> str | None:
     for candidate in (
         f"{low}.post0",
         f"{low}+m",
@@ -820,11 +842,8 @@ def _between(vlow: Version, low: str, vhigh: Version) -> str | None:
         f"{low}.1",
         f"{low}a1",
     ):
-        try:
-            parsed = Version(candidate)
-        except InvalidVersion:
-            continue
-        if vlow < parsed < vhigh:
+        parsed = _pooled_version(candidate, memo)
+        if parsed is not None and vlow < parsed < vhigh:
             return candidate
     return None
 
@@ -836,7 +855,11 @@ _POOL_ANCHORS: tuple[tuple[Version, str], ...] = tuple(
 
 
 def _version_pool(
-    entries: Iterable[tuple[Version, str]], *, elevate_epoch: bool, max_cells: int
+    entries: Iterable[tuple[Version, str]],
+    *,
+    elevate_epoch: bool,
+    max_cells: int,
+    memo: Memo,
 ) -> list[str]:
     parsed: list[tuple[Version, str]] = list(_POOL_ANCHORS)
     seen: set[str] = {text for _, text in _POOL_ANCHORS}
@@ -851,7 +874,7 @@ def _version_pool(
     for (vlow, slow), (vhigh, _shigh) in pairwise(parsed):
         if vlow == vhigh:
             continue
-        mid = _between(vlow, slow, vhigh)
+        mid = _between(vlow, slow, vhigh, memo)
         if mid is not None:
             extra.append(mid)
 
@@ -881,12 +904,14 @@ def _elevate_epochs(
     return elevated
 
 
-def _membership_candidates(atom: Atom) -> list[str]:
+def _membership_candidates(atom: Atom, memo: Memo) -> list[str]:
     subs = _substrings(atom.literal)
     if atom.derive_mm:
         # A1 membership tests the major.minor of a full version, so realisable
         # points are the substrings of the literal that are themselves versions.
-        return [s for s in subs if _parses_version(s)]
+        return [
+            s for s in subs if _pooled_version(s.removesuffix(".*"), memo) is not None
+        ]
     return subs
 
 
@@ -898,7 +923,7 @@ def _mixes_mm_and_full(atoms: Sequence[Atom]) -> bool:
 
 
 def _dedupe_candidates(
-    candidates: Iterable[str], *, pure_version: bool, max_cells: int
+    candidates: Iterable[str], *, pure_version: bool, max_cells: int, memo: Memo
 ) -> list[str]:
     ordered: list[str] = []
     seen: set[str] = set()
@@ -908,7 +933,7 @@ def _dedupe_candidates(
         # A pure Version axis holds only PEP 440 versions, so a non-version
         # candidate is unrealisable there. The twins keep every non-version
         # candidate, including the OTHER-cell representative.
-        if pure_version and not _strict_version(candidate):
+        if pure_version and _pooled_version(candidate, memo) is None:
             continue
         seen.add(candidate)
         ordered.append(candidate)
@@ -930,7 +955,7 @@ def _other_representative(literals: Sequence[str]) -> str:
 
 
 def _reduce_work_exceeds(
-    variable: str, literals: Sequence[str], atom_count: int, max_cells: int
+    variable: str, literals: Sequence[str], atom_count: int, max_cells: int, memo: Memo
 ) -> bool:
     """Whether the axis's guaranteed reduce work already exceeds ``max_cells``.
 
@@ -943,7 +968,7 @@ def _reduce_work_exceeds(
     seen: set[str] = set()
     for literal in literals:
         key = literal.removesuffix(".*") if pure else literal
-        if key in seen or (pure and not _strict_version(key)):
+        if key in seen or (pure and _pooled_version(key, memo) is None):
             continue
         seen.add(key)
         if len(seen) * atom_count > max_cells:
@@ -952,12 +977,12 @@ def _reduce_work_exceeds(
 
 
 def _value_candidates(
-    variable: str, atoms: Sequence[Atom], max_cells: int
+    variable: str, atoms: Sequence[Atom], max_cells: int, memo: Memo
 ) -> list[str]:
     literals = [atom.literal for atom in atoms]
 
     reject_oversized_version_literals(variable, literals)
-    if _reduce_work_exceeds(variable, literals, len(atoms), max_cells):
+    if _reduce_work_exceeds(variable, literals, len(atoms), max_cells, memo):
         msg = f"axis work over {len(atoms)} atoms exceeds max_cells={max_cells}"
         raise IntractableMarkerSet(msg)
 
@@ -979,7 +1004,7 @@ def _value_candidates(
             if spent > max_cells:
                 msg = f"substring enumeration exceeds max_cells={max_cells}"
                 raise IntractableMarkerSet(msg)
-            candidates.extend(_membership_candidates(atom))
+            candidates.extend(_membership_candidates(atom, memo))
 
     if is_version_dispatch(variable):
         _reject_mint_overflow(literals)
@@ -991,10 +1016,14 @@ def _value_candidates(
                 entries,
                 elevate_epoch=_mixes_mm_and_full(atoms),
                 max_cells=max_cells,
+                memo=memo,
             )
         )
     return _dedupe_candidates(
-        candidates, pure_version=raw_kind == DOMAIN_VERSION, max_cells=max_cells
+        candidates,
+        pure_version=raw_kind == DOMAIN_VERSION,
+        max_cells=max_cells,
+        memo=memo,
     )
 
 
@@ -1037,7 +1066,7 @@ def partition_value_axis(
 ) -> list[Cell]:
     """Cells of a version/string value axis."""
     return _reduce_cells(
-        _value_candidates(variable, atoms, max_cells), atoms, max_cells, memo
+        _value_candidates(variable, atoms, max_cells, memo), atoms, max_cells, memo
     )
 
 

--- a/nab-provider/tests/test_marker_algebra.py
+++ b/nab-provider/tests/test_marker_algebra.py
@@ -1108,6 +1108,34 @@ def test_mint_overflow_at_parse_limit_reports_complexity() -> None:
         sys.set_int_max_str_digits(original)
 
 
+def test_warm_version_pool_does_not_bypass_the_oversized_literal_guard() -> None:
+    # A store carries its parsed versions across decisions, so a parse taken under
+    # a disabled int-string limit outlives that limit. A decision under a limit the
+    # literal overruns has to reach the guard rather than the store's copy.
+    literal = "1." + "9" * 700
+    store = markersets.DecisionStore()
+    original = sys.get_int_max_str_digits()
+
+    sys.set_int_max_str_digits(0)
+    try:
+        assert ms(f'python_full_version >= "{literal}"').is_empty(store=store) is False
+    finally:
+        sys.set_int_max_str_digits(original)
+
+    assert literal in store.versions
+
+    sys.set_int_max_str_digits(640)
+    try:
+        # Both parse-limit guards reject this literal, so the match is on the
+        # oversize guard's own message to pin which one fired.
+        with pytest.raises(
+            IntractableMarkerSet, match="exceeds the 640-digit parse limit"
+        ):
+            ms(f'python_full_version < "{literal}"').is_empty(store=store)
+    finally:
+        sys.set_int_max_str_digits(original)
+
+
 def _nested_alternating(depth: int) -> MarkerSet:
     # Algebra assembles the op-tree without recursing, so a tree far deeper than
     # the stack is built at any recursion limit; only the walk that decides it

--- a/tasks/vendoring/packaging.patch
+++ b/tasks/vendoring/packaging.patch
@@ -1,9 +1,9 @@
 diff --git a/nab-provider/src/nab_provider/_vendor/packaging/_markersets.py b/nab-provider/src/nab_provider/_vendor/packaging/_markersets.py
 new file mode 100644
-index 0000000..c10016a
+index 0000000..04c833a
 --- /dev/null
 +++ b/nab-provider/src/nab_provider/_vendor/packaging/_markersets.py
-@@ -0,0 +1,1905 @@
+@@ -0,0 +1,1934 @@
 +"""Marker algebra engine: reason about PEP 508 markers as sets of environments.
 +
 +The private engine behind :class:`~packaging.markersets.MarkerSet`. Parses a
@@ -693,21 +693,23 @@ index 0000000..c10016a
 +
 +
 +class Memo:
-+    """The emptiness verdicts, partitions and atom truths a decision re-reads.
++    """The verdicts, partitions, atom truths and version parses a decision re-reads.
 +
 +    A run over related trees decides the same tree shape more than once. Within one
-+    decision, one axis is re-partitioned for overlapping atom sets and one atom
-+    re-read on one point across those partitions. All three are memoised here. One
-+    decision makes its own unless the caller passes one to share; see
++    decision, one axis is re-partitioned for overlapping atom sets, one atom re-read
++    on one point across those partitions, and the literals those partitions share
++    parsed as versions once per partition. All four are memoised here. One decision
++    makes its own unless the caller passes one to share; see
 +    :class:`~packaging.markersets.DecisionStore` for the sharing contract.
 +    """
 +
-+    __slots__ = ("decisions", "partitions", "truths")
++    __slots__ = ("decisions", "partitions", "truths", "versions")
 +
 +    def __init__(self) -> None:
 +        self.decisions: dict[tuple, _Decision] = {}
 +        self.partitions: dict[tuple, list[Cell]] = {}
 +        self.truths: dict[tuple[Atom, str], bool] = {}
++        self.versions: dict[str, Version | None] = {}
 +
 +
 +def _truth(atom: Atom, point: object, memo: Memo) -> bool:
@@ -719,6 +721,26 @@ index 0000000..c10016a
 +    if hit is None:
 +        hit = memo.truths[key] = atom.holds(point)
 +    return hit
++
++
++def _pooled_version(text: str, memo: Memo) -> Version | None:
++    """Return ``text`` parsed as a version, or None, memoised for the operation's span.
++
++    Distinct atom subsets of one axis re-derive their candidate pools from
++    overlapping literals, so the parse is shared rather than repeated per subset.
++
++    Keyed on text alone where :func:`_apply` also keys on the int-string limit.
++    Every text pooled here is an axis literal, a substring of one, or a neighbour
++    minted from one, and the parse-limit guards bound each of those ahead of its
++    read, so a hit is never a parse the current limit forbids.
++    """
++    versions = memo.versions
++    if text not in versions:
++        try:
++            versions[text] = Version(text)
++        except InvalidVersion:
++            versions[text] = None
++    return versions[text]
 +
 +
 +def _substring_cost(text: str) -> int:
@@ -818,7 +840,7 @@ index 0000000..c10016a
 +    return [version.public, str(padded)]
 +
 +
-+def _between(vlow: Version, low: str, vhigh: Version) -> str | None:
++def _between(vlow: Version, low: str, vhigh: Version, memo: Memo) -> str | None:
 +    for candidate in (
 +        f"{low}.post0",
 +        f"{low}+m",
@@ -826,11 +848,8 @@ index 0000000..c10016a
 +        f"{low}.1",
 +        f"{low}a1",
 +    ):
-+        try:
-+            parsed = Version(candidate)
-+        except InvalidVersion:
-+            continue
-+        if vlow < parsed < vhigh:
++        parsed = _pooled_version(candidate, memo)
++        if parsed is not None and vlow < parsed < vhigh:
 +            return candidate
 +    return None
 +
@@ -842,7 +861,11 @@ index 0000000..c10016a
 +
 +
 +def _version_pool(
-+    entries: Iterable[tuple[Version, str]], *, elevate_epoch: bool, max_cells: int
++    entries: Iterable[tuple[Version, str]],
++    *,
++    elevate_epoch: bool,
++    max_cells: int,
++    memo: Memo,
 +) -> list[str]:
 +    parsed: list[tuple[Version, str]] = list(_POOL_ANCHORS)
 +    seen: set[str] = {text for _, text in _POOL_ANCHORS}
@@ -857,7 +880,7 @@ index 0000000..c10016a
 +    for (vlow, slow), (vhigh, _shigh) in pairwise(parsed):
 +        if vlow == vhigh:
 +            continue
-+        mid = _between(vlow, slow, vhigh)
++        mid = _between(vlow, slow, vhigh, memo)
 +        if mid is not None:
 +            extra.append(mid)
 +
@@ -887,12 +910,14 @@ index 0000000..c10016a
 +    return elevated
 +
 +
-+def _membership_candidates(atom: Atom) -> list[str]:
++def _membership_candidates(atom: Atom, memo: Memo) -> list[str]:
 +    subs = _substrings(atom.literal)
 +    if atom.derive_mm:
 +        # A1 membership tests the major.minor of a full version, so realisable
 +        # points are the substrings of the literal that are themselves versions.
-+        return [s for s in subs if _parses_version(s)]
++        return [
++            s for s in subs if _pooled_version(s.removesuffix(".*"), memo) is not None
++        ]
 +    return subs
 +
 +
@@ -904,7 +929,7 @@ index 0000000..c10016a
 +
 +
 +def _dedupe_candidates(
-+    candidates: Iterable[str], *, pure_version: bool, max_cells: int
++    candidates: Iterable[str], *, pure_version: bool, max_cells: int, memo: Memo
 +) -> list[str]:
 +    ordered: list[str] = []
 +    seen: set[str] = set()
@@ -914,7 +939,7 @@ index 0000000..c10016a
 +        # A pure Version axis holds only PEP 440 versions, so a non-version
 +        # candidate is unrealisable there. The twins keep every non-version
 +        # candidate, including the OTHER-cell representative.
-+        if pure_version and not _strict_version(candidate):
++        if pure_version and _pooled_version(candidate, memo) is None:
 +            continue
 +        seen.add(candidate)
 +        ordered.append(candidate)
@@ -936,7 +961,7 @@ index 0000000..c10016a
 +
 +
 +def _reduce_work_exceeds(
-+    variable: str, literals: Sequence[str], atom_count: int, max_cells: int
++    variable: str, literals: Sequence[str], atom_count: int, max_cells: int, memo: Memo
 +) -> bool:
 +    """Whether the axis's guaranteed reduce work already exceeds ``max_cells``.
 +
@@ -949,7 +974,7 @@ index 0000000..c10016a
 +    seen: set[str] = set()
 +    for literal in literals:
 +        key = literal.removesuffix(".*") if pure else literal
-+        if key in seen or (pure and not _strict_version(key)):
++        if key in seen or (pure and _pooled_version(key, memo) is None):
 +            continue
 +        seen.add(key)
 +        if len(seen) * atom_count > max_cells:
@@ -958,12 +983,12 @@ index 0000000..c10016a
 +
 +
 +def _value_candidates(
-+    variable: str, atoms: Sequence[Atom], max_cells: int
++    variable: str, atoms: Sequence[Atom], max_cells: int, memo: Memo
 +) -> list[str]:
 +    literals = [atom.literal for atom in atoms]
 +
 +    reject_oversized_version_literals(variable, literals)
-+    if _reduce_work_exceeds(variable, literals, len(atoms), max_cells):
++    if _reduce_work_exceeds(variable, literals, len(atoms), max_cells, memo):
 +        msg = f"axis work over {len(atoms)} atoms exceeds max_cells={max_cells}"
 +        raise IntractableMarkerSet(msg)
 +
@@ -985,7 +1010,7 @@ index 0000000..c10016a
 +            if spent > max_cells:
 +                msg = f"substring enumeration exceeds max_cells={max_cells}"
 +                raise IntractableMarkerSet(msg)
-+            candidates.extend(_membership_candidates(atom))
++            candidates.extend(_membership_candidates(atom, memo))
 +
 +    if is_version_dispatch(variable):
 +        _reject_mint_overflow(literals)
@@ -997,10 +1022,14 @@ index 0000000..c10016a
 +                entries,
 +                elevate_epoch=_mixes_mm_and_full(atoms),
 +                max_cells=max_cells,
++                memo=memo,
 +            )
 +        )
 +    return _dedupe_candidates(
-+        candidates, pure_version=raw_kind == DOMAIN_VERSION, max_cells=max_cells
++        candidates,
++        pure_version=raw_kind == DOMAIN_VERSION,
++        max_cells=max_cells,
++        memo=memo,
 +    )
 +
 +
@@ -1043,7 +1072,7 @@ index 0000000..c10016a
 +) -> list[Cell]:
 +    """Cells of a version/string value axis."""
 +    return _reduce_cells(
-+        _value_candidates(variable, atoms, max_cells), atoms, max_cells, memo
++        _value_candidates(variable, atoms, max_cells, memo), atoms, max_cells, memo
 +    )
 +
 +


### PR DESCRIPTION
Emitting the `max-25-tuples` universal lock retires between 107.3 and 109.1 million fewer instructions, 3.42% to 3.48% of that run, over three callgrind repeats with `PYTHONHASHSEED=0`. Stopping the same scenario before the lock leaves the resolve inside about 0.07% either way, the spread of its own repeats.

| workload | instructions | change |
| --- | --- | --- |
| `max-25-tuples`, lock emitted | 3,136,441,039 -> 3,027,349,748 | -109,091,291 (-3.48%) |
| `scientific-python-multi`, lock emitted | 5,490,959,425 -> 5,481,784,680 | -9,174,745 (-0.17%) |

`Memo` gains `versions: dict[str, Version | None]`, so a literal is parsed once per decision rather than once per atom subset that re-derives a candidate pool from it. The four parse sites read it:

- the five neighbours `_between` mints
- the pure-version filter in `_dedupe_candidates`
- the literal scan in `_reduce_work_exceeds`
- the substring filter in `_membership_candidates`

The `max-25-tuples` emit builds 4,831 `Version` objects where it built 9,439, and makes about 81,000 fewer calls including `_pooled_version`'s own 4,792.

The pool sits on the existing `Memo`, so a caller sharing a store across decisions holds those parses for the store's life. All 13 locks the 18-scenario universal benchmark set emits are byte for byte unchanged.