### PR TITLE
Fix lazy wheel read looping on a 206 that selects no bytes

### DIFF
--- a/nab-index/src/nab_index/lazy_wheel.py
+++ b/nab-index/src/nab_index/lazy_wheel.py
@@ -294,7 +294,9 @@ async def _suffix_attempt(
 
     A 206 whose Content-Range is absent, unparseable, or of unknown length
     (``bytes a-b/*``) gives no offset to anchor the returned bytes, so it
-    steps down to absolute ranges rather than guessing what the body is.
+    steps down to absolute ranges rather than guessing what the body is.  One
+    selecting no bytes (``bytes 10-9/10``, invalid under RFC 9110 section
+    14.4) steps down too: the window it anchors holds nothing and cannot grow.
     """
     response = await _range_get(transport, url, f"bytes=-{tail_size}")
     status = response.status_code
@@ -306,7 +308,8 @@ async def _suffix_attempt(
         if parsed is None:
             return _SuffixOutcome("downgrade")
         start, end, total = parsed
-        if end == total - 1 and end - start + 1 == len(body):
+        width = end - start + 1
+        if width > 0 and end == total - 1 and width == len(body):
             return _SuffixOutcome("suffix", total=total, low=start, body=body)
         return _SuffixOutcome("downgrade")
     if status not in _RANGE_REJECT_STATUSES and status not in (
@@ -487,16 +490,22 @@ async def _open_zip(
     tail_low: int,
     wheel_hash: tuple[str, str] | None,
 ) -> zipfile.ZipFile | None:
-    """Open a ZipFile over the sparse buffer, growing the window on demand."""
+    """Open a ZipFile over the sparse buffer, doubling the window on demand.
+
+    A window that doubling cannot widen ends the read: it already spans the
+    whole file, or it holds no bytes to double.
+    """
     total = sparse._length  # noqa: SLF001
     while True:
         opened = _try_open(sparse)
         if opened is not None:
             return opened
+
         have = total - tail_low
-        if have >= total:
-            return None
         new_size = min(have * 2, total)
+        if new_size <= have:
+            return None
+
         new_low = total - new_size
         response = await _range_get(transport, url, f"bytes={new_low}-{tail_low - 1}")
         low = _absorb_range(response, sparse, new_low, wheel_hash)

--- a/nab-index/tests/test_lazy_wheel.py
+++ b/nab-index/tests/test_lazy_wheel.py
@@ -462,6 +462,10 @@ def test_full_body_not_a_zip_is_missing() -> None:
     assert result.outcome is RangeOutcome.MISSING
 
 
+# Fail a reader that loops re-requesting the same range, rather than hang.
+_SCRIPTED_REQUEST_CAP = 20
+
+
 class _ScriptedTransport:
     """Serve responses from per-request-shape callables."""
 
@@ -475,6 +479,9 @@ class _ScriptedTransport:
         self, url: str, *, headers: dict[str, str] | None = None
     ) -> _FakeResponse:
         await asyncio.sleep(0)
+        if len(self.requests) >= _SCRIPTED_REQUEST_CAP:
+            msg = f"reader still requesting after {_SCRIPTED_REQUEST_CAP} round trips"
+            raise AssertionError(msg)
         headers = headers or {}
         rng = headers.get("Range")
         if rng is None:
@@ -979,6 +986,40 @@ def test_suffix_206_oversized_total_downgrades() -> None:
     result = _run_scripted(script, wheel=build_wheel_member_front())
     assert result.outcome is RangeOutcome.PARTIAL
     assert result.text == _META.decode("utf-8")
+
+
+def test_suffix_206_empty_range_downgrades() -> None:
+    """A 206 selecting no bytes is not a tail.
+
+    Taking it as one leaves a window that holds nothing and cannot grow.
+    """
+
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        if kind == "suffix":
+            headers = {"content-range": f"bytes {t.total}-{t.total - 1}/{t.total}"}
+            return _FakeResponse(206, headers, b"")
+        return t.partial(a, b)
+
+    result = _run_scripted(script)
+    assert result.outcome is RangeOutcome.PARTIAL
+    assert result.text == _META.decode("utf-8")
+
+
+def test_zero_tail_size_gives_up_instead_of_re_requesting() -> None:
+    """A window with nothing to double ends the read rather than looping.
+
+    A zero-length tail request comes back as the empty range at the end of the
+    file, so the window starts at zero width.
+    """
+
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        if kind == "suffix":
+            return t.partial(max(0, t.total - a), t.total - 1)
+        return t.partial(a, b)
+
+    result = _run_scripted(script, tail_size=0)
+    assert result.outcome is RangeOutcome.MISSING
+    assert result.text is None
 
 
 def test_parse_content_range_at_int_limit() -> None:


### PR DESCRIPTION
A host that answers a suffix range with a 206 whose Content-Range selects no bytes, `bytes 10-9/10`, sends the lazy wheel read into a request loop. The header is invalid under RFC 9110 section 14.4, but the suffix guard accepted it: the range ends on the last byte and its width matches the empty body, so the read anchored a zero-width window at offset 10.

Growing the window doubles it, and doubling zero is zero, so every pass asks for the same bytes:

    Range: bytes=10-9

Whether that ever ends is up to the server: a 416 steps the read down to a plain GET, while another empty 206 puts the reader back where it started.

The fix is in two places:

- `_suffix_attempt` now requires the Content-Range to select at least one byte, so an empty one downgrades to absolute ranges along with the other 206s it cannot anchor.
- `_open_zip` stops when doubling cannot widen the window, rather than only when the window already spans the file. That also ends a read started with `tail_size=0`, which reaches the same zero-width state through the absolute path.
