### PR TITLE
Fix nab lock traceback when a marker overruns the algebra's budget

### DIFF
--- a/nab-project/src/nab_project/_lockfile/pylock.py
+++ b/nab-project/src/nab_project/_lockfile/pylock.py
@@ -46,6 +46,7 @@ from nab_provider._vendor.packaging.specifiers import SpecifierSet
 from nab_provider._vendor.packaging.utils import canonicalize_name, is_normalized_name
 from nab_provider._vendor.packaging.version import InvalidVersion, Version
 from nab_provider.conflict_kind import KIND_GROUP, MARKER_VARIABLE_FOR_KIND
+from nab_provider.marker_holds import intractable_as_error
 
 from ..config import conflict_exclusion_groups, conflict_member_groups
 from .builder import require_artifact_hashes
@@ -235,11 +236,14 @@ def render_lock(lock_input: LockInput, *, lock_dir: Path | None = None) -> str:
     ``nab lock --locked`` to render the would-be lock for comparison.
 
     Raises :class:`LockValidationError` when the document it would build
-    does not satisfy PEP 751.
+    does not satisfy PEP 751, and
+    :class:`~nab_provider.marker_holds.IntractableMarkerError` when a marker
+    overruns the algebra's budget.
     """
     require_artifact_hashes(lock_input)
     _check_extra_names(lock_input.extras)
-    pylock = build_pylock(lock_input, lock_dir=lock_dir)
+    with intractable_as_error():
+        pylock = build_pylock(lock_input, lock_dir=lock_dir)
 
     # ``Pylock.validate`` is ``from_dict(to_dict())``, so validating the mapping
     # about to be emitted runs the same check without a second ``to_dict``.

--- a/nab-project/src/nab_project/_lockfile/validate.py
+++ b/nab-project/src/nab_project/_lockfile/validate.py
@@ -41,7 +41,11 @@ from nab_provider._vendor.packaging.pylock import Pylock, PylockValidationError
 from nab_provider._vendor.packaging.requirements import Requirement
 from nab_provider._vendor.packaging.specifiers import SpecifierSet
 from nab_provider._vendor.packaging.utils import canonicalize_name
-from nab_provider.marker_holds import UnevaluableMarkerError, dependency_marker_holds
+from nab_provider.marker_holds import (
+    IntractableMarkerError,
+    UnevaluableMarkerError,
+    dependency_marker_holds,
+)
 from nab_provider.metadata import validate_specifier_versions
 from nab_provider.target import NonIntervalMarkerError, micro_boundary_points
 
@@ -339,7 +343,7 @@ def _marker_skips(
         return True
     try:
         active = dependency_marker_holds(marker, marker_env)
-    except (UnevaluableMarkerError, UndefinedEnvironmentName):
+    except (UnevaluableMarkerError, IntractableMarkerError, UndefinedEnvironmentName):
         return True
     return not active
 

--- a/nab-project/tests/test_pylock.py
+++ b/nab-project/tests/test_pylock.py
@@ -22,7 +22,7 @@ if sys.version_info >= (3, 11):
 else:
     import tomli as tomllib  # type: ignore[no-redef]
 
-from nab_project._lockfile import pylock
+from nab_project._lockfile import disjointness, pylock
 from nab_project._lockfile.coverage import CoverageError
 from nab_project._lockfile.disjointness import validate_marker_disjointness
 from nab_project._lockfile.pylock import (
@@ -57,6 +57,7 @@ from nab_provider._vendor.packaging.markersets import (
 from nab_provider._vendor.packaging.pylock import Package, PackageWheel
 from nab_provider._vendor.packaging.utils import canonicalize_name
 from nab_provider._vendor.packaging.version import Version
+from nab_provider.marker_holds import IntractableMarkerError
 from nab_provider.tags import PlatformSpec
 from nab_provider.target import ResolveTarget, environment_declaration
 
@@ -239,6 +240,69 @@ class TestDisjointnessVerdictInvariance:
         assert self._passes([linux, linux]) is False
         simplified = self._simplify(linux)
         assert self._passes([simplified, simplified]) is False
+
+
+# The two boundary runs scale the guard down to this: a four-extra pair sits
+# under it and a five-extra pair trips it, where sitting under the shipped
+# 100,000 takes 2**16 selections per declared environment.
+_SCALED_SELECTIONS = 16
+
+
+class TestSelectionBudgetRefusal:
+    """Rendering a same-name pair whose markers reference many extras.
+
+    No conflict declares the extras, so every one of them is free and the
+    disjointness walk enumerates their powerset.
+    """
+
+    def _lock(self, extras_count: int) -> LockInput:
+        """A lock whose two ``foo`` pins split ``extras_count`` extra gates."""
+        extras = tuple(f"e{i}" for i in range(extras_count))
+        half = extras_count // 2
+        older, newer = _target("3.11"), _target("3.12")
+        targets = {
+            older.label: TargetLock(
+                target=older,
+                pins={"foo": _index_pin("foo", "1.0")},
+                package_gates={"foo": tuple(("extra", e) for e in extras[:half])},
+            ),
+            newer.label: TargetLock(
+                target=newer,
+                pins={"foo": _index_pin("foo", "2.0")},
+                package_gates={"foo": tuple(("extra", e) for e in extras[half:])},
+            ),
+        }
+        return LockInput(
+            targets=targets,
+            environments=[_row(older), _row(newer)],
+            extras=extras,
+        )
+
+    def test_pair_inside_the_budget_renders(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Four free names is 2**4 selections, which the scaled guard allows."""
+        monkeypatch.setattr(disjointness, "_MAX_SELECTIONS", _SCALED_SELECTIONS)
+        data = tomllib.loads(render_lock(self._lock(4)))
+        assert sorted(p["version"] for p in data["packages"]) == ["1.0", "2.0"]
+
+    def test_pair_over_the_budget_refuses(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Five free names is 2**5, past the scaled guard, so it refuses."""
+        monkeypatch.setattr(disjointness, "_MAX_SELECTIONS", _SCALED_SELECTIONS)
+        with pytest.raises(
+            IntractableMarkerError, match=f"selections exceed {_SCALED_SELECTIONS}"
+        ):
+            render_lock(self._lock(5))
+
+    def test_shipped_budget_sets_the_boundary_at_seventeen_free_names(self) -> None:
+        """The declared guard the two scaled runs stand in for.
+
+        2**16 selections fit under it and 2**17 do not, so a same-name pair
+        gating on 17 unconstrained extras is the first the walk refuses.
+        """
+        assert disjointness._MAX_SELECTIONS == 100_000
 
 
 class TestOutOfUniverseDivergence:

--- a/nab-project/tests/test_requirements_file.py
+++ b/nab-project/tests/test_requirements_file.py
@@ -17,7 +17,7 @@ from nab_project.pyproject_files import (
 from nab_provider._vendor.packaging.requirements import Requirement
 from nab_provider._vendor.packaging.specifiers import SpecifierSet
 from nab_provider._vendor.packaging.utils import InvalidName
-from nab_provider.marker_holds import UnevaluableMarkerError
+from nab_provider.marker_holds import IntractableMarkerError, UnevaluableMarkerError
 from nab_provider.requirements_file import (
     InvalidProjectRequirementError,
     InvalidProjectTableError,
@@ -745,6 +745,35 @@ class TestExpandExtraRequirements:
         out = expand_extra_requirements(opt, "mypkg", ["all"])
         dep = next(r for r in out if r.name == "some-dep")
         assert dep.marker is None
+
+    @pytest.mark.parametrize(
+        "literal",
+        [
+            pytest.param(_AT_LIMIT, id="at-limit"),
+            pytest.param(_OVERSIZED, id="over-limit"),
+        ],
+    )
+    def test_oversized_self_ref_marker_version_refuses(self, literal: str) -> None:
+        """Reducing a self-ref marker decomposes it, so the algebra refuses.
+
+        The limit itself refuses too: decomposition mints neighbouring
+        versions by incrementing a component, which needs a digit of headroom.
+        """
+        opt = {
+            "all": [f'mypkg[fast]; python_full_version < "{literal}"'],
+            "fast": ["some-dep"],
+        }
+        with pytest.raises(IntractableMarkerError, match="parse limit"):
+            expand_extra_requirements(opt, "mypkg", ["all"])
+
+    def test_self_ref_marker_version_below_the_limit_expands(self) -> None:
+        """One digit under the limit leaves the headroom, so the walk runs."""
+        opt = {
+            "all": [f'mypkg[fast]; python_full_version < "{_AT_LIMIT[:-1]}"'],
+            "fast": ["some-dep"],
+        }
+        out = expand_extra_requirements(opt, "mypkg", ["all"])
+        assert [r.name for r in out] == ["some-dep"]
 
     def test_self_ref_siblings_flattened_in_sorted_order(
         self, monkeypatch: pytest.MonkeyPatch

--- a/nab-provider/src/nab_provider/marker_holds.py
+++ b/nab-provider/src/nab_provider/marker_holds.py
@@ -9,18 +9,19 @@ resolve engine never imports ``packaging.markersets``;
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
 from nab_provider._vendor.packaging.markers import (
     UndefinedComparison,
     UndefinedEnvironmentName,
 )
-from nab_provider._vendor.packaging.markersets import MarkerSet
+from nab_provider._vendor.packaging.markersets import IntractableMarkerSet, MarkerSet
 
 from .conflict_kind import EMPTY_MEMBERSHIP_SETS
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Iterator, Mapping
     from collections.abc import Set as AbstractSet
 
     from nab_provider._vendor.packaging.markers import Marker
@@ -39,6 +40,15 @@ class UnevaluableMarkerError(ValueError):
     """
 
 
+class IntractableMarkerError(ValueError):
+    """A marker question that overran a budget instead of being decided.
+
+    The budgets bound a version literal's digits, a decomposition's cells, and
+    the lock emitter's selection walk, so a pathological marker stops the run
+    rather than iterating unbounded.
+    """
+
+
 def _unevaluable(
     marker: Marker, exc: UndefinedComparison | UndefinedEnvironmentName
 ) -> UnevaluableMarkerError:
@@ -47,6 +57,15 @@ def _unevaluable(
     The failing clause alone does not say which dependency to edit.
     """
     return UnevaluableMarkerError(f"marker {marker} cannot be evaluated: {exc}")
+
+
+@contextmanager
+def intractable_as_error() -> Iterator[None]:
+    """Report an intractable marker set as :class:`IntractableMarkerError`."""
+    try:
+        yield
+    except IntractableMarkerSet as exc:
+        raise IntractableMarkerError(str(exc)) from exc
 
 
 def marker_set(marker: Marker) -> MarkerSet:
@@ -91,10 +110,12 @@ def dependency_marker_holds(
     ``UndefinedEnvironmentName``.  The lockfile-only set variables are seeded
     empty, so a marker that tests one evaluates to False rather than raising.
 
-    A clause no comparison decides raises :class:`UnevaluableMarkerError`.
+    A clause no comparison decides raises :class:`UnevaluableMarkerError`, and
+    a marker that overruns a budget raises :class:`IntractableMarkerError`.
     """
     env: dict[str, str | AbstractSet[str]] = {"extra": frozenset()}
     env.update(environment)
     env.update(EMPTY_MEMBERSHIP_SETS)
 
-    return marker_set(marker).evaluate(env)
+    with intractable_as_error():
+        return marker_set(marker).evaluate(env)

--- a/nab-provider/src/nab_provider/requirements_file.py
+++ b/nab-provider/src/nab_provider/requirements_file.py
@@ -11,7 +11,7 @@ from nab_provider._vendor.packaging.markers import Marker
 from nab_provider._vendor.packaging.requirements import Requirement
 from nab_provider._vendor.packaging.utils import canonicalize_name
 
-from .marker_holds import dependency_marker_holds, marker_set
+from .marker_holds import dependency_marker_holds, intractable_as_error, marker_set
 from .metadata import validate_specifier_versions
 from .resolver_inputs import (
     raise_for_unsatisfiable as raise_for_unsatisfiable,  # noqa: PLC0414  (re-export)
@@ -253,14 +253,16 @@ def _environment_residual(marker: Marker, extra: str) -> str | bool:
     extra``) is kept as a residual atom over the target's own value rather
     than decided against the machine running nab.
     """
-    residual = marker_set(marker).restrict(
-        {"extra": frozenset({extra})}, on_unknown_variable="residual"
-    )
+    with intractable_as_error():
+        residual = marker_set(marker).restrict(
+            {"extra": frozenset({extra})}, on_unknown_variable="residual"
+        )
 
-    if residual.is_empty():
-        return False
+        if residual.is_empty():
+            return False
 
-    text = residual.to_marker_string()
+        text = residual.to_marker_string()
+
     return True if text is None else text
 
 

--- a/nab-provider/src/nab_provider/target.py
+++ b/nab-provider/src/nab_provider/target.py
@@ -36,7 +36,7 @@ from nab_provider._vendor.packaging.specifiers import (
 from nab_provider._vendor.packaging.version import InvalidVersion, Version
 
 from .conflict_kind import EMPTY_MEMBERSHIP_SETS, MARKER_VARIABLE_FOR_KIND
-from .marker_holds import UnevaluableMarkerError
+from .marker_holds import IntractableMarkerError, UnevaluableMarkerError
 from .tags import (
     FREE_THREADED_MIN_PYTHON,
     PlatformSpec,
@@ -55,6 +55,7 @@ __all__ = [
     "PLATFORM_MARKERS",
     "UNBOUNDABLE_MARKER_VARIABLES",
     "EnvironmentSource",
+    "IntractableMarkerError",
     "Matrix",
     "NonIntervalMarkerError",
     "ResolveTarget",

--- a/nab-provider/tests/test_marker_holds.py
+++ b/nab-provider/tests/test_marker_holds.py
@@ -7,13 +7,18 @@ gated ``extra == "a"`` activates for ``[a, b]``.
 
 from __future__ import annotations
 
+import sys
 from collections.abc import Set as AbstractSet
 
 import pytest
 
 from nab_provider._vendor.packaging.markers import MARKERS_ALLOWING_SET, Marker
 from nab_provider.conflict_kind import EMPTY_MEMBERSHIP_SETS
-from nab_provider.marker_holds import UnevaluableMarkerError, dependency_marker_holds
+from nab_provider.marker_holds import (
+    IntractableMarkerError,
+    UnevaluableMarkerError,
+    dependency_marker_holds,
+)
 
 _ENV: dict[str, str] = {
     "python_version": "3.11",
@@ -139,3 +144,23 @@ class TestDependencyMarkerHoldsUnevaluableClause:
     ) -> None:
         """``~=`` stays supported wherever PEP 440 gives it a meaning."""
         assert dependency_marker_holds(Marker(marker_text), _ENV) is want
+
+
+class TestDependencyMarkerHoldsIntractableInput:
+    """A marker the algebra refuses to decide within its budget.
+
+    The digit runs come off ``sys.get_int_max_str_digits()`` because
+    ``PYTHONINTMAXSTRDIGITS`` moves the limit.
+    """
+
+    def test_oversized_version_literal_refuses(self) -> None:
+        """A literal one digit past the parse limit stops the run."""
+        literal = "1" * (sys.get_int_max_str_digits() + 1)
+        with pytest.raises(IntractableMarkerError, match="parse limit"):
+            dependency_marker_holds(Marker(f'python_full_version < "{literal}"'), _ENV)
+
+    def test_literal_at_the_limit_still_evaluates(self) -> None:
+        """Evaluation converts the literal once, so the limit itself is fine."""
+        literal = "1" * sys.get_int_max_str_digits()
+        marker = Marker(f'python_full_version < "{literal}"')
+        assert dependency_marker_holds(marker, _ENV) is True

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -78,7 +78,7 @@ from nab_provider.requirements_file import (
     expand_extra_requirements,
     resolve_groups_to_requirements,
 )
-from nab_provider.target import UnevaluableMarkerError
+from nab_provider.target import IntractableMarkerError, UnevaluableMarkerError
 
 from . import cli as _cli
 from .cli import (
@@ -572,6 +572,7 @@ def _fast_fail_locked(
         InvalidProjectRequirementError,
         LookupError,
         UnevaluableMarkerError,
+        IntractableMarkerError,
     ):
         return
 
@@ -744,15 +745,15 @@ def _emit_pylock(
 
 
 def _write_lock_or_exit(lock_input: LockInput, *, target: Path | None) -> str:
-    """Write the lock, mapping every render-time refusal to a clean exit."""
+    """Write the lock, printing a render refusal as one error line and exiting 1."""
     return _render_or_exit(lambda: write_lock(lock_input, output_path=target))
 
 
 def _render_or_exit(render: Callable[[], str]) -> str:
-    """Run a lock render, mapping every refusal it raises to a clean exit."""
+    """Run a lock render, printing a refusal as one error line and exiting 1."""
     try:
         return render()
-    except (MissingHashError, LockValidationError) as e:
+    except (MissingHashError, LockValidationError, IntractableMarkerError) as e:
         _cli.printer().error(f"cannot lock: {e}")
         sys.exit(1)
     except (DisjointnessError, DivergentBaseDependencyError) as e:

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -74,7 +74,11 @@ from nab_provider.requirements_file import (
     InvalidProjectRequirementError,
     InvalidProjectTableError,
 )
-from nab_provider.target import NonIntervalMarkerError, UnevaluableMarkerError
+from nab_provider.target import (
+    IntractableMarkerError,
+    NonIntervalMarkerError,
+    UnevaluableMarkerError,
+)
 from nab_resolver.errors import ResolutionError
 
 from .output import (
@@ -713,6 +717,7 @@ def _resolve(  # noqa: PLR0913, PLR0912, C901 - one wrapper per resolve_for_targ
         SourceNameMismatchError,
         NonIntervalMarkerError,
         UnevaluableMarkerError,
+        IntractableMarkerError,
     ) as e:
         printer().error(f"{failure_prefix}: {e}")
         sys.exit(1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -95,7 +95,7 @@ from nab_provider.provider import (
 from nab_provider.records import WheelFile
 from nab_provider.requirements_file import InvalidProjectRequirementError
 from nab_provider.tags import PlatformSpec
-from nab_provider.target import ResolveTarget, host_environment
+from nab_provider.target import IntractableMarkerError, ResolveTarget, host_environment
 from nab_resolver.errors import ResolutionError
 
 V = Version
@@ -1769,6 +1769,24 @@ class TestLockCommandSpecific:
         )
         assert err.splitlines() == [expected]
 
+    def test_oversized_marker_version_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A marker literal the algebra refuses exits 1, not a traceback."""
+        literal = "1" * (sys.get_int_max_str_digits() + 1)
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\nname = "root"\nversion = "0"\n'
+            f"dependencies = ['somepkg; python_full_version < \"{literal}\"']\n",
+        )
+        with pytest.raises(SystemExit, match="1"):
+            lock(pyproject, offline=True, output=Path("-"), cache=False)
+
+        err = capsys.readouterr().err
+        assert "cannot lock: version literal" in err
+        assert "parse limit" in err
+        assert "Traceback" not in err
+
     def test_local_source_naming_another_project_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
@@ -2614,6 +2632,25 @@ class TestLockCommandUniversal:
             lock(pyproject, output=tmp_path / "pylock.toml")
         err = capsys.readouterr().err
         assert f"error: {hint}\n" in err
+
+    def test_pylock_intractable_marker_error_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A render refusal reaches the user as one error line and exit 1."""
+        pyproject = _universal_pyproject(tmp_path)
+        message = "conflict-respecting selections exceed 100000"
+        with (
+            patch(
+                "nab.cli.resolve_for_targets",
+                return_value=_universal_result(success=True),
+            ),
+            patch("nab._lock.write_lock", side_effect=IntractableMarkerError(message)),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, output=tmp_path / "pylock.toml")
+        err = capsys.readouterr().err
+        assert f"error: cannot lock: {message}\n" in err
+        assert "Traceback" not in err
 
     def test_base_group_naming_a_declared_group_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]

--- a/tests/test_lock_locked.py
+++ b/tests/test_lock_locked.py
@@ -1008,6 +1008,69 @@ def test_unreadable_requirement_with_changed_envelope_reports_the_parse_error(
     assert "is out of date" not in err
 
 
+def test_intractable_requirement_marker_reports_the_marker_error(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A direct requirement gated on a marker the algebra refuses to decide.
+
+    Whether the requirement is active cannot be read here, so the validity
+    check treats it as indeterminate rather than as a missing pin.
+    """
+    literal = "1" * (sys.get_int_max_str_digits() + 1)
+    pyproject = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "proj"\nversion = "0"\ndependencies = ["foo"]\n',
+    )
+    out = tmp_path / "pylock.toml"
+    _write_lock(pyproject, out, _result({"foo": "1.0"}))
+    capsys.readouterr()
+    pyproject.write_text(
+        '[project]\nname = "proj"\nversion = "0"\n'
+        f"dependencies = ['foo; python_full_version < \"{literal}\"']\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        _run_locked_unmocked(pyproject, out)
+
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "cannot lock: version literal" in err
+    assert "is out of date" not in err
+
+
+def test_intractable_self_ref_marker_reports_the_marker_error(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A self-referencing extra whose marker the algebra refuses to decide.
+
+    The refusal stops the pre-resolve read of the project's own requirements,
+    so no validity check runs and the resolve reports the marker.
+    """
+    literal = "1" * (sys.get_int_max_str_digits() + 1)
+    body = (
+        '[project]\nname = "proj"\nversion = "0"\ndependencies = []\n'
+        "[project.optional-dependencies]\n"
+        'fast = ["foo"]\n'
+    )
+    pyproject = _write_pyproject(tmp_path, f'{body}all = ["proj[fast]"]\n')
+    out = tmp_path / "pylock.toml"
+    _write_lock(pyproject, out, _result({"foo": "1.0"}), "--extras", "all")
+    capsys.readouterr()
+    pyproject.write_text(
+        f"{body}all = ['proj[fast]; python_full_version < \"{literal}\"']\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        _run_locked_unmocked(pyproject, out, "--extras", "all")
+
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "cannot lock: version literal" in err
+    assert "is out of date" not in err
+
+
 # --- --python cases: the flag is named, never the lock ---
 
 


### PR DESCRIPTION
A universal `nab lock` ends in a traceback whenever the PEP 751 disjointness validator hits its selection budget:

    nab_provider._vendor.packaging._markersets.IntractableMarkerSet: conflict-respecting selections exceed 100000

The validator walks every conflict-respecting membership selection for each same-name package pair, so a pair whose markers reference 17 declared extras that no conflict set constrains reaches `2**17` selections and trips the 100,000 guard. `render_lock` lets the vendored exception through and `_render_or_exit` names only nab's own refusals, so the stack reaches the user where every other refusal prints one error line. It exited 1 either way, so only the message changes.

A second input takes the same escape: a root requirement whose marker carries a version literal past `sys.get_int_max_str_digits()` digits, 4300 by default, trips the parse-limit guard during the resolve.

Both budgets now raise `IntractableMarkerError`, and the lock render and the resolve wrapper report it like any other refusal:

    error: cannot lock: conflict-respecting selections exceed 100000

`nab lock --locked` checks the committed lock before it resolves, and the two places that already treat an undecidable marker as the resolve's problem take the new error too. The direct-requirement check counts it as indeterminate rather than a missing pin, and the read of the project's own requirements defers to the resolve.
