### PR TITLE
Drop JSON from the sdist cache record, half the instructions to read one

### DIFF
--- a/docs/reference/cache.md
+++ b/docs/reference/cache.md
@@ -10,7 +10,8 @@ and reset it with [`nab cache`](cli.md).
 
 Each record nab writes is one file under a versioned bucket directory.
 Bumping a bucket's version suffix retires the old format: the stale
-directory is harmless and `nab cache clear` reclaims it.
+directory is harmless and `nab cache clear` reclaims it. The one
+exception is `sdist-v1/`, which nab still reads.
 
 | Bucket | Holds |
 | ------ | ----- |
@@ -18,7 +19,12 @@ directory is harmless and `nab cache clear` reclaims it.
 | `simple-parsed-v0/` | the parsed listing, an accelerator for the body |
 | `simple-neg-v0/` | a short-lived record that a name returned a 404 |
 | `metadata-v1/` | PEP 658 metadata and recovered wheel `METADATA`, immutable |
-| `sdist-v1/` | an sdist's `PKG-INFO` and `pyproject.toml`, immutable |
+| `sdist-v2/` | an sdist's `PKG-INFO` and `pyproject.toml`, immutable |
+| `sdist-v1/` | the same records in the retired JSON format |
+
+An `sdist-v1/` record is read when `sdist-v2/` misses, rewritten into
+`sdist-v2/`, and left where it is, so a cache filled by an earlier nab
+keeps its records instead of downloading each archive again.
 
 Record buckets are keyed per index, so two indexes never share an entry.
 A listing body is stored as PEP 691 JSON; when the index answers in PEP

--- a/nab-index/src/nab_index/cache.py
+++ b/nab-index/src/nab_index/cache.py
@@ -14,14 +14,18 @@ Layout under ``root``:
     simple-parsed-v0/<index>[-<serialization>]/<package>.parsed  <- parsed blob
     simple-neg-v0/<index>[-<serialization>]/<package>.neg <- {fetched_at, max_age, etag}
     metadata-v1/<index>/<package>/<url digest>.metadata
-    sdist-v1/<index>/<package>/<version>.json  <- {pkg_info, pyproject}
+    sdist-v2/<index>/<package>/<version>.record  <- pkg_info and pyproject,
+                                                    length-prefixed UTF-8
+    sdist-v1/<index>/<package>/<version>.json    <- the same pair, as JSON
 
 An index pinned to one serialization gets its own listings directory,
 since a stored body records nothing about which serialization it came from.
 
 A versioned bucket name (``simple-v2``) gives zero-cost schema
 migration: when the on-disk format changes, bump the suffix and the
-old directory is harmless.
+old directory is harmless. ``sdist-v1`` is the exception, still read
+when ``sdist-v2`` misses, since rebuilding one of its records means
+downloading the archive again.
 
 When the index serves PEP 503 HTML the stored body is nab's own rendering
 of the page. A 304 revalidation keeps the old body, so changing that
@@ -54,7 +58,7 @@ from .atomic import atomic_write
 from .parsed_listing import corruption_reason as _parsed_corruption
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
 
 logger = logging.getLogger(__name__)
 
@@ -75,7 +79,10 @@ CACHE_VERSION_SIMPLE = "v2"
 CACHE_VERSION_SIMPLE_PARSED = "v0"
 CACHE_VERSION_SIMPLE_NEG = "v0"
 CACHE_VERSION_METADATA = "v1"
-CACHE_VERSION_SDIST = "v1"
+CACHE_VERSION_SDIST = "v2"
+# Retired bucket of JSON sdist records, read when the current bucket misses
+# and rewritten there, since rebuilding one costs an archive download.
+_CACHE_VERSION_SDIST_JSON = "v1"
 CACHE_VERSION_VCS = "v1"
 CACHE_VERSION_ARCHIVE = "v1"
 
@@ -231,6 +238,7 @@ class OnDiskCache:
         self._neg_dir = root / f"simple-neg-{CACHE_VERSION_SIMPLE_NEG}" / simple_index
         self._metadata_dir = root / f"metadata-{CACHE_VERSION_METADATA}" / self._index
         self._sdist_dir = root / f"sdist-{CACHE_VERSION_SDIST}" / self._index
