### PR TITLE
Fix nab lock crash on an sdist with a malformed PAX sparse map

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -694,7 +694,9 @@ def _extract_sdist_files_if_readable(
     except (
         tarfile.TarError,
         OSError,
-        UnicodeDecodeError,
+        # tarfile converts archive-controlled header text with int(), and a
+        # member's bad UTF-8 fails decode(); both surface as ValueError.
+        ValueError,
         KeyError,
         EOFError,
         zlib.error,
@@ -803,11 +805,19 @@ def extract_sdist_archive(
     except KeyError as exc:
         msg = f"broken link in sdist member: {exc}"
         raise ValueError(msg) from exc
-    except (tarfile.TarError, OSError, EOFError, zlib.error, RecursionError) as exc:
+    except (
+        tarfile.TarError,
+        OSError,
+        EOFError,
+        zlib.error,
+        RecursionError,
+        ValueError,
+    ) as exc:
         # gzip raises BadGzipFile (an OSError) on a bad header, a bare EOFError on
         # a truncated stream, and zlib.error on a corrupt deflate block; none of
         # them is a TarError.  RecursionError comes from tarfile recursing once
-        # per link to resolve a chain of link members.
+        # per link to resolve a chain of link members, and tarfile converts header
+        # text with int(), so a bad value arrives as ValueError.
         msg = f"unreadable sdist archive: {exc}"
         raise ValueError(msg) from exc
 

--- a/nab-project/tests/test_archive.py
+++ b/nab-project/tests/test_archive.py
@@ -107,6 +107,23 @@ def _half(data: bytes) -> bytes:
     return data[: len(data) // 2]
 
 
+# A digit run just past CPython's int-from-string limit.
+_OVERSIZED_DIGITS = "1" * sys.get_int_max_str_digits() + "1"
+
+
+def _pax_sparse_map_sdist(sparse_map: str) -> bytes:
+    """Return ``.tar.gz`` bytes carrying ``sparse_map`` as a PAX ``GNU.sparse.map``.
+
+    ``tarfile`` runs ``int()`` over the record while opening the archive.
+    """
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz", format=tarfile.PAX_FORMAT) as tar:
+        info = tarfile.TarInfo("foo-1.0.0/sparse")
+        info.pax_headers = {"GNU.sparse.map": sparse_map}
+        tar.addfile(info, io.BytesIO(b""))
+    return buf.getvalue()
+
+
 _CLEAN_PREFIX = 1 << 20
 _INVALID_DEFLATE_BLOCK = b"\x07" * 8
 
@@ -1349,8 +1366,18 @@ class TestExtractArchive:
             gzip.compress(b"not a tar"),
             _half(_make_sdist("foo", "1.0.0", _PYPROJECT)),
             _corrupt_deflate_sdist(),
+            _pax_sparse_map_sdist(_OVERSIZED_DIGITS + ",1"),
+            _pax_sparse_map_sdist("nope,1"),
         ],
-        ids=["empty", "not-gzip", "gzip-not-tar", "truncated", "corrupt-deflate"],
+        ids=[
+            "empty",
+            "not-gzip",
+            "gzip-not-tar",
+            "truncated",
+            "corrupt-deflate",
+            "sparse-map-past-int-limit",
+            "sparse-map-non-numeric",
+        ],
     )
     def test_unreadable_archive_raises_value_error(
         self, data: bytes, tmp_path: Path

--- a/nab-project/tests/test_async_transports.py
+++ b/nab-project/tests/test_async_transports.py
@@ -1820,6 +1820,28 @@ def _build_tarball(members: list[tuple[str, bytes | None]]) -> bytes:
     return buf.getvalue()
 
 
+# A digit run just past CPython's int-from-string limit.
+_OVERSIZED_DIGITS = "1" * sys.get_int_max_str_digits() + "1"
+
+
+def _build_pax_sparse_map_tarball(sparse_map: str) -> bytes:
+    """Build a tar.gz whose first member carries a PAX ``GNU.sparse.map`` record.
+
+    The PKG-INFO after it is valid, so a ``(None, None)`` result comes from the
+    sparse map rather than from absent metadata.
+    """
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz", format=tarfile.PAX_FORMAT) as tar:
+        sparse = tarfile.TarInfo("pkg-1.0/sparse")
+        sparse.pax_headers = {"GNU.sparse.map": sparse_map}
+        tar.addfile(sparse, io.BytesIO(b""))
+        pkg_info = b"Metadata-Version: 2.1\nName: pkg\n"
+        info = tarfile.TarInfo("pkg-1.0/PKG-INFO")
+        info.size = len(pkg_info)
+        tar.addfile(info, io.BytesIO(pkg_info))
+    return buf.getvalue()
+
+
 SDIST_BODY = _build_tarball(
     [
         ("demo-1.0/PKG-INFO", b"Metadata-Version: 2.2\nName: demo\nVersion: 1.0\n"),
@@ -2242,6 +2264,18 @@ class TestExtractSdistFiles:
 
     def test_returns_none_on_tar_error(self) -> None:
         assert _extract_sdist_files(b"not-a-tarball") == (None, None)
+
+    @pytest.mark.parametrize(
+        "sparse_map",
+        [_OVERSIZED_DIGITS + ",1", "nope,1"],
+        ids=["digits-past-int-limit", "non-numeric"],
+    )
+    def test_returns_none_when_gnu_sparse_map_will_not_convert(
+        self, sparse_map: str
+    ) -> None:
+        """A ``GNU.sparse.map`` that tarfile cannot convert reads as unreadable."""
+        body = _build_pax_sparse_map_tarball(sparse_map)
+        assert _extract_sdist_files(body) == (None, None)
 
     def test_returns_none_when_pkg_info_missing(self) -> None:
         body = _build_tarball([("pkg-1.0/setup.py", b"# nothing")])


### PR DESCRIPTION
`nab lock` dies with a raw tarfile traceback when an sdist's PAX `GNU.sparse.map` header is not a list of integers. tarfile runs `int()` over that record while opening the archive, and neither sdist reader in `nab_index.client` catches `ValueError`.

```
  File ".../tarfile.py", line 1564, in _proc_gnusparse_01
    sparse = [int(x) for x in pax_headers["GNU.sparse.map"].split(",")]
ValueError: Exceeds the limit (4300 digits) for integer string conversion: value has 4301 digits; use sys.set_int_max_str_digits() to increase the limit
```

Two ways in, both chosen by the archive:

- a digit run past CPython's int-from-string limit, 4300 digits by default
- anything non-numeric, which gives `invalid literal for int() with base 10: 'nope'`

`_extract_sdist_files` now returns `(None, None)` for both, so the sdist's metadata reads as absent and the resolve takes the path it already takes for a truncated or non-gzip archive. It catches `ValueError` in place of `UnicodeDecodeError`, a subclass, so nothing stops being caught.

`extract_sdist_archive` catches it too, and a build reports `unreadable sdist archive: ...` instead of the bare `int()` message.
