### PR TITLE
Assert the config layer stays silent on NAB_VERBOSITY and NAB_NO_PROGRESS

### DIFF
--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -156,15 +156,23 @@ class TestConfigList:
         self,
         hermetic_roots: Path,
         monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
         var: str,
         value: str,
     ) -> None:
-        # NAB_VERBOSITY / NAB_NO_PROGRESS belong to the output layer, so the
-        # config env-layer must not reject them as unknown NAB_* settings.
+        # NAB_VERBOSITY and NAB_NO_PROGRESS belong to the output layer, so the
+        # config env-layer skips them: no warning, and no rejected entry.
         _project(hermetic_roots)
         monkeypatch.setenv(var, value)
-        out = _run_config(["list", "--path", str(hermetic_roots / "pyproject.toml")])
+        path = str(hermetic_roots / "pyproject.toml")
+
+        with caplog.at_level(logging.WARNING, logger="nab_project"):
+            out = _run_config(["list", "--path", path])
+            rejected = _run_config(["list", "--include-rejected", "--path", path])
+
         assert "offline" in out
+        assert var not in caplog.text
+        assert var not in rejected
 
     def test_unknown_env_var_warns_and_runs(
         self,


### PR DESCRIPTION
`test_output_env_vars_do_not_trip_config_layer` passes whether or not the config env layer still reserves `NAB_VERBOSITY` and `NAB_NO_PROGRESS` for the output layer. It sets one of the two, runs `nab config list`, and asserts `offline` appears in the table, which it does either way. No other test names `reserved_env`, so nothing covered the reservation.

The assertion meant something when an unrecognized `NAB_*` name raised `SourceConfigError`: the command exited 1 and printed no table, so reaching the table was the check. Turning that refusal into a warning left the table printing regardless.

Drop `reserved_env=OUTPUT_ENV_VARS` from `effective_config` on main and nothing fails, while `nab config`, `nab lock`, `nab download` and `nab cache` all start warning about a variable the CLI reference tells people to set:

```
warning: NAB_VERBOSITY is not a recognized nab setting and was ignored; the known NAB_* variables are ['NAB_CACHE_DIR', 'NAB_HTTP_BACKEND', 'NAB_MAX_CONCURRENCY', 'NAB_OFFLINE'].
```

The test now runs the command twice, plain and with `--include-rejected`, and checks both places the guard can surface a name: nothing logged under `nab_project`, and no entry in the `rejected:` section.