+        self._sdist_json_dir = root / f"sdist-{_CACHE_VERSION_SDIST_JSON}" / self._index
         self._store_failed = False
 
     def _store(self, path: Path, data: bytes) -> bool:
@@ -267,7 +275,12 @@ class OnDiskCache:
     def _sdist_path(self, package: str, version: str) -> Path:
         package_segment = _require_single_segment(package)
         version_segment = _require_single_segment(version)
-        return self._sdist_dir / package_segment / f"{version_segment}.json"
+        return self._sdist_dir / package_segment / f"{version_segment}.record"
+
+    def _sdist_json_path(self, package: str, version: str) -> Path:
+        package_segment = _require_single_segment(package)
+        version_segment = _require_single_segment(version)
+        return self._sdist_json_dir / package_segment / f"{version_segment}.json"
 
     def _metadata_file(self, package: str, metadata_url: str) -> str:
         """Return the path of the file holding the sidecar at ``metadata_url``.
@@ -424,16 +437,38 @@ class OnDiskCache:
         try:
             raw = path.read_bytes()
         except OSError:
-            return None
-        try:
-            doc = json.loads(raw)
-            return (doc["pkg_info"], doc["pyproject"])
-        except (ValueError, KeyError, TypeError):
+            return self._carry_over_json_record(package, version)
+        record = _decode_sdist_record(raw)
+        if record is None:
             logger.warning(
-                "Corrupt sdist cache record %s: not parseable; treating as a miss",
+                "Corrupt sdist cache record %s: not decodable; treating as a miss",
+                path,
+            )
+        return record
+
+    def _carry_over_json_record(
+        self, package: str, version: str
+    ) -> tuple[str | None, str | None] | None:
+        """Return a record from the retired JSON bucket, rewriting it in this one.
+
+        Rebuilding an sdist record means downloading the archive again, so a
+        cache filled before the format change stays warm. The JSON record is
+        left in place, so a downgrade still reads it.
+        """
+        path = self._sdist_json_path(package, version)
+        try:
+            raw = path.read_bytes()
+        except OSError:
+            return None
+        record = _decode_json_sdist_record(raw)
+        if record is None:
+            logger.warning(
+                "Corrupt sdist cache record %s: not decodable; treating as a miss",
                 path,
             )
             return None
+        self.put_sdist_files(package, version, *record)
+        return record
 
     def put_sdist_files(
         self,
@@ -445,9 +480,7 @@ class OnDiskCache:
         """Write the ``(pkg_info, pyproject_toml)`` pair as one record."""
         self._store(
             self._sdist_path(package, version),
-            json.dumps({"pkg_info": pkg_info, "pyproject": pyproject_toml}).encode(
-                "utf-8"
-            ),
+            _encode_sdist_record(pkg_info, pyproject_toml),
         )
 
     def get_negative(self, package: str) -> CachePolicy | None:
@@ -525,10 +558,10 @@ class OnDiskCache:
         """Return a corruption reason for a cache entry, or ``None`` if it parses.
 
         Parses by suffix, matching each kind's read path: ``.policy`` and
