### PR TITLE
Defer the urllib3 transport for an offline lock, ~7% off a small lock

### DIFF
--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -294,7 +294,9 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
     if locked:
         _fast_fail_locked(run, config=config, workspace_to_drop=workspace_to_drop)
 
-    transport = _cli._make_transport(settings.http_backend)  # noqa: SLF001
+    transport = _cli._make_resolve_transport(  # noqa: SLF001
+        settings.http_backend, offline=settings.offline
+    )
     result = _cli._resolve(  # noqa: SLF001
         path,
         config=config,

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -90,7 +90,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator, Mapping
     from typing import TextIO
 
-    from nab_index.transport import AsyncHttpTransport
+    from nab_index.transport import AsyncHttpTransport, HttpResponse
     from nab_project.resolve import ResolveResult
     from nab_provider.provider import ResolutionStrategy
 
@@ -156,6 +156,15 @@ def printer() -> Printer:
     return _printer if _printer is not None else Printer()
 
 
+def _make_urllib3_transport() -> AsyncHttpTransport:
+    """Return a urllib3 transport, importing urllib3 and truststore to build it."""
+    from nab_index.urllib3_async_transport import (  # noqa: PLC0415
+        Urllib3AsyncTransport,
+    )
+
+    return Urllib3AsyncTransport()
+
+
 def _make_transport(backend: HttpBackend) -> AsyncHttpTransport:
     """Return the transport for ``backend``.
 
@@ -182,11 +191,44 @@ def _make_transport(backend: HttpBackend) -> AsyncHttpTransport:
             )
             sys.exit(1)
 
-    from nab_index.urllib3_async_transport import (  # noqa: PLC0415
-        Urllib3AsyncTransport,
-    )
+    return _make_urllib3_transport()
 
-    return Urllib3AsyncTransport()
+
+class _DeferredUrllib3Transport:
+    """Transport that builds a urllib3 transport on the first request.
+
+    Building one imports urllib3 and truststore, which a resolve answered
+    entirely from the cache never needs.
+    """
+
+    def __init__(self) -> None:
+        self._transport: AsyncHttpTransport | None = None
+
+    async def get(
+        self, url: str, *, headers: dict[str, str] | None = None
+    ) -> HttpResponse:
+        if self._transport is None:
+            self._transport = _make_urllib3_transport()
+        return await self._transport.get(url, headers=headers)
+
+    async def aclose(self) -> None:
+        if self._transport is not None:
+            await self._transport.aclose()
+
+
+def _make_resolve_transport(
+    backend: HttpBackend, *, offline: bool
+) -> AsyncHttpTransport:
+    """Return the transport for a resolve on ``backend``.
+
+    An offline resolve is served from the cache and asks for no URL, so the
+    urllib3 transport is built only if something does. httpx is built up front
+    either way: a missing httpx exits the CLI, which has to happen on the main
+    thread before the resolve starts.
+    """
+    if offline and backend == "urllib3":
+        return _DeferredUrllib3Transport()
+    return _make_transport(backend)
 
 
 def _default_cache_dir() -> Path:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,7 @@ import inspect
 import io
 import json
 import logging
+import os
 import re
 import runpy
 import stat
@@ -45,6 +46,7 @@ from nab._lock import (
 from nab.cli import (
     _DEFAULT_OUTPUT,
     _default_cache_dir,
+    _make_resolve_transport,
     _make_transport,
     _normalize_layered_bool_flags,
     _resolve,
@@ -5884,6 +5886,154 @@ class TestMakeTransport:
         assert "nab[httpx]" in err
         assert "HTTP/2" in err
         assert "httpx is not installed" not in err
+
+
+class _RecordingTransport:
+    """Transport that records every request it is asked for and every close."""
+
+    def __init__(self) -> None:
+        self.requests: list[tuple[str, dict[str, str] | None]] = []
+        self.closes = 0
+
+    async def get(
+        self, url: str, *, headers: dict[str, str] | None = None
+    ) -> tuple[str, dict[str, str] | None]:
+        self.requests.append((url, headers))
+        return self.requests[-1]
+
+    async def aclose(self) -> None:
+        self.closes += 1
+
+
+_OFFLINE_LOCK_PROBE = """
+import sys
+
+from nab.cli import main
+
+sys.argv = ["nab", "lock", sys.argv[1], "--offline", "--no-cache", "--output", "-"]
+try:
+    main()
+except SystemExit as exc:
+    assert not exc.code, f"the lock exited {exc.code}"
+
+roots = {name.partition(".")[0] for name in sys.modules}
+leaked = sorted(roots & {"truststore", "urllib3"})
+assert not leaked, f"an offline lock loaded {leaked}"
+"""
+
+
+class TestResolveTransport:
+    """Which transport a resolve is handed, and when it is built."""
+
+    def test_online_resolve_gets_the_transport_up_front(self) -> None:
+        """A resolve that may fetch is handed the real transport."""
+        with patch("nab.cli._make_transport") as make:
+            transport = _make_resolve_transport("urllib3", offline=False)
+
+        assert transport is make.return_value
+        make.assert_called_once_with("urllib3")
+
+    def test_offline_httpx_resolve_gets_it_up_front_too(self) -> None:
+        """Only urllib3 defers; httpx is built while the CLI can still exit."""
+        with patch("nab.cli._make_transport") as make:
+            transport = _make_resolve_transport("httpx", offline=True)
+
+        assert transport is make.return_value
+        make.assert_called_once_with("httpx")
+
+    def test_offline_lock_without_httpx_exits_with_the_hint(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """An offline lock on a urllib3-only install still names the extra."""
+        pyproject = _make_pyproject(
+            tmp_path, '[project]\nname = "root"\nversion = "0"\ndependencies = []\n'
+        )
+        original_import = builtins.__import__
+
+        def fake_import(name: str, *args: object, **kwargs: object) -> object:
+            if name == "nab_index.httpx_async_transport":
+                raise ImportError(name)
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        with pytest.raises(SystemExit) as info:
+            lock(
+                pyproject,
+                output=tmp_path / "pylock.toml",
+                offline=True,
+                http_backend="httpx",
+                cache=False,
+            )
+
+        assert info.value.code == 1
+        assert "httpx is not installed" in capsys.readouterr().err
+
+    def test_offline_lock_builds_no_transport(self, tmp_path: Path) -> None:
+        """An offline lock resolves without building a urllib3 transport."""
+        pyproject = _make_pyproject(
+            tmp_path, '[project]\nname = "root"\nversion = "0"\ndependencies = []\n'
+        )
+        with patch("nab.cli._make_urllib3_transport") as make:
+            lock(pyproject, output=tmp_path / "pylock.toml", offline=True, cache=False)
+
+        make.assert_not_called()
+
+    def test_first_request_builds_one_transport_and_forwards(self) -> None:
+        """A deferred transport builds its inner one once, on the first get."""
+        inner = _RecordingTransport()
+        with patch("nab.cli._make_urllib3_transport", return_value=inner) as make:
+            transport = _make_resolve_transport("urllib3", offline=True)
+            make.assert_not_called()
+
+            async def fetch_twice() -> None:
+                await transport.get("https://example.invalid/a")
+                await transport.get(
+                    "https://example.invalid/b", headers={"Accept": "x"}
+                )
+
+            asyncio.run(fetch_twice())
+
+        make.assert_called_once_with()
+        assert inner.requests == [
+            ("https://example.invalid/a", None),
+            ("https://example.invalid/b", {"Accept": "x"}),
+        ]
+
+    def test_close_closes_the_transport_it_built(self) -> None:
+        """Closing a deferred transport that fetched closes the inner one."""
+        inner = _RecordingTransport()
+        with patch("nab.cli._make_urllib3_transport", return_value=inner):
+            transport = _make_resolve_transport("urllib3", offline=True)
+
+            async def fetch_then_close() -> None:
+                await transport.get("https://example.invalid/a")
+                await transport.aclose()
+
+            asyncio.run(fetch_then_close())
+
+        assert inner.closes == 1
+
+    def test_close_without_a_request_builds_nothing(self) -> None:
+        """Closing a deferred transport that never fetched builds nothing."""
+        with patch("nab.cli._make_urllib3_transport") as make:
+            transport = _make_resolve_transport("urllib3", offline=True)
+            asyncio.run(transport.aclose())
+
+        make.assert_not_called()
+
+    def test_an_offline_lock_leaves_urllib3_unimported(self, tmp_path: Path) -> None:
+        """urllib3 and truststore stay unimported across a whole offline lock."""
+        pyproject = _make_pyproject(
+            tmp_path, '[project]\nname = "root"\nversion = "0"\ndependencies = []\n'
+        )
+        subprocess.run(  # noqa: S603 - the probe is this file's own source
+            [sys.executable, "-c", _OFFLINE_LOCK_PROBE, str(pyproject)],
+            check=True,
+            env={**os.environ, "XDG_CONFIG_HOME": str(tmp_path / "config")},
+        )
 
 
 _HTTP_LIBRARY_PROBE = """


### PR DESCRIPTION
An offline `nab lock` built a urllib3 transport and then closed it again without ever asking it for a URL. Not building it removes 90,890,957 instructions from a one-dependency offline lock, 7.0% of the 1,304,251,750 that command retires, and 94,177,707 from an offline lock of `google-cloud-bigquery>=3` and `soda-core` at `--python 3.11 --project-resolution lowest`, 2.2% of its 4,199,683,249. Both counted with callgrind under `PYTHONHASHSEED=0`. The saving is fixed per invocation and zero on any run that reaches the network.

The one-dependency lock finishes with 422 modules in `sys.modules` instead of 461; the 39 that go are urllib3, truststore and what those pull in. Peak memory is between about 1% and 5% lower on that run's roughly 39 MB, locally.

`lock` now takes its transport from `_make_resolve_transport(backend, offline=...)`. Only urllib3 defers: a missing httpx has to print its hint and exit before the resolve starts, so httpx is built up front either way.