### PR TITLE
Split METADATA headers into logical lines, ~2.7% off a copick resolve

### DIFF
--- a/nab-provider/src/nab_provider/metadata.py
+++ b/nab-provider/src/nab_provider/metadata.py
@@ -9,10 +9,10 @@ LRU cache so repeated dep strings parse once.
 
 from __future__ import annotations
 
+import re
 from contextlib import suppress
 from dataclasses import dataclass, field
 from functools import lru_cache
-from io import StringIO
 from typing import TYPE_CHECKING, Any
 
 from nab_provider._vendor.packaging.requirements import Requirement
@@ -208,6 +208,28 @@ def _is_field_name(raw: str) -> bool:
     return raw.isascii() and raw.isprintable() and " " not in raw
 
 
+# A line ending closes a header only when the line under it is not a fold, so
+# splitting on these leaves every folded value whole inside one logical line.
+_LOGICAL_LINE = re.compile(r"\n(?![ \t])")
+
+# The same boundary for a document that also ends lines on a bare \r, as
+# email's own reader does.
+_LOGICAL_LINE_CR = re.compile(r"(?:\r\n|\r(?!\n)|\n)(?![ \t])")
+
+
+def _logical_lines(text: str) -> list[str]:
+    r"""Split ``text`` into RFC 822 logical lines, each holding its own folds.
+
+    A line ending inside a fold stays. The ending that closes a logical line
+    goes, except that the common pattern splits on the ``\n`` of a ``\r\n``
+    and leaves the ``\r`` at the end of the line.
+    """
+    # Equal counts mean every \r begins a \r\n, so no line ends on a bare one.
+    if "\r" in text and text.count("\r") != text.count("\r\n"):
+        return _LOGICAL_LINE_CR.split(text)
+    return _LOGICAL_LINE.split(text)
+
+
 def _read_header_fields(text: str) -> dict[str, list[str]]:
     """Map each name in ``_READ_FIELDS`` that ``text`` carries to its values.
 
@@ -224,18 +246,15 @@ def _read_header_fields(text: str) -> dict[str, list[str]]:
     """
     fields: dict[str, list[str]] = {}
     name = ""
-    value: list[str] = []
-    # newline="" leaves a bare \r ending a line, which is what email splits on.
-    for line in StringIO(text, newline=""):
-        first = line[0]
+    value = ""
+    for line in _logical_lines(text):
+        first = line[:1]
+        # A fold can only open the first logical line, where no field is open.
         if first in {" ", "\t"}:
-            if name:
-                value.append(line)
             continue
 
         if name:
-            joined = "".join(value).lstrip(" \t\r\n")
-            fields.setdefault(name, []).append(joined.rstrip("\r\n"))
+            fields.setdefault(name, []).append(value)
             name = ""
 
         if first == "F" and line.startswith("From "):
@@ -244,17 +263,21 @@ def _read_header_fields(text: str) -> dict[str, list[str]]:
         colon = line.find(":")
         if colon < 0:
             break
+
         raw_name = line[:colon]
-        if not _is_field_name(raw_name):
-            break
         candidate = raw_name.lower()
+
+        # The set lookup can precede the validity test: U+212A is the only
+        # character _is_field_name rejects that lowercases into ASCII, and no
+        # _READ_FIELDS name holds the "k" it becomes.
         if candidate in _READ_FIELDS:
             name = candidate
-            value = [line[colon + 1 :]]
+            value = line[colon + 1 :].lstrip(" \t\r\n").rstrip("\r\n")
+        elif not _is_field_name(raw_name):
+            break
 
     if name:
-        joined = "".join(value).lstrip(" \t\r\n")
-        fields.setdefault(name, []).append(joined.rstrip("\r\n"))
+        fields.setdefault(name, []).append(value)
     return fields
 
 

--- a/nab-provider/src/nab_provider/metadata.py
+++ b/nab-provider/src/nab_provider/metadata.py
@@ -138,6 +138,22 @@ def _parse_requirement_cached(req_str: str) -> Requirement:
     return req
 
 
