### PR TITLE
Fix nab lock --locked blaming the lockfile for an invalid --python

### DIFF
--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -34,7 +34,6 @@ from nab_project.config import (
     NabProjectConfig,
     ResolveMode,
     plan_targets,
-    with_python_override,
 )
 from nab_project.lockfile import (
     DisjointnessError,
@@ -526,7 +525,13 @@ def _fast_fail_locked(
     Reads and parses the committed lock, then runs the envelope and validity
     checks.  On the first disqualification it prints the reason and exits
     non-zero; otherwise it returns and the full resolve runs.
+
+    ``--python`` is applied first so a rejected value reports as the flag
+    error: reporting a stale lock instead would point at a refresh command
+    carrying the same rejected value.
     """
+    retargeted = _cli._python_override_or_exit(config, run.python)  # noqa: SLF001
+
     target = _locked_target_path(run)
     refresh = run.refresh_command()
 
@@ -558,7 +563,7 @@ def _fast_fail_locked(
         )
         sys.exit(1)
 
-    resolve_target = _locked_resolve_target(config, python=run.python)
+    resolve_target = _locked_resolve_target(retargeted)
 
     try:
         disqualification = check_locked(
@@ -598,18 +603,17 @@ def _fast_fail_locked(
     sys.exit(1)
 
 
-def _locked_resolve_target(
-    config: NabProjectConfig, *, python: str | None
-) -> ResolveTarget | None:
+def _locked_resolve_target(config: NabProjectConfig) -> ResolveTarget | None:
     """Return the target the validity checks evaluate markers against.
 
-    ``None`` when the declaration excludes this run's target, which leaves
-    the validity checks to the full resolve.  The envelope checks still run.
-    The checks read the target's marker environment; the target itself says
-    which markers its micro slices decide instead.
+    ``config`` arrives retargeted onto any ``--python``.  ``None`` when the
+    declaration excludes this run's target, which leaves the validity checks
+    to the full resolve.  The envelope checks still run.  The checks read the
+    target's marker environment; the target itself says which markers its
+    micro slices decide instead.
     """
     try:
-        return plan_targets(with_python_override(config, python))[0]
+        return plan_targets(config)[0]
     except ConfigError:
         return None
 

--- a/tests/test_lock_locked.py
+++ b/tests/test_lock_locked.py
@@ -960,6 +960,74 @@ def test_unreadable_requirement_with_changed_envelope_reports_the_parse_error(
     assert "is out of date" not in err
 
 
+# --- --python cases: the flag is named, never the lock ---
+
+
+def test_invalid_python_value_reports_the_flag_error(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A malformed --python names the flag, not the stale lock."""
+    body = '[project]\ndependencies = ["foo"]\n[tool.nab]\nrequires-python = ">=3.8"\n'
+    pyproject = _write_pyproject(tmp_path, body)
+    out = tmp_path / "pylock.toml"
+    _write_lock(pyproject, out, _result({"foo": "1.0"}))
+    capsys.readouterr()
+    pyproject.write_text(body.replace(">=3.8", ">=3.9"), encoding="utf-8")
+
+    mock = _locked_mock()
+    with pytest.raises(SystemExit) as exc:
+        _run_locked(pyproject, out, mock, "--python", "3.x")
+
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "error: --python must be a version like '3.12' or '3.12.4', got '3.x'" in err
+    assert "is out of date" not in err
+    assert "re-run `nab lock" not in err
+    mock.assert_not_called()
+
+
+def test_invalid_python_value_is_reported_before_a_missing_lock(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The missing-lock remedy would hand the rejected value back."""
+    pyproject = _write_pyproject(tmp_path, '[project]\ndependencies = ["foo"]\n')
+    out = tmp_path / "pylock.toml"
+
+    mock = _locked_mock()
+    with pytest.raises(SystemExit) as exc:
+        _run_locked(pyproject, out, mock, "--python", "3.x")
+
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "error: --python must be a version like" in err
+    assert "no lockfile" not in err
+    assert "run `nab lock" not in err
+    mock.assert_not_called()
+
+
+def test_python_outside_requires_python_reports_the_declaration_error(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A --python the declaration excludes names requires-python, not the lock."""
+    body = '[project]\ndependencies = ["foo"]\n[tool.nab]\nrequires-python = ">=3.8"\n'
+    pyproject = _write_pyproject(tmp_path, body)
+    out = tmp_path / "pylock.toml"
+    _write_lock(pyproject, out, _result({"foo": "1.0"}))
+    capsys.readouterr()
+    pyproject.write_text(body.replace(">=3.8", ">=3.9"), encoding="utf-8")
+
+    mock = _locked_mock()
+    with pytest.raises(SystemExit) as exc:
+        _run_locked(pyproject, out, mock, "--python", "3.7")
+
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "requires-python = '>=3.9' excludes the resolve target Python 3.7" in err
+    assert "is out of date" not in err
+    assert "re-run `nab lock" not in err
+    mock.assert_not_called()
+
+
 # --- precondition cases: no resolve runs ---
 
 


### PR DESCRIPTION
`nab lock --locked --python 3.x` blames the lockfile for a value the flag itself rejects, and the command it suggests hands that value straight back:

```
error: --locked: lockfile pylock.toml is out of date: the lockfile requires-python >=3.8 does not match this run's >=3.9; re-run `nab lock --python 3.x` to update it.
```

Running that gives the error that should have come first, `--python must be a version like '3.12' or '3.12.4', got '3.x'`. A missing lockfile does the same, pointing at `nab lock --python 3.x`.

The `--locked` fast-fail path applied `--python` inside `_locked_resolve_target`, a helper that catches `ConfigError` and returns `None` so a declaration excluding the run's target leaves the validity checks to the resolve. A malformed value raises the same `ConfigError` and was swallowed with it, so the lock checks ran anyway and reported a stale lock. With an up-to-date lock the resolve runs and reports the flag correctly, so which error you get depends on the state of the lock.

`--locked` now applies `--python` up front through the CLI's own override handling and passes the retargeted config to the checks. The same fix makes `--python 3.7` under `requires-python = ">=3.9"` name the declaration rather than the lock.
