### PR TITLE
Fix nab_index.vcs docstring: no canonicalised cache key, no git clone

### DIFF
--- a/nab-index/src/nab_index/vcs.py
+++ b/nab-index/src/nab_index/vcs.py
@@ -1,19 +1,22 @@
 """Shallow VCS clone helper for nab-index.
 
-Performs ``git clone --depth 1`` against a directory under the cache
-root.  URL admission lives upstream in
-:func:`nab_provider.vcs_admission.admit_vcs_url`.
+Lands one commit under the cache root with ``git init``,
+``git fetch --depth 1`` and ``git checkout FETCH_HEAD``.  URL admission
+lives upstream in :func:`nab_provider.vcs_admission.admit_vcs_url`.
 
 Cache layout under ``cache_root / "vcs"``:
 
     <repo-key>/<commit-sha>/
 
-``repo-key`` is the 16-char prefix of a SHA-256 over the canonicalised
-repo URL (``vcs+`` prefix stripped).  ``commit-sha`` is always a
-concrete 40-char hash; floating refs are resolved via
-``git ls-remote`` before the clone runs.  A finished clone carries a
-``.git/nab-complete`` marker file; a tree without it is discarded and
-recloned.
+``repo-key`` is the 16-char prefix of a SHA-256 over
+``VcsRequest.repo_url``: the requirement URL without its ``git+``
+prefix, ``@<ref>`` suffix and ``#`` fragment.  Nothing canonicalises
+what is left, so two spellings of one repo get two cache entries.
+
+``commit-sha`` is always a concrete 40-char hash; floating refs are
+resolved via ``git ls-remote`` before the fetch runs.  A finished clone
+carries a ``.git/nab-complete`` marker file; a tree without it is
+discarded and refetched.
 """
 
 from __future__ import annotations

--- a/nab-project/tests/test_vcs.py
+++ b/nab-project/tests/test_vcs.py
@@ -1,7 +1,7 @@
 """Tests for nab_index.vcs URL parsing + clone helpers.
 
-The clone path itself shells out to ``git`` and is not unit-tested
-here; integration tests live alongside the runner.
+The clone path shells out to ``git``, so its tests stub
+:func:`subprocess.run`.
 """
 
 from __future__ import annotations
@@ -129,6 +129,11 @@ class TestVcsRequestParse:
     def test_bzr_scheme_refused(self) -> None:
         with pytest.raises(VcsCloneError, match="not a recognised"):
             VcsRequest.parse("bzr+https://bzr.example.com/repo")
+
+    def test_vcs_prefix_refused(self) -> None:
+        """``vcs+`` is not a scheme: ``git+`` is the only prefix stripped."""
+        with pytest.raises(VcsCloneError, match="not a recognised"):
+            VcsRequest.parse("vcs+https://example.com/repo.git")
 
     def test_ssh_shortcut_with_ref(self) -> None:
         req = VcsRequest.parse("git+git@github.com:x/y.git@" + "c" * 40)
@@ -657,6 +662,83 @@ class TestPrepareClone:
         clone = prepare_clone(tmp_path, req, require_pin=True)
         assert clone.path == dest
         assert payload.read_text() == "kept"
+
+
+class TestCacheLayout:
+    """The clone cache key, and the git commands that fill an entry."""
+
+    def _clone(
+        self,
+        cache_root: Path,
+        requirement_url: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> tuple[Path, list[list[str]]]:
+        """Clone a ``git+`` URL with git stubbed; return the tree and the argv."""
+        argv: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> object:
+            argv.append(cmd)
+            if cmd[:2] == ["git", "init"]:
+                (Path(str(kwargs["cwd"])) / ".git").mkdir(exist_ok=True)
+            return type("P", (), {"returncode": 0})()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        clone = prepare_clone(
+            cache_root,
+            VcsRequest.parse(requirement_url),
+            require_pin=True,
+        )
+        return clone.path, argv
+
+    def test_repo_key_covers_the_repo_url_alone(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The ``git+`` prefix, the ``@<sha>`` ref and the fragment are not keyed."""
+        sha = "a" * 40
+        path, _ = self._clone(
+            tmp_path,
+            f"git+https://example.com/repo.git@{sha}#subdirectory=pkg",
+            monkeypatch,
+        )
+
+        # 3f71ca0a9a455fa9 is sha256("https://example.com/repo.git")[:16].
+        assert path == tmp_path / "vcs" / "3f71ca0a9a455fa9" / sha
+
+    def test_spellings_of_one_repo_do_not_share_an_entry(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """One repo written three ways gets three entries: nothing canonicalises."""
+        sha = "b" * 40
+        spellings = (
+            "https://example.com/repo.git",
+            "https://example.com/repo",
+            "https://example.com/repo.git/",
+        )
+        trees = [
+            self._clone(tmp_path, f"git+{url}@{sha}", monkeypatch)[0]
+            for url in spellings
+        ]
+
+        assert len({tree.parent for tree in trees}) == len(spellings)
+
+    def test_entry_is_filled_by_init_fetch_checkout(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        sha = "c" * 40
+        url = "https://example.com/repo.git"
+        _, argv = self._clone(tmp_path, f"git+{url}@{sha}", monkeypatch)
+
+        assert argv == [
+            ["git", "init", "--quiet"],
+            ["git", "fetch", "--quiet", "--depth", "1", url, sha],
+            ["git", "checkout", "--quiet", "FETCH_HEAD"],
+        ]
 
 
 class TestAmbientGitEnvironment:

--- a/nab-provider/src/nab_provider/vcs_request.py
+++ b/nab-provider/src/nab_provider/vcs_request.py
@@ -86,7 +86,7 @@ class VcsRequest:
 
 
 def _split_repo_ref(inner: str) -> tuple[str, str]:
-    """Split ``inner`` (no ``vcs+`` prefix, no fragment) into ``(repo, ref)``.
+    """Split ``inner`` (no ``git+`` prefix, no fragment) into ``(repo, ref)``.
 
     For URL forms (``scheme://...``), the ref is everything after the
     last ``@`` that appears in the path component (after the netloc),


### PR DESCRIPTION
`nab_index.vcs`'s module docstring described a cache key and a clone command that do not exist:

| Docstring said | Code does |
| --- | --- |
| `git clone --depth 1` | `git init`, `git fetch --depth 1 <url> <sha>`, `git checkout FETCH_HEAD` |
| SHA-256 over the canonicalised repo URL | SHA-256 over `VcsRequest.repo_url` as written |
| `vcs+` prefix stripped | `git+` stripped; `vcs+` is refused by `VcsRequest.parse` |

The canonicalisation line is the one that misleads. Nothing normalises the URL, so `git+https://example.com/repo.git`, `git+https://example.com/repo` and `git+https://example.com/repo.git/` get three cache entries and fetch the same commit three times.

Tests now pin each row: the key covers `repo_url` alone, three spellings of one repo land in three directories, and the git argv is exactly init, fetch, checkout. `vcs+https://...` gets its own parse test.

`_split_repo_ref` carried the same `vcs+` slip, and the test module's docstring said the clone path is not unit-tested here while the clone tests around it already stub `subprocess.run`.
