### PR TITLE
Cache a readable sdist that yields no PKG-INFO

### DIFF
--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -29,7 +29,7 @@ from .client import (
     MalformedSimpleResponseError,
     SdistFile,
     WheelFile,
-    _extract_sdist_files,
+    _extract_sdist_files_if_readable,
     _header,
     _listing_body,
     _parse_files,
@@ -837,7 +837,10 @@ class CachedAsyncSimpleClient:
         Cache miss + offline raises :class:`OfflineError`.  Either
         element may be ``None`` if the corresponding file is absent
         from the archive (or the archive cannot be parsed).  Both are
-        treated as immutable: cached forever, never revalidated.
+        treated as immutable: cached forever, never revalidated.  An
+        archive that was read is cached even when neither file came out
+        of it; one that could not be read is not, so a later run can try
+        again.
 
         When ``sdist_hashes`` carries an acceptable published digest, the
         downloaded archive is verified against it before extraction. A
@@ -861,15 +864,16 @@ class CachedAsyncSimpleClient:
         selected = select_artifact_hash(sdist_hashes)
         if selected is not None:
             verify_sdist_hash(response.content, selected)
-        pkg_info, pyproject_toml = _extract_sdist_files(response.content)
+        files = _extract_sdist_files_if_readable(response.content)
 
         if self._sdist_archive_hold is not None:
             self._sdist_archive_hold.put(package, version, response.content)
 
-        if pkg_info is not None or pyproject_toml is not None:
-            self._cache.put_sdist_files(package, version, pkg_info, pyproject_toml)
+        if files is None:
+            return (None, None)
 
-        return (pkg_info, pyproject_toml)
+        self._cache.put_sdist_files(package, version, *files)
+        return files
 
     async def get_sdist_archive(
         self,

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -664,6 +664,20 @@ def _extract_sdist_files(data: bytes) -> tuple[str | None, str | None]:
 
     .zip sdists are intentionally unsupported.
     """
+    files = _extract_sdist_files_if_readable(data)
+    return (None, None) if files is None else files
+
+
+def _extract_sdist_files_if_readable(
+    data: bytes,
+) -> tuple[str | None, str | None] | None:
+    """Extract the sdist pair, or ``None`` if the archive could not be read.
+
+    A readable archive answers ``(None, None)`` when
+    :func:`_select_sdist_root` takes no PKG-INFO from it.  Caching that
+    answer freezes that choice of root, so changing it means bumping
+    ``CACHE_VERSION_SDIST``.
+    """
     try:
         return _read_tar_sdist_files(data)
     except (
@@ -677,7 +691,7 @@ def _extract_sdist_files(data: bytes) -> tuple[str | None, str | None]:
         # cycle of links only ends at the recursion limit.
         RecursionError,
     ):
-        return (None, None)
+        return None
 
 
 def _read_tar_sdist_files(data: bytes) -> tuple[str | None, str | None]:

--- a/nab-project/tests/test_cached_client.py
+++ b/nab-project/tests/test_cached_client.py
@@ -3318,6 +3318,36 @@ class TestGetSdistFiles:
         assert asyncio.run(go()) == (None, None)
         assert cache.get_sdist_files("pkg", "1.0") is None
 
+    @pytest.mark.parametrize(
+        "members",
+        [
+            pytest.param([("pkg-1.0/setup.py", b"setup()\n")], id="no-metadata-file"),
+            pytest.param(
+                [("pkg-1.0/pyproject.toml", b'[project]\nname = "pkg"\n')],
+                id="pyproject-only",
+            ),
+        ],
+    )
+    def test_sdist_without_pkg_info_is_cached_and_not_refetched(
+        self, tmp_path: Path, members: list[tuple[str, bytes]]
+    ) -> None:
+        cache = _make_cache(tmp_path)
+        transport = _FakeTransport([_FakeResponse(_build_tarball(members))])
+
+        async def go() -> list[tuple[str | None, str | None]]:
+            client = CachedAsyncSimpleClient(transport, cache)
+            try:
+                return [
+                    await client.get_sdist_files("pkg", "1.0", "https://x/pkg.tar.gz")
+                    for _ in range(2)
+                ]
+            finally:
+                await client.aclose()
+
+        assert asyncio.run(go()) == [(None, None), (None, None)]
+        assert cache.get_sdist_files("pkg", "1.0") == (None, None)
+        assert len(transport.calls) == 1
+
     def test_offline_miss_raises(self, tmp_path: Path) -> None:
         cache = _make_cache(tmp_path)
         transport = _FakeTransport()


### PR DESCRIPTION
A warm `pip:trustllm --resolution lowest` resolve downloads and re-extracts the same four sdist archives on every run. The branch reads them once.

| run | sdist-cache hits | misses | archives read | bytes |
| --- | ---: | ---: | ---: | ---: |
| main, every run | 585 | 4 | 4 | 2,129,686 |
| branch, first run | 585 | 4 | 4 | 2,129,686 |
| branch, after that | 589 | 0 | 0 | 0 |

Both sides resolve the same 271 decisions and 22 conflicts; `pip:langchain-ml-course --resolution lowest` has twelve such archives.

`CachedAsyncSimpleClient.get_sdist_files` wrote the `(pkg_info, pyproject_toml)` pair to the cache only when one of the two was present, so an archive nab found no PKG-INFO in left no record and was fetched again. `regex` 2014.8.28 is one: its PKG-INFO sits at the archive root, one level above where `_read_tar_sdist_files` looks. The pair is now stored whenever the archive was read, `(None, None)` included; one that could not be opened still caches nothing.

With `HTTP_PROXY` and `HTTPS_PROXY` at a closed port and the cache otherwise warm, main gives up at 261 decisions on trustllm and the branch resolves.

Caching the answer freezes `_select_sdist_root`'s choice of root, so changing it means bumping `CACHE_VERSION_SDIST`.