### PR TITLE
Factor environment disjuncts before simplifying, ~10% off a 25-target lock

### DIFF
--- a/nab-project/src/nab_project/_lockfile/pylock.py
+++ b/nab-project/src/nab_project/_lockfile/pylock.py
@@ -11,6 +11,7 @@ disjointness validation lives in
 from __future__ import annotations
 
 import os
+import re
 from collections import Counter, defaultdict
 from dataclasses import dataclass, replace
 from functools import lru_cache, reduce
@@ -21,7 +22,10 @@ from typing import TYPE_CHECKING, Any, TypeAlias
 import tomli_w
 
 from nab_index.atomic import atomic_write_text
-from nab_provider._vendor.packaging.markers import Marker
+from nab_provider._vendor.packaging.markers import (
+    MARKERS_REQUIRING_VERSION,
+    Marker,
+)
 from nab_provider._vendor.packaging.markersets import (
     DecisionStore,
     IntractableMarkerSet,
@@ -40,7 +44,7 @@ from nab_provider._vendor.packaging.pylock import (
 )
 from nab_provider._vendor.packaging.specifiers import SpecifierSet
 from nab_provider._vendor.packaging.utils import canonicalize_name, is_normalized_name
-from nab_provider._vendor.packaging.version import Version
+from nab_provider._vendor.packaging.version import InvalidVersion, Version
 from nab_provider.conflict_kind import KIND_GROUP, MARKER_VARIABLE_FOR_KIND
 
 from ..config import conflict_exclusion_groups, conflict_member_groups
@@ -93,6 +97,8 @@ class _ForkAxes:
     held fixed.  ``markers`` is each fork's unprojected selection marker,
     which does not vary by package, and ``gates`` each fork's
     :attr:`~nab_project.lockfile.TargetLock.package_gates` as sets.
+    ``env_rows`` is the values the declared environments pin, or ``None``
+    when the factoring has no table to read (:func:`_emission_scope`).
     """
 
     exclusion_groups: tuple[AbstractSet[tuple[str, str]], ...]
@@ -101,6 +107,7 @@ class _ForkAxes:
     env_signatures: Mapping[str, _EnvSignature]
     markers: Mapping[str, str]
     gates: Mapping[tuple[str, str], _Members]
+    env_rows: tuple[Mapping[str, str], ...] | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -285,9 +292,9 @@ def build_pylock(lock_input: LockInput, *, lock_dir: Path | None = None) -> Pylo
     environment_rows = [
         MarkerSet.from_marker(marker) for marker in lock_input.environments
     ]
-    universe = _emission_universe(lock_input, store, rows=environment_rows)
+    universe, env_rows = _emission_scope(lock_input, store, rows=environment_rows)
     package_records = _build_packages(
-        lock_input, base, exclusion_groups, universe, store
+        lock_input, base, exclusion_groups, universe, env_rows, store
     )
     package_records.sort(key=_package_sort_key)
     validate_marker_disjointness(
@@ -549,12 +556,12 @@ def _sdist_to_package(sdist: SdistArtifact, *, lock_dir: Path) -> PackageSdist:
     )
 
 
-def _emission_universe(
+def _emission_scope(
     lock_input: LockInput,
     store: DecisionStore | None = None,
     rows: Sequence[MarkerSet] | None = None,
-) -> MarkerSet:
-    """Return the environment universe simplification must agree over.
+) -> tuple[MarkerSet, tuple[Mapping[str, str], ...] | None]:
+    """Return the universe simplification must agree over, with its row table.
 
     The union of the declared ``environments`` rows, or the full set when none
     are declared.  PEP 751 step 4 has a conforming installer read a per-package
@@ -567,11 +574,15 @@ def _emission_universe(
     exactly when every row is, so rows are tested one at a time rather than as a
     whole-matrix product, and a row too wide to decide counts as inhabited.
 
+    The row table it returns is the point form of the same environments.  It
+    comes back ``None`` on both routes to the full set, so the factoring never
+    selects over rows the universe has stopped covering.
+
     ``rows`` are ``lock_input.environments`` already built as sets; they are
     built here when omitted.
     """
     if not lock_input.environments:
-        return MarkerSet.full()
+        return MarkerSet.full(), None
     if rows is None:
         rows = [MarkerSet.from_marker(m) for m in lock_input.environments]
     try:
