### PR TITLE
Fix build env blaming the index when dist-policy excludes the wheels

### DIFF
--- a/docs/reference/build-policy.md
+++ b/docs/reference/build-policy.md
@@ -148,6 +148,12 @@ backend than `[build-system].requires` asked for without saying so.  The
 requirement resolves as written and the refusal names the version it
 landed on.
 
+A per-package or per-index `dist-policy` narrows the resolve the other
+way.  `sdist-only` and `sdist-install` keep a build requirement's
+wheels out of the environment even where the index publishes one this
+host installs, so satisfying it means building it, and the refusal
+names the policy rather than the listing.
+
 What the build produces has to be the release nab resolved, because
 the dependencies installed beside it were resolved for that release.
 A backend that computes its own version and emits another one is

--- a/nab-project/src/nab_project/_build/env.py
+++ b/nab-project/src/nab_project/_build/env.py
@@ -55,7 +55,7 @@ from nab_provider.vcs_admission import UnsupportedVcsError
 
 from ..config import NabProjectConfig
 from ..download import DownloadError, download_lock
-from ..lockfile import IndexPin
+from ..lockfile import IndexPin, strip_userinfo
 from .errors import BuildBackendError
 
 if TYPE_CHECKING:
@@ -564,22 +564,24 @@ class NabBuildEnv:
 
         label = chain_label(pin.name, pin.version)
         chain = self._chain
+
         if pin.sdist is None:
-            msg = (
-                f"{label} publishes no wheel this build host can install,"
-                f" and no sdist to build{_chain_suffix(chain)}"
-            )
+            reason = _no_wheel_clause(self._config, pin, label)
+            msg = f"{reason}, and no sdist to build{_chain_suffix(chain)}"
             raise BuildEnvError(msg)
+
         # A cycle before a depth: raising the depth to walk into a loop is
         # the one piece of advice that cannot help.
         if label in chain:
             msg = f"cyclic build requirement: {' -> '.join([*chain, label])}"
             raise BuildEnvError(msg)
+
         if self._build_budget <= 0:
+            reason = _no_wheel_clause(self._config, pin, label)
             msg = (
-                f"{label} publishes no wheel this build host can install, so"
-                " satisfying it means building it; [tool.nab].build-requires-depth"
-                f" is {self._config.build_requires_depth}{_chain_suffix(chain)}"
+                f"{reason}, so satisfying it means building it;"
+                " [tool.nab].build-requires-depth is"
+                f" {self._config.build_requires_depth}{_chain_suffix(chain)}"
             )
             raise BuildEnvError(msg)
 
@@ -656,6 +658,75 @@ def _check_built_identity(pending: _PendingBuild, wheel: Path) -> None:
 def _chain_suffix(chain: BuildChain) -> str:
     """Render ``chain`` for an error message, or nothing when it is empty."""
     return f" (chain: {' -> '.join(chain)})" if chain else ""
+
+
+def _wheel_barring_dist_policy(
+    config: NabProjectConfig, pin: IndexPin
+) -> DistPolicy | None:
+    """Return the ``dist-policy`` in force for ``pin`` when it bars wheels.
+
+    ``None`` when neither a per-package nor a per-index override sets
+    ``sdist-only`` or ``sdist-install``: those two are the whole of what
+    can bar a wheel here, because the build env's own resolve runs at
+    ``wheel-or-sdist``.  Whether the index published a wheel to bar is
+    not known here, so a returned policy says the env would have refused
+    one, not that one existed.
+
+    A per-package and a per-index override that both set the field are a
+    conflict the resolve has already raised, so the per-package one is
+    read first.
+    """
+    canonical = canonicalize_name(pin.name)
+    version = Version(pin.version)
+
+    policy = next(
+        (
+            package.dist_policy
+            for package in config.package_overrides
+            if package.dist_policy is not None
+            and package.name == canonical
+            and version in package.version_range
+        ),
+        None,
+    )
+
+    if policy is None:
+        policy = _serving_index_dist_policy(config, pin.index)
+
+    if policy is DistPolicy.SDIST_ONLY or policy is DistPolicy.SDIST_INSTALL:
+        return policy
+    return None
+
+
+def _serving_index_dist_policy(
+    config: NabProjectConfig, pin_index: str
+) -> DistPolicy | None:
+    """Return the ``dist-policy`` the index that served ``pin_index`` sets.
+
+    An override is keyed by the configured index name, and a pin records
+    its index URL with credentials stripped, so the match runs over
+    stripped URLs.  Two indexes differing only in credentials are
+    indistinguishable to a pin, so neither is read.
+    """
+    serving = [
+        index for index in config.indexes if strip_userinfo(index.url) == pin_index
+    ]
+    if len(serving) != 1:
+        return None
+
+    override = config.index_overrides.get(serving[0].name)
+    return override.dist_policy if override is not None else None
+
+
+def _no_wheel_clause(config: NabProjectConfig, pin: IndexPin, label: str) -> str:
+    """Return the opening of a refusal: why the env has no wheel of ``label``."""
+    barred_by = _wheel_barring_dist_policy(config, pin)
+    if barred_by is None:
+        return f"{label} publishes no wheel this build host can install"
+    return (
+        f"{label} has dist-policy '{barred_by.value}',"
+        " which admits no wheel into the build env"
+    )
 
 
 def _without_build_permission(override: _OverrideT) -> _OverrideT:

