### PR TITLE
Compile the vendored specifier regex once, 1.3% off a one-dependency lock

### DIFF
--- a/nab-provider/src/nab_provider/_vendor/packaging/PROVENANCE.md
+++ b/nab-provider/src/nab_provider/_vendor/packaging/PROVENANCE.md
@@ -41,6 +41,12 @@ most one checked-in patch.
     Upstream's opening `assert isinstance(marker, (list, tuple, str))` is
     dropped, so a value of any other type now returns unchanged instead of
     tripping the assertion.
+  - `specifiers.py` and `_tokenizer.py`: `Specifier._regex` compiles the
+    specifier pattern without the surrounding `\s*`, and `Specifier.__init__`
+    strips the string before matching it, so `DEFAULT_RULES["SPECIFIER"]` can be
+    that same compiled object instead of a second compile of the same pattern.
+    `SpecifierSet._canonical_specs` sorts on each clause's equality key rather
+    than on its text.
 
   Upstream PRs are planned for the bound ordering, the direct subset and
   disjoint walks, `filter`'s `assume_sorted` fast path,

--- a/nab-provider/src/nab_provider/_vendor/packaging/_tokenizer.py
+++ b/nab-provider/src/nab_provider/_vendor/packaging/_tokenizer.py
@@ -77,10 +77,8 @@ DEFAULT_RULES: dict[str, re.Pattern[str]] = {
         """,
         re.VERBOSE,
     ),
-    "SPECIFIER": re.compile(
-        Specifier._specifier_regex_str,
-        re.VERBOSE | re.IGNORECASE,
-    ),
+    # Shared with Specifier so the pattern compiles once.
+    "SPECIFIER": Specifier._regex,
     "AT": re.compile(r"\@"),
     "URL": re.compile(r"[^ \t]+"),
     "IDENTIFIER": re.compile(r"\b[a-zA-Z0-9][a-zA-Z0-9._-]*\b"),

--- a/nab-provider/src/nab_provider/_vendor/packaging/specifiers.py
+++ b/nab-provider/src/nab_provider/_vendor/packaging/specifiers.py
@@ -329,9 +329,8 @@ class Specifier(BaseSpecifier):
         )
         """
 
-    _regex = re.compile(
-        r"\s*" + _specifier_regex_str + r"\s*", re.VERBOSE | re.IGNORECASE
-    )
+    # No surrounding \s*, so _tokenizer can share this object; __init__ strips first.
+    _regex = re.compile(_specifier_regex_str, re.VERBOSE | re.IGNORECASE)
 
     # Legacy unused attribute, kept for backward compatibility
     _operators: Final = {
@@ -358,10 +357,11 @@ class Specifier(BaseSpecifier):
         :raises InvalidSpecifier:
             If the given specifier is invalid (i.e. bad syntax).
         """
-        if not self._regex.fullmatch(spec):
+        stripped = spec.strip()
+        if not self._regex.fullmatch(stripped):
             raise InvalidSpecifier(f"Invalid specifier: {spec!r}")
 
-        spec = spec.strip()
+        spec = stripped
         if spec.startswith("==="):
             operator, version = spec[:3], spec[3:].strip()
         elif spec.startswith(("~=", "==", "!=", "<=", ">=")):

--- a/nab-provider/tests/test_vendor_specifier_pattern_shared.py
+++ b/nab-provider/tests/test_vendor_specifier_pattern_shared.py
@@ -1,0 +1,64 @@
+"""Tests for the vendored patch that shares one compiled specifier pattern.
+
+The tokenizer rule is ``Specifier._regex`` itself, and that pattern matches no
+surrounding whitespace, so ``Specifier.__init__`` strips before matching. Both
+are pinned: ``re`` caches on the pattern text, so the identity assertion alone
+would still hold if the tokenizer compiled the string a second time.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from nab_provider._vendor.packaging._tokenizer import DEFAULT_RULES
+from nab_provider._vendor.packaging.requirements import Requirement
+from nab_provider._vendor.packaging.specifiers import InvalidSpecifier, Specifier
+
+# Padding ``Specifier`` accepts, with the operator and version it parses to.
+# ``str.strip()`` and ``\s`` have to accept the same characters, hence ``\xa0``.
+PADDED = [
+    (" ==1.0", ("==", "1.0")),
+    ("==1.0 ", ("==", "1.0")),
+    ("\t==1.0\n", ("==", "1.0")),
+    ("\x0b==1.0\x0c", ("==", "1.0")),
+    ("\xa0==1.0\xa0", ("==", "1.0")),
+    ("  ===  ", ("===", "")),
+]
+
+# Strings the pattern refuses however they are padded.
+REFUSED = ["", " ", "=1.0", "== ", "==1.0 2.0", "~=1"]
+
+
+def test_the_tokenizer_rule_is_the_specifier_pattern_object() -> None:
+    assert DEFAULT_RULES["SPECIFIER"] is Specifier._regex
+
+
+def test_the_pattern_carries_no_surrounding_whitespace() -> None:
+    assert Specifier._regex.pattern == Specifier._specifier_regex_str
+
+
+@pytest.mark.parametrize(("spec", "expected"), PADDED)
+def test_padding_is_stripped_before_the_operator_split(
+    spec: str, expected: tuple[str, str]
+) -> None:
+    parsed = Specifier(spec)
+
+    assert (parsed.operator, parsed.version) == expected
+
+
+@pytest.mark.parametrize("spec", REFUSED)
+def test_a_refused_specifier_is_reported_with_its_padding(spec: str) -> None:
+    padded = f" {spec}\t"
+    message = re.escape(f"Invalid specifier: {padded!r}")
+
+    with pytest.raises(InvalidSpecifier, match=message):
+        Specifier(padded)
+
+
+def test_the_tokenizer_reads_a_specifier_out_of_a_requirement() -> None:
+    requirement = Requirement('foo >=1.0,<2.0; python_version >= "3.9"')
+
+    assert str(requirement.specifier) == "<2.0,>=1.0"
+    assert str(requirement.marker) == 'python_version >= "3.9"'

--- a/tasks/vendoring/packaging.patch
+++ b/tasks/vendoring/packaging.patch
@@ -2076,6 +2076,23 @@ index e312a1f..29c32bc 100644
      def __hash__(self) -> int:
          return hash((self.version, self.inclusive))
  
+diff --git a/nab-provider/src/nab_provider/_vendor/packaging/_tokenizer.py b/nab-provider/src/nab_provider/_vendor/packaging/_tokenizer.py
+index 7158421..6384493 100644
+--- a/nab-provider/src/nab_provider/_vendor/packaging/_tokenizer.py
++++ b/nab-provider/src/nab_provider/_vendor/packaging/_tokenizer.py
+@@ -77,10 +77,8 @@ DEFAULT_RULES: dict[str, re.Pattern[str]] = {
+         """,
+         re.VERBOSE,
+     ),
+-    "SPECIFIER": re.compile(
+-        Specifier._specifier_regex_str,
+-        re.VERBOSE | re.IGNORECASE,
+-    ),
++    # Shared with Specifier so the pattern compiles once.
++    "SPECIFIER": Specifier._regex,
+     "AT": re.compile(r"\@"),
+     "URL": re.compile(r"[^ \t]+"),
+     "IDENTIFIER": re.compile(r"\b[a-zA-Z0-9][a-zA-Z0-9._-]*\b"),
 diff --git a/nab-provider/src/nab_provider/_vendor/packaging/markers.py b/nab-provider/src/nab_provider/_vendor/packaging/markers.py
 index 609099c..fa29c65 100644
 --- a/nab-provider/src/nab_provider/_vendor/packaging/markers.py
@@ -3459,3 +3476,51 @@ index 4fbf48e..d52f359 100644
      @classmethod
      def _from_specifier_set(cls, specifier_set: SpecifierSet) -> VersionRange:
          """Build the range accepted by ``specifier_set``.
+diff --git a/nab-provider/src/nab_provider/_vendor/packaging/specifiers.py b/nab-provider/src/nab_provider/_vendor/packaging/specifiers.py
+index dd46b56..c3d1ba5 100644
+--- a/nab-provider/src/nab_provider/_vendor/packaging/specifiers.py
++++ b/nab-provider/src/nab_provider/_vendor/packaging/specifiers.py
+@@ -329,9 +329,8 @@ class Specifier(BaseSpecifier):
+         )
+         """
+ 
+-    _regex = re.compile(
+-        r"\s*" + _specifier_regex_str + r"\s*", re.VERBOSE | re.IGNORECASE
+-    )
++    # No surrounding \s*, so _tokenizer can share this object; __init__ strips first.
++    _regex = re.compile(_specifier_regex_str, re.VERBOSE | re.IGNORECASE)
+ 
+     # Legacy unused attribute, kept for backward compatibility
+     _operators: Final = {
+@@ -358,10 +357,11 @@ class Specifier(BaseSpecifier):
+         :raises InvalidSpecifier:
+             If the given specifier is invalid (i.e. bad syntax).
+         """
+-        if not self._regex.fullmatch(spec):
++        stripped = spec.strip()
++        if not self._regex.fullmatch(stripped):
+             raise InvalidSpecifier(f"Invalid specifier: {spec!r}")
+ 
+-        spec = spec.strip()
++        spec = stripped
+         if spec.startswith("==="):
+             operator, version = spec[:3], spec[3:].strip()
+         elif spec.startswith(("~=", "==", "!=", "<=", ">=")):
+@@ -829,9 +829,15 @@ class SpecifierSet(BaseSpecifier):
+         self._prereleases = prereleases
+ 
+     def _canonical_specs(self) -> tuple[Specifier, ...]:
+-        """Deduplicate, sort, and cache specs for order-sensitive operations."""
++        """Deduplicate, sort, and cache specs for order-sensitive operations.
++
++        Sorting on each clause's equality key rather than its text gives two equal
++        sets the same order, so ``__eq__`` and ``__hash__`` agree across respellings.
++        """
+         if not self._canonicalized:
+-            self._specs = tuple(dict.fromkeys(sorted(self._specs, key=str)))
++            self._specs = tuple(
++                dict.fromkeys(sorted(self._specs, key=lambda s: s._canonical_spec))
++            )
+             self._canonicalized = True
+         return self._specs
+ 


### PR DESCRIPTION
A one-dependency offline `nab lock` retires 14,363,364 fewer instructions, 1.3% of that run's 1,132,997,114. The counts are exact; the wall bound below is local.

Stacked on #967, the base of the diff and of the counts.

`Specifier._specifier_regex_str` is a 3,852-character verbose pattern compiled in two module scopes with the same flags. The only difference was the `\s*` `specifiers.py` wrapped around it, and `re` keys its cache on the pattern text, so six characters were enough to miss. `import nab.cli` now reaches the regex compiler 86 times over 9,736 pattern characters, against 87 and 13,594.

`Specifier._regex` drops the wrapper and `__init__` strips before matching instead of after, so `DEFAULT_RULES["SPECIFIER"]` becomes that object. `InvalidSpecifier` still reports the string as passed in.

Nothing is traded for it:

- Constructing a `Specifier` costs about 209 instructions less, over 124,000 replays of the 124 that lock makes.
- No code point in `range(0x110000)` is treated differently by `str.strip()` and `\s`, and `wrapped.fullmatch(s)` agreed with `unwrapped.fullmatch(s.strip())` over 205,096 padded and random strings.

The clock cannot see a change this small; the timing rules out a wall regression above about 3.4% and puts peak RSS inside about 0.3% either way.

The regenerated `packaging.patch` also carries #967's own `_canonical_specs` hunk.