@@ -579,8 +590,11 @@ def _emission_universe(
     except IntractableMarkerSet:
         uninhabited = False
     if uninhabited:
-        return MarkerSet.full()
-    return reduce(MarkerSet.union, rows, MarkerSet.empty())
+        return MarkerSet.full(), None
+    return (
+        reduce(MarkerSet.union, rows, MarkerSet.empty()),
+        _pinned_env_rows(lock_input.environments),
+    )
 
 
 @lru_cache(maxsize=4096)
@@ -663,6 +677,7 @@ def _build_packages(
     lock_dir: Path,
     exclusion_groups: Sequence[AbstractSet[tuple[str, str]]],
     universe: MarkerSet,
+    env_rows: tuple[Mapping[str, str], ...] | None,
     store: DecisionStore,
 ) -> list[Package]:
     """Collapse the per-target pins into Package entries with markers.
@@ -731,6 +746,7 @@ def _build_packages(
             for label, lock in targets.items()
             for name, gate in lock.package_gates.items()
         },
+        env_rows=env_rows,
     )
     projections = _fork_projections(axes, pin_groups, env_fork_counts, base_names)
 
@@ -1051,7 +1067,7 @@ def _build_marker(
     # every environment collapsed to its env-only marker. A member-only
     # dep present in all forks of an env keeps the membership OR, so it
     # is not unconditional even at full coverage.
-    by_gate: defaultdict[tuple[tuple[str, str], ...], list[Marker]] = defaultdict(list)
+    by_gate: defaultdict[tuple[tuple[str, str], ...], list[str]] = defaultdict(list)
     loose: list[Marker] = []
     unconditional = len(labels) >= len(targets)
     for signature, env_labels in by_env.items():
@@ -1066,7 +1082,7 @@ def _build_marker(
 
         if collapses and agreed_gate:
             merged = _merge_gates(gates[label] for label in env_labels)
-            by_gate[merged].append(_parsed_marker(head.environment_marker_string))
+            by_gate[merged].append(head.environment_marker_string)
             continue
 
         # Forks that disagree on the gate still agree on what they share,
@@ -1075,7 +1091,7 @@ def _build_marker(
         if collapses:
             shared = _common_gate(gates[label] for label in env_labels)
             if shared:
-                by_gate[shared].append(_parsed_marker(head.environment_marker_string))
+                by_gate[shared].append(head.environment_marker_string)
 
         loose.extend(
             _parsed_marker(text)
@@ -1084,7 +1100,7 @@ def _build_marker(
         unconditional = False
 
     parts = tuple(
-        _GatedMarker(_or_markers(environments), gate)
+        _GatedMarker(_env_disjunction(environments, axes.env_rows), gate)
         for gate, environments in by_gate.items()
     )
     if loose:
@@ -1499,6 +1515,156 @@ def _count(
     for signature in signatures:
         counts[signature] += 1
     return counts
+
+
+_PINNED_ATOM = re.compile(r'\A(\w+) == "([^"]*)"\Z')
+
+
+def _pinned_values(text: str) -> dict[str, str] | None:
+    """Return the value each variable of ``text`` is pinned to.
+
+    ``None`` unless ``text`` is an ``and`` of ``variable == "value"`` atoms over
+    distinct variables.  Anything else, an interval or a disjunction, selects a
+    region rather than a point.
+    """
+    if "(" in text or " or " in text:
+        return None
+    pinned: dict[str, str] = {}
+    for atom in text.split(" and "):
+        match = _PINNED_ATOM.match(atom)
+        if match is None or match[1] in pinned:
+            return None
+        pinned[match[1]] = match[2]
+    return pinned
+
+
+def _pinned_env_rows(
+    environments: Sequence[Marker],
+) -> tuple[Mapping[str, str], ...] | None:
+    """Return the values each declared environment row pins, or ``None``.
+
+    ``None`` when nothing is declared, when a row is not a conjunction of
+    equality atoms, or when two rows spell one version differently.  The table
+    is matched by string, so those are the rows it can stand for.
+    """
+    if not environments:
+        return None
+    rows: list[Mapping[str, str]] = []
+    for row in environments:
+        pinned = _pinned_values(str(row))
+        if pinned is None:
+            return None
+        rows.append(pinned)
+    if _version_spellings_collide(rows):
+        return None
+    return tuple(rows)
+
+
+def _version_spellings_collide(rows: Sequence[Mapping[str, str]]) -> bool:
+    """Whether two rows write one version two ways on a version-compared name.
+
+    ``==`` on those variables is PEP 440 comparison, so ``"3.10"`` and
+    ``"3.10.0"`` each select the other's row while the table reads them as two
+    values.  A value no specifier accepts compares as a string, so it keys on
+    itself.
+    """
+    for name in MARKERS_REQUIRING_VERSION:
+        spellings: dict[object, str] = {}
+        for row in rows:
+            value = row.get(name)
+            if value is None:
+                continue
+            try:
+                key: object = Version(value)
+            except InvalidVersion:
+                key = value
+            if spellings.setdefault(key, value) != value:
+                return True
+    return False
+
+
+def _pinned_points(
+    texts: Sequence[str],
+) -> tuple[tuple[str, ...], set[tuple[str, ...]]] | None:
+    """Return the variables the non-empty ``texts`` pin and the points they name.
+
+    ``None`` unless every text pins the same variables in the same order, which
+    is what makes the points comparable across the declared rows.
+    """
+    first = _pinned_values(texts[0])
+    if first is None:
+        return None
+    variables = tuple(first)
+    points = {tuple(first.values())}
+    for text in texts[1:]:
+        pinned = _pinned_values(text)
+        if pinned is None or tuple(pinned) != variables:
+            return None
+        points.add(tuple(pinned.values()))
+    return variables, points
+
+
+def _collapsed_env_marker(
+    texts: Sequence[str], rows: tuple[Mapping[str, str], ...] | None
+) -> str | None:
+    """Return ``texts`` as one factored marker, or ``None`` to keep the ``or``.
+
+    Each text pins the same variables to a point.  Read off the values those
+    points give each variable and offer the product of those value sets: where
+    the product selects exactly the declared rows the texts do, it is equivalent
+    to their ``or``.  A variable already taking every value the rows take
+    narrows nothing and drops out.
+
+    ``None`` when the texts do not pin one variable set, when a row leaves one
+    of those variables open, or when the product reaches a row the texts do not.
+    """
+    if rows is None or len(texts) <= 1:
+        return None
+    named = _pinned_points(texts)
+    if named is None:
+        return None
+    variables, selected = named
+    if any(name not in row for row in rows for name in variables):
+        return None
+
+    points = {tuple(row[name] for name in variables) for row in rows}
+    axes = range(len(variables))
+    chosen = [{point[axis] for point in selected} for axis in axes]
+
+    if {p for p in points if all(p[axis] in chosen[axis] for axis in axes)} != selected:
+        return None
+
+    kept = [axis for axis in axes if chosen[axis] != {p[axis] for p in points}]
+    if not kept:
+        # Every row is named, so one variable's values already spell all of them.
+        return _product_marker([(variables[0], chosen[0])])
+    return _product_marker([(variables[axis], chosen[axis]) for axis in kept])
+
+
+def _product_marker(factors: Sequence[tuple[str, AbstractSet[str]]]) -> str:
+    """Render the marker selecting the product of ``factors``.
+
+    Each factor is a variable and the values it may take.  ``and`` binds tighter
+    than ``or``, so a variable given several values is parenthesised whenever
+    there is more than one factor.
+    """
+    clauses = []
+    for name, values in factors:
+        clause = " or ".join(f'{name} == "{value}"' for value in sorted(values))
+        clauses.append(
+            f"({clause})" if len(values) > 1 and len(factors) > 1 else clause
+        )
+    return " and ".join(clauses)
+
+
+def _env_disjunction(
+    texts: Sequence[str], rows: tuple[Mapping[str, str], ...] | None
+) -> Marker:
+    """Return the marker selecting the environments ``texts`` name."""
+    collapsed = _collapsed_env_marker(texts, rows)
+    if collapsed is not None:
+        return _parsed_marker(collapsed)
+    return _or_markers([_parsed_marker(text) for text in texts])
 
 
 def _or_markers(markers: Sequence[Marker]) -> Marker:

--- a/nab-project/tests/test_pylock.py
+++ b/nab-project/tests/test_pylock.py
@@ -8,6 +8,7 @@ fail-closed verify on the emitted bytes.
 from __future__ import annotations
 
 import importlib.util
+import itertools
 import json
 import sys
 from functools import reduce
@@ -26,9 +27,14 @@ from nab_project._lockfile.coverage import CoverageError
 from nab_project._lockfile.disjointness import validate_marker_disjointness
 from nab_project._lockfile.pylock import (
     UnsoundSimplificationError,
-    _emission_universe,
+    _collapsed_env_marker,
+    _emission_scope,
+    _env_disjunction,
     _finalize_cached,
     _finalize_marker,
+    _or_markers,
+    _pinned_env_rows,
+    _pinned_values,
     build_pylock,
     render_lock,
 )
@@ -362,8 +368,8 @@ class TestNonCoveringEnvironments:
         assert str(result) == str(raw)
 
 
-class TestEmissionUniverse:
-    """The universe the emitter simplifies against.
+class TestEmissionScope:
+    """The universe the emitter simplifies against, and its row table.
 
     These declarations are hand-built; nab's own resolve never produces them.
     """
@@ -378,18 +384,37 @@ class TestEmissionUniverse:
         )
 
     def test_no_environments_is_the_full_set(self) -> None:
