### PR TITLE
Fix `nab lock` RecursionError on a deeply nested table in the lockfile

### DIFF
--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -22,10 +22,9 @@ from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from string import Formatter
-from typing import TYPE_CHECKING, Annotated, NamedTuple, NoReturn
+from typing import TYPE_CHECKING, Annotated, Any, NamedTuple, NoReturn
 
 import tomli
-import tomli_w
 import tyro
 
 from nab._version import __version__
@@ -369,16 +368,18 @@ def _emit(
         )
 
 
-def _packages_only(text: str) -> str:
-    """Re-render lock TOML without the volatile ``[tool.nab]`` block.
+def _packages_only(text: str) -> dict[str, Any]:
+    """Parse lock TOML without the volatile ``[tool.nab]`` block.
 
     Drops the provenance block (its command line and timestamp change every
     run) so two locks compare equal whenever their packages, environments,
-    and metadata match.
+    and metadata match.  Returning the parsed tables keeps the comparison
+    off ``tomli_w``, which recurses once per table level and so cannot
+    re-render every document tomli accepts.
     """
     data = toml_io.loads(text)
     data.pop("tool", None)
-    return tomli_w.dumps(data)
+    return data
 
 
 _BUILD_DEFAULT_OUTPUT: dict[str, str] = {

--- a/tests/test_lock_locked.py
+++ b/tests/test_lock_locked.py
@@ -628,6 +628,34 @@ def test_non_sticky_stale_falls_through_out_of_date(
     mock.assert_called_once()
 
 
+def test_a_deeply_nested_extra_table_falls_through_out_of_date(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A table too deep for ``tomli_w`` to render still reaches a verdict.
+
+    tomli parses table depths the writer cannot write back, so the
+    comparison must not round-trip the committed lock through the writer.
+    """
+    pyproject = _write_pyproject(tmp_path, '[project]\ndependencies = ["foo>=1.0"]\n')
+    out = tmp_path / "pylock.toml"
+    _write_lock(pyproject, out, _result({"foo": "1.0"}))
+    capsys.readouterr()
+    # Past the writer's per-level recursion, inside the part count tomli takes.
+    deep = ".".join(f"k{level}" for level in range(995))
+    with out.open("a", encoding="utf-8") as handle:
+        handle.write(f"\n[{deep}]\nx = 1\n")
+
+    mock = _locked_mock(_result({"foo": "1.0"}))
+    with pytest.raises(SystemExit) as exc:
+        _run_locked(pyproject, out, mock)
+
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    remedy = _remedy(str(pyproject), "--output", str(out))
+    assert f"is out of date; re-run `{remedy}` to update it" in err
+    mock.assert_called_once()
+
+
 def test_a_stale_build_lock_names_the_build_command(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
A committed `pylock.toml` carrying a table nested close to a thousand levels deep ends `nab lock --locked` in a traceback rather than a verdict, and only after the whole resolve has run.

`--locked` drops the volatile `[tool.nab]` block by re-rendering the committed lock through `tomli_w`, which recurses once per table level. tomli parses documents deeper than the writer can render back, so `_packages_only` blew the stack on a lock tomli had just accepted. Against a 995-part key:

```
  File "src/nab/_lock.py", line 381, in _packages_only
    return tomli_w.dumps(data)
  File "tomli_w/_writer.py", line 97, in gen_table_chunks
    yield from gen_table_chunks(v, ctx, name=display_name, inside_aot=in_aot)
  [Previous line repeated 954 more times]
RecursionError: maximum recursion depth exceeded
```

The comparison now runs on the parsed tables, keeping `tomli_w` off the `--locked` path. That lock reports as out of date instead.

Comparing parsed tables also makes `--locked` insensitive to key order within a table, where re-rendering was not.
