### PR TITLE
Make `hatch shell` build the `.venv` contributing.md documents

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -5,8 +5,8 @@ from the workspace check-out.
 
 ## Development install
 
-nab uses [hatch] as its environment manager; clone the repository and
-let hatch do the editable installs:
+nab uses [hatch] as its environment manager. Install it, then clone the
+repository and let it do the editable installs:
 
 ```bash
 git clone https://github.com/notatallshaw/nab.git
@@ -15,9 +15,12 @@ hatch shell
 nab --version
 ```
 
-`hatch shell` enters a virtual environment (`.venv` by default) with
-all five distributions installed editable, plus the test, lint, docs,
-and types environments available via `hatch run`.
+That shell runs in the check-out's `.venv`, with all five distributions
+installed editable plus the `tests` and `nox` dependency-groups. The
+commands below run its tools by path, so they work outside the shell too.
+
+Ruff and the docs toolchain live in their own hatch environments, reached
+through `hatch run`.
 
 [hatch]: https://hatch.pypa.io/
 
@@ -42,12 +45,11 @@ own data file, so combine before reporting:
 ```
 
 CI gates each workspace's coverage on its own tests through nox (see
-`noxfile.py`). With nox installed (`pip install nox`), reproduce a single
-workspace, or all of them, with:
+`noxfile.py`). Reproduce a single workspace, or all of them, with:
 
 ```bash
-nox -s tests                              # every workspace, each gated
-nox -s tests -- project                   # just one workspace
+.venv/bin/nox -s tests                    # every workspace, each gated
+.venv/bin/nox -s tests -- project         # just one workspace
 ```
 
 Property-based tests are opt-in via marker:
@@ -56,18 +58,22 @@ Property-based tests are opt-in via marker:
 .venv/bin/python -m pytest -m property    # Hypothesis-only suites
 ```
 
-Lint and format with ruff; type-check with pyright:
+Lint and format with ruff, out of the `lint` environment:
 
 ```bash
-.venv/bin/python -m ruff check .
-.venv/bin/python -m ruff format .
-.venv/bin/python -m pyright
+hatch run lint:check
+hatch run lint:fmt
 ```
 
-CI checks the same trees with five checkers rather than one, so a change
-pyright accepts can still fail the matrix. Reproduce a single cell with
-`nox -s "types(checker='mypy')"`; the trees are `TYPED_TREES` in
-`noxfile.py`.
+Type-check through nox, which installs the pinned checker lock and runs
+one checker over its own scope:
+
+```bash
+.venv/bin/nox -s "types(checker='pyright')"   # or mypy, ty, pyrefly, zuban
+```
+
+CI runs all five rather than one, so a change pyright accepts can still
+fail the matrix; the trees are `TYPED_TREES` in `noxfile.py`.
 
 ## The build backend
 

--- a/hatch.toml
+++ b/hatch.toml
@@ -1,7 +1,18 @@
+# The contributor's environment, at the path docs/contributing.md runs its
+# tools from. Every other environment is detached or names itself as its own
+# template, because inheriting `path` would land it here too.
 [envs.default]
+path = ".venv"
 workspace.members = ["nab-resolver", "nab-provider", "nab-project", "nab-index"]
+dependency-groups = ["tests", "nox"]
+# The umbrella pins its siblings to the unreleased version under development,
+# and hatch installs it before syncing the members, so the members go in first.
+pre-install-commands = [
+    "python -m pip install -e nab-resolver -e nab-provider -e nab-index -e nab-project",
+]
 
 [envs.hatch-test]
