### PR TITLE
Stop 24 test_resolve tests crashing the fetcher thread on shutdown

### DIFF
--- a/nab-project/tests/test_resolve.py
+++ b/nab-project/tests/test_resolve.py
@@ -15,7 +15,7 @@ import respx
 
 from nab_index.client import SdistFile, WheelFile
 from nab_index.httpx_async_transport import HttpxAsyncTransport
-from nab_index.transport import HttpError
+from nab_index.transport import AsyncHttpTransport, HttpError
 from nab_project._resolve.engine import (
     _augment_resolution_error,
     _raise_for_source_python,
@@ -77,14 +77,15 @@ from nab_resolver.types import Incompatibility, IncompatibilityCause, Term
 
 V = Version
 
-# A sentinel transport. resolve_pyproject just hands it to FetchCoordinator,
-# which is mocked in these tests, so the value never gets used.
-_FAKE_TRANSPORT = MagicMock(name="FakeTransport")
+# Specced so aclose() is awaitable: the coordinator awaits it on shutdown.
+_FAKE_TRANSPORT = MagicMock(spec=AsyncHttpTransport, name="FakeTransport")
 
 _FORTY = "0123456789abcdef0123456789abcdef01234567"
 
 
-def _resolved(path: Path, transport: object = None, **kwargs: object) -> ResolveResult:
+def _resolved(
+    path: Path, transport: object = _FAKE_TRANSPORT, **kwargs: object
+) -> ResolveResult:
     """Resolve and surface a failed target's error.
 
     The engine records a target that did not resolve rather than raising,
@@ -2083,6 +2084,29 @@ class TestResolvePyprojectVcs:
                 _FAKE_TRANSPORT,
                 python_version="3.12.0",
             )
+
+    def test_refused_dependency_closes_the_transport(
+        self, caplog: pytest.LogCaptureFixture, tmp_path: Path
+    ) -> None:
+        """A refusal closes the transport, and the fetcher thread survives it."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            "[project]\ndependencies = "
+            f'["foo @ git+https://github.com/foo/bar.git@{_FORTY}"]\n',
+        )
+        closes_before = _FAKE_TRANSPORT.aclose.await_count
+
+        with pytest.raises(UnsupportedVcsError):
+            _resolved(pyproject, _FAKE_TRANSPORT, python_version="3.12.0")
+
+        fetch_errors = [
+            record.getMessage()
+            for record in caplog.records
+            if record.name == "nab_project.fetch" and record.levelno >= logging.ERROR
+        ]
+
+        assert fetch_errors == []
+        assert _FAKE_TRANSPORT.aclose.await_count > closes_before
 
     def test_vcs_constraint_refused_at_config_load(self, tmp_path: Path) -> None:
         """An admitting VCS policy does not matter: config load refuses it first."""


### PR DESCRIPTION
24 of the 256 tests in `nab-project/tests/test_resolve.py` run a real `FetchCoordinator`, and every one of them kills its fetcher thread on the way out. They pass anyway, because the thread dies in the coordinator's `finally` after the assertion has already run:

```
ERROR    nab_project.fetch:fetch.py:749 Fetcher thread crashed
Traceback (most recent call last):
  ...
  File "nab-project/src/nab_project/fetch.py", line 870, in _async_fetcher
    await client.aclose()
  File "nab-index/src/nab_index/cached_client.py", line 360, in aclose
    await self._transport.aclose()
TypeError: object MagicMock can't be used in 'await' expression
```

Two sources, both in the module's helpers:

- `_resolved` defaulted `transport` to `None`, which 19 of the 24 take. `await None.aclose()` raises `AttributeError: 'NoneType' object has no attribute 'aclose'`.
- `_FAKE_TRANSPORT` was a bare `MagicMock`, which the other 5 pass explicitly. Awaiting its `aclose()` gives the `TypeError` above.

The sentinel's comment said `FetchCoordinator` is mocked in these tests so the transport is never used. That holds for most of the module, not for those 24.

Speccing the sentinel against `AsyncHttpTransport` makes `aclose` an `AsyncMock`, so shutdown finishes, and `_resolved` now defaults to that sentinel instead of `None`. A new VCS test pins it: a refused `git+https` dependency closes the transport and leaves `nab_project.fetch` quiet.