-        assert _emission_universe(self._with_environments([])).is_full()
+        assert _emission_scope(self._with_environments([]))[0].is_full()
 
     def test_uninhabited_rows_fall_back_to_the_full_set(self) -> None:
         rows = [Marker('sys_platform == "linux" and sys_platform == "win32"')]
-        assert _emission_universe(self._with_environments(rows)).is_full()
+        assert _emission_scope(self._with_environments(rows))[0].is_full()
+
+    def test_uninhabited_point_rows_leave_no_table_to_factor_against(self) -> None:
+        # Each row is a point, and each is empty because its two python axes
+        # contradict, so the universe widens to the full set.
+        rows = [
+            Marker(
+                f'python_version == "3.10" and sys_platform == "{platform}"'
+                ' and python_full_version == "3.11.0"'
+            )
+            for platform in ("linux", "win32")
+        ]
+        universe, env_rows = _emission_scope(self._with_environments(rows))
+        assert universe.is_full()
+        assert env_rows is None
+
+    def test_inhabited_point_rows_carry_their_table(self) -> None:
+        _, env_rows = _emission_scope(self._with_environments(_ENVS))
+        assert env_rows is not None
+        assert len(env_rows) == len(_ENVS)
 
     def test_one_inhabited_row_keeps_the_declared_union(self) -> None:
         rows = [
             Marker('sys_platform == "linux" and sys_platform == "win32"'),
             Marker('sys_platform == "linux"'),
         ]