+template = "hatch-test"
 workspace.members = ["nab-resolver", "nab-provider", "nab-project", "nab-index"]
 features = ["httpx"]
 extra-dependencies = [
@@ -11,6 +22,7 @@ extra-dependencies = [
 ]
 
 [envs.crosshair]
+template = "crosshair"
 workspace.members = ["nab-resolver", "nab-provider", "nab-project", "nab-index"]
 extra-dependencies = [
     "crosshair-tool>=0.0.104",
@@ -24,6 +36,7 @@ extra-dependencies = [
 check = "pytest -m crosshair {args}"
 
 [envs.types]
+template = "types"
 workspace.members = ["nab-resolver", "nab-provider", "nab-project", "nab-index"]
 dependencies = [
     "pyright>=1.1.400",
@@ -58,6 +71,7 @@ fmt-check = "ruff format --check ."
 # is what nab locks into .github/requirements/pylock.docs.toml, which is what CI
 # and Read the Docs install.  Only the live-reload server is local-only.
 [envs.docs]
+template = "docs"
 skip-install = true
 dependency-groups = ["docs"]
 dependencies = [

--- a/tests/test_contributing_docs.py
+++ b/tests/test_contributing_docs.py
@@ -2,28 +2,40 @@
 
 A contributor pastes these into a shell, so a documented pytest flag has to be
 one the installed pytest accepts, and the documented coverage recipe has to run
-the steps CI's gate runs.
+the steps CI's gate runs. A tool the page runs out of the development
+environment has to be one that environment carries.
 """
 
 from __future__ import annotations
 
 import ast
+import itertools
 import os
 import re
 import shlex
 import subprocess
 import sys
 from pathlib import Path, PurePosixPath
+from typing import Any
 
 import pytest
+import tomli
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 CONTRIBUTING = REPO_ROOT / "docs" / "contributing.md"
 NOXFILE = REPO_ROOT / "noxfile.py"
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+HATCH_TOML = REPO_ROOT / "hatch.toml"
 
 _FENCE = re.compile(r"^```.*?^```", re.DOTALL | re.MULTILINE)
 _INLINE = re.compile(r"`([^`\n]+)`")
+
+_VENV = ".venv"
+_VENV_BIN = f"{_VENV}/bin/"
+
+# A dependency specifier down to its bare name.
+_REQUIREMENT_NAME = re.compile(r"^[^\[=<>!~;\s]+")
 
 
 def _documented_commands() -> list[str]:
@@ -99,6 +111,94 @@ def _ci_coverage_steps() -> set[str]:
     return steps
 
 
+def _canonical(name: str) -> str:
+    """A distribution, module or script name in one spelling."""
+    return name.lower().replace("_", "-")
+
+
+def _group_names(group: str, groups: dict[str, list[object]]) -> set[str]:
+    """The distributions one dependency-group installs, through its includes."""
+    names = set()
+    for entry in groups[group]:
+        if isinstance(entry, dict):
+            names |= _group_names(str(entry["include-group"]), groups)
+        else:
+            match = _REQUIREMENT_NAME.match(str(entry))
+            assert match is not None
+            names.add(_canonical(match.group()))
+    return names
+
+
+def _project_names(directory: Path) -> set[str]:
+    """The distribution name and console scripts one project directory ships."""
+    project = tomli.loads((directory / "pyproject.toml").read_text(encoding="utf-8"))[
+        "project"
+    ]
+    return {_canonical(project["name"])} | {
+        _canonical(script) for script in project.get("scripts", {})
+    }
+
+
+def _hatch_envs() -> dict[str, Any]:
+    """The environments hatch.toml declares."""
+    return tomli.loads(HATCH_TOML.read_text(encoding="utf-8"))["envs"]
+
+
+def _installed_names() -> set[str]:
+    """The distributions and scripts hatch's default environment names.
+
+    Transitive dependencies are left out: the page runs a tool the environment
+    asks for, not one pulled in behind another.
+    """
+    default = _hatch_envs()["default"]
+    groups = tomli.loads(PYPROJECT.read_text(encoding="utf-8"))["dependency-groups"]
+
+    # The umbrella installs from the repo root, its members from subdirectories.
+    installed = _project_names(REPO_ROOT)
+    for member in default["workspace"]["members"]:
+        installed |= _project_names(REPO_ROOT / str(member))
+    for group in default["dependency-groups"]:
+        installed |= _group_names(str(group), groups)
+    return installed
+
+
+def _pre_install_editables(env: dict[str, Any]) -> set[str]:
+    """The directories an environment installs editable ahead of hatch's own install."""
+    paths = set()
+    for command in env.get("pre-install-commands", []):
+        args = shlex.split(str(command))
+        paths.update(value for flag, value in itertools.pairwise(args) if flag == "-e")
+    return paths
+
+
+def _venv_tools() -> set[str]:
+    """The tools the page runs out of the development environment."""
+    tools = set()
+    for command in _documented_commands():
+        if not command.startswith(_VENV_BIN):
+            continue
+        invocation = _invocation(command)
+        if invocation is not None:
+            tools.add(_canonical(invocation[0]))
+    return tools
+
+
+def _documented_hatch_scripts() -> set[tuple[str, str]]:
+    """The `hatch run <env>:<script>` targets the page prints."""
+    targets = set()
+    for command in _documented_commands():
+        invocation = _invocation(command)
+        if invocation is None:
+            continue
+        tool, args = invocation
+        if tool != "hatch" or args[:1] != ("run",) or len(args) < 2:
+            continue
+        env, _, script = args[1].partition(":")
+        if script:
+            targets.add((env, script))
+    return targets
+
+
 def test_documented_pytest_arguments_are_accepted() -> None:
     """Each documented pytest command must parse and name paths that exist."""
     documented = _documented_pytest_arguments()
@@ -139,3 +239,63 @@ def test_documented_coverage_recipe_matches_ci() -> None:
     assert not missing, (
         f"contributing.md omits the coverage step(s) CI runs: {sorted(missing)}"
     )
+
+
+def test_development_environment_lives_where_the_page_runs_it() -> None:
+    """The page runs tools by path, so hatch's default environment has to be `.venv`."""
+    assert _hatch_envs()["default"].get("path") == _VENV, (
+        f"contributing.md runs tools out of {_VENV_BIN}, which is not where "
+        f"hatch.toml puts the default environment"
+    )
+
+
+def test_only_the_default_environment_is_the_check_out_venv() -> None:
+    """Hatch environments inherit `path`, so every one but the default opts out."""
+    sharing = sorted(
+        name
+        for name, env in _hatch_envs().items()
+        if name != "default" and not env.get("detached") and env.get("template") != name
+    )
+    assert not sharing, (
+        f"hatch environments {sharing} inherit the default environment's path, "
+        f"so they would share {_VENV} with it"
+    )
+
+
+def test_workspace_members_go_in_before_the_umbrella() -> None:
+    """The default environment installs its members ahead of hatch's own install.
+
+    The umbrella pins them to the unreleased version under development, so
+    hatch's install resolves only once they are already there.
+    """
+    default = _hatch_envs()["default"]
+    assert _pre_install_editables(default) == set(default["workspace"]["members"])
+
+
+def test_documented_venv_tools_are_installed() -> None:
+    """The development environment must carry every tool the page runs from it."""
+    installed = _installed_names()
+    assert installed, "hatch's default environment carries nothing"
+
+    tools = _venv_tools()
+    assert tools, f"contributing.md runs nothing out of {_VENV_BIN}"
+
+    missing = sorted(tools - installed)
+    assert not missing, (
+        f"contributing.md runs {missing} out of {_VENV_BIN}, which hatch's "
+        f"default environment does not carry"
+    )
+
+
+def test_documented_hatch_scripts_exist() -> None:
+    """Each `hatch run <env>:<script>` the page prints names a script hatch.toml has."""
+    envs = _hatch_envs()
+    documented = _documented_hatch_scripts()
+    assert documented, "contributing.md documents no hatch script"
+
+    missing = sorted(
+        f"{env}:{script}"
+        for env, script in documented
+        if script not in envs.get(env, {}).get("scripts", {})
+    )
+    assert not missing, f"contributing.md runs undeclared hatch scripts: {missing}"


### PR DESCRIPTION
`hatch shell`, the development install contributing.md documents, cannot build its environment:

```
No matching distribution found for nab-index==0.0.15.dev0
```

Hatch installs the umbrella project on its own before it syncs `workspace.members`, and the umbrella pins its four siblings to the unreleased version under development, so that lone install goes looking on PyPI. The failed attempt leaves the environment directory behind, so the next run reports `Environment 'default' already exists` and skips the install instead of retrying.

Two more defects sit behind it:

- `hatch env find default` returns `~/.local/share/hatch/env/virtual/nab/<hash>/nab`. The nine commands the page prints run out of `.venv/bin/`, which hatch never creates.
- The default environment carries no test tooling, and the page runs `.venv/bin/python -m ruff` and `-m pyright` from it. Those live in the `lint` and `types` environments.

So `[envs.default]` now sets `path = ".venv"` and `dependency-groups = ["tests", "nox"]`, and a `pre-install-commands` line puts the four members in editable ahead of hatch's own install.

Pinning `path` has a trap. Environments inherit the default's config unless `template` names another env, so on hatch 1.16.5 `hatch env find docs`, `types` and `crosshair` all came back as `<project>/.venv` too. Each now names itself as its own template, the same mechanism `detached = true` already uses on `lint` and `release`.

On the page, ruff moves to `hatch run lint:check` and `lint:fmt`, pyright becomes `.venv/bin/nox -s "types(checker='pyright')"`, and the nox lines run `.venv/bin/nox` rather than asking for a separate `pip install nox`.

`tests/test_contributing_docs.py` gains five guards: the default environment's path is `.venv`, no other declared environment inherits it, its pre-install editables are exactly `workspace.members`, every tool the page runs out of `.venv/bin/` is one that environment carries, and every `hatch run <env>:<script>` it prints exists in `hatch.toml`.