+@lru_cache(maxsize=4096)
+def _parse_requires_python_cached(value: str) -> SpecifierSet:
+    """Cache ``Requires-Python`` parsing across wheel metadata.
+
+    The same string recurs across a project's wheels the way dep strings do.
+    ``SpecifierSet.prereleases`` is settable, but nab never assigns to it and
+    passes ``prereleases`` per call instead, so sharing the object is safe.
+
+    Raises ``ValueError`` when the string does not parse or a clause
+    version will not convert.
+    """
+    specifier_set = SpecifierSet(value)
+    validate_specifier_versions(specifier_set)
+    return specifier_set
+
+
 @lru_cache(maxsize=65536)
 def intern_version(version_str: str) -> Version:
     """Return a shared :class:`Version` for ``version_str``.
@@ -305,8 +321,7 @@ def parse_metadata(data: str | bytes) -> WheelMetadata:
     requires_python = None
     if requires_python_str:
         try:
-            requires_python = SpecifierSet(requires_python_str)
-            validate_specifier_versions(requires_python)
+            requires_python = _parse_requires_python_cached(requires_python_str)
         except ValueError as exc:
             # A malformed Requires-Python is invalid metadata; raise rather
             # than silently drop the field.

--- a/nab-provider/tests/test_metadata.py
+++ b/nab-provider/tests/test_metadata.py
@@ -10,6 +10,7 @@ import pytest
 from nab_provider._vendor.packaging.specifiers import SpecifierSet
 from nab_provider._vendor.packaging.version import Version
 from nab_provider.metadata import (
+    _READ_FIELDS,
     _read_header_fields,
     metadata_deps_are_static,
     metadata_header_block,
@@ -407,6 +408,13 @@ class TestReadHeaderFields:
             "From nobody Wed Aug 20 03:00:00 2026\nName: foo\nFrom someone else\n"
         ) == {"name": ["foo"]}
 
+    def test_last_field_stays_open_to_the_end_of_the_text(self) -> None:
+        """A document that stops without a line ending still yields its last field."""
+        assert _read_header_fields("Name: foo\nVersion: 1.0") == {
+            "name": ["foo"],
+            "version": ["1.0"],
+        }
+
     def test_bare_carriage_return_ends_a_line(self) -> None:
         """A lone ``\\r`` ends a line, as it does in :mod:`email`'s own reader."""
         assert _read_header_fields("Name: foo\rVersion: 1.0\r") == {
@@ -427,11 +435,15 @@ class TestReadHeaderFields:
         """Anything but a continuation or ``name:`` ends the headers."""
         assert _read_header_fields(text) == {"name": ["foo"]}
 
-    def test_field_name_is_checked_before_it_is_lowercased(self) -> None:
+    def test_a_non_ascii_name_that_lowercases_to_ascii_is_not_a_field(self) -> None:
         """U+212A lowercases to ASCII ``k``, which does not make it a field name."""
         assert _read_header_fields("Name: foo\n\u212a: x\nVersion: 1.0\n") == {
             "name": ["foo"]
         }
+
+    def test_no_read_field_name_contains_k(self) -> None:
+        """A ``k`` in a read field would let U+212A reach the lookup as that field."""
+        assert not any("k" in name for name in _READ_FIELDS)
 
     def test_field_with_an_empty_name_is_skipped(self) -> None:
         """A line starting with a colon has no name, and the headers continue."""


### PR DESCRIPTION
This takes 202 to 220 million instructions off a warm `pip:copick --resolution lowest` resolve, 2.7% to 3.0% of its 7.42 billion (callgrind, `PYTHONHASHSEED=0`, three pairs). The resolve parses the same 1,250 METADATA documents and reaches the same 236 decisions and 56 conflicts either way, so the saving is in the parsing and not in a different search.

- `_read_header_fields` read each document one physical line at a time out of a `StringIO`, rejoining folded continuations when the next header arrived. A regex now splits the text into RFC 822 logical lines up front, so the loop runs once per logical line and the value is sliced out at the colon. Moving the `_READ_FIELDS` lookup ahead of the name check drops `_is_field_name` from 33,124 calls to 26,567.
- The second commit memoises `Requires-Python` parsing, turning that resolve's 204 parses into 23, one per distinct string.

The cost removed is per physical line of header text: `pip:google-bigquery-soda` parses 179 documents and saves about 0.4%.

Timing copick rules out a wall regression above about 5.7% and puts peak memory inside about 0.22% either way.