### PR TITLE
Fix dropped-constraint warning that recommends a spelling nab rejects

### DIFF
--- a/nab-project/src/nab_project/_resolve/engine.py
+++ b/nab-project/src/nab_project/_resolve/engine.py
@@ -496,9 +496,9 @@ class _EngineSettings:
     # of the listing filter reads are fixed for the run.
     listing_filter_cache: ListingFilterCache = field(default_factory=ListingFilterCache)
 
-    # The root requirements _warn_dropped_root_marker already reported, so a
-    # root read once per target per fork and again in the base pass warns once.
-    warned_root_markers: set[str] = field(default_factory=set)
+    # The (kind, text) pairs already reported, so an entry read once per
+    # target per fork and again in the base pass warns once.
+    warned_dropped_markers: set[tuple[str, str]] = field(default_factory=set)
 
 
 def _threaded_preferences(
@@ -556,7 +556,7 @@ def _resolve_one_target(
             config.vcs,
             environment=environment,
             marker_holds=settings.marker_holds,
-            warned=settings.warned_root_markers,
+            warned=settings.warned_dropped_markers,
         )
         constraint_ranges = build_resolver_inputs(
             constraints,
@@ -564,7 +564,7 @@ def _resolve_one_target(
             environment=environment,
             marker_holds=settings.marker_holds,
             kind="constraint",
-            warned=settings.warned_root_markers,
+            warned=settings.warned_dropped_markers,
         ).ranges
         resolver_constraints = ProxyConstraints(constraint_ranges)
     except ResolutionError as exc:

--- a/nab-project/tests/test_resolve.py
+++ b/nab-project/tests/test_resolve.py
@@ -71,7 +71,10 @@ from nab_provider.provider import (
     UnsupportedVcsError,
     VcsConfig,
 )
-from nab_provider.requirements_file import InvalidProjectRequirementError
+from nab_provider.requirements_file import (
+    InvalidProjectRequirementError,
+    expand_extra_requirements,
+)
 from nab_provider.tags import PlatformSpec
 from nab_provider.target import ResolveTarget
 from nab_resolver.errors import ResolutionError
@@ -159,6 +162,16 @@ def _build_constraints(
         marker_holds=dependency_marker_holds,
         kind="constraint",
     ).ranges
+
+
+def _constraints_pyproject(tmp_path: Path, entries: str) -> Path:
+    """A minimal project whose ``[tool.nab].constraints`` holds ``entries``."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        '[project]\nname = "x"\nversion = "0"\ndependencies = []\n'
+        f"[tool.nab]\nconstraints = [{entries}]\n"
+    )
+    return pyproject
 
 
 def _malformed_group_pyproject(tmp_path: Path) -> Path:
@@ -2670,6 +2683,91 @@ class TestBuildResolverInputs:
         assert "foo" not in resolver_requirements
         assert not caplog.records
 
+    def test_root_requirement_warning_points_at_extras_of_package(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The requirement pass names a root requirement and points at pkg[extra]."""
+        with caplog.at_level("WARNING", logger="nab_provider.resolver_inputs"):
+            build_resolver_inputs(
+                [Requirement('foo<2.0 ; extra == "fast"')],
+                VcsConfig(),
+                environment={},
+                marker_holds=dependency_marker_holds,
+            )
+
+        (record,) = caplog.records
+        assert record.message.startswith(
+            "Root requirement 'foo<2.0; extra == \"fast\"'"
+        )
+        assert "pkg[extra] (extras-of-package)" in record.message
+
+    def test_warning_cause_holds_when_the_extra_was_selected(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The cause it gives is true on a run that did select the extra.
+
+        ``--extras fast`` folds the extra's entries into the requirement list
+        and leaves the marker environment alone, so blaming an inactive extra
+        would send the user after a flag they already passed.
+        """
+        selected = expand_extra_requirements(
+            {"fast": ['foo<2.0 ; extra == "fast"']}, "proj", ["fast"]
+        )
+        with caplog.at_level("WARNING", logger="nab_provider.resolver_inputs"):
+            build_resolver_inputs(
+                selected,
+                VcsConfig(),
+                environment={},
+                marker_holds=dependency_marker_holds,
+            )
+
+        (record,) = caplog.records
+        assert (
+            "folded into the requirements rather than the environment" in record.message
+        )
+        assert "no extra or dependency group is active" not in record.message
+
+    def test_unknown_kind_is_named_after_itself(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """``kind`` is a free string, so one with no subject warns, not raises."""
+        with caplog.at_level("WARNING", logger="nab_provider.resolver_inputs"):
+            build_resolver_inputs(
+                [Requirement('foo<2.0 ; extra == "fast"')],
+                VcsConfig(),
+                environment={},
+                marker_holds=dependency_marker_holds,
+                kind="override",
+            )
+
+        (record,) = caplog.records
+        assert record.message.startswith("Override 'foo<2.0; extra == \"fast\"'")
+
+    def test_repeated_text_warns_once_per_kind(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """One warned set covers both passes, and each keeps its own wording.
+
+        A target's requirement pass and constraint pass share the set, so a
+        project that writes the same line in both must still get the advice
+        that fits a constraint.
+        """
+        reqs = [Requirement('foo<2.0 ; extra == "fast"')]
+        warned: set[tuple[str, str]] = set()
+        with caplog.at_level("WARNING", logger="nab_provider.resolver_inputs"):
+            for kind in ("requirement", "requirement", "constraint"):
+                build_resolver_inputs(
+                    reqs,
+                    VcsConfig(),
+                    environment={},
+                    marker_holds=dependency_marker_holds,
+                    kind=kind,
+                    warned=warned,
+                )
+
+        subjects = [rec.message.split(" '", 1)[0] for rec in caplog.records]
+        assert subjects == ["Root requirement", "Constraint"]
+
     def test_multi_extra_proxy_keys_sorted(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -2758,6 +2856,96 @@ class TestBuildConstraints:
             NabProjectConfig(constraints=('foo<2.0 ; "x" in extras',)), environment={}
         )
         assert "foo" not in out
+
+    def _drop_warning(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        constraint: str = 'foo<2.0 ; extra == "fast"',
+        environment: dict[str, str] | None = None,
+    ) -> str:
+        """The one warning a membership-gated constraint logs when dropped."""
+        with caplog.at_level("WARNING", logger="nab_provider.resolver_inputs"):
+            out = _build_constraints(
+                NabProjectConfig(constraints=(constraint,)),
+                environment={} if environment is None else environment,
+            )
+
+        assert "foo" not in out
+        (record,) = caplog.records
+        return record.message
+
+    def test_dropped_constraint_warning_names_a_constraint(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The drop warning names the entry a constraint, not a root requirement."""
+        message = self._drop_warning(caplog)
+
+        assert message.startswith("Constraint 'foo<2.0; extra == \"fast\"'")
+        assert "Root requirement" not in message
+
+    def test_dropped_constraint_warning_omits_pkg_extra(
+        self, caplog: pytest.LogCaptureFixture, tmp_path: Path
+    ) -> None:
+        """pkg[extra] is the one spelling the constraint parser refuses."""
+        message = self._drop_warning(caplog)
+
+        assert "pkg[extra]" not in message
+        assert "A constraint cannot carry extras" in message
+
+        with pytest.raises(ConfigError, match="cannot have extras"):
+            read_pyproject_config(_constraints_pyproject(tmp_path, '"foo[fast]<2.0"'))
+
+    def test_dropped_group_constraint_warning_omits_the_extras_rule(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A group membership has no extras spelling, so that sentence stays out."""
+        message = self._drop_warning(caplog, 'foo<2.0 ; "docs" in dependency_groups')
+
+        assert "cannot carry extras" not in message
+        assert "Drop the membership test from the marker and keep the rest." in message
+
+    def test_dropped_constraint_repair_still_bounds_the_package(
+        self, caplog: pytest.LogCaptureFixture, tmp_path: Path
+    ) -> None:
+        """The repair the warning asks for parses and still bounds foo."""
+        message = self._drop_warning(caplog)
+        assert message.endswith(
+            "so drop the membership test from the marker and keep the rest."
+        )
+
+        config = read_pyproject_config(_constraints_pyproject(tmp_path, '"foo<2.0"'))
+        out = _build_constraints(config, environment={})
+        assert V("1.0") in out["foo"]
+        assert V("5.0") not in out["foo"]
+
+    def test_repaired_compound_marker_keeps_its_environment_test(
+        self, caplog: pytest.LogCaptureFixture, tmp_path: Path
+    ) -> None:
+        """Keeping the rest of the marker leaves foo unbound on other interpreters.
+
+        Dropping the whole marker instead would bound foo everywhere, which
+        is not what the project wrote.
+        """
+        on_39 = {"python_version": "3.9", "python_full_version": "3.9.18"}
+        message = self._drop_warning(
+            caplog,
+            'foo<2.0 ; extra == "fast" and python_version < "3.10"',
+            environment=on_39,
+        )
+
+        assert message.endswith(
+            "so drop the membership test from the marker and keep the rest."
+        )
+
+        config = read_pyproject_config(
+            _constraints_pyproject(tmp_path, "\"foo<2.0 ; python_version < '3.10'\"")
+        )
+        out = _build_constraints(config, environment=on_39)
+        assert V("1.0") in out["foo"]
+        assert V("5.0") not in out["foo"]
+
+        on_311 = {"python_version": "3.11", "python_full_version": "3.11.2"}
+        assert "foo" not in _build_constraints(config, environment=on_311)
 
 
 class TestResolvePyprojectConflicts:

--- a/nab-project/tests/test_resolve_targets.py
+++ b/nab-project/tests/test_resolve_targets.py
@@ -806,8 +806,8 @@ class TestTwoConflictSetsPartialInstall:
         }
 
 
-class TestDroppedRootMarkerWarnedOnce:
-    """One mistaken root requirement is reported once per run, however
+class TestDroppedMembershipMarkerWarnedOnce:
+    """One mistaken top-level entry is reported once per run, however
     many targets, forks and base passes read it."""
 
     def _coordinator(self) -> FakeFetchPort:
@@ -861,6 +861,32 @@ class TestDroppedRootMarkerWarnedOnce:
         assert len(warned) == 2
         assert sum('gated; extra == "test"' in msg for msg in warned) == 1
         assert sum('other; "dev" in extras' in msg for msg in warned) == 1
+
+    def test_dropped_constraint_warns_once_across_targets_and_forks(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The constraint pass shares the run's warned set with the root pass."""
+        plain = tuple(_reqs("base"))
+        forks = [
+            ResolveFork((("extra", "cpu"),), plain),
+            ResolveFork((("extra", "gpu"),), plain),
+        ]
+        with caplog.at_level(logging.WARNING, logger="nab_provider.resolver_inputs"):
+            result = resolve_with_coordinator(
+                self._coordinator(),
+                self._two_targets(),
+                forks=forks,
+                base_requirements=plain,
+                config=_no_build(constraints=('base<2.0 ; extra == "test"',)),
+            )
+        assert result.success
+        warned = [
+            rec.getMessage()
+            for rec in caplog.records
+            if "membership marker" in rec.message
+        ]
+        assert len(warned) == 1
+        assert warned[0].startswith("Constraint 'base<2.0; extra == \"test\"'")
 
 
 class TestDirectPackages:

--- a/nab-provider/src/nab_provider/resolver_inputs.py
+++ b/nab-provider/src/nab_provider/resolver_inputs.py
@@ -18,7 +18,11 @@ from nab_provider._vendor.packaging.utils import canonicalize_name
 from nab_resolver.errors import ResolutionError
 from nab_resolver.types import RootRequirement
 
-from .conflict_kind import membership_set_in_marker
+from .conflict_kind import (
+    KIND_EXTRA,
+    MARKER_VARIABLE_FOR_KIND,
+    membership_set_in_marker,
+)
 from .errors import ConfigError
 from .extra_keys import join_extra, split_extra
 from .vcs_admission import admit_vcs_url
@@ -36,6 +40,15 @@ if TYPE_CHECKING:
 
 
 _logger = logging.getLogger(__name__)
+
+# What a dropped entry is called in its warning.  A kind not listed here is
+# named after itself, since ``kind`` is a free string on the public entry point.
+_DROPPED_MARKER_SUBJECT = {
+    "requirement": "Root requirement",
+    "constraint": "Constraint",
+}
+
+_EXTRAS_VARIABLE = MARKER_VARIABLE_FOR_KIND[KIND_EXTRA]
 
 
 def raise_for_unsatisfiable(
@@ -61,27 +74,53 @@ def raise_for_unsatisfiable(
     raise ResolutionError(msg)
 
 
-def _warn_dropped_root_marker(req: Requirement, warned: set[str]) -> None:
-    """Warn when a dropped root requirement tests an extra/group membership.
+def _repair_advice(*, kind: str, tests_extra: bool) -> str:
+    """Return the fix a dropped entry's warning ends with.
 
-    Root activates no extra or group, so a marker testing ``extra``,
-    ``extras`` or ``dependency_groups`` membership never holds.  ``warned``
-    holds the requirements already reported, so one mistake warns once.
+    A constraint cannot be pointed at ``pkg[extra]``, since the constraint
+    parser rejects a constraint carrying extras, so it is asked to edit the
+    marker instead.  Every other kind keeps the extras-of-package advice.
+    """
+    if kind == "constraint":
+        if tests_extra:
+            return (
+                "A constraint cannot carry extras, so drop the membership test "
+                "from the marker and keep the rest."
+            )
+        return "Drop the membership test from the marker and keep the rest."
+    return "For an extra, use pkg[extra] (extras-of-package)."
+
+
+def _warn_dropped_membership_marker(
+    req: Requirement, warned: set[tuple[str, str]], *, kind: str
+) -> None:
+    """Warn when a dropped top-level entry tests an extra or group membership.
+
+    A selected extra or group is folded into the requirements rather than the
+    environment, so ``extra``, ``extras`` and ``dependency_groups`` are empty
+    whatever the run selects and a membership test never holds.  ``kind`` names
+    the entry in the message and picks the repair.  ``warned`` holds the
+    ``(kind, text)`` pairs already reported, so one mistake warns once per kind.
     """
     marker_text = str(req.marker)
-    if "extra ==" not in marker_text and not membership_set_in_marker(marker_text):
+    membership_set = membership_set_in_marker(marker_text)
+    if "extra ==" not in marker_text and membership_set is None:
         return
 
     text = str(req)
-    if text in warned:
+    if (kind, text) in warned:
         return
+    warned.add((kind, text))
 
-    warned.add(text)
+    tests_extra = "extra ==" in marker_text or membership_set == _EXTRAS_VARIABLE
     _logger.warning(
-        "Root requirement %r tests an extra or dependency-group membership "
-        "marker; the dep is dropped because root activates no extra or group "
-        "at resolve time. For an extra, use pkg[extra] (extras-of-package).",
+        "%s %r tests an extra or dependency-group membership marker; it is "
+        "dropped because a selected extra or group is folded into the "
+        "requirements rather than the environment, so extra, extras and "
+        "dependency_groups are empty at resolve time. %s",
+        _DROPPED_MARKER_SUBJECT.get(kind, kind.capitalize()),
         text,
+        _repair_advice(kind=kind, tests_extra=tests_extra),
     )
 
 
@@ -100,7 +139,7 @@ def build_resolver_inputs(
     environment: Mapping[str, str],
     marker_holds: MarkerHolds,
     kind: str = "requirement",
-    warned: set[str] | None = None,
+    warned: set[tuple[str, str]] | None = None,
 ) -> _ResolverInputs:
     """Convert PEP 508 requirements to the resolver's input shape.
 
@@ -118,13 +157,14 @@ def build_resolver_inputs(
     constraint intersection is caught here by :func:`raise_for_unsatisfiable`
     rather than by the solver.
 
-    ``warned`` collects the root markers already reported: callers sharing one
-    warn once between them, a caller that omits it warns per call.
+    ``warned`` collects the entries already reported, keyed by ``kind``:
+    callers sharing one set warn once between them, a caller that omits it
+    warns per call.
     """
     roots: list[RootRequirement[str, VersionRange]] = []
     resolver_requirements: dict[str, VersionRange] = {}
     root_extras: set[tuple[str, str]] = set()
-    already_warned = set() if warned is None else warned
+    already_warned: set[tuple[str, str]] = set() if warned is None else warned
 
     for req in requirements:
         if kind == "constraint" and req.extras:
@@ -132,7 +172,7 @@ def build_resolver_inputs(
             raise ConfigError(msg)
 
         if req.marker is not None and not marker_holds(req.marker, environment):
-            _warn_dropped_root_marker(req, already_warned)
+            _warn_dropped_membership_marker(req, already_warned, kind=kind)
             continue
 
         if req.url is not None:


### PR DESCRIPTION
A `[tool.nab].constraints` entry whose marker tests an extra is dropped, and the warning about it gets both halves wrong:

    Root requirement 'foo<2.0; extra == "fast"' tests an extra or dependency-group membership marker; the dep is dropped because root activates no extra or group at resolve time. For an extra, use pkg[extra] (extras-of-package).

A constraint is not a root requirement, so you go looking in `dependencies` for a line that is not there. And the spelling it recommends fails the config parse before any resolving happens:

    error: in [tool.nab]: constraints[0] cannot have extras: foo[fast]<2.0

The constraint pass now names the entry and ends with a fix that parses:

    Constraint 'foo<2.0; extra == "fast"' tests an extra or dependency-group membership marker; it is dropped because a selected extra or group is folded into the requirements rather than the environment, so extra, extras and dependency_groups are empty at resolve time. A constraint cannot carry extras, so drop the membership test from the marker and keep the rest.

A marker testing `dependency_groups` has no extras spelling to rule out, so its warning ends with just "Drop the membership test from the marker and keep the rest."

Both kinds share that middle clause, so the root-requirement wording changes too. "root activates no extra or group" was misleading on `nab lock --extras fast`, which does select the extra: the selection is folded into the requirement list, not into the marker environment.

`build_resolver_inputs` keys `warned` by `(kind, text)` rather than text, so a line written into both `dependencies` and `constraints` warns once for each instead of once with whichever pass ran first, and a `kind` it has no subject for is named after itself rather than raising `KeyError`.
