### PR TITLE
Fix docs naming two dynamic fields as the local-source build trigger

### DIFF
--- a/docs/how-to/local-sources.md
+++ b/docs/how-to/local-sources.md
@@ -22,10 +22,9 @@ the declared `name`.  A `path` that lands on a different project
 fails the resolve.
 
 The directory is read once.  nab reads the version from
-`[project].version` in the local pyproject.toml.  When the pyproject
-declares `dynamic = ["version"]`, nab computes it through the build
-backend instead, the same PEP 517 path used for dynamic dependencies
-below.
+`[project].version` in the local pyproject.toml.  A `version` listed
+in `[project].dynamic` comes from the build backend instead, one of
+the cases under "Dynamic metadata" below.
 
 The named package becomes the only candidate the resolver will
 consider for that name; the resolver does not fall back to
@@ -34,8 +33,8 @@ PyPI for it.  This is the same single-source semantics as
 
 ## Reading static metadata
 
-Reading static `[project].dependencies` from a local pyproject
-works at every `build-policy` level:
+Reading static metadata from a local pyproject works at every
+`build-policy` level:
 
 ```toml
 [tool.nab]
@@ -48,13 +47,20 @@ path = "../my-fork"
 
 See [build policy](../reference/build-policy.md) for the full ladder.
 
-## Dynamic dependencies
+## Dynamic metadata
 
-Local sources whose pyproject.toml lists `dynamic = ["dependencies"]`
-require `build-policy = "build-local"` (the default) or
-`"build-remote"`.  nab spins up an isolated venv, installs the
-declared build requirements, and invokes the PEP 517 backend
-through `pyproject_hooks` to extract the live dependency list.
+When the static read of the checkout's pyproject.toml comes up
+empty, nab builds the project instead.  That needs
+`build-policy = "build-local"` (the default) or `"build-remote"`.
+Empty means a missing or malformed `[project]`, or a `dynamic` list
+covering `version`, `requires-python`, `dependencies`, or
+`optional-dependencies`.
+
+nab spins up an isolated venv, installs the declared build
+requirements, and asks the PEP 517 backend for the wheel
+`METADATA`, building the wheel when the backend does not supply
+that metadata on its own.
+
 Setting `"never"` instead ends the resolve.  nab reads the source
 while listing its one version, so there is no candidate to
 reject.  The error names the source and the policy that forbade

--- a/docs/how-to/vcs.md
+++ b/docs/how-to/vcs.md
@@ -72,12 +72,14 @@ URL in each `[[tool.nab.vcs-sources]]` table is run through the
 same admission as project-root requirements, so it must pass
 `allowed-schemes`, `allowed-repos`, and `require-pin`.
 
-Reading static dependencies from the cloned tree works at any
-`build-policy` level.  Dynamic dependencies on a VCS clone
-require `build-policy = "build-remote"` (a clone is considered
-"remote" for build purposes because the source bytes are
-network-fetched, even though they end up on disk before the
-backend runs).  See the [build policy](../reference/build-policy.md) page.
+Reading static metadata from the cloned tree works at any
+`build-policy` level.  When the static read comes up empty, nab
+builds the clone instead, which needs
+`build-policy = "build-remote"` (a clone counts as remote because
+the source bytes are network-fetched, even though they end up on
+disk before the backend runs).  The
+[build policy](../reference/build-policy.md) page lists what
+counts as empty.
 
 ## Offline runs
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -664,9 +664,11 @@ editable by default (see [Lock a workspace](../how-to/workspaces.md)).
 `subdirectory` locates the package below `path`, for monorepo
 layouts.
 
-Reading static dependencies from a local pyproject.toml works at
-every `build-policy` level.  Dynamic dependencies require
-`build-policy = "build-local"` or `"build-remote"`.
+Reading static metadata from a local pyproject.toml works at every
+`build-policy` level.  When the static read comes up empty, nab builds
+the checkout instead, which needs `build-policy = "build-local"` or
+`"build-remote"`.  See [Build policy](build-policy.md) for what counts
+as empty.
 
 ## Pinned VCS sources
 
@@ -678,8 +680,9 @@ beyond `vcs.policy = "allow"`, the URL's scheme must be listed in
 `vcs.allowed-schemes` and its repository in `vcs.allowed-repos`, both
 empty by default so each denies every URL until an entry is added, and
 the URL must pin a 40-char commit hash unless `vcs.require-pin = false`.
-Reading static dependencies works at any `build-policy`.  Dynamic
-dependencies on a VCS clone require `build-policy = "build-remote"`.
+Reading static metadata works at any `build-policy`.  Building a clone
+whose static read comes up empty needs `build-policy = "build-remote"`;
+see [Build policy](build-policy.md).
 
 ```toml
 [[tool.nab.vcs-sources]]
@@ -703,8 +706,9 @@ url  = "https://example.com/my-fork-1.0.tar.gz#sha256=<hex>"
 Only `.tar.gz` source archives are supported; a wheel or other
 format is refused at parse.  A `&subdirectory=` fragment locates the
 package below the archive root, for monorepo layouts.  Reading static
-dependencies works at any `build-policy`; dynamic dependencies require
-`build-policy = "build-remote"`, like a remote sdist.
+metadata works at any `build-policy`.  Building an extracted tree whose
+static read comes up empty needs `build-policy = "build-remote"`, like a
+remote sdist; see [Build policy](build-policy.md).
 
 The URL is read by its own scheme, whatever the configured indexes use:
 a `file://` archive is read from disk, and any other archive is fetched

