### PR TITLE
Raise the listing counters once per pass, ~1% off a bigquery-soda resolve

### DIFF
--- a/nab-provider/src/nab_provider/_provider/listing.py
+++ b/nab-provider/src/nab_provider/_provider/listing.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 
     from ..fetch_port import Waitable
     from ..policy import ArchiveSource, LocalSource, VcsSource
-    from ..provider import DistFile, Provider
+    from ..provider import DistFile, Provider, ProviderStats
     from ..tags import TagSet
 
     _PreparedListing = tuple[
@@ -468,6 +468,17 @@ def _filter_base(
     return _canonicalize_equal_versions(result)
 
 
+def _count_files_seen(stats: ProviderStats, wheels: int, sdists: int) -> None:
+    """Raise the listing counters by the wheels and sdists one pass classified.
+
+    Both preparation passes call this from a ``finally``, so a pass that
+    raises part way through still reports the files it reached.
+    """
+    stats.distributions_seen += wheels + sdists
+    stats.wheels_seen += wheels
+    stats.sdists_seen += sdists
+
+
 def _prepare_listing(
     provider: Provider,
     normalized: str,
@@ -495,44 +506,48 @@ def _prepare_listing(
     sort_with_wheel_first = False
     overridden = policy.overridden
     sdist_install_versions: set[Version] = set()
-    for dist in files:
-        provider.stats.distributions_seen += 1
-        if isinstance(dist, WheelFile):
-            provider.stats.wheels_seen += 1
-        else:
-            provider.stats.sdists_seen += 1
+    wheels_walked = 0
+    sdists_walked = 0
+    try:
+        for dist in files:
+            if isinstance(dist, WheelFile):
+                wheels_walked += 1
+            else:
+                sdists_walked += 1
 
-        # Parse the version first: the policy and the cutoff are
-        # version-scoped, so an unparseable version is dropped before
-        # either is consulted.
-        try:
-            version = _intern_version(dist.version)
-        except InvalidVersion:
-            continue
+            # Parse the version first: the policy and the cutoff are
+            # version-scoped, so an unparseable version is dropped before
+            # either is consulted.
+            try:
+                version = _intern_version(dist.version)
+            except InvalidVersion:
+                continue
 
-        if overridden:
-            effective_dist_policy = provider.effective_dist_policy(
-                normalized, version, policy.index_name
-            )
-        else:
-            effective_dist_policy = policy.default_dist_policy
+            if overridden:
+                effective_dist_policy = provider.effective_dist_policy(
+                    normalized, version, policy.index_name
+                )
+            else:
+                effective_dist_policy = policy.default_dist_policy
 
-        if excluded_by_dist_policy(dist, effective_dist_policy):
-            provider.stats.excluded_by_dist_policy += 1
-            continue
+            if excluded_by_dist_policy(dist, effective_dist_policy):
+                provider.stats.excluded_by_dist_policy += 1
+                continue
 
-        if effective_dist_policy is DistPolicy.SDIST_INSTALL:
-            sdist_install_versions.add(version)
-            sort_with_wheel_first = True
-        elif effective_dist_policy is DistPolicy.PREFER_WHEEL:
-            sort_with_wheel_first = True
+            if effective_dist_policy is DistPolicy.SDIST_INSTALL:
+                sdist_install_versions.add(version)
+                sort_with_wheel_first = True
+            elif effective_dist_policy is DistPolicy.PREFER_WHEEL:
+                sort_with_wheel_first = True
 
-        if target_drops and python_or_time_cause(
-            provider, normalized, version, dist, policy
-        ):
-            continue
+            if target_drops and python_or_time_cause(
+                provider, normalized, version, dist, policy
+            ):
+                continue
 
-        result.append((version, dist))
+            result.append((version, dist))
+    finally:
+        _count_files_seen(provider.stats, wheels_walked, sdists_walked)
 
     return result, sdist_install_versions, sort_with_wheel_first
 
@@ -571,48 +586,52 @@ def _prepare_listing_defaults(
 
     result: list[tuple[Version, DistFile]] = []
     sdist_install_versions: set[Version] = set()
-    for dist in files:
-        stats.distributions_seen += 1
-        is_wheel = isinstance(dist, WheelFile)
-        if is_wheel:
-            stats.wheels_seen += 1
-        else:
-            stats.sdists_seen += 1
+    wheels_walked = 0
+    sdists_walked = 0
+    try:
+        for dist in files:
+            is_wheel = isinstance(dist, WheelFile)
+            if is_wheel:
+                wheels_walked += 1
+            else:
+                sdists_walked += 1
 
-        # Parse before the kind check so an unparseable file is not
-        # counted as a dist-policy exclusion.
-        try:
-            version = _intern_version(dist.version)
-        except InvalidVersion:
-            continue
+            # Parse before the kind check so an unparseable file is not
+            # counted as a dist-policy exclusion.
+            try:
+                version = _intern_version(dist.version)
+            except InvalidVersion:
+                continue
 
-        wrong_kind = drops_wheels if is_wheel else drops_sdists
-        if wrong_kind:
-            stats.excluded_by_dist_policy += 1
-            continue
+            wrong_kind = drops_wheels if is_wheel else drops_sdists
+            if wrong_kind:
+                stats.excluded_by_dist_policy += 1
+                continue
 
-        if sdist_install:
-            sdist_install_versions.add(version)
+            if sdist_install:
+                sdist_install_versions.add(version)
 
-        requires_python = dist.requires_python
-        excluded = (
-            requires_python_cache.get(requires_python) if requires_python else False
-        )
-        if excluded is None:
-            excluded = excluded_by_python(provider, dist, None)
-        elif excluded:
-            # excluded_by_python counts its own drops; a cache hit skips it.
-            stats.excluded_by_python += 1
+            requires_python = dist.requires_python
+            excluded = (
+                requires_python_cache.get(requires_python) if requires_python else False
+            )
+            if excluded is None:
+                excluded = excluded_by_python(provider, dist, None)
+            elif excluded:
+                # excluded_by_python counts its own drops; a cache hit skips it.
+                stats.excluded_by_python += 1
 
-        if excluded:
-            continue
+            if excluded:
+                continue
 
-        if time_filter_active and _excluded_by_upload_time(
-            provider, normalized, dist, cutoff
-        ):
-            continue
+            if time_filter_active and _excluded_by_upload_time(
+                provider, normalized, dist, cutoff
+            ):
+                continue
 
-        result.append((version, dist))
+            result.append((version, dist))
+    finally:
+        _count_files_seen(stats, wheels_walked, sdists_walked)
 
     return result, sdist_install_versions, sort_with_wheel_first
 

--- a/nab-provider/tests/test_provider_declared_target.py
+++ b/nab-provider/tests/test_provider_declared_target.py
@@ -26,6 +26,7 @@ from nab_provider._vendor.packaging.version import Version
 from nab_provider.provider import (
     BuildPolicy,
     DistPolicy,
+    InvalidUploadTimeError,
     ListingFilterCache,
     MetadataError,
     Provider,
@@ -970,6 +971,88 @@ class TestListingFilterSharedAcrossPythons:
 
         assert py311.stats.excluded_by_python == 1
         assert py312.stats.excluded_by_python == 1
+
+
+class TestListingWalkCounters:
+    """Every file a listing walk reaches is counted, as a wheel or as an sdist."""
+
+    @staticmethod
+    def _provider(
+        files: Sequence[WheelFile | SdistFile],
+        *,
+        shared: bool = False,
+        uploaded_prior_to: datetime | None = None,
+        overridden: bool = False,
+    ) -> Provider:
+        """A 3.11 provider over ``files``.
+
+        ``shared`` gives it a matrix cache, which moves the Requires-Python
+        and cutoff drops out of the walk.  ``overridden`` gives it an
+        override for another package, which routes the walk through the
+        general pass rather than the defaults one.
+        """
+        overrides = (
+            (pkg_override("other", requires_python=">=3.11"),) if overridden else ()
+        )
+        return Provider(
+            _index_with_files(files),
+            _LINUX_TARGET,
+            uploaded_prior_to=uploaded_prior_to,
+            package_overrides=overrides,
+            listing_filter_cache=ListingFilterCache(2) if shared else None,
+        )
+
+    @pytest.mark.parametrize("shared", [False, True], ids=["defaults", "general"])
+    def test_the_walk_counts_every_file_by_kind(self, shared: bool) -> None:
+        """A file joins the wheel or the sdist tally whether or not it survives.
+
+        2.0 loses to Requires-Python and 3.0.oops never parses; the walk
+        counts both as wheels.
+        """
+        files: list[WheelFile | SdistFile] = [
+            _make_wheel("1.0"),
+            _make_wheel("2.0", requires_python=">=3.12"),
+            _make_wheel("3.0.oops"),
+            _sdist("4.0"),
+            _sdist("5.0"),
+        ]
+
+        provider = self._provider(files, shared=shared)
+        provider.fetch_versions("pkg")
+
+        assert provider.stats.distributions_seen == 5
+        assert provider.stats.wheels_seen == 3
+        assert provider.stats.sdists_seen == 2
+
+    @pytest.mark.parametrize("overridden", [False, True], ids=["defaults", "general"])
+    def test_a_walk_that_raises_counts_the_files_it_reached(
+        self, overridden: bool
+    ) -> None:
+        """A raise out of the middle of the walk leaves the prefix counted.
+
+        The cutoff refuses 3.0's timezone-naive upload time.  The walk
+        classifies a file before it reaches that check, so the tally
+        covers the first three files and not 4.0.
+        """
+        files: list[WheelFile | SdistFile] = [
+            _make_wheel("1.0", upload_time="2026-01-01T00:00:00Z"),
+            _sdist("2.0"),
+            _make_wheel("3.0", upload_time="2026-01-01T00:00:00"),
+            _make_wheel("4.0", upload_time="2026-01-01T00:00:00Z"),
+        ]
+
+        provider = self._provider(
+            files,
+            uploaded_prior_to=datetime(2026, 3, 1, tzinfo=timezone.utc),
+            overridden=overridden,
+        )
+
+        with pytest.raises(InvalidUploadTimeError):
+            provider.fetch_versions("pkg")
+
+        assert provider.stats.distributions_seen == 3
+        assert provider.stats.wheels_seen == 2
+        assert provider.stats.sdists_seen == 1
 
 
 class TestUnsetKnobAcceptsAnyLevel:


### PR DESCRIPTION
About 47 million instructions come off a `pip:google-bigquery-soda --resolution lowest` resolve, 1.1% of a 4.22-billion-instruction run, counted three times under callgrind with `PYTHONHASHSEED=0`.

That resolve walks 39,824 listing files in 49 passes, and every file raised two `ProviderStats` counters: `distributions_seen`, plus `wheels_seen` or `sdists_seen`. `_prepare_listing` and `_prepare_listing_defaults` now bump a `wheels_walked` or `sdists_walked` local instead and flush the three counters once at the end of the pass. So 79,648 attribute read-modify-writes become 39,824 local increments, 147 attribute writes and 49 `_count_files_seen` calls.

The flush sits in a `finally`, which is what keeps the old counts. A timezone-naive upload time raises `InvalidUploadTimeError`, `has_satisfying_version` catches it and answers False, and the pass that stopped part way through still reports the files it reached.

A timing run on the same scenario rules out a wall regression above about 5%.