-        ``.neg`` decode as a policy, ``.metadata`` as UTF-8, ``.json`` as
-        JSON (an sdist record also carries its two fields), ``.parsed`` as a
-        parsed-listing blob. Any other suffix is not a nab entry and is
-        reported clean.
+        ``.neg`` decode as a policy, ``.metadata`` as UTF-8, ``.record`` as an
+        sdist record, ``.json`` as JSON (a retired sdist record also carries
+        its two fields), ``.parsed`` as a parsed-listing blob. Any other
+        suffix is not a nab entry and is reported clean.
         """
         try:
             raw = path.read_bytes()
@@ -537,13 +570,10 @@ class OnDiskCache:
         suffix = path.suffix
         if suffix in (".policy", ".neg"):
             return None if _decode_policy(raw) is not None else "policy not decodable"
-        if suffix == ".parsed":
-            return _read_parsed_reason(raw)
-        if suffix == ".metadata":
-            return _read_metadata_reason(raw)
         if suffix == ".json":
             return self._read_json_reason(path, raw)
-        return None
+        read_reason = _ENTRY_READERS.get(suffix)
+        return read_reason(raw) if read_reason is not None else None
 
     def _read_json_reason(self, path: Path, raw: bytes) -> str | None:
         try:
@@ -587,6 +617,112 @@ class OnDiskCache:
         return removed
 
 
+# A record is this magic, the two field lengths, a newline, then the fields.
+# A change to that shape bumps both this and CACHE_VERSION_SDIST.
+_SDIST_MAGIC = b"nabsdist1 "
+# Length stored for a file the sdist does not ship. An empty file stores 0.
+_SDIST_ABSENT = -1
+
+
+def _decode_json_sdist_record(raw: bytes) -> tuple[str | None, str | None] | None:
+    """Decode a retired JSON sdist record, or ``None`` when it is not one.
+
+    A field holds a file's text, or ``null`` for a file the sdist does not
+    ship. Any other JSON type is corruption, since the pair is re-encoded
+    into the current bucket.
+    """
+    try:
+        doc = json.loads(raw)
+        pkg_info, pyproject = doc["pkg_info"], doc["pyproject"]
+    except (ValueError, KeyError, TypeError):
+        return None
+    if not isinstance(pkg_info, str | None) or not isinstance(pyproject, str | None):
+        return None
+    return (pkg_info, pyproject)
+
+
+def _encode_sdist_field(text: str | None) -> tuple[bytes, int]:
+    """Return one field's bytes and the length the header stores for it.
+
+    ``surrogatepass`` keeps every ``str`` a caller can store round-tripping,
+    including a lone surrogate with no UTF-8 form.
+    """
+    if text is None:
+        return (b"", _SDIST_ABSENT)
+    blob = text.encode("utf-8", "surrogatepass")
+    return (blob, len(blob))
+
+
+def _encode_sdist_record(pkg_info: str | None, pyproject: str | None) -> bytes:
+    """Encode the pair as a header of byte lengths followed by the two texts."""
+    pkg_blob, pkg_len = _encode_sdist_field(pkg_info)
+    pyproject_blob, pyproject_len = _encode_sdist_field(pyproject)
+    header = f"{pkg_len} {pyproject_len}\n".encode("ascii")
+    return b"".join([_SDIST_MAGIC, header, pkg_blob, pyproject_blob])
+
+
+def _sdist_record_header(raw: bytes) -> tuple[int, int, int] | None:
+    """Return the two field lengths and the body offset, or ``None``.
+
+    A length of ``-1`` marks a file the sdist does not ship. Bytes in any
+    other format fail the magic rather than misdecoding.
+    """
+    if not raw.startswith(_SDIST_MAGIC):
+        return None
+    header_end = raw.find(b"\n", len(_SDIST_MAGIC))
+    if header_end < 0:
+        return None
+    try:
+        pkg_len, pyproject_len = (
+            int(field) for field in raw[len(_SDIST_MAGIC) : header_end].split(b" ")
+        )
+    except ValueError:
+        return None
+    if pkg_len < _SDIST_ABSENT or pyproject_len < _SDIST_ABSENT:
+        return None
+    return (pkg_len, pyproject_len, header_end + 1)
+
+
+def _decode_sdist_record(raw: bytes) -> tuple[str | None, str | None] | None:
+    """Decode stored sdist-record bytes, or ``None`` when they are not a record.
+
+    A truncated or overlong body is rejected by the total length, so a field
+    is only ever decoded from the bytes the writer put in it.
+    """
+    header = _sdist_record_header(raw)
+    if header is None:
+        return None
+    pkg_len, pyproject_len, pkg_start = header
+    pyproject_start = pkg_start + max(pkg_len, 0)
+    if len(raw) != pyproject_start + max(pyproject_len, 0):
+        return None
+    view = memoryview(raw)
+    try:
+        return (
+            _decode_sdist_field(view, pkg_start, pkg_len),
+            _decode_sdist_field(view, pyproject_start, pyproject_len),
+        )
+    except UnicodeDecodeError:
+        return None
+
+
+def _decode_sdist_field(view: memoryview, start: int, length: int) -> str | None:
+    """Decode one record field, or ``None`` for a file the sdist does not ship.
+
+    Decodes from a slice of the view, so the field is never copied out of the
+    record first.
+    """
+    if length == _SDIST_ABSENT:
+        return None
+    return str(view[start : start + length], "utf-8", "surrogatepass")
+
+
+def _read_sdist_reason(raw: bytes) -> str | None:
+    if _decode_sdist_record(raw) is None:
+        return "sdist record not decodable"
+    return None
+
+
 def _read_metadata_reason(raw: bytes) -> str | None:
     try:
         raw.decode("utf-8")
@@ -600,6 +736,15 @@ def _read_parsed_reason(raw: bytes) -> str | None:
     # blob at read time, so verify does not check it. The codec owns the check so
     # verify and the read path agree on what counts as corrupt.
     return _parsed_corruption(raw)
+
+
+# Suffixes whose corruption check is one reader over the bytes. ``.policy`` and
+# ``.neg`` share a reader and ``.json`` also needs the path, so both stay inline.
+_ENTRY_READERS: dict[str, Callable[[bytes], str | None]] = {
+    ".parsed": _read_parsed_reason,
+    ".metadata": _read_metadata_reason,
+    ".record": _read_sdist_reason,
+}
 
 
 def _encode_policy(policy: CachePolicy) -> bytes:

--- a/nab-project/tests/test_cache.py
+++ b/nab-project/tests/test_cache.py
@@ -361,11 +361,92 @@ class TestOnDiskCache:
         cache.put_sdist_files("foo", "1.0", "Name: foo\n", None)
         assert cache.get_sdist_files("foo", "1.0") == ("Name: foo\n", None)
 
-    def test_sdist_corrupt_record_is_a_miss(self, tmp_path: Path) -> None:
+    def test_sdist_no_pkg_info_is_a_hit_not_a_miss(self, tmp_path: Path) -> None:
+        cache = self._make(tmp_path)
+        cache.put_sdist_files("foo", "1.0", None, "[project]\n")
+        assert cache.get_sdist_files("foo", "1.0") == (None, "[project]\n")
+
+    def test_sdist_empty_field_is_not_an_absent_one(self, tmp_path: Path) -> None:
+        cache = self._make(tmp_path)
+        cache.put_sdist_files("foo", "1.0", "", "")
+        assert cache.get_sdist_files("foo", "1.0") == ("", "")
+
+    def test_sdist_lone_surrogate_round_trips(self, tmp_path: Path) -> None:
+        """A text field holds any ``str``, including one with no UTF-8 form."""
+        cache = self._make(tmp_path)
+        cache.put_sdist_files("foo", "1.0", "Name: \ud800\n", None)
+        assert cache.get_sdist_files("foo", "1.0") == ("Name: \ud800\n", None)
+
+    def test_sdist_json_record_is_carried_over(self, tmp_path: Path) -> None:
+        """A record the retired bucket holds is a hit, and is rewritten here."""
+        cache = self._make(tmp_path)
+        legacy = cache._sdist_json_path("foo", "1.0")
+        legacy.parent.mkdir(parents=True, exist_ok=True)
+        legacy.write_text(
+            json.dumps({"pkg_info": "Name: foo\n", "pyproject": None}),
+            encoding="utf-8",
+        )
+
+        assert cache.get_sdist_files("foo", "1.0") == ("Name: foo\n", None)
+
+        assert cache._sdist_path("foo", "1.0").exists()
+        assert legacy.exists()
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            pytest.param(b"nabsdist1 10 -1", id="no-header-end"),
+            pytest.param(b"nabsdist1 x -1\n", id="length-not-a-number"),
+            pytest.param(b"nabsdist1 1\n", id="one-length"),
+            pytest.param(b"nabsdist1 -2 -1\nA", id="length-below-absent"),
+            pytest.param(b"nabsdist1 1 -1\nAB", id="body-longer-than-declared"),
+            pytest.param(b"nabsdist1 1 -1\n\xff", id="field-not-utf-8"),
+        ],
+    )
+    def test_sdist_malformed_record_is_a_miss(self, tmp_path: Path, raw: bytes) -> None:
         cache = self._make(tmp_path)
         path = cache._sdist_path("foo", "1.0")
         path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(raw)
+        assert cache.get_sdist_files("foo", "1.0") is None
+
+    def test_sdist_record_without_magic_is_a_miss(self, tmp_path: Path) -> None:
+        """Bytes that would parse as a record, but do not carry the magic."""
+        cache = self._make(tmp_path)
+        path = cache._sdist_path("foo", "1.0")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"otherfmt1 5 -1\nhello")
+        assert cache.get_sdist_files("foo", "1.0") is None
+
+    def test_sdist_json_record_not_json_is_a_miss(self, tmp_path: Path) -> None:
+        cache = self._make(tmp_path)
+        path = cache._sdist_json_path("foo", "1.0")
+        path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("not-json", encoding="utf-8")
+        assert cache.get_sdist_files("foo", "1.0") is None
+
+    @pytest.mark.parametrize(
+        "record",
+        [
+            {"pkg_info": 5, "pyproject": None},
+            {"pkg_info": [], "pyproject": None},
+            {"pkg_info": "Name: foo\n", "pyproject": 5},
+        ],
+    )
+    def test_sdist_json_record_non_text_field_is_a_miss(
+        self, tmp_path: Path, record: dict[str, object]
+    ) -> None:
+        cache = self._make(tmp_path)
+        path = cache._sdist_json_path("foo", "1.0")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(record), encoding="utf-8")
+        assert cache.get_sdist_files("foo", "1.0") is None
+
+    def test_sdist_json_record_not_an_object_is_a_miss(self, tmp_path: Path) -> None:
+        cache = self._make(tmp_path)
+        path = cache._sdist_json_path("foo", "1.0")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('["Name: foo\\n", null]', encoding="utf-8")
         assert cache.get_sdist_files("foo", "1.0") is None
 
     def test_put_metadata_rejects_multi_segment_package(self, tmp_path: Path) -> None:
@@ -378,7 +459,7 @@ class TestOnDiskCache:
         cache = self._make(tmp_path)
         with pytest.raises(ValueError, match="not a single path segment"):
             cache.put_sdist_files("foo", "1.0/../../elsewhere", "Name: foo\n", None)
-        assert list(tmp_path.rglob("*.json")) == []
+        assert list(tmp_path.rglob("*.record")) == []
 
     def test_metadata_url_cannot_escape_the_package_dir(self, tmp_path: Path) -> None:
         cache = self._make(tmp_path)
@@ -626,7 +707,20 @@ class TestCorruptEntryLogging:
         cache = self._make(tmp_path)
         path = cache._sdist_path("foo", "1.0")
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text("not-json", encoding="utf-8")
+        path.write_bytes(b"not a record")
+        with caplog.at_level(logging.WARNING, logger="nab_index.cache"):
+            assert cache.get_sdist_files("foo", "1.0") is None
+        warnings = _warnings(caplog)
+        assert len(warnings) == 1
+        assert str(path) in warnings[0].getMessage()
+
+    def test_non_text_sdist_json_field_logs_one_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        cache = self._make(tmp_path)
+        path = cache._sdist_json_path("foo", "1.0")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('{"pkg_info": 5, "pyproject": null}', encoding="utf-8")
         with caplog.at_level(logging.WARNING, logger="nab_index.cache"):
             assert cache.get_sdist_files("foo", "1.0") is None
         warnings = _warnings(caplog)
@@ -639,7 +733,7 @@ class TestCorruptEntryLogging:
         cache = self._make(tmp_path)
         path = cache._sdist_path("foo", "1.0")
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_bytes(b"\xff\xfe not utf-8")
+        path.write_bytes(b"nabsdist1 1 -1\n\xff")
         with caplog.at_level(logging.WARNING, logger="nab_index.cache"):
             assert cache.get_sdist_files("foo", "1.0") is None
         warnings = _warnings(caplog)
@@ -828,9 +922,9 @@ class TestReadCacheEntry:
         path = tmp_path / SIMPLE_BUCKET / "pypi" / "foo.json"
         assert cache.read_cache_entry(path) is None
 
-    def test_sdist_record_missing_fields(self, tmp_path: Path) -> None:
+    def test_sdist_json_record_missing_fields(self, tmp_path: Path) -> None:
         cache = self._cache(tmp_path)
-        path = tmp_path / "sdist-v1" / "pypi" / "foo" / "1.0.json"
+        path = cache._sdist_json_path("foo", "1.0")
         path.parent.mkdir(parents=True)
         path.write_bytes(b'{"pkg_info": "x"}')
         assert cache.read_cache_entry(path) is not None
@@ -838,8 +932,15 @@ class TestReadCacheEntry:
     def test_valid_sdist_record(self, tmp_path: Path) -> None:
         cache = self._cache(tmp_path)
         cache.put_sdist_files("foo", "1.0", "info", None)
-        path = tmp_path / "sdist-v1" / "pypi" / "foo" / "1.0.json"
+        path = tmp_path / SDIST_BUCKET / "pypi" / "foo" / "1.0.record"
         assert cache.read_cache_entry(path) is None
+
+    def test_undecodable_sdist_record(self, tmp_path: Path) -> None:
+        cache = self._cache(tmp_path)
+        path = tmp_path / SDIST_BUCKET / "pypi" / "foo" / "1.0.record"
+        path.parent.mkdir(parents=True)
+        path.write_bytes(b"nabsdist1 4 -1\nab")
+        assert cache.read_cache_entry(path) == "sdist record not decodable"
 
     def test_unknown_suffix_is_clean(self, tmp_path: Path) -> None:
         # A leftover atomic-write temp file is not a nab entry and is ignored.
@@ -903,10 +1004,10 @@ class TestClearCache:
             SIMPLE_BUCKET,
             "simple-neg-v0",
             "metadata-v1",
-            "sdist-v1",
+            SDIST_BUCKET,
         }
         assert not (tmp_path / SIMPLE_BUCKET).exists()
-        assert not (tmp_path / "sdist-v1").exists()
+        assert not (tmp_path / SDIST_BUCKET).exists()
 
     def test_unlinks_symlinked_bucket_without_following(self, tmp_path: Path) -> None:
         outside = tmp_path / "outside"

--- a/tests/test_cache_cmd.py
+++ b/tests/test_cache_cmd.py
@@ -8,12 +8,18 @@ import pytest
 
 from nab import cli as nab_cli
 from nab.cli import app
-from nab_index.cache import CACHE_VERSION_SIMPLE, CachePolicy, OnDiskCache
+from nab_index.cache import (
+    CACHE_VERSION_SDIST,
+    CACHE_VERSION_SIMPLE,
+    CachePolicy,
+    OnDiskCache,
+)
 from nab_index.parsed_listing import encode as _encode_parsed
 from nab_project.config_sources import SourceRoots
 
 # Derived so a bucket-version bump does not need every path updated.
 SIMPLE_BUCKET = f"simple-{CACHE_VERSION_SIMPLE}"
+SDIST_BUCKET = f"sdist-{CACHE_VERSION_SDIST}"
 
 _FRESH = CachePolicy(fetched_at=0, max_age=600, etag=None)
 
@@ -335,7 +341,7 @@ class TestCacheClear:
         assert not (root / SIMPLE_BUCKET).exists()
         assert not (root / "simple-neg-v0").exists()
         assert not (root / "metadata-v1").exists()
-        assert not (root / "sdist-v1").exists()
+        assert not (root / SDIST_BUCKET).exists()
         assert sibling.read_text() == "keep me"
         assert str(root) in capsys.readouterr().err
 


### PR DESCRIPTION
Reading one cached sdist record costs about 134,000 instructions instead of about 259,000. A warm `pip:google-bigquery-soda --resolution lowest` resolve reads 71 of them, which takes 8 to 9 million instructions off its 4.19 billion, roughly 0.2%. Both are callgrind counts at `PYTHONHASHSEED=0`, so they reproduce anywhere; a timed A/B of that scenario cannot resolve anything below about 3% and only rules out a wall regression above that.

The cost was decoding the record as JSON. `put_sdist_files` now writes the magic `nabsdist1 `, the two fields' byte lengths, a newline, then `PKG-INFO` and `pyproject.toml` encoded with `surrogatepass`. `get_sdist_files` checks the magic and the total length, then decodes each field from a `memoryview` slice.

Records move to `sdist-v2/<index>/<package>/<version>.record`. One still sitting in `sdist-v1/` is read as JSON on the first miss, rewritten into `sdist-v2/` and left where it is, so an upgrade neither re-downloads an archive nor breaks a downgrade.