### PR TITLE
Stop blaming [project].name for a name the build backend computed

### DIFF
--- a/docs/how-to/local-sources.md
+++ b/docs/how-to/local-sources.md
@@ -17,9 +17,9 @@ Relative `path` entries resolve against the directory holding
 `pyproject.toml`, not the process's current working directory.
 Absolute paths are recorded as-is.
 
-The `[project].name` in the target directory must canonicalise to
-the declared `name`.  A `path` that lands on a different project
-fails the resolve.
+The target project's name must canonicalise to the declared
+`name`.  A `path` that lands on a different project fails the
+resolve.
 
 The directory is read once.  nab reads the version from
 `[project].version` in the local pyproject.toml.  When the pyproject

--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -3975,6 +3975,56 @@ class TestLocalSources:
             provider.fetch_versions("foo")
         assert "foo" in str(excinfo.value)
 
+    @pytest.mark.parametrize(
+        "body",
+        [
+            '[build-system]\nrequires = []\nbuild-backend = "stub"\n',
+            '[project]\nname = "bar"\ndynamic = ["version"]\n',
+        ],
+        ids=["no-project-table", "dynamic-version"],
+    )
+    def test_built_source_name_mismatch_points_at_the_project(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        body: str,
+    ) -> None:
+        """The mismatch message points at the built project rather than a key.
+
+        The name comes back from the backend either way, and a tree with no
+        ``[project]`` table has no key to blame.
+        """
+        self._write_local(tmp_path, body)
+
+        built = WheelMetadata(
+            name="bar",
+            version=V("2.3.0"),
+            requires_python=None,
+            requires_dist=[],
+            provides_extra=[],
+        )
+        monkeypatch.setattr(
+            "nab_project.build_backend.extract_metadata",
+            lambda _path, **_kwargs: built,
+        )
+
+        coordinator = make_coordinator([], package="foo")
+        provider = Provider(
+            coordinator,
+            local_sources=[LocalSource("foo", str(tmp_path))],
+            build_policy=BuildPolicy.BUILD_LOCAL,
+        )
+
+        with pytest.raises(SourceNameMismatchError) as excinfo:
+            provider.fetch_versions("foo")
+
+        msg = str(excinfo.value)
+        assert "[project].name" not in msg
+        assert (
+            "local source 'foo' declares package 'foo' but the project at"
+            f" {tmp_path} is named 'bar'" in msg
+        )
+
     def test_build_local_source_failure_propagates(
         self,
         tmp_path: Path,

--- a/nab-provider/src/nab_provider/_provider/sources.py
+++ b/nab-provider/src/nab_provider/_provider/sources.py
@@ -3,8 +3,8 @@
 A declared source becomes the only candidate for its package: PyPI is not
 consulted.  The clone, the download and the directory read are the host's,
 behind :meth:`~nab_provider.fetch_port.FetchPort.request_source_listing`; what
-comes back becomes one synthetic ``SdistFile`` whose version is read from
-``[project].version``.
+comes back becomes one synthetic ``SdistFile`` whose version the host read
+from ``[project].version`` or took from the build backend.
 """
 
 from __future__ import annotations
@@ -61,9 +61,9 @@ def seed_synthetic_listing(
     actual = canonicalize_name(metadata.name)
     if actual != normalized:
         msg = (
-            f"{descriptor} declares package {normalized!r} but its"
-            f" [project].name is {actual!r} (at {path}); a source declared for"
-            f" one name must not provide a different project"
+            f"{descriptor} declares package {normalized!r} but the project at"
+            f" {path} is named {actual!r}; a source declared for one name must"
+            f" not provide a different project"
         )
         raise SourceNameMismatchError(msg)
 

--- a/nab-provider/src/nab_provider/errors.py
+++ b/nab-provider/src/nab_provider/errors.py
@@ -104,8 +104,8 @@ class SourceNameMismatchError(Exception):
     """Raised when a materialised source's project name differs from its declaration.
 
     A declared source is the only candidate for the package it names, so a tree
-    whose ``[project].name`` does not canonicalise to that name would pin
-    another distribution.
+    whose project name does not canonicalise to that name would pin another
+    distribution.
     """
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -364,8 +364,8 @@ def _mismatched_local_source_project(tmp_path: Path) -> str:
 def _source_name_mismatch_message(tmp_path: Path, prefix: str) -> str:
     target = (tmp_path / "bar").resolve()
     return (
-        f"error: {prefix}: local source 'foo' declares package 'foo' but its"
-        f" [project].name is 'bar' (at {target}); a source declared for one name"
+        f"error: {prefix}: local source 'foo' declares package 'foo' but the"
+        f" project at {target} is named 'bar'; a source declared for one name"
         " must not provide a different project"
     )
 


### PR DESCRIPTION
A declared source whose tree has no `[project]` table fails with an error naming a key that tree does not have:

```
error: cannot lock: local source 'foo' declares package 'foo' but its [project].name is 'bar' (at /tmp/nm/bar); a source declared for one name must not provide a different project
```

`/tmp/nm/bar/pyproject.toml` holds a `[build-system]` table and nothing else. The static read returns nothing, so the PEP 517 backend runs and `bar` comes back from the metadata it produced. A tree with `dynamic = ["version"]` goes the same way.

The message now names the project instead:

```
error: cannot lock: local source 'foo' declares package 'foo' but the project at /tmp/nm/bar is named 'bar'; a source declared for one name must not provide a different project
```

Local, VCS and archive sources all raise it. Three places repeated the assumption and no longer do: the local-sources how-to, the `SourceNameMismatchError` docstring, and the sources module docstring, which said the version always comes from `[project].version`.