-        universe = _emission_universe(self._with_environments(rows))
+        universe, _ = _emission_scope(self._with_environments(rows))
         assert universe.equivalent(MarkerSet.from_marker('sys_platform == "linux"'))
 
     @pytest.mark.usefixtures("ungated")
@@ -405,7 +430,7 @@ class TestEmissionUniverse:
 
     def test_undecidable_row_counts_as_inhabited(self) -> None:
         wide = Marker(" and ".join(f'"e{i}" in extras' for i in range(20)))
-        universe = _emission_universe(self._with_environments([wide]))
+        universe, _ = _emission_scope(self._with_environments([wide]))
         # The full set would drop a tautology; an undecidable universe decides
         # nothing, so the marker ships raw.
         tautology = Marker('python_version == "3.11" or python_version != "3.11"')
@@ -876,3 +901,203 @@ class TestEmissionStore:
         assert len(seen) >= 3
         assert {id(store) for store in seen} == {id(seen[0])}
         assert isinstance(seen[0], DecisionStore)
+
+
+def _env_rows(*texts: str) -> tuple[Mapping[str, str], ...] | None:
+    """The pinned-value table for environment rows written as marker text."""
+    return _pinned_env_rows([Marker(text) for text in texts])
+
+
+def _point(python: str, platform: str) -> str:
+    """One environment, pinned on both axes, as marker text."""
+    return f'python_version == "{python}" and sys_platform == "{platform}"'
+
+
+def _grid(*axes: tuple[str, tuple[str, ...]]) -> list[str]:
+    """Every point of the product of ``axes``, as environment marker text."""
+    names = [name for name, _ in axes]
+    return [
+        " and ".join(
+            f'{name} == "{value}"' for name, value in zip(names, values, strict=True)
+        )
+        for values in itertools.product(*(values for _, values in axes))
+    ]
+
+
+_PYTHONS = ("3.10", "3.11", "3.12")
+_PLATFORMS = ("darwin", "linux", "win32")
+_THREE_BY_THREE_POINTS = [
+    _point(python, platform) for python in _PYTHONS for platform in _PLATFORMS
+]
+_THREE_BY_THREE = _env_rows(*_THREE_BY_THREE_POINTS)
+
+
+class TestPinnedEnvironmentRows:
+    """What a declared environment has to be for the factoring to place it."""
+
+    def test_a_repeated_variable_is_not_a_point(self) -> None:
+        assert (
+            _pinned_values('sys_platform == "linux" and sys_platform == "win32"')
+            is None
+        )
+
+    def test_no_declared_environments_leave_no_table(self) -> None:
+        assert _pinned_env_rows([]) is None
+
+    def test_a_disjoined_row_leaves_no_table(self) -> None:
+        assert _env_rows('sys_platform == "linux" or sys_platform == "win32"') is None
+
+    def test_two_spellings_of_one_version_leave_no_table(self) -> None:
+        assert _env_rows(_point("3.10", "linux"), _point("3.10.0", "win32")) is None
+
+    def test_a_value_no_specifier_accepts_is_kept_as_a_string(self) -> None:
+        rows = _env_rows('python_version == "unreleased"', 'python_version == "3.10"')
+        assert rows is not None
+
+
+class TestEnvironmentDisjunctFactoring:
+    """What :func:`_collapsed_env_marker` hands to simplification.
+
+    One disjunct per target becomes the product of the values those targets
+    take, so what these pin is the guards that keep the product equal to the
+    disjunction it replaces.
+    """
+
+    def test_a_variable_every_row_agrees_on_drops_out(self) -> None:
+        texts = [_point("3.10", platform) for platform in _PLATFORMS]
+        assert (
+            _collapsed_env_marker(texts, _THREE_BY_THREE) == 'python_version == "3.10"'
+        )
+
+    def test_a_product_keeps_the_variables_it_narrows(self) -> None:
+        texts = [
+            _point(python, platform)
+            for python in ("3.10", "3.11")
+            for platform in ("darwin", "linux")
+        ]
+        assert _collapsed_env_marker(texts, _THREE_BY_THREE) == (
+            '(python_version == "3.10" or python_version == "3.11")'
+            ' and (sys_platform == "darwin" or sys_platform == "linux")'
+        )
+
+    def test_texts_naming_every_row_render_one_variable(self) -> None:
+        assert _collapsed_env_marker(_THREE_BY_THREE_POINTS, _THREE_BY_THREE) == (
+            'python_version == "3.10" or python_version == "3.11"'
+            ' or python_version == "3.12"'
+        )
+
+    def test_a_selection_the_product_overshoots_keeps_its_disjuncts(self) -> None:
+        texts = [_point("3.10", "darwin"), _point("3.11", "linux")]
+        assert _collapsed_env_marker(texts, _THREE_BY_THREE) is None
+
+    def test_disjuncts_pinning_different_variables_keep_their_shape(self) -> None:
+        texts = [_point("3.10", "darwin"), 'python_version == "3.11"']
+        assert _collapsed_env_marker(texts, _THREE_BY_THREE) is None
+
+    def test_an_interval_is_not_a_point(self) -> None:
+        texts = ['python_full_version >= "3.10.0"', _point("3.11", "linux")]
+        assert _collapsed_env_marker(texts, _THREE_BY_THREE) is None
+
+    def test_a_row_leaving_a_variable_open_places_nothing(self) -> None:
+        rows = _env_rows('python_version == "3.10"', _point("3.11", "linux"))
+        texts = [_point("3.10", "darwin"), _point("3.11", "linux")]
+        assert _collapsed_env_marker(texts, rows) is None
+
+    def test_a_single_disjunct_is_left_to_the_algebra(self) -> None:
+        assert (
+            _collapsed_env_marker([_point("3.10", "darwin")], _THREE_BY_THREE) is None
+        )
+
+
+_THREE_AXIS_POINTS = _grid(
+    ("python_version", ("3.10", "3.11")),
+    ("sys_platform", ("linux", "win32")),
+    ("platform_machine", ("arm64", "x86_64")),
+)
+_SPARE_VARIABLE_ROWS = _grid(
+    ("python_version", _PYTHONS),
+    ("sys_platform", ("linux", "win32")),
+    ("platform_machine", ("arm64", "x86_64")),
+)
+_SPARE_VARIABLE_TEXTS = [
+    _point(python, platform) for python in _PYTHONS for platform in ("linux", "win32")
+]
+_RAGGED_ROWS = [
+    _point("3.10", "linux"),
+    _point("3.10", "win32"),
+    _point("3.11", "linux"),
+    _point("3.12", "win32"),
+]
+
+# Declared rows, the texts to select from, and how many of those selections
+# the factoring collapses.
+_SELECTION_TABLES = [
+    ("two full axes", _THREE_BY_THREE_POINTS, _THREE_BY_THREE_POINTS, 40),
+    ("three full axes", _THREE_AXIS_POINTS, _THREE_AXIS_POINTS, 19),
+    ("a variable only the rows pin", _SPARE_VARIABLE_ROWS, _SPARE_VARIABLE_TEXTS, 15),
+    ("a ragged matrix", _RAGGED_ROWS, _RAGGED_ROWS, 7),
+]
+
+
+class TestFactoringEquivalence:
+    """Every collapse selects the environments its disjunction selects.
+
+    The factoring runs before :func:`_finalize_marker`, whose soundness check
+    compares the emitted bytes against what it was handed, so a collapse that
+    widened a marker would pass that check.  Each case selects every subset of
+    a declared matrix and checks the collapse against the ``or`` it replaced.
+    """
+
+    @pytest.mark.parametrize(
+        ("rows", "texts", "collapses"),
+        [case[1:] for case in _SELECTION_TABLES],
+        ids=[case[0] for case in _SELECTION_TABLES],
+    )
+    def test_a_collapse_is_equivalent_within_the_declared_rows(
+        self, rows: Sequence[str], texts: Sequence[str], collapses: int
+    ) -> None:
+        table = _env_rows(*rows)
+        assert table is not None
+        within = _union([Marker(row) for row in rows])
+
+        seen = 0
+        for size in range(1, len(texts) + 1):
+            for selection in itertools.combinations(texts, size):
+                emitted = _env_disjunction(list(selection), table)
+                raw = _or_markers([Marker(text) for text in selection])
+                if str(emitted) == str(raw):
+                    continue
+                seen += 1
+                assert MarkerSet.from_marker(emitted).equivalent_within(
+                    MarkerSet.from_marker(raw), within
+                ), (selection, str(emitted))
+
+        # Counting them keeps a table that never collapses from passing.
+        assert seen == collapses
+
+
+class TestFactoringReachesEmission:
+    """A lock build hands the factored marker to simplification."""
+
+    def test_the_span_lock_finalises_the_product(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        handed: dict[str, str] = {}
+        real = pylock._finalize_marker
+
+        def capture(
+            raw: Marker | None,
+            within: MarkerSet,
+            name: str = "",
+            store: DecisionStore | None = None,
+        ) -> Marker | None:
+            if raw is not None:
+                handed[name] = str(raw)
+            return real(raw, within, name, store)
+
+        monkeypatch.setattr(pylock, "_finalize_marker", capture)
+        assert _marker_of(_span_lock(), "foo") == 'sys_platform == "linux"'
+
+        assert handed == {
+            "foo": 'sys_platform == "linux" and platform_machine == "x86_64"'
+        }


### PR DESCRIPTION
Locking `universal:max-25-tuples` (25 targets) runs about 257 million fewer instructions, roughly 10% of the run's 2.47 billion; `universal:scientific-python-multi` (12 targets) is about 0.4%. The 25-target lock is about 7% faster on the clock.

`_build_marker` handed `MarkerSet.simplify` one disjunct per target and left it to work the factored shape back out. `importlib-metadata`, on 15 of the 25 targets, arrived as

    (python_version == "3.10" and sys_platform == "darwin" and platform_machine == "arm64")
    or ... fourteen more, one per target ...

and now arrives as `python_version == "3.10" or python_version == "3.11" or python_version == "3.9"`. Over that lock, simplification's `restrict_tree` runs 1,729 times instead of 12,507, the same on any machine.

`_collapsed_env_marker` replaces the `or` only when the product of the values those disjuncts pin selects exactly the declared rows the `or` does. That test is the guard on the step: `_finalize_marker`'s equivalence check runs after the factoring, so it compares against the factored marker. Importing `nab_project.lockfile` costs 598,487 instructions more, inside those counts.

All 18 `universal.toml` scenarios render byte-identical locks, 13 with packages, because nab's matrices are full grids. On a ragged matrix the factored marker can render differently from what the disjunction simplifies to, while selecting the same declared environments.