--- a/nab-project/tests/test_local_source_docs.py
+++ b/nab-project/tests/test_local_source_docs.py
@@ -1,0 +1,120 @@
+"""Check what the docs say triggers a build of a local source.
+
+A checkout goes to a PEP 517 backend when ``extract_static_metadata``
+returns ``None`` for it.  Two pages enumerate the ``[project].dynamic``
+entries that empty the static read, so the expected set is derived from
+the reader rather than repeated here.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from nab_project.build_backend import extract_static_metadata
+
+_DOCS = Path(__file__).resolve().parents[2] / "docs"
+
+# Every [project] field a backend may compute, and so every name the
+# static read could refuse.  PEP 621 forbids listing name in dynamic.
+_PROJECT_FIELDS = frozenset(
+    {
+        "version",
+        "description",
+        "readme",
+        "requires-python",
+        "license",
+        "license-files",
+        "authors",
+        "maintainers",
+        "keywords",
+        "classifiers",
+        "urls",
+        "scripts",
+        "gui-scripts",
+        "entry-points",
+        "dependencies",
+        "optional-dependencies",
+    }
+)
+
+
+def _how_to_section() -> str:
+    """The local-source how-to's "Dynamic metadata" body."""
+    text = (_DOCS / "how-to" / "local-sources.md").read_text(encoding="utf-8")
+    _, marker, rest = text.partition("\n## Dynamic metadata\n")
+    if not marker:
+        raise AssertionError("no dynamic-metadata section in local-sources.md")
+    return rest.partition("\n## ")[0]
+
+
+def _build_policy_bullet() -> str:
+    """The build-policy reference's local-checkout bullet under ``never``."""
+    text = (_DOCS / "reference" / "build-policy.md").read_text(encoding="utf-8")
+    _, marker, rest = text.partition("\n* Local checkouts declared via")
+    if not marker:
+        raise AssertionError("no local-checkout bullet in build-policy.md")
+    return rest.partition("\n* ")[0]
+
+
+_SECTIONS: dict[str, Callable[[], str]] = {
+    "how-to/local-sources.md": _how_to_section,
+    "reference/build-policy.md": _build_policy_bullet,
+}
+
+
+def _checkout(path: Path, dynamic_field: str) -> Path:
+    """A checkout whose ``[project]`` is static apart from ``dynamic_field``.
+
+    PEP 621 forbids giving a field a static value while listing it in
+    ``dynamic``, so the static ``version`` drops out when ``version`` is
+    the dynamic field.
+    """
+    path.mkdir(parents=True)
+
+    fields = ['name = "my-fork"']
+    if dynamic_field != "version":
+        fields.append('version = "1.0"')
+    fields.append(f'dynamic = ["{dynamic_field}"]')
+
+    body = "[project]\n" + "\n".join(fields) + "\n"
+    (path / "pyproject.toml").write_text(body, encoding="utf-8")
+    return path
+
+
+def _fields_forcing_a_build(tmp_path: Path) -> frozenset[str]:
+    """The fields that empty the static read by appearing in ``dynamic``."""
+    return frozenset(
+        field
+        for field in _PROJECT_FIELDS
+        if extract_static_metadata(_checkout(tmp_path / field, field)) is None
+    )
+
+
+def _fields_named(section: str) -> frozenset[str]:
+    """The ``[project]`` field names ``section`` quotes in backticks."""
+    return _PROJECT_FIELDS & set(re.findall(r"`([a-z-]+)`", section))
+
+
+@pytest.mark.parametrize("page", sorted(_SECTIONS))
+def test_page_names_every_dynamic_field_that_forces_a_build(
+    page: str, tmp_path: Path
+) -> None:
+    """The page's list is exactly the set the static reader refuses."""
+    assert _fields_named(_SECTIONS[page]()) == _fields_forcing_a_build(tmp_path)
+
+
+@pytest.mark.parametrize("page", sorted(_SECTIONS))
+def test_page_names_a_missing_project_table(page: str, tmp_path: Path) -> None:
+    """The other trigger, a checkout with no ``[project]``, is named too."""
+    (tmp_path / "pyproject.toml").write_text(
+        '[build-system]\nrequires = ["setuptools"]\n', encoding="utf-8"
+    )
+    assert extract_static_metadata(tmp_path) is None
+
+    section = _SECTIONS[page]()
+    assert "missing" in section
+    assert "`[project]`" in section


### PR DESCRIPTION
`docs/how-to/local-sources.md` names two `[project].dynamic` fields as what sends a local checkout to the build backend, `dependencies` and `version`. The static reader refuses four, `version`, `requires-python`, `dependencies` and `optional-dependencies`, and refuses a missing or malformed `[project]` as well.

So a checkout with `dynamic = ["optional-dependencies"]`, or one with no `[project]` table because it is configured in `setup.cfg`, needs a build the page says it does not. Under `build-policy = "never"` that is the difference between a resolve and an error.

The same section describes the backend call as extracting the live dependency list. nab asks for the wheel `METADATA`, and builds the wheel when the backend has no `prepare_metadata_for_build_wheel`.

`docs/reference/build-policy.md` already carried the full list. The narrow version was repeated in the local-source and VCS how-tos and in the local, VCS and archive entries of the configuration reference. Those now say the build happens when the static read comes up empty, and link to the build-policy page for what empty means.

The new test builds a one-field checkout for every `[project]` field a backend can compute and asks `extract_static_metadata` which ones it refuses, so a page that falls behind the code fails.
