### PR TITLE
Slice a wheel's tag suffix out of its filename, ~0.7% off a soda resolve

### DIFF
--- a/nab-provider/src/nab_provider/tags.py
+++ b/nab-provider/src/nab_provider/tags.py
@@ -61,9 +61,10 @@ FREE_THREADED_MIN_PYTHON = (3, 13)
 TagsSource = Callable[[], "Iterable[Tag]"]
 
 
-# PEP 427: a wheel filename has at least 5 dash-separated segments
-# (name-version-pythontag-abitag-platformtag.whl), or 6 with a build tag.
-_MIN_WHEEL_FILENAME_PARTS = 5
+# PEP 427: a wheel filename's last 3 dash-separated segments are the tag
+# suffix (pythontag-abitag-platformtag), behind a name, a version, and an
+# optional build tag, so the whole filename has at least 5 segments.
+_WHEEL_TAG_SEGMENTS = 3
 
 # A PEP 425 compressed tag set is a cross product, so an index-supplied
 # filename naming 40 interpreters, 40 abis and 40 platforms would parse into
@@ -474,20 +475,18 @@ def wheel_tag_set(filename: str) -> frozenset[Tag] | None:
     filename or one with too few segments.
 
     The tag set is a pure function of the filename, so the whole
-    result is memoized on it, and a repeated filename skips the string
-    splitting.  The parse and Tag interning are shared further across
-    distinct filenames by :func:`_parse_tag_str`, keyed on the tag
-    suffix.
+    result is memoized on it, and a repeated filename skips the split.
+    The parse and Tag interning are shared further across distinct
+    filenames by :func:`_parse_tag_str`, keyed on the tag suffix.
     """
     if not filename.endswith(".whl"):
         return None
 
-    stem = filename[:-4]
-    parts = stem.split("-")
-    if len(parts) < _MIN_WHEEL_FILENAME_PARTS:
+    head = filename.rsplit("-", _WHEEL_TAG_SEGMENTS)[0]
+    if "-" not in head:  # fewer than five segments
         return None
 
-    return _parse_tag_str("-".join(parts[-3:]))
+    return _parse_tag_str(filename[len(head) + 1 : -4])
 
 
 def _build_tag_sort_key(filename: str) -> tuple[int, str]:

--- a/nab-provider/tests/test_tags.py
+++ b/nab-provider/tests/test_tags.py
@@ -733,6 +733,11 @@ class TestWheelCompatibility:
         )
         assert not _compatible(wheel, python_version="3.11", spec=spec)
 
+    def test_four_segment_filename_is_not_a_wheel(self) -> None:
+        """Four segments is one short, even when the last three parse as tags."""
+        assert wheel_tag_set("foo-py3-none-any.whl") is None
+        assert wheel_tag_set("foo-1.0-py3-none.whl") is None
+
     def test_non_whl_extension_rejected(self) -> None:
         """A filename without ``.whl`` extension is rejected."""
         spec = PlatformSpec("linux_x86_64")


### PR DESCRIPTION
About 30 million instructions come off a `pip:google-bigquery-soda --resolution lowest` resolve, about 0.7% of it, when `wheel_tag_set` slices the tag suffix out of the filename instead of splitting the whole filename apart. Both rows are callgrind under `PYTHONHASHSEED=0`.

| workload | base | branch | removed | share |
| --- | ---: | ---: | ---: | ---: |
| `pip:google-bigquery-soda --resolution lowest` | 4,223,436,699 | 4,193,269,413 | 30,167,286 | 0.71% |
| `ai-stack:vllm-transformers-floor --resolution highest` | 7,553,827,523 | 7,496,954,444 | 56,873,079 | 0.75% |

The old code split the stem into every segment to keep three of them. The new one takes `filename.rsplit("-", 3)[0]` and slices the suffix straight out of the filename. `rsplit` with `maxsplit=3` leaves a dash in that head exactly when the filename has a fourth one, so `"-" not in head` is the old five-segment guard, and `test_four_segment_filename_is_not_a_wheel` pins that.

The clock cannot see a change this small: timing the same resolve 20 times each way only rules out a slowdown above about 6%.