### PR TITLE
Deny Path.stat in deny_access, whose os.stat patch misses Python 3.10

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -113,23 +113,28 @@ def _cap_writes(budget: int) -> Iterator[None]:
 
 @contextmanager
 def _deny_access(target: Path) -> Iterator[None]:
-    real_stat, real_open = os.stat, Path.open
+    real_os_stat, real_path_stat, real_open = os.stat, Path.stat, Path.open
     denied = os.fspath(target)
 
     def refuse(candidate: Any) -> None:
         if isinstance(candidate, (str, os.PathLike)) and os.fspath(candidate) == denied:
             raise PermissionError(errno.EACCES, "Permission denied", denied)
 
-    def denying_stat(path: Any, *args: Any, **kwargs: Any) -> Any:
+    def denying_os_stat(path: Any, *args: Any, **kwargs: Any) -> Any:
         refuse(path)
-        return real_stat(path, *args, **kwargs)
+        return real_os_stat(path, *args, **kwargs)
+
+    def denying_path_stat(self: Path, *args: Any, **kwargs: Any) -> Any:
+        refuse(self)
+        return real_path_stat(self, *args, **kwargs)
 
     def denying_open(self: Path, *args: Any, **kwargs: Any) -> Any:
         refuse(self)
         return real_open(self, *args, **kwargs)
 
     with (
-        patch.object(os, "stat", denying_stat),
+        patch.object(os, "stat", denying_os_stat),
+        patch.object(Path, "stat", denying_path_stat),
         patch.object(Path, "open", denying_open),
     ):
         yield
@@ -142,9 +147,11 @@ def deny_access() -> Callable[[Path], AbstractContextManager[None]]:
     Inside ``deny_access(p)`` every stat and open of ``p`` raises ``EACCES``,
     which is what a parent directory without the search bit does to both
     halves of a read. chmod cannot express that on Windows, so the state is
-    simulated rather than created. ``os.stat`` is the patch point rather than
-    ``Path.stat`` because every presence check ends up there, whether it went
-    through ``pathlib`` or ``os.path``.
+    simulated rather than created.
+
+    Both stat routes are patched: on Python 3.10 ``Path.stat`` calls an
+    ``os.stat`` pathlib bound at import, which a patch of ``os.stat`` does
+    not reach.
     """
     return _deny_access
 

--- a/nab-project/tests/test_paths.py
+++ b/nab-project/tests/test_paths.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import errno
 import os
 import stat
+from collections.abc import Callable
+from contextlib import AbstractContextManager
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 from nab_project.paths import PathState, path_state, resolve_path
@@ -56,6 +59,30 @@ class TestPathState:
             state = path_state(path)
         assert state is PathState.UNREADABLE
         assert state.should_read
+
+
+class TestDenyAccessFixture:
+    """The shared ``deny_access`` fixture, exercised through ``path_state``."""
+
+    def test_denies_stat_bound_into_pathlib_at_import(
+        self,
+        tmp_path: Path,
+        deny_access: Callable[[Path], AbstractContextManager[None]],
+    ) -> None:
+        path = tmp_path / "pyproject.toml"
+        path.write_text("")
+
+        # Python 3.10's pathlib stats through an os.stat bound at import.
+        # Rebuilding that binding puts every interpreter on the 3.10 route.
+        bound_at_import = os.stat
+
+        def stat_through_binding(self: Path, **kwargs: Any) -> os.stat_result:
+            return bound_at_import(self, **kwargs)
+
+        with patch.object(Path, "stat", stat_through_binding), deny_access(path):
+            state = path_state(path)
+
+        assert state is PathState.UNREADABLE
 
 
 class TestResolvePath:


### PR DESCRIPTION
On Python 3.10 the shared `deny_access` fixture denied opens but never stats. The twelve tests that check EACCES is not read as absence got `PathState.FILE` back from the presence check they exist to cover, on the three Python 3.10 cells of the fifteen-job test matrix.

pathlib on 3.10 stats through an `os.stat` it binds at import, so patching `os.stat` never reaches `Path.stat`. Python 3.11 dropped that indirection and calls `os.stat` by name, which is why the fixture worked everywhere else.

Nothing went red because each of those tests writes the file it then denies:

- the stat succeeds and reports a regular file
- the read that follows hits the patched `Path.open` and raises the EACCES the test matches on
- `PathState.UNREADABLE` is never reached, so a guard that read EACCES as absence would have passed on 3.10 too

`tests/test_lock_locked.py` says it outright, in a comment that was false on 3.10:

    # EACCES lands on the presence check's stat, before any open.

The fixture now patches both routes, as `as_fifo` in `tests/conftest.py` already does. The new test in `nab-project/tests/test_paths.py` rebuilds 3.10's route on any interpreter, so the next hole like this fails everywhere instead of hiding on three jobs.
