### PR TITLE
Stop a sibling's undecidable marker disabling the divergence check

### DIFF
--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -9264,6 +9264,32 @@ class TestAwaitMetadataBatchEdgeCases:
         assert ("foo", V("2.0")) not in provider.deps_cache
         assert provider.has_invalid_metadata("foo", V("2.0"))
 
+    def test_batch_constants_only_marker_refuses_version(self) -> None:
+        """A marker comparing two literals in the batch path refuses the version.
+
+        A quoted left operand makes packaging read the right one as an
+        environment key, so the clause fails only when the decode evaluates
+        it. The batch leaves v2.0 un-cached and look-ahead's get_dependencies
+        refuses it instead of the failure aborting the resolve, so the scan
+        falls through to v1.0.
+        """
+        wheels = [make_wheel("3.0"), make_wheel("2.0"), make_wheel("1.0")]
+        coordinator = make_coordinator(
+            wheels,
+            metadata_by_version={
+                "3.0": "Metadata-Version: 2.1\nName: foo\nVersion: 3.0\nRequires-Dist: bar>=5.0\n",
+                "2.0": 'Metadata-Version: 2.1\nName: foo\nVersion: 2.0\nRequires-Dist: pytz>=1; "extra" == "gpu"\n',
+                "1.0": "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\n",
+            },
+            package="foo",
+        )
+        root_reqs = {"bar": SpecifierSet("<2.0").to_range()}
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
+
+        assert provider.choose_version("foo", SpecifierSet("").to_range()) == V("1.0")
+        assert ("foo", V("2.0")) not in provider.deps_cache
+        assert provider.has_invalid_metadata("foo", V("2.0"))
+
     def test_batch_none_metadata_refuses_version(self) -> None:
         """Missing metadata text in the batch path refuses the version.
 
@@ -12196,6 +12222,32 @@ class TestSiblingMetadataDivergence:
 
         provider = Provider(coordinator, target=_LINUX311)
         assert sorted(provider.get_dependencies("pkg", self._V)) == ["alpha"]
+
+    def test_unevaluable_sibling_marker_stops_the_run(self) -> None:
+        """A tie sibling with an undecidable marker stops the run.
+
+        A quoted left operand makes packaging read the right one as an
+        environment key, so the clause fails only when the sibling is
+        projected.  Skipping the sibling there would pin the pick's
+        ``common`` and lose the ``gamma`` the sibling also declares.
+        """
+        wheel_a = _sib_wheel("py2.py3-none-any")
+        wheel_b = _sib_wheel("py3-none-any")
+        coordinator = make_coordinator([wheel_a, wheel_b], package="pkg")
+
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _sib_meta("common>=1"), metadata_url=wheel_a.metadata_url
+        )
+        coordinator.index.store_metadata(
+            "pkg",
+            "1.0",
+            _sib_meta("common>=1", "gamma>=1", 'beta>=1; "extra" == "gpu"'),
+            metadata_url=wheel_b.metadata_url,
+        )
+
+        provider = Provider(coordinator, target=_LINUX311)
+        with pytest.raises(UnevaluableMarkerError, match='"extra" == "gpu"'):
+            provider.get_dependencies("pkg", self._V)
 
     def test_provides_extra_override_folds_divergence(self) -> None:
         """A provides-extra override is applied to both siblings before compare.

--- a/nab-provider/src/nab_provider/_provider/metadata_resolver.py
+++ b/nab-provider/src/nab_provider/_provider/metadata_resolver.py
@@ -27,7 +27,7 @@ from ..errors import (
     UnsupportedSdistError,
 )
 from ..extra_keys import join_extra
-from ..marker_holds import evaluate_prepared
+from ..marker_holds import UnevaluableMarkerError, evaluate_prepared
 from ..metadata import (
     DEPENDENCY_FIELDS,
     WheelMetadata,
@@ -1215,6 +1215,11 @@ def _tie_sibling_signature(
     marker's version will not convert: a marker holds its version as a string
     until it is evaluated against an environment, so it fails here instead of
     at the parse.
+
+    A marker nothing decides arrives here as an
+    :class:`~nab_provider.marker_holds.UnevaluableMarkerError` and propagates:
+    skipping would answer the version from the pick alone, which is the
+    disagreement this check exists to catch.
     """
     package, version = sig_key
     metadata = _tie_sibling_metadata(provider, index, package, version, sibling)
@@ -1222,6 +1227,8 @@ def _tie_sibling_signature(
         return None
     try:
         return target_dep_signature(provider, sig_key, metadata)
+    except UnevaluableMarkerError:
+        raise
     except ValueError:
         return None
 


### PR DESCRIPTION
A tie-ranked sibling wheel carrying one undecidable marker line silently switches off `check_sibling_metadata_divergence` for that sibling. Given a pick declaring `common>=1` and a tie sibling declaring `common>=1`, `gamma>=1` and `beta>=1; "extra" == "gpu"`, `get_dependencies("pkg", 1.0)` answers just `common` with nothing logged. Delete only the marker line and the same pair raises `SiblingMetadataDivergenceError` naming `base:gamma`.

`_tie_sibling_signature` skips a sibling on `ValueError`, which was written for a marker whose version will not convert. `marker_holds.evaluate_prepared` reports a marker nothing decides as `UnevaluableMarkerError`, itself a `ValueError`, so the skip takes that too and the version is pinned from the pick alone. An installer that picks the sibling installs `gamma` and the lock has no entry for it, which is the disagreement the check exists to catch.

That error now propagates out of the sibling projection, so the run stops and names the marker:

```
error: cannot lock: marker "extra" == "gpu" cannot be evaluated: 'gpu'
```