--- a/nab-project/src/nab_project/_lockfile/builder.py
+++ b/nab-project/src/nab_project/_lockfile/builder.py
@@ -63,6 +63,7 @@ __all__ = [
     "read_lockfile_anchor",
     "read_lockfile_packages",
     "require_artifact_hashes",
+    "strip_userinfo",
 ]
 
 
@@ -238,7 +239,7 @@ def read_lockfile_packages(path: Path) -> dict[str, Version] | None:
     }
 
 
-def _strip_userinfo(url: str) -> str:
+def strip_userinfo(url: str) -> str:
     """Return ``url`` with credential userinfo removed.
 
     Lockfiles are committed to version control, so an index or VCS URL
@@ -567,7 +568,7 @@ def _index_pin_from_listing(
     return IndexPin(
         name=canonical,
         version=str(version),
-        index=_strip_userinfo(index_url),
+        index=strip_userinfo(index_url),
         sdist=sdist,
         wheels=wheels,
         requires_python=requires_python,
@@ -591,7 +592,7 @@ def _build_artifact(
     hashes = _filter_acceptable_hashes(source.hashes)
     return cls(
         filename=source.filename,
-        url=_strip_userinfo(source.url),
+        url=strip_userinfo(source.url),
         hashes=hashes,
         size=source.size,
         upload_time=_parse_upload_time(source.upload_time),
@@ -740,7 +741,7 @@ def _vcs_pin_from_source(
 
     # Compose a pinned installable URL from the parsed pieces, not from source.url,
     # so credentials are stripped and the sha replaces any floating ref.
-    bare_repo_url = _strip_userinfo(parsed.repo_url)
+    bare_repo_url = strip_userinfo(parsed.repo_url)
     repo_url = f"{parsed.scheme}+{bare_repo_url}@{resolved_sha}"
     if parsed.subdirectory:
         repo_url += f"#subdirectory={quote(parsed.subdirectory, safe='/')}"
@@ -778,7 +779,7 @@ def _archive_pin_from_source(
     return ArchivePin(
         name=canonical,
         version=str(version),
-        url=_strip_userinfo(request.url),
+        url=strip_userinfo(request.url),
         hashes=request.hashes,
         subdirectory=request.subdirectory or None,
     )

--- a/nab-project/src/nab_project/lockfile.py
+++ b/nab-project/src/nab_project/lockfile.py
@@ -28,6 +28,7 @@ from ._lockfile.builder import (
     build_target_lock,
     read_lockfile_anchor,
     read_lockfile_packages,
+    strip_userinfo,
 )
 from ._lockfile.disjointness import DisjointnessError
 from ._lockfile.groups import BASE_MEMBER
@@ -94,6 +95,7 @@ __all__ = [
     "read_lockfile_anchor",
     "read_lockfile_packages",
     "render_lock",
+    "strip_userinfo",
     "summarize_lock",
     "write_lock",
     "write_requirements_with_hashes",

--- a/nab-project/tests/test_build_runner.py
+++ b/nab-project/tests/test_build_runner.py
@@ -67,6 +67,7 @@ from nab_project.config import (
     IndexOverride,
     MatrixConfig,
     NabProjectConfig,
+    PackageOverride,
     ResolveMode,
 )
 from nab_project.download import DownloadError, DownloadResult, iter_artifacts
@@ -74,6 +75,7 @@ from nab_project.lockfile import (
     IndexPin,
     LocalPin,
     LockInput,
+    PinShape,
     SdistArtifact,
     TargetLock,
     WheelArtifact,
@@ -2920,6 +2922,265 @@ class TestInstallPickIsNotTheMetadataPick:
 
         with pytest.raises(BuildEnvError, match=r"chain: meson 1\.4\.2 -> ninja 1\.11"):
             env._planned_pin(self._sdist_pin(), self._tags(), [])
+
+
+class TestRefusalNamesTheDistPolicyThatBarsTheWheels:
+    """Why a pin has no wheel decides what the refusal is allowed to say.
+
+    A per-package or per-index ``dist-policy`` governs the build env's
+    own resolve, so ``sdist-only`` and ``sdist-install`` leave a pin
+    carrying its sdist alone even where the index publishes a wheel this
+    host installs.  Blaming the index there sends the reader after a
+    wheel that is not missing.
+    """
+
+    NAME = "demo"
+    VERSION = "1.0"
+    INDEX_NAME = "local"
+    INDEX_URL = "https://pypi.example/simple/"
+    CREDENTIALED_URL = "https://user:token@pypi.example/simple/"
+    OTHER_INDEX_NAME = "mirror"
+    OTHER_INDEX_URL = "https://mirror.example/simple/"
+
+    @staticmethod
+    def _tags() -> TagSet:
+        return ResolveTarget.for_declared(
+            python_version="3.12", spec=PlatformSpec(platform_id="linux_x86_64")
+        ).tags
+
+    @classmethod
+    def _pin(cls) -> IndexPin:
+        """A pin the resolve settled on carrying its sdist alone."""
+        filename = f"{cls.NAME}-{cls.VERSION}.tar.gz"
+        return IndexPin(
+            name=cls.NAME,
+            version=cls.VERSION,
+            index=cls.INDEX_URL,
+            sdist=SdistArtifact(
+                filename=filename,
+                url=f"https://pypi.example/{filename}",
+                hashes=(("sha256", "1" * 64),),
+            ),
+        )
+
+    def _refusal(self, **fields: Any) -> str:
+        """Return the message the env refuses ``_pin`` with.
+
+        ``fields`` are the config fields the case sets.  The pin is
+        served by ``INDEX_NAME`` unless a case declares its own
+        ``indexes``.
+        """
+        fields.setdefault("indexes", (IndexConfig(self.INDEX_NAME, self.INDEX_URL),))
+        config = NabProjectConfig(**fields)
+        env = NabBuildEnv(requires=[], config=config)
+
+        with pytest.raises(BuildEnvError) as excinfo:
+            env._planned_pin(self._pin(), self._tags(), [])
+        return str(excinfo.value)
+
+    @pytest.mark.parametrize(
+        "policy",
+        [DistPolicy.SDIST_ONLY, DistPolicy.SDIST_INSTALL],
+        ids=["sdist-only", "sdist-install"],
+    )
+    def test_a_package_override_is_named_as_the_cause(self, policy: DistPolicy) -> None:
+        """The key the user set is what the message points at."""
+        message = self._refusal(
+            package_overrides=(pkg_override(self.NAME, dist_policy=policy),)
+        )
+
+        assert (
+            f"demo 1.0 has dist-policy '{policy.value}', which admits"
+            " no wheel into the build env" in message
+        )
+        assert "publishes no wheel" not in message
+
+        assert "build-requires-depth is 0" in message
+
+    def test_an_index_override_is_named_as_the_cause(self) -> None:
+        """The per-index surface reaches the build env the same way."""
+        message = self._refusal(
+            index_overrides={
+                self.INDEX_NAME: IndexOverride(dist_policy=DistPolicy.SDIST_ONLY)
+            }
+        )
+
+        assert "demo 1.0 has dist-policy 'sdist-only'" in message
+
+    def test_an_index_override_reaches_a_pin_from_a_credentialed_index(self) -> None:
+        """A pin records its index URL stripped of the credentials config has."""
+        message = self._refusal(
+            indexes=(IndexConfig(self.INDEX_NAME, self.CREDENTIALED_URL),),
+            index_overrides={
+                self.INDEX_NAME: IndexOverride(dist_policy=DistPolicy.SDIST_ONLY)
+            },
+        )
+
+        assert "demo 1.0 has dist-policy 'sdist-only'" in message
+
+    def test_indexes_differing_only_in_credentials_are_not_named(self) -> None:
+        """Both strip to the pin's URL, so which one served it is unknown."""
+        message = self._refusal(
+            indexes=(
+                IndexConfig(self.INDEX_NAME, self.INDEX_URL),
+                IndexConfig(self.OTHER_INDEX_NAME, self.CREDENTIALED_URL),
+            ),
+            index_overrides={
+                self.OTHER_INDEX_NAME: IndexOverride(dist_policy=DistPolicy.SDIST_ONLY)
+            },
+        )
+
+        assert "demo 1.0 publishes no wheel this build host can install" in message
+        assert "dist-policy" not in message
+
+    def test_an_index_override_on_another_index_is_not_named(self) -> None:
+        """Only the index that served the pin can have barred its wheels."""
+        message = self._refusal(
+            indexes=(
+                IndexConfig(self.INDEX_NAME, self.INDEX_URL),
+                IndexConfig(self.OTHER_INDEX_NAME, self.OTHER_INDEX_URL),
+            ),
+            index_overrides={
+                self.OTHER_INDEX_NAME: IndexOverride(dist_policy=DistPolicy.SDIST_ONLY)
+            },
+        )
+
+        assert "demo 1.0 publishes no wheel this build host can install" in message
+        assert "dist-policy" not in message
+
+    @pytest.mark.parametrize(
+        "override",
+        [
+            pkg_override("other", dist_policy=DistPolicy.SDIST_ONLY),
+            pkg_override("demo>2", dist_policy=DistPolicy.SDIST_ONLY),
+            pkg_override("demo", dist_policy=DistPolicy.PREFER_WHEEL),
+        ],
+        ids=["another-package", "outside-the-range", "admits-wheels"],
+    )
+    def test_an_override_that_did_not_bar_the_wheels_is_not_named(
+        self, override: PackageOverride
+    ) -> None:
+        """The name, the range, and the policy value all have to match."""
+        message = self._refusal(package_overrides=(override,))
+
+        assert "demo 1.0 publishes no wheel this build host can install" in message
+        assert "dist-policy" not in message
+
+
+class TestDistPolicyExcludesAWheelTheHostCanInstall:
+    """``sdist-only`` on a build requirement, over a real inner resolve.
+
+    The ``file://`` index publishes a wheel this host installs beside
+    the sdist.  The first test pins that the env installs that wheel,
+    so the refusal in the second can only be the override's doing.
+    Only the download is stubbed; nothing here reaches the network.
+    """
+
+    NAME = "buildstub"
+    VERSION = "1.0"
+    WHEEL = "buildstub-1.0-py3-none-any.whl"
+
+    def _config(self, tmp_path: Path, **fields: Any) -> NabProjectConfig:
+        """Config over an index serving a wheel beside a PEP 643 sdist."""
+        index_dir = tmp_path / "index"
+        _make_local_index(index_dir, self.NAME, self.VERSION)
+        return NabProjectConfig(
+            indexes=(IndexConfig("local", index_dir.as_uri()),), **fields
+        )
+
+    @staticmethod
+    def _planned_pins(monkeypatch: pytest.MonkeyPatch) -> list[PinShape]:
+        """Return a list that fills with the pins the plan sends to download."""
+        planned: list[PinShape] = []
+
+        def fake_download_lock(
+            lock_input: LockInput, _transport: object, _wheel_dir: Path, *_a: object
+        ) -> DownloadResult:
+            for lock in lock_input.targets.values():
+                planned.extend(lock.pins.values())
+            return DownloadResult(written=(), skipped=())
+
+        monkeypatch.setattr("nab_project._build.env.download_lock", fake_download_lock)
+        return planned
+
+    def _resolve(self, config: NabProjectConfig, tmp_path: Path) -> None:
+        """Run the inner resolve and its install plan, nothing further."""
+        wheel_dir = tmp_path / "wheels"
+        wheel_dir.mkdir()
+        env = NabBuildEnv(requires=[self.NAME], config=config)
+        env._resolve_and_download(wheel_dir)
+
+    def test_the_published_wheel_is_what_the_env_installs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With no override the plan narrows the pin to that wheel."""
+        planned = self._planned_pins(monkeypatch)
+
+        self._resolve(self._config(tmp_path), tmp_path)
+
+        pin = planned[0]
+        assert isinstance(pin, IndexPin)
+        assert [wheel.filename for wheel in pin.wheels] == [self.WHEEL]
+        assert pin.sdist is None
+
+    def test_the_refusal_names_dist_policy_and_not_the_index(
+        self, tmp_path: Path
+    ) -> None:
+        """The same wheel is published; the override is why it cannot be used."""
+        config = self._config(
+            tmp_path,
+            package_overrides=(
+                pkg_override(self.NAME, dist_policy=DistPolicy.SDIST_ONLY),
+            ),
+        )
+
+        with pytest.raises(BuildEnvError) as excinfo:
+            self._resolve(config, tmp_path)
+
+        message = str(excinfo.value)
+        assert f"{self.NAME} {self.VERSION} has dist-policy 'sdist-only'" in message
+        assert "publishes no wheel" not in message
+
+
+class TestDistPolicyOverAPackageThatPublishesNoWheel:
+    """``sdist-only`` where the index had no wheel to bar.
+
+    A pin arrives carrying its sdist alone whether the policy rejected
+    a wheel or the index never served one, and the env cannot tell
+    those apart.  So the clause says what the policy admits, not that
+    the package has wheels somewhere.
+    """
+
+    NAME = "buildstub"
+    VERSION = "1.0"
+
+    def _refusal(self, tmp_path: Path) -> str:
+        """Return the message an index-wide ``sdist-only`` refuses with."""
+        index_dir = tmp_path / "index"
+        _make_local_index(index_dir, self.NAME, self.VERSION, sdist_only=True)
+        config = NabProjectConfig(
+            indexes=(IndexConfig("local", index_dir.as_uri()),),
+            index_overrides={"local": IndexOverride(dist_policy=DistPolicy.SDIST_ONLY)},
+        )
+        wheel_dir = tmp_path / "wheels"
+        wheel_dir.mkdir()
+        env = NabBuildEnv(requires=[self.NAME], config=config)
+
+        with pytest.raises(BuildEnvError) as excinfo:
+            env._resolve_and_download(wheel_dir)
+        return str(excinfo.value)
+
+    def test_the_refusal_does_not_say_the_package_has_wheels(
+        self, tmp_path: Path
+    ) -> None:
+        """The policy is named; the package's own wheels are not claimed."""
+        message = self._refusal(tmp_path)
+
+        assert "its wheels" not in message
+        assert (
+            f"{self.NAME} {self.VERSION} has dist-policy 'sdist-only', which"
+            " admits no wheel into the build env" in message
+        )
 
 
 class TestBuildRequirementNeedingItsOwnBuild:


### PR DESCRIPTION
`dist-policy = "sdist-only"` on a build requirement makes the build env refuse it with a message that blames the index:

```
setuptools 80.9.0 publishes no wheel this build host can install, so satisfying it means building it; [tool.nab].build-requires-depth is 0
```

PyPI publishes `setuptools-80.9.0-py3-none-any.whl` and this host installs it. The config is what kept it out: `sdist-only` and `sdist-install` govern the build env's own resolve too, so the pin arrives with its sdist alone and the refusal reports the only cause it knows about. The reader goes hunting for a wheel that is not missing.

The message now names the policy:

```
setuptools 80.9.0 has dist-policy 'sdist-only', which admits no wheel into the build env, so satisfying it means building it; [tool.nab].build-requires-depth is 0
```

`build-requires-depth` defaults to 0, so an `sdist-only` build requirement hits this refusal by default rather than in a corner case.

The clause says what the policy admits, not that the package has wheels: a pin arrives with its sdist alone whether a wheel was rejected or never published. A policy is named only where it could be the cause, so a package override has to match on name, version range and value, and an index override has to be the one that served the pin, matched on the URL the pin records so a credentialed index still matches.
