### PR TITLE
Fix a self-dependency printed as a package incompatible with itself

### DIFF
--- a/nab-project/src/nab_project/_resolve/engine.py
+++ b/nab-project/src/nab_project/_resolve/engine.py
@@ -818,15 +818,31 @@ def _diagnostics_block(
     return "\n".join(lines)
 
 
+def _rules_out_candidate(node: Incompatibility[Any, Any]) -> bool:
+    """Whether ``node`` is a dependency clause ruling its own candidate out.
+
+    A look-ahead group states the candidate's range against a blocker's, both
+    positive.  A self-dependency names one package twice, so its terms merge
+    into a single positive term.  The candidate is the first term either way.
+    """
+    if node.cause is not IncompatibilityCause.DEPENDENCY:
+        return False
+
+    terms = node.terms
+    if len(terms) == _GROUPED_CLAUSE_TERMS:
+        return terms[0].is_positive() and terms[1].is_positive()
+    return len(terms) == 1 and terms[0].is_positive()
+
+
 def _walk_no_versions_packages(
     incompatibility: Incompatibility[Any, Any],
 ) -> list[str]:
     """Return the packages a no-versions diagnostic may name.
 
-    NO_VERSIONS clauses name every package they carry.  Look-ahead grouped
-    clauses (DEPENDENCY cause, two positive terms) name their candidate: a
-    union widened over the whole listing conflicts during propagation, with
-    no second ``choose_version`` ask to raise a NO_VERSIONS clause.
+    NO_VERSIONS clauses name every package they carry.  A dependency clause
+    that rules its own candidate's versions out names that candidate: a union
+    widened over the whole listing conflicts during propagation, with no
+    second ``choose_version`` ask to raise a NO_VERSIONS clause.
 
     The walk is iterative: the tree gains a level per conflict, and recursion
     would overflow on a deeply backtracked resolve.
@@ -846,12 +862,7 @@ def _walk_no_versions_packages(
                 pkg = term.package
                 if isinstance(pkg, str):
                     out.append(pkg)
-        elif (
-            node.cause is IncompatibilityCause.DEPENDENCY
-            and len(node.terms) == _GROUPED_CLAUSE_TERMS
-            and node.terms[0].is_positive()
-            and node.terms[1].is_positive()
-        ):
+        elif _rules_out_candidate(node):
             pkg = node.terms[0].package
             if isinstance(pkg, str):
                 out.append(pkg)

--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -2210,10 +2210,17 @@ class TestNoVersionsReasons:
         coordinator = make_coordinator([], package="foo")
         provider = Provider(coordinator)
         # Plant a blocker for a different candidate in each of the
-        # three pending stores so all the filter branches fire.
+        # four pending stores so all the filter branches fire.
         provider.pending_blocks[("other", "bar", V("1.0"))].append(V("1.0"))
         provider.pending_range_blocks[
             ("other", "baz", SpecifierSet("<2.0").to_range())
+        ].append(V("1.0"))
+        provider.pending_self_blocks[
+            (
+                "other",
+                SpecifierSet("==5.0").to_range(),
+                SpecifierSet(">=6.0").to_range(),
+            )
         ].append(V("1.0"))
         provider.pending_root_blocks[
             (
@@ -4960,6 +4967,73 @@ class TestDecisionLookAhead:
         terms = clauses[0].terms
         assert {t.package for t in terms} == {"foo", "bar"}
 
+    def test_self_dependency_rejection_merges_into_one_term(self) -> None:
+        """A candidate excluded by its own requirement gets one merged term.
+
+        ``foo`` 1.0 requires ``foo==5.0`` while the solution holds ``foo<2.0``.
+        Both terms would name ``foo``, and a clause holds at most one term per
+        package, so they merge to the versions the requirement rules out and
+        the clause carries the declared range.
+        """
+        wheels = [make_wheel("1.0")]
+        meta = make_metadata("foo", "1.0", "foo==5.0")
+        coordinator = make_coordinator(wheels, metadata_text=meta, package="foo")
+        provider = Provider(coordinator, target=_PY312)
+        provider.receive_partial_solution_hint(
+            {"foo": SpecifierSet("<2.0").to_range()}, {}
+        )
+
+        assert provider._look_ahead_ok("foo", V("1.0")) is False
+        provider._flush_pending_blocks()
+
+        (clause,) = provider.consume_pending_clauses()
+        (term,) = clause.terms
+        assert term.package == "foo"
+        assert term.is_positive()
+
+        assert V("1.0") in term.constraint
+        assert V("5.0") not in term.constraint
+        assert clause.dependency_range == SpecifierSet("==5.0").to_range()
+
+    def test_self_dependency_report_names_the_edge(self) -> None:
+        """The report states the self-dependency rather than a tautology.
+
+        ``proj`` 3.0 requires ``proj==2.0`` while the solution holds ``>2.0``
+        from ``app``, so look-ahead rejects it.  Two positive terms for
+        ``proj`` would print as ``proj`` being incompatible with itself.
+        """
+        coordinator = make_coordinator(
+            listings={
+                "app": [make_wheel("1.0")],
+                "proj": [make_wheel("3.0"), make_wheel("2.0")],
+            },
+            metadata_by_version={
+                "1.0": make_metadata("app", "1.0", "proj>2.0"),
+                "3.0": make_metadata("proj", "3.0", "proj==2.0"),
+                "2.0": make_metadata("proj", "2.0", "proj==2.0"),
+            },
+        )
+        root_reqs = {"app": VersionRange.full(admit_arbitrary=False)}
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
+        resolver = Resolver(
+            provider,
+            range_type=VersionRange,
+            root_version="0",
+            format_range=provider.format_range,
+        )
+        with pytest.raises(ResolutionError) as exc_info:
+            resolver.resolve(dict(root_reqs))
+
+        lines = str(exc_info.value).splitlines()
+        assert "because proj >=3.0 depends on proj ==2.0" in lines
+        assert not any(
+            "incompatible with" in line and line.count("proj") > 1 for line in lines
+        )
+
+        assert short_reason(provider, "proj") == (
+            "every version needs proj in ==2.0, but the resolve holds proj in >2.0"
+        )
+
     def test_flush_widens_terms_onto_listed_gaps(self) -> None:
         """Consecutive rejected candidates coalesce into one segment and the
         blocker covers every version the scanned candidates exclude."""
@@ -5473,6 +5547,18 @@ class TestLookAheadAbort:
         provider.pending_blocks[("foo", "bar", V("1.0"))].append(V("0.9"))
         provider.pending_range_blocks[
             ("foo", "baz", SpecifierSet("<2.0").to_range())
+        ].append(V("0.9"))
+        assert provider._should_abort_lookahead("foo") is None
+
+    def test_should_abort_none_when_self_block_present(self) -> None:
+        provider = self._provider()
+        provider.pending_blocks[("foo", "bar", V("1.0"))].append(V("0.9"))
+        provider.pending_self_blocks[
+            (
+                "foo",
+                SpecifierSet("==5.0").to_range(),
+                SpecifierSet(">=6.0").to_range(),
+            )
         ].append(V("0.9"))
         assert provider._should_abort_lookahead("foo") is None
 

--- a/nab-project/tests/test_resolve.py
+++ b/nab-project/tests/test_resolve.py
@@ -3310,6 +3310,15 @@ class TestAugmentResolutionError:
         )
         assert _walk_no_versions_packages(clause) == ["cand"]
 
+    def test_walk_names_merged_self_dependency_candidate(self) -> None:
+        """A self-dependency merges to one positive term and still names it."""
+        clause = Incompatibility(
+            [Term("cand", Range.full(), positive=True)],
+            cause=IncompatibilityCause.DEPENDENCY,
+            dependency_range=Range.singleton(1),
+        )
+        assert _walk_no_versions_packages(clause) == ["cand"]
+
     def test_grouped_clause_hint_survives_a_later_range(self) -> None:
         """Accepted tolerance: reasons are keyed by package name, so a later
         range still surfaces the reason an earlier ask recorded."""

--- a/nab-provider/src/nab_provider/_provider/lookahead.py
+++ b/nab-provider/src/nab_provider/_provider/lookahead.py
@@ -4,13 +4,15 @@ Owns ``_look_ahead_ok`` and the pending-block tables that record why a
 candidate was rejected.  ``flush_pending_blocks`` turns those into
 incompatibilities at the end of ``choose_version``.  A decision or
 positive-range rejection becomes a grouped binary incompatibility
-(``{candidate range, blocker range}``).  Version-derived terms are
-widened onto the listing's gaps, which leaves the selectable versions
-they name unchanged.  The blocker term widens further when every
-rejection in the group recorded a dependency range: each fired because
-the blocker sat outside that range, so every blocker version outside
-their union repeats the same rejections.  Groups queued without ranges,
-such as the extras block path, keep the narrower term.
+(``{candidate range, blocker range}``); a candidate blocked by a
+requirement on itself names one package on both sides, so the two terms
+merge into one and the declared range is kept on the clause.
+Version-derived terms are widened onto the listing's gaps, which leaves
+the selectable versions they name unchanged.  The blocker term widens
+further when every rejection in the group recorded a dependency range:
+each fired because the blocker sat outside that range, so every blocker
+version outside their union repeats the same rejections.  Groups queued
+without ranges, such as the extras block path, keep the narrower term.
 
 A root-requirement or metadata rejection has no blocker to name: nothing
 later in the resolve undoes it, so its versions are banned outright.
@@ -29,7 +31,7 @@ from ..errors import MetadataError
 from .listing_diagnosis import MetadataBlock
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Mapping
 
     from nab_provider._vendor.packaging.version import Version
 
@@ -112,33 +114,58 @@ def look_ahead_ok(
                 ].append(version)
                 return False
 
-        if decisions is not None:
-            decided_version = decisions.get(dep_normalized)
-            if decided_version is not None and decided_version not in dep_range:
-                decision_key = (package, dep_normalized, decided_version)
-                provider.pending_blocks[decision_key].append(version)
-                provider.pending_decision_dep_ranges[decision_key] = (
-                    provider.pending_decision_dep_ranges[decision_key].record(dep_range)
-                )
-                return False
+        if decisions is not None and _blocked_by_solution(
+            provider, package, version, dep_normalized, dep_range, decisions
+        ):
+            return False
 
-            # Positive-range disagreement: {candidate==v, dep in pos_range}
-            # is impossible.  Sound across backjumps because the
-            # ``dep in pos_range`` term goes UNDETERMINED if the supporting
-            # derivation is reverted.
-            pos_range = provider.solution_ranges.get(dep_normalized)
-            if (
-                pos_range is not None
-                and decided_version is None
-                and dep_range.is_disjoint(pos_range)
-            ):
-                range_key = (package, dep_normalized, pos_range)
-                provider.pending_range_blocks[range_key].append(version)
-                provider.pending_range_dep_ranges[range_key] = (
-                    provider.pending_range_dep_ranges[range_key].record(dep_range)
-                )
-                return False
+    return True
 
+
+def _blocked_by_solution(
+    provider: Provider,
+    package: str,
+    version: Version,
+    dep_normalized: str,
+    dep_range: VersionRange,
+    decisions: Mapping[str, Version],
+) -> bool:
+    """Whether the partial solution already rules ``dep_range`` out.
+
+    Queues the rejection it finds: against the decision that contradicts the
+    range, against the positive range disjoint from it, or, when the candidate
+    named itself, under the range it declared.
+    """
+    decided_version = decisions.get(dep_normalized)
+    if decided_version is not None:
+        if decided_version in dep_range:
+            return False
+
+        decision_key = (package, dep_normalized, decided_version)
+        provider.pending_blocks[decision_key].append(version)
+        provider.pending_decision_dep_ranges[decision_key] = (
+            provider.pending_decision_dep_ranges[decision_key].record(dep_range)
+        )
+        return True
+
+    # Positive-range disagreement: {candidate==v, dep in pos_range} is
+    # impossible.  Sound across backjumps because the ``dep in pos_range``
+    # term goes UNDETERMINED if the supporting derivation is reverted.
+    pos_range = provider.solution_ranges.get(dep_normalized)
+    if pos_range is None or not dep_range.is_disjoint(pos_range):
+        return False
+
+    # A self-dependency is grouped by the range it declared, so the merged
+    # clause has one edge to name.
+    if dep_normalized == package:
+        provider.pending_self_blocks[(package, dep_range, pos_range)].append(version)
+        return True
+
+    range_key = (package, dep_normalized, pos_range)
+    provider.pending_range_blocks[range_key].append(version)
+    provider.pending_range_dep_ranges[range_key] = provider.pending_range_dep_ranges[
+        range_key
+    ].record(dep_range)
     return True
 
 
@@ -191,6 +218,7 @@ def reset_pending_blocks(provider: Provider) -> None:
     provider.pending_decision_dep_ranges = defaultdict(DepRangeUnion.zero)
     provider.pending_range_blocks = defaultdict(list)
     provider.pending_range_dep_ranges = defaultdict(DepRangeUnion.zero)
+    provider.pending_self_blocks = defaultdict(list)
     provider.pending_root_blocks = defaultdict(list)
     provider.pending_metadata_blocks = defaultdict(dict)
 
@@ -208,6 +236,12 @@ def flush_pending_blocks(provider: Provider) -> None:
     groups and the captured positive range for range-keyed ones.  Sound across
     backjumps because the blocker term goes UNDETERMINED when the supporting
     decision is reverted, so the candidate range can be reconsidered.
+
+    A candidate rejected by a requirement on itself has no separate blocker:
+    both terms name it, so they merge to the rejected versions the declared
+    range keeps out, and the clause carries that range for the report.  The
+    ban is unconditional, which is sound: a version that requires itself to
+    be elsewhere can never be selected.
 
     Root-requirement and metadata rejections have no such blocker: neither a
     root requirement nor unreadable metadata changes over the resolve, so each
@@ -278,6 +312,23 @@ def flush_pending_blocks(provider: Provider) -> None:
                     Term(blocker_pkg, blocker_term, positive=True),
                 ],
                 cause=IncompatibilityCause.DEPENDENCY,
+            )
+        )
+
+    # Self-dependency rejections: the candidate is its own blocker, so the
+    # two terms merge into one.
+    for (
+        candidate_pkg,
+        dep_range,
+        _pos_range,
+    ), versions in provider.pending_self_blocks.items():
+        rejected = _candidate_union(provider, candidate_pkg, versions)
+        merged = Term(candidate_pkg, rejected & dep_range.complement(), positive=True)
+        provider.pending_clauses.append(
+            Incompatibility(
+                [merged],
+                cause=IncompatibilityCause.DEPENDENCY,
+                dependency_range=dep_range,
             )
         )
 

--- a/nab-provider/src/nab_provider/provider.py
+++ b/nab-provider/src/nab_provider/provider.py
@@ -716,6 +716,14 @@ class Provider:
             tuple[str, str, RangeProtocol[Version]], list[Version]
         ] = defaultdict(list)
 
+        # Self-dependency rejections, keyed by (candidate, the range it
+        # declared on itself, the positive range the solution holds).  The
+        # merged clause needs only the declared range; the positive range is
+        # carried for the no-versions reason line.
+        self.pending_self_blocks: defaultdict[
+            tuple[str, VersionRange, RangeProtocol[Version]], list[Version]
+        ] = defaultdict(list)
+
         # The dep range each rejected candidate declared for the blocker,
         # unioned per group.  Feeds the membership widening of the flushed
         # blocker term, and the no-versions message, which names the range the
@@ -1564,14 +1572,13 @@ class Provider:
     def _should_abort_lookahead(self, normalized: str) -> tuple[str, Version] | None:
         """Return the single shared blocker if every rejection blames it.
 
-        The trigger is intentionally narrow: only when *every* rejection
-        for ``normalized`` is a decision block with the same
-        ``(blocker_pkg, blocker_version)`` key and there are no
-        range / root / metadata blocks.  Returns ``(blocker_pkg,
-        blocker_version)`` when the condition holds, else ``None``.
-        Mixed-cause scans keep the per-version clauses because at least
-        one rejection cause is a real constraint the resolver still
-        needs to learn.
+        The trigger is intentionally narrow: only when *every* rejection for
+        ``normalized`` is a decision block with the same ``(blocker_pkg,
+        blocker_version)`` key and no other kind of block was queued.
+        Returns ``(blocker_pkg, blocker_version)`` when the condition holds,
+        else ``None``.  Mixed-cause scans keep the per-version clauses
+        because at least one rejection cause is a real constraint the
+        resolver still needs to learn.
         """
         seen: set[tuple[str, Version]] = set()
         for cand, blocker_pkg, blocker_version in self.pending_blocks:
@@ -1579,25 +1586,33 @@ class Provider:
                 seen.add((blocker_pkg, blocker_version))
                 if len(seen) > 1:
                     return None
-        if len(seen) != 1:
-            return None
-        if any(cand == normalized for cand, *_ in self.pending_range_blocks):
-            return None
-        if any(cand == normalized for cand, *_ in self.pending_root_blocks):
-            return None
-        if normalized in self.pending_metadata_blocks:
+        if len(seen) != 1 or self._has_non_decision_block(normalized):
             return None
         return next(iter(seen))
+
+    def _has_non_decision_block(self, normalized: str) -> bool:
+        """Whether ``normalized`` was rejected for a reason beyond a decision.
+
+        Range, self-dependency, root and metadata blocks each state a
+        constraint the resolver still has to learn, so the abort path must
+        leave their clauses alone.
+        """
+        return (
+            normalized in self.pending_metadata_blocks
+            or any(cand == normalized for cand, *_ in self.pending_range_blocks)
+            or any(cand == normalized for cand, *_ in self.pending_self_blocks)
+            or any(cand == normalized for cand, *_ in self.pending_root_blocks)
+        )
 
     def _discard_pending_decision_blocks(self, normalized: str) -> None:
         """Drop decision-block entries for ``normalized`` without emitting clauses.
 
         Used by the look-ahead abort path: the blocker clauses the queue
         would otherwise produce are exactly the ones that mislead the
-        resolver into picking a deep candidate.  Range / root / metadata
-        blocks are left in place because the abort path only fires when none
-        exist for this candidate; this helper still scopes its delete to the
-        matching candidate name for safety.
+        resolver into picking a deep candidate.  The other block kinds are
+        left in place because the abort path only fires when none exist for
+        this candidate; this helper still scopes its delete to the matching
+        candidate name for safety.
         """
         self.pending_blocks = defaultdict(
             list,
@@ -1789,6 +1804,18 @@ class Provider:
                     _diagnosis.BlockerKind.HELD,
                     blocker_pkg,
                     _declared_ranges(recorded),
+                    pos_range,
+                )
+            )
+
+        for cand, dep_range, pos_range in self.pending_self_blocks:
+            if cand != normalized:
+                continue
+            out.append(
+                _diagnosis.Blocker(
+                    _diagnosis.BlockerKind.HELD,
+                    cand,
+                    (dep_range,),
                     pos_range,
                 )
             )


### PR DESCRIPTION
`proj` 3.0 requires `proj==2.0` and `app` depends on `proj>2.0`. The failure's first line names one package on both sides over the same range:

```
because proj >=3.0 is incompatible with proj >=3.0
```

It becomes:

```
because proj >=3.0 depends on proj ==2.0
```

`flush_pending_blocks` queues a look-ahead rejection as two positive terms, `{candidate range, blocker range}`. When the candidate is its own blocker both name it, and a clause holds at most one term per package, so the renderer prints the pair as a tautology.

Self-blocked rejections now group by the range the candidate declared and flush as one term: the rejected versions that range keeps out, with the range on `dependency_range`. That is the merge `Resolver._decide_next` already makes for a decided package depending on itself. The ban no longer rests on the blocker's positive range, and does not need to: a version that requires itself to be elsewhere can never be selected.

Two other readers of the clause shape:

- `_walk_no_versions_packages` matched look-ahead clauses by their two positive terms, so the merge would have dropped `proj`'s `Diagnostics:` line. It now matches a dependency clause that rules its own candidate out.
- `_should_abort_lookahead` skips the abort when a scan carries a block other than a decision. The self-dependency table joins the ones it checks.
