### PR TITLE
Inline three range helpers and skip a redundant fold, ~1.5% off a resolve

### DIFF
--- a/nab-provider/src/nab_provider/_vendor/packaging/PROVENANCE.md
+++ b/nab-provider/src/nab_provider/_vendor/packaging/PROVENANCE.md
@@ -21,6 +21,9 @@ most one checked-in patch.
     `_bisect_predicate`, `_partition_indexes`, `_make_project`, `_check_order`,
     `_lattice_release`, `_release_boundary_point`); the `RangeRelation` and
     `SortedOrder` `__all__` entries; and the class-docstring lines naming them.
+    `VersionRange._build` takes a `canonical` keyword that skips the bound
+    fold for callers whose bounds are folded already: the set algebra, `full`,
+    and `empty`.
   - `_ranges.py`: an unbounded end canonicalizes its inclusivity, and
     `LowerBound.__gt__`, `LowerBound.__le__`, and `UpperBound.__gt__` are
     written out beside `functools.total_ordering`, which still derives the

--- a/nab-provider/src/nab_provider/_vendor/packaging/PROVENANCE.md
+++ b/nab-provider/src/nab_provider/_vendor/packaging/PROVENANCE.md
@@ -18,8 +18,9 @@ most one checked-in patch.
     `is_subset` and `is_disjoint` answered by a direct walk over the interval
     lists instead of an intermediate range; the module-level helpers they need
     (`_relate_bounds`, `_subset_bounds`, `_disjoint_bounds`,
-    `_bisect_predicate`, `_partition_indexes`, `_make_project`, `_check_order`,
-    `_lattice_release`, `_release_boundary_point`); the `RangeRelation` and
+    `_bisect_predicate`, `_partition_indexes`, `_make_project`,
+    `_project_plain`, `_check_order`, `_lattice_release`,
+    `_release_boundary_point`); the `RangeRelation` and
     `SortedOrder` `__all__` entries; and the class-docstring lines naming them.
     `VersionRange._build` takes a `canonical` keyword that skips the bound
     fold for callers whose bounds are folded already: the set algebra, `full`,

--- a/nab-provider/src/nab_provider/_vendor/packaging/PROVENANCE.md
+++ b/nab-provider/src/nab_provider/_vendor/packaging/PROVENANCE.md
@@ -24,7 +24,10 @@ most one checked-in patch.
     `SortedOrder` `__all__` entries; and the class-docstring lines naming them.
     `VersionRange._build` takes a `canonical` keyword that skips the bound
     fold for callers whose bounds are folded already: the set algebra, `full`,
-    and `empty`.
+    and `empty`. Pre-release policy compatibility is tested inline at each set
+    operation and relation query, so `_check_policy_compat` is called only to
+    raise. The set operations test both operands' `===` literals inline too,
+    in place of upstream's `_has_literals`, which the patch deletes.
   - `_ranges.py`: an unbounded end canonicalizes its inclusivity, and
     `LowerBound.__gt__`, `LowerBound.__le__`, and `UpperBound.__gt__` are
     written out beside `functools.total_ordering`, which still derives the

--- a/nab-provider/src/nab_provider/_vendor/packaging/ranges.py
+++ b/nab-provider/src/nab_provider/_vendor/packaging/ranges.py
@@ -424,9 +424,9 @@ def _bisect_predicate(
     The predicate must be monotonic (false runs then true runs). Equivalent to
     ``bisect.bisect_left`` on the mapped booleans, done by hand because the
     ``key`` parameter for :mod:`bisect` only exists on Python 3.10 and later.
-    ``project`` maps a probed item to the version it sorts by; ``None`` means
-    the items sort by themselves, and a probe that is already a
-    :class:`~packaging.version.Version` skips the call.
+    ``project`` maps a probed item to the version it sorts by; ``None`` maps it
+    with :func:`_project_plain`, skipping the call for a probe that is already a
+    :class:`~packaging.version.Version`.
     """
     low, high = 0, len(items)
     while low < high:
@@ -475,9 +475,9 @@ def _partition_indexes(
 def _project_plain(item: Any) -> Version:  # noqa: ANN401
     """The version a key-less entry of an ordered sequence sorts by.
 
-    An item that does not parse cannot sit in version order at all, which is a
-    broken precondition rather than a non-match, so this raises rather than
-    dropping the item the way :meth:`VersionRange.filter` drops it.
+    An item that does not parse cannot sit in version order at all, so this
+    raises on the broken precondition rather than dropping the item the way
+    :meth:`VersionRange.filter` drops a non-match.
     """
     parsed = item if isinstance(item, Version) else coerce_version(item)
     if parsed is None:
@@ -494,8 +494,8 @@ def _make_project(
     """Build the item-to-:class:`~packaging.version.Version` map for a sorted walk.
 
     The bisections compare against bound predicates that only accept a
-    :class:`~packaging.version.Version`, so a projected item is coerced.
-    Without a ``key`` that map is :func:`_project_plain`.
+    :class:`~packaging.version.Version`, so the map coerces anything else.
+    Without a ``key`` it is :func:`_project_plain`.
     """
     if key is None:
         return _project_plain
@@ -2144,8 +2144,8 @@ class VersionRange:
         """
         bounds = tuple(reversed(self._bounds)) if descending else self._bounds
 
-        # Without a key an entry is the version it sorts by, so the bisections
-        # project only an entry that is not already one.
+        # Passing no projection lets the bisections skip the call for an entry
+        # that is already a Version.
         bisect_project = None if key is None else project
 
         if prereleases is True:

--- a/nab-provider/src/nab_provider/_vendor/packaging/ranges.py
+++ b/nab-provider/src/nab_provider/_vendor/packaging/ranges.py
@@ -1270,6 +1270,7 @@ class VersionRange:
         *,
         pre_region: tuple[Interval, ...] = (),
         prereleases_configured: bool | None = None,
+        canonical: bool = False,
     ) -> VersionRange:
         """Internal factory; bypasses :meth:`__new__`.
 
@@ -1279,8 +1280,16 @@ class VersionRange:
         pre-release policy is set here and never reassigned afterwards;
         ``pre_region`` is canonicalized like the bounds and clipped to them,
         or dropped when a configured policy makes it inert.
+
+        ``canonical=True`` says the bounds and the region are folded already,
+        so the fold is skipped. The set algebra can promise that:
+        ``intersect_ranges`` and ``_union_ranges`` reuse operand bounds
+        unchanged, and ``_complement_ranges`` flips inclusivity as it swaps a
+        bound's side, which lands either on the inclusivity the fold ignores or
+        on a version a canonical operand has already shown is no least successor.
         """
-        bounds = _canonicalize(bounds)
+        if not canonical:
+            bounds = _canonicalize(bounds)
 
         if admit and reject:
             admit = admit - reject
@@ -1304,16 +1313,15 @@ class VersionRange:
         instance._admit_arbitrary = admit_arbitrary
         instance._prereleases_configured = prereleases_configured
 
-        # A configured policy makes the region inert, so drop it. Otherwise fold
-        # least-successor bounds (_from_specifier_set passes the region unfolded),
-        # so ``>1.0a1`` and ``>=1.0a2.dev0`` carry the same region, then clip it
-        # to the bounds so the opt-in never reaches past the range's own versions.
+        # A configured policy makes the region inert, so drop it.
         if prereleases_configured is not None or not pre_region:
             instance._pre_region = ()
         else:
-            instance._pre_region = tuple(
-                intersect_ranges(_canonicalize(pre_region), bounds)
-            )
+            # Folding (_from_specifier_set passes the region unfolded) makes
+            # ``>1.0a1`` and ``>=1.0a2.dev0`` carry the same region; clipping
+            # keeps the opt-in inside the range's own versions.
+            region = pre_region if canonical else _canonicalize(pre_region)
+            instance._pre_region = tuple(intersect_ranges(region, bounds))
 
         return instance
 
@@ -1365,8 +1373,7 @@ class VersionRange:
         if not self._pre_region:
             return other._pre_region
 
-        # Both sides carry a region; merge them. _build re-canonicalizes and
-        # clips, so the plain union is fine here.
+        # Both sides carry a region; a union of canonical regions is canonical.
         return tuple(_union_ranges(self._pre_region, other._pre_region))
 
     def _with_policy(
@@ -1391,7 +1398,7 @@ class VersionRange:
         >>> "1.0" in VersionRange.empty()
         False
         """
-        return cls._build((), prereleases_configured=prereleases)
+        return cls._build((), prereleases_configured=prereleases, canonical=True)
 
     @classmethod
     def full(
@@ -1416,6 +1423,7 @@ class VersionRange:
             FULL_RANGE,
             admit_arbitrary=admit_arbitrary,
             prereleases_configured=prereleases,
+            canonical=True,
         )
 
     @classmethod
@@ -1546,6 +1554,7 @@ class VersionRange:
                 admit_arbitrary=combined_arb,
                 pre_region=new_region,
                 prereleases_configured=configured,
+                canonical=True,
             )
 
         return self._combine_literals(
@@ -1593,6 +1602,7 @@ class VersionRange:
                 admit_arbitrary=combined_arb,
                 pre_region=new_region,
                 prereleases_configured=configured,
+                canonical=True,
             )
 
         return self._combine_literals(
@@ -1636,6 +1646,7 @@ class VersionRange:
             admit_arbitrary=self._admit_arbitrary,
             pre_region=(),
             prereleases_configured=self._prereleases_configured,
+            canonical=True,
         )
 
     def difference(self, other: VersionRange) -> VersionRange:
@@ -1692,6 +1703,7 @@ class VersionRange:
                 admit_arbitrary=combined_arb,
                 pre_region=new_region,
                 prereleases_configured=self._prereleases_configured,
+                canonical=True,
             )
 
         return self._combine_literals(
@@ -1713,7 +1725,11 @@ class VersionRange:
         pre_region: tuple[Interval, ...],
         prereleases_configured: bool | None,
     ) -> VersionRange:
-        """Resolve admit/reject for ``self`` ``op`` ``other`` over their literals."""
+        """Resolve admit/reject for ``self`` ``op`` ``other`` over their literals.
+
+        Every caller is a set operation, so ``new_bounds`` and ``pre_region``
+        arrive folded.
+        """
         admits: set[str] = set()
         rejects: set[str] = set()
 
@@ -1741,6 +1757,7 @@ class VersionRange:
             admit_arbitrary=admit_arbitrary,
             pre_region=pre_region,
             prereleases_configured=prereleases_configured,
+            canonical=True,
         )
 
     def _matches_literal(self, literal: str) -> bool:

--- a/nab-provider/src/nab_provider/_vendor/packaging/ranges.py
+++ b/nab-provider/src/nab_provider/_vendor/packaging/ranges.py
@@ -1347,7 +1347,10 @@ class VersionRange:
         )
 
     def _check_policy_compat(self, other: VersionRange) -> None:
-        """Refuse combining ranges with different pre-release policies."""
+        """Refuse combining ranges with different pre-release policies.
+
+        Callers test compatibility inline and call this when that test fails.
+        """
         if not isinstance(other, VersionRange):
             raise TypeError(f"expected VersionRange, got {type(other).__name__}")
         if self._prereleases_configured != other._prereleases_configured:
@@ -1533,7 +1536,11 @@ class VersionRange:
         >>> a.intersection(b) == SpecifierSet(">=1.0,<2.0").to_range()
         True
         """
-        self._check_policy_compat(other)
+        if (
+            type(other) is not VersionRange
+            or self._prereleases_configured != other._prereleases_configured
+        ):
+            self._check_policy_compat(other)
 
         configured = self._prereleases_configured
         new_bounds = tuple(intersect_ranges(self._bounds, other._bounds))
@@ -1577,7 +1584,11 @@ class VersionRange:
         >>> "1.5" in a.union(b)
         False
         """
-        self._check_policy_compat(other)
+        if (
+            type(other) is not VersionRange
+            or self._prereleases_configured != other._prereleases_configured
+        ):
+            self._check_policy_compat(other)
 
         configured = self._prereleases_configured
         new_bounds = tuple(_union_ranges(self._bounds, other._bounds))
@@ -1670,7 +1681,11 @@ class VersionRange:
         >>> a.difference(VersionRange.empty()) == a
         True
         """
-        self._check_policy_compat(other)
+        if (
+            type(other) is not VersionRange
+            or self._prereleases_configured != other._prereleases_configured
+        ):
+            self._check_policy_compat(other)
 
         # Subtracting a nothing-admitting set is a no-op; return self unchanged.
         if not other._bounds and not other._admit:
@@ -1821,7 +1836,11 @@ class VersionRange:
         >>> outer.is_subset(punctured)
         False
         """
-        self._check_policy_compat(other)
+        if (
+            type(other) is not VersionRange
+            or self._prereleases_configured != other._prereleases_configured
+        ):
+            self._check_policy_compat(other)
 
         # A live arbitrary admission has non-version strings as members, which
         # no bounds cover; only another live admission contains them.
@@ -1861,7 +1880,11 @@ class VersionRange:
         if self is other:
             return _EMPTY_REL if self.is_empty else _SUBSET_REL
 
-        self._check_policy_compat(other)
+        if (
+            type(other) is not VersionRange
+            or self._prereleases_configured != other._prereleases_configured
+        ):
+            self._check_policy_compat(other)
 
         if self._is_plain() and other._is_plain():
             # On plain ranges the bounds decide membership, so equal bounds
@@ -1890,7 +1913,11 @@ class VersionRange:
         True
         """
         # Type-guards a non-VersionRange other before delegating to is_subset.
-        self._check_policy_compat(other)
+        if (
+            type(other) is not VersionRange
+            or self._prereleases_configured != other._prereleases_configured
+        ):
+            self._check_policy_compat(other)
         return other.is_subset(self)
 
     def is_disjoint(self, other: VersionRange) -> bool:
@@ -1914,7 +1941,11 @@ class VersionRange:
         ... )
         True
         """
-        self._check_policy_compat(other)
+        if (
+            type(other) is not VersionRange
+            or self._prereleases_configured != other._prereleases_configured
+        ):
+            self._check_policy_compat(other)
 
         # Plain ranges: disjointness is an empty bounds intersection.
         if self._is_plain() and other._is_plain():

--- a/nab-provider/src/nab_provider/_vendor/packaging/ranges.py
+++ b/nab-provider/src/nab_provider/_vendor/packaging/ranges.py
@@ -1325,9 +1325,6 @@ class VersionRange:
 
         return instance
 
-    def _has_literals(self) -> bool:
-        return bool(self._admit) or bool(self._reject)
-
     def _arbitrary_active(self) -> bool:
         """True when ``_admit_arbitrary`` actually admits non-version strings.
 
@@ -1343,7 +1340,8 @@ class VersionRange:
         bounds-only fast paths in :meth:`is_subset` and :meth:`is_disjoint`.
         """
         return (
-            not self._has_literals()
+            not self._admit
+            and not self._reject
             and not self._admit_arbitrary
             and self._prereleases_configured is not False
         )
@@ -1548,7 +1546,7 @@ class VersionRange:
             self._admit_arbitrary and other._admit_arbitrary and bool(new_bounds)
         )
 
-        if not self._has_literals() and not other._has_literals():
+        if not (self._admit or self._reject or other._admit or other._reject):
             return self._build(
                 new_bounds,
                 admit_arbitrary=combined_arb,
@@ -1596,7 +1594,7 @@ class VersionRange:
             # Nothing widened, so keeping the flags keeps ``r | r == r``.
             combined_arb = self._admit_arbitrary or other._admit_arbitrary
 
-        if not self._has_literals() and not other._has_literals():
+        if not (self._admit or self._reject or other._admit or other._reject):
             return self._build(
                 new_bounds,
                 admit_arbitrary=combined_arb,
@@ -1697,7 +1695,7 @@ class VersionRange:
         # admission neither operand had.
         combined_arb = self._admit_arbitrary and new_bounds == self._bounds
 
-        if not self._has_literals() and not other._has_literals():
+        if not (self._admit or self._reject or other._admit or other._reject):
             return self._build(
                 new_bounds,
                 admit_arbitrary=combined_arb,

--- a/nab-provider/src/nab_provider/_vendor/packaging/ranges.py
+++ b/nab-provider/src/nab_provider/_vendor/packaging/ranges.py
@@ -425,13 +425,18 @@ def _bisect_predicate(
     ``bisect.bisect_left`` on the mapped booleans, done by hand because the
     ``key`` parameter for :mod:`bisect` only exists on Python 3.10 and later.
     ``project`` maps a probed item to the version it sorts by; ``None`` means
-    the items are already :class:`~packaging.version.Version` instances.
+    the items sort by themselves, and a probe that is already a
+    :class:`~packaging.version.Version` skips the call.
     """
     low, high = 0, len(items)
     while low < high:
         mid = (low + high) // 2
         item = items[mid]
-        if predicate(item if project is None else project(item)):
+        if project is None:
+            version = item if item.__class__ is Version else _project_plain(item)
+        else:
+            version = project(item)
+        if predicate(version):
             high = mid
         else:
             low = mid + 1
@@ -467,20 +472,36 @@ def _partition_indexes(
     return start, stop
 
 
+def _project_plain(item: Any) -> Version:  # noqa: ANN401
+    """The version a key-less entry of an ordered sequence sorts by.
+
+    An item that does not parse cannot sit in version order at all, which is a
+    broken precondition rather than a non-match, so this raises rather than
+    dropping the item the way :meth:`VersionRange.filter` drops it.
+    """
+    parsed = item if isinstance(item, Version) else coerce_version(item)
+    if parsed is None:
+        raise ValueError(
+            f"{item!r} does not parse as a version, so the given sequence "
+            f"is not in version order"
+        )
+    return parsed
+
+
 def _make_project(
     key: Callable[[Any], Version | str] | None,
 ) -> Callable[[Any], Version]:
     """Build the item-to-:class:`~packaging.version.Version` map for a sorted walk.
 
     The bisections compare against bound predicates that only accept a
-    :class:`~packaging.version.Version`, so every probed item is coerced. An
-    item that does not parse cannot sit in version order at all, which is a
-    broken precondition rather than a non-match, so this raises rather than
-    dropping the item the way :meth:`VersionRange.filter` drops it.
+    :class:`~packaging.version.Version`, so a projected item is coerced.
+    Without a ``key`` that map is :func:`_project_plain`.
     """
+    if key is None:
+        return _project_plain
 
     def project(item: Any) -> Version:  # noqa: ANN401
-        raw: Version | str = item if key is None else key(item)
+        raw = key(item)
         parsed = raw if isinstance(raw, Version) else coerce_version(raw)
         if parsed is None:
             raise ValueError(
@@ -2126,10 +2147,14 @@ class VersionRange:
         """
         bounds = tuple(reversed(self._bounds)) if descending else self._bounds
 
+        # Without a key an entry is the version it sorts by, so the bisections
+        # project only an entry that is not already one.
+        bisect_project = None if key is None else project
+
         if prereleases is True:
             for lower, upper in bounds:
                 start, stop = _partition_indexes(
-                    versions, lower, upper, project, descending=descending
+                    versions, lower, upper, bisect_project, descending=descending
                 )
                 for index in range(start, stop):
                     yield versions[index]
@@ -2142,7 +2167,7 @@ class VersionRange:
 
         for lower, upper in bounds:
             start, stop = _partition_indexes(
-                versions, lower, upper, project, descending=descending
+                versions, lower, upper, bisect_project, descending=descending
             )
             for index in range(start, stop):
                 item = versions[index]

--- a/nab-provider/src/nab_provider/_vendor/packaging/ranges.py
+++ b/nab-provider/src/nab_provider/_vendor/packaging/ranges.py
@@ -1368,10 +1368,7 @@ class VersionRange:
         )
 
     def _check_policy_compat(self, other: VersionRange) -> None:
-        """Refuse combining ranges with different pre-release policies.
-
-        Callers test compatibility inline and call this when that test fails.
-        """
+        """Refuse combining ranges with different pre-release policies."""
         if not isinstance(other, VersionRange):
             raise TypeError(f"expected VersionRange, got {type(other).__name__}")
         if self._prereleases_configured != other._prereleases_configured:

--- a/nab-provider/tests/test_vendor_literal_operands.py
+++ b/nab-provider/tests/test_vendor_literal_operands.py
@@ -1,0 +1,70 @@
+"""Tests for the vendored patch's inline ``===`` literal test in the set operations.
+
+``intersection``, ``union`` and ``difference`` each test both operands for
+literals inline and take the bounds-only shortcut when neither carries one.
+Missing one operand there drops its literals from the result without failing, so
+each operation is pinned separately with the literal on one side at a time.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nab_provider._vendor.packaging.ranges import VersionRange
+from nab_provider._vendor.packaging.specifiers import SpecifierSet
+
+LITERAL = "foo"
+
+# The two ways an operand carries the literal: admitting it, and excluding it
+# from a range that would otherwise admit any arbitrary string.
+ADMITS = SpecifierSet(f"==={LITERAL}").to_range()
+REJECTS = VersionRange.full().difference(ADMITS)
+
+# Operands with no literal of their own. ``ARBITRARY`` admits the string
+# anyway, ``BOUNDED`` admits nothing but versions.
+ARBITRARY = VersionRange.full()
+BOUNDED = SpecifierSet(">=1.0,<2.0").to_range()
+
+
+@pytest.mark.parametrize(
+    ("left", "right", "admitted"),
+    [
+        pytest.param(ARBITRARY, REJECTS, False, id="right-rejects"),
+        pytest.param(REJECTS, ARBITRARY, False, id="left-rejects"),
+        pytest.param(ARBITRARY, ADMITS, True, id="right-admits"),
+        pytest.param(ADMITS, ARBITRARY, True, id="left-admits"),
+    ],
+)
+def test_intersection_reads_the_literals_of_both_operands(
+    left: VersionRange, right: VersionRange, *, admitted: bool
+) -> None:
+    assert (LITERAL in left.intersection(right)) is admitted
+
+
+@pytest.mark.parametrize(
+    ("left", "right", "admitted"),
+    [
+        pytest.param(BOUNDED, REJECTS, False, id="right-rejects"),
+        pytest.param(REJECTS, BOUNDED, False, id="left-rejects"),
+        pytest.param(BOUNDED, ADMITS, True, id="right-admits"),
+        pytest.param(ADMITS, BOUNDED, True, id="left-admits"),
+    ],
+)
+def test_union_reads_the_literals_of_both_operands(
+    left: VersionRange, right: VersionRange, *, admitted: bool
+) -> None:
+    assert (LITERAL in left.union(right)) is admitted
+
+
+@pytest.mark.parametrize(
+    ("left", "right", "admitted"),
+    [
+        pytest.param(ARBITRARY, REJECTS, True, id="right-rejects"),
+        pytest.param(ARBITRARY, ADMITS, False, id="right-admits"),
+        pytest.param(ADMITS, BOUNDED, True, id="left-admits"),
+    ],
+)
+def test_difference_reads_the_literals_of_both_operands(
+    left: VersionRange, right: VersionRange, *, admitted: bool
+) -> None:
+    assert (LITERAL in left.difference(right)) is admitted

--- a/nab-provider/tests/test_vendor_literal_operands.py
+++ b/nab-provider/tests/test_vendor_literal_operands.py
@@ -2,8 +2,8 @@
 
 ``intersection``, ``union`` and ``difference`` each test both operands for
 literals inline and take the bounds-only shortcut when neither carries one.
-Missing one operand there drops its literals from the result without failing, so
-each operation is pinned separately with the literal on one side at a time.
+Omitting an operand from that test silently drops its literals, so each
+operation is pinned with the literal on one side at a time.
 """
 
 from __future__ import annotations
@@ -56,6 +56,9 @@ def test_union_reads_the_literals_of_both_operands(
     assert (LITERAL in left.union(right)) is admitted
 
 
+# No left-rejects case: reaching the literal test with only ``self`` carrying a
+# reject needs a plain ``other`` with bounds, and subtracting one shrinks the
+# bounds, dropping the arbitrary admission the reject exists to narrow.
 @pytest.mark.parametrize(
     ("left", "right", "admitted"),
     [

--- a/nab-provider/tests/test_vendor_policy_guard.py
+++ b/nab-provider/tests/test_vendor_policy_guard.py
@@ -1,8 +1,8 @@
 """Tests for the vendored patch's pre-release policy guard.
 
 Every set operation and relation query tests policy compatibility inline and
-calls ``_check_policy_compat`` only when that test fails, so each one is checked
-here against both of the errors that guard raises.
+calls ``_check_policy_compat`` only when that test fails, so each is checked
+here against both errors the guard raises.
 """
 
 from __future__ import annotations
@@ -25,7 +25,7 @@ OPERATIONS = [
 
 @pytest.fixture
 def unconfigured() -> VersionRange:
-    """A range that carries no configured pre-release policy."""
+    """A plain range that carries no configured pre-release policy."""
     return SpecifierSet(">=1.0,<2.0").to_range()
 
 
@@ -41,13 +41,16 @@ def test_a_non_range_operand_is_refused(
 def test_a_differently_configured_operand_is_refused(
     operation: str, unconfigured: VersionRange
 ) -> None:
-    configured = VersionRange.full(prereleases=True)
+    # Plain on both sides: an operation that stopped testing the policy would
+    # answer from its bounds-only fast path rather than raise further down.
+    configured = VersionRange.singleton("1.5", prereleases=True)
     with pytest.raises(ValueError, match="different pre-release policies"):
         getattr(unconfigured, operation)(configured)
 
 
 @pytest.mark.parametrize("operation", OPERATIONS)
 def test_a_matching_policy_is_accepted(operation: str) -> None:
+    """Matching policies reach the operation instead of raising."""
     configured = VersionRange.full(prereleases=True)
     other = VersionRange.singleton("1.5", prereleases=True)
     getattr(configured, operation)(other)

--- a/nab-provider/tests/test_vendor_policy_guard.py
+++ b/nab-provider/tests/test_vendor_policy_guard.py
@@ -1,0 +1,53 @@
+"""Tests for the vendored patch's pre-release policy guard.
+
+Every set operation and relation query tests policy compatibility inline and
+calls ``_check_policy_compat`` only when that test fails, so each one is checked
+here against both of the errors that guard raises.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nab_provider._vendor.packaging.ranges import VersionRange
+from nab_provider._vendor.packaging.specifiers import SpecifierSet
+
+OPERATIONS = [
+    "difference",
+    "intersection",
+    "is_disjoint",
+    "is_subset",
+    "is_superset",
+    "relation",
+    "union",
+]
+
+
+@pytest.fixture
+def unconfigured() -> VersionRange:
+    """A range that carries no configured pre-release policy."""
+    return SpecifierSet(">=1.0,<2.0").to_range()
+
+
+@pytest.mark.parametrize("operation", OPERATIONS)
+def test_a_non_range_operand_is_refused(
+    operation: str, unconfigured: VersionRange
+) -> None:
+    with pytest.raises(TypeError, match="expected VersionRange, got str"):
+        getattr(unconfigured, operation)(">=1.5")
+
+
+@pytest.mark.parametrize("operation", OPERATIONS)
+def test_a_differently_configured_operand_is_refused(
+    operation: str, unconfigured: VersionRange
+) -> None:
+    configured = VersionRange.full(prereleases=True)
+    with pytest.raises(ValueError, match="different pre-release policies"):
+        getattr(unconfigured, operation)(configured)
+
+
+@pytest.mark.parametrize("operation", OPERATIONS)
+def test_a_matching_policy_is_accepted(operation: str) -> None:
+    configured = VersionRange.full(prereleases=True)
+    other = VersionRange.singleton("1.5", prereleases=True)
+    getattr(configured, operation)(other)

--- a/nab-provider/tests/test_vendor_sorted_filter.py
+++ b/nab-provider/tests/test_vendor_sorted_filter.py
@@ -376,6 +376,14 @@ class TestSortedFilterOrderContract:
         with pytest.raises(ValueError, match="'frobnicate' does not parse"):
             _range(">=1.0").filter(["1.0", "frobnicate"], assume_sorted="ascending")
 
+    def test_unparsable_keyed_endpoint_is_rejected(self) -> None:
+        entries: list[tuple[Any, str]] = [
+            (V("1.0"), "pkg-1.0.whl"),
+            ("frobnicate", "pkg-frobnicate.whl"),
+        ]
+        with pytest.raises(ValueError, match="'frobnicate' does not parse"):
+            _range(">=1.0").filter(entries, key=_first, assume_sorted="ascending")
+
     def test_an_unrecognised_order_is_rejected(self) -> None:
         for claimed in ("Descending", "desc", "sorted", ""):
             with pytest.raises(ValueError, match="must be 'ascending' or 'descending'"):

--- a/tasks/vendoring/packaging.patch
+++ b/tasks/vendoring/packaging.patch
@@ -2638,7 +2638,7 @@ index 0000000..a5e2740
 +    def __repr__(self) -> str:
 +        return f"<{type(self).__name__} {_markersets.describe(self._tree)!r}>"
 diff --git a/nab-provider/src/nab_provider/_vendor/packaging/ranges.py b/nab-provider/src/nab_provider/_vendor/packaging/ranges.py
-index 4fbf48e..a4a5912 100644
+index 4fbf48e..67b99ca 100644
 --- a/nab-provider/src/nab_provider/_vendor/packaging/ranges.py
 +++ b/nab-provider/src/nab_provider/_vendor/packaging/ranges.py
 @@ -24,6 +24,7 @@ import typing
@@ -3013,7 +3013,7 @@ index 4fbf48e..a4a5912 100644
  
          if admit and reject:
              admit = admit - reject
-@@ -1044,16 +1334,15 @@ class VersionRange:
+@@ -1044,22 +1334,18 @@ class VersionRange:
          instance._admit_arbitrary = admit_arbitrary
          instance._prereleases_configured = prereleases_configured
  
@@ -3036,7 +3036,33 @@ index 4fbf48e..a4a5912 100644
  
          return instance
  
-@@ -1105,8 +1394,7 @@ class VersionRange:
+-    def _has_literals(self) -> bool:
+-        return bool(self._admit) or bool(self._reject)
+-
+     def _arbitrary_active(self) -> bool:
+         """True when ``_admit_arbitrary`` actually admits non-version strings.
+ 
+@@ -1075,13 +1361,17 @@ class VersionRange:
+         bounds-only fast paths in :meth:`is_subset` and :meth:`is_disjoint`.
+         """
+         return (
+-            not self._has_literals()
++            not self._admit
++            and not self._reject
+             and not self._admit_arbitrary
+             and self._prereleases_configured is not False
+         )
+ 
+     def _check_policy_compat(self, other: VersionRange) -> None:
+-        """Refuse combining ranges with different pre-release policies."""
++        """Refuse combining ranges with different pre-release policies.
++
++        Callers test compatibility inline and call this when that test fails.
++        """
+         if not isinstance(other, VersionRange):
+             raise TypeError(f"expected VersionRange, got {type(other).__name__}")
+         if self._prereleases_configured != other._prereleases_configured:
+@@ -1105,8 +1395,7 @@ class VersionRange:
          if not self._pre_region:
              return other._pre_region
  
@@ -3046,7 +3072,7 @@ index 4fbf48e..a4a5912 100644
          return tuple(_union_ranges(self._pre_region, other._pre_region))
  
      def _with_policy(
-@@ -1131,7 +1419,7 @@ class VersionRange:
+@@ -1131,7 +1420,7 @@ class VersionRange:
          >>> "1.0" in VersionRange.empty()
          False
          """
@@ -3055,7 +3081,7 @@ index 4fbf48e..a4a5912 100644
  
      @classmethod
      def full(
-@@ -1156,6 +1444,7 @@ class VersionRange:
+@@ -1156,6 +1445,7 @@ class VersionRange:
              FULL_RANGE,
              admit_arbitrary=admit_arbitrary,
              prereleases_configured=prereleases,
@@ -3063,7 +3089,7 @@ index 4fbf48e..a4a5912 100644
          )
  
      @classmethod
-@@ -1189,6 +1478,73 @@ class VersionRange:
+@@ -1189,6 +1479,73 @@ class VersionRange:
              prereleases_configured=prereleases,
          )
  
@@ -3137,7 +3163,27 @@ index 4fbf48e..a4a5912 100644
      def intersection(self, other: VersionRange) -> VersionRange:
          """Range containing exactly the versions in both self and other.
  
-@@ -1219,6 +1575,7 @@ class VersionRange:
+@@ -1200,7 +1557,11 @@ class VersionRange:
+         >>> a.intersection(b) == SpecifierSet(">=1.0,<2.0").to_range()
+         True
+         """
+-        self._check_policy_compat(other)
++        if (
++            type(other) is not VersionRange
++            or self._prereleases_configured != other._prereleases_configured
++        ):
++            self._check_policy_compat(other)
+ 
+         configured = self._prereleases_configured
+         new_bounds = tuple(intersect_ranges(self._bounds, other._bounds))
+@@ -1213,12 +1574,13 @@ class VersionRange:
+             self._admit_arbitrary and other._admit_arbitrary and bool(new_bounds)
+         )
+ 
+-        if not self._has_literals() and not other._has_literals():
++        if not (self._admit or self._reject or other._admit or other._reject):
+             return self._build(
+                 new_bounds,
                  admit_arbitrary=combined_arb,
                  pre_region=new_region,
                  prereleases_configured=configured,
@@ -3145,7 +3191,27 @@ index 4fbf48e..a4a5912 100644
              )
  
          return self._combine_literals(
-@@ -1266,6 +1623,7 @@ class VersionRange:
+@@ -1243,7 +1605,11 @@ class VersionRange:
+         >>> "1.5" in a.union(b)
+         False
+         """
+-        self._check_policy_compat(other)
++        if (
++            type(other) is not VersionRange
++            or self._prereleases_configured != other._prereleases_configured
++        ):
++            self._check_policy_compat(other)
+ 
+         configured = self._prereleases_configured
+         new_bounds = tuple(_union_ranges(self._bounds, other._bounds))
+@@ -1260,12 +1626,13 @@ class VersionRange:
+             # Nothing widened, so keeping the flags keeps ``r | r == r``.
+             combined_arb = self._admit_arbitrary or other._admit_arbitrary
+ 
+-        if not self._has_literals() and not other._has_literals():
++        if not (self._admit or self._reject or other._admit or other._reject):
+             return self._build(
+                 new_bounds,
                  admit_arbitrary=combined_arb,
                  pre_region=new_region,
                  prereleases_configured=configured,
@@ -3153,7 +3219,7 @@ index 4fbf48e..a4a5912 100644
              )
  
          return self._combine_literals(
-@@ -1309,6 +1667,7 @@ class VersionRange:
+@@ -1309,6 +1676,7 @@ class VersionRange:
              admit_arbitrary=self._admit_arbitrary,
              pre_region=(),
              prereleases_configured=self._prereleases_configured,
@@ -3161,7 +3227,27 @@ index 4fbf48e..a4a5912 100644
          )
  
      def difference(self, other: VersionRange) -> VersionRange:
-@@ -1365,6 +1724,7 @@ class VersionRange:
+@@ -1334,7 +1702,11 @@ class VersionRange:
+         >>> a.difference(VersionRange.empty()) == a
+         True
+         """
+-        self._check_policy_compat(other)
++        if (
++            type(other) is not VersionRange
++            or self._prereleases_configured != other._prereleases_configured
++        ):
++            self._check_policy_compat(other)
+ 
+         # Subtracting a nothing-admitting set is a no-op; return self unchanged.
+         if not other._bounds and not other._admit:
+@@ -1359,12 +1731,13 @@ class VersionRange:
+         # admission neither operand had.
+         combined_arb = self._admit_arbitrary and new_bounds == self._bounds
+ 
+-        if not self._has_literals() and not other._has_literals():
++        if not (self._admit or self._reject or other._admit or other._reject):
+             return self._build(
+                 new_bounds,
                  admit_arbitrary=combined_arb,
                  pre_region=new_region,
                  prereleases_configured=self._prereleases_configured,
@@ -3169,7 +3255,7 @@ index 4fbf48e..a4a5912 100644
              )
  
          return self._combine_literals(
-@@ -1386,7 +1746,11 @@ class VersionRange:
+@@ -1386,7 +1759,11 @@ class VersionRange:
          pre_region: tuple[Interval, ...],
          prereleases_configured: bool | None,
      ) -> VersionRange:
@@ -3182,7 +3268,7 @@ index 4fbf48e..a4a5912 100644
          admits: set[str] = set()
          rejects: set[str] = set()
  
-@@ -1414,6 +1778,7 @@ class VersionRange:
+@@ -1414,6 +1791,7 @@ class VersionRange:
              admit_arbitrary=admit_arbitrary,
              pre_region=pre_region,
              prereleases_configured=prereleases_configured,
@@ -3190,7 +3276,7 @@ index 4fbf48e..a4a5912 100644
          )
  
      def _matches_literal(self, literal: str) -> bool:
-@@ -1469,6 +1834,15 @@ class VersionRange:
+@@ -1469,8 +1847,21 @@ class VersionRange:
          False
          >>> VersionRange.empty().is_subset(outer)
          True
@@ -3204,9 +3290,16 @@ index 4fbf48e..a4a5912 100644
 +        >>> outer.is_subset(punctured)
 +        False
          """
-         self._check_policy_compat(other)
+-        self._check_policy_compat(other)
++        if (
++            type(other) is not VersionRange
++            or self._prereleases_configured != other._prereleases_configured
++        ):
++            self._check_policy_compat(other)
  
-@@ -1479,12 +1853,52 @@ class VersionRange:
+         # A live arbitrary admission has non-version strings as members, which
+         # no bounds cover; only another live admission contains them.
+@@ -1479,12 +1870,56 @@ class VersionRange:
  
          # Plain ranges: subset reduces to bounds containment, no algebra needed.
          if self._is_plain() and other._is_plain():
@@ -3242,7 +3335,11 @@ index 4fbf48e..a4a5912 100644
 +        if self is other:
 +            return _EMPTY_REL if self.is_empty else _SUBSET_REL
 +
-+        self._check_policy_compat(other)
++        if (
++            type(other) is not VersionRange
++            or self._prereleases_configured != other._prereleases_configured
++        ):
++            self._check_policy_compat(other)
 +
 +        if self._is_plain() and other._is_plain():
 +            # On plain ranges the bounds decide membership, so equal bounds
@@ -3260,7 +3357,20 @@ index 4fbf48e..a4a5912 100644
      def is_superset(self, other: VersionRange) -> bool:
          """Return whether every member of other is also a member of self.
  
-@@ -1515,12 +1929,19 @@ class VersionRange:
+@@ -1499,7 +1934,11 @@ class VersionRange:
+         True
+         """
+         # Type-guards a non-VersionRange other before delegating to is_subset.
+-        self._check_policy_compat(other)
++        if (
++            type(other) is not VersionRange
++            or self._prereleases_configured != other._prereleases_configured
++        ):
++            self._check_policy_compat(other)
+         return other.is_subset(self)
+ 
+     def is_disjoint(self, other: VersionRange) -> bool:
+@@ -1515,12 +1954,23 @@ class VersionRange:
          True
          >>> a.is_disjoint(SpecifierSet(">=1.5,<2.5").to_range())
          False
@@ -3272,7 +3382,12 @@ index 4fbf48e..a4a5912 100644
 +        ... )
 +        True
          """
-         self._check_policy_compat(other)
+-        self._check_policy_compat(other)
++        if (
++            type(other) is not VersionRange
++            or self._prereleases_configured != other._prereleases_configured
++        ):
++            self._check_policy_compat(other)
  
          # Plain ranges: disjointness is an empty bounds intersection.
          if self._is_plain() and other._is_plain():
@@ -3281,7 +3396,7 @@ index 4fbf48e..a4a5912 100644
          return self.intersection(other).is_empty
  
      def _same_releases(self, other: VersionRange) -> bool:
-@@ -1539,6 +1960,8 @@ class VersionRange:
+@@ -1539,6 +1989,8 @@ class VersionRange:
          iterable: Iterable[UnparsedVersionVar],
          prereleases: bool | None = None,
          key: None = ...,
@@ -3290,7 +3405,7 @@ index 4fbf48e..a4a5912 100644
      ) -> Iterator[UnparsedVersionVar]: ...
  
      @typing.overload
-@@ -1547,6 +1970,28 @@ class VersionRange:
+@@ -1547,6 +1999,28 @@ class VersionRange:
          iterable: Iterable[T],
          prereleases: bool | None = None,
          key: Callable[[T], UnparsedVersion] = ...,
@@ -3319,7 +3434,7 @@ index 4fbf48e..a4a5912 100644
      ) -> Iterator[T]: ...
  
      def filter(
-@@ -1554,6 +1999,8 @@ class VersionRange:
+@@ -1554,6 +2028,8 @@ class VersionRange:
          iterable: Iterable[Any],
          prereleases: bool | None = None,
          key: Callable[[Any], Version | str] | None = None,
@@ -3328,7 +3443,7 @@ index 4fbf48e..a4a5912 100644
      ) -> Iterator[Any]:
          """Yield items from iterable whose version falls inside the range.
  
-@@ -1564,13 +2011,56 @@ class VersionRange:
+@@ -1564,13 +2040,56 @@ class VersionRange:
          ``prereleases=True`` would yield it). A flushed buffer comes after
          every in-place yield, so the output is not version-sorted.
  
@@ -3386,7 +3501,7 @@ index 4fbf48e..a4a5912 100644
          region: tuple[Interval, ...] = ()
          if prereleases is None:
              # The region applies only under the autodetect default; a configured
-@@ -1578,19 +2068,97 @@ class VersionRange:
+@@ -1578,19 +2097,97 @@ class VersionRange:
              prereleases = self._prereleases_configured
              region = self._pre_region
  
@@ -3489,7 +3604,7 @@ index 4fbf48e..a4a5912 100644
      def _filter_with_admission(
          self,
          iterable: Iterable[Any],
-@@ -1678,6 +2246,123 @@ class VersionRange:
+@@ -1678,6 +2275,123 @@ class VersionRange:
          if not found_final:
              yield from all_nonfinal
  

--- a/tasks/vendoring/packaging.patch
+++ b/tasks/vendoring/packaging.patch
@@ -2638,7 +2638,7 @@ index 0000000..a5e2740
 +    def __repr__(self) -> str:
 +        return f"<{type(self).__name__} {_markersets.describe(self._tree)!r}>"
 diff --git a/nab-provider/src/nab_provider/_vendor/packaging/ranges.py b/nab-provider/src/nab_provider/_vendor/packaging/ranges.py
-index 4fbf48e..d52f359 100644
+index 4fbf48e..c92e4df 100644
 --- a/nab-provider/src/nab_provider/_vendor/packaging/ranges.py
 +++ b/nab-provider/src/nab_provider/_vendor/packaging/ranges.py
 @@ -24,6 +24,7 @@ import typing
@@ -2966,7 +2966,83 @@ index 4fbf48e..d52f359 100644
          )
  
      @classmethod
-@@ -1189,6 +1449,73 @@ class VersionRange:
+@@ -1010,6 +1270,7 @@ class VersionRange:
+         *,
+         pre_region: tuple[Interval, ...] = (),
+         prereleases_configured: bool | None = None,
++        canonical: bool = False,
+     ) -> VersionRange:
+         """Internal factory; bypasses :meth:`__new__`.
+ 
+@@ -1019,8 +1280,16 @@ class VersionRange:
+         pre-release policy is set here and never reassigned afterwards;
+         ``pre_region`` is canonicalized like the bounds and clipped to them,
+         or dropped when a configured policy makes it inert.
++
++        ``canonical=True`` says the bounds and the region are folded already,
++        so the fold is skipped. The set algebra can promise that:
++        ``intersect_ranges`` and ``_union_ranges`` reuse operand bounds
++        unchanged, and ``_complement_ranges`` flips inclusivity as it swaps a
++        bound's side, which lands either on the inclusivity the fold ignores or
++        on a version a canonical operand has already shown is no least successor.
+         """
+-        bounds = _canonicalize(bounds)
++        if not canonical:
++            bounds = _canonicalize(bounds)
+ 
+         if admit and reject:
+             admit = admit - reject
+@@ -1044,16 +1313,15 @@ class VersionRange:
+         instance._admit_arbitrary = admit_arbitrary
+         instance._prereleases_configured = prereleases_configured
+ 
+-        # A configured policy makes the region inert, so drop it. Otherwise fold
+-        # least-successor bounds (_from_specifier_set passes the region unfolded),
+-        # so ``>1.0a1`` and ``>=1.0a2.dev0`` carry the same region, then clip it
+-        # to the bounds so the opt-in never reaches past the range's own versions.
++        # A configured policy makes the region inert, so drop it.
+         if prereleases_configured is not None or not pre_region:
+             instance._pre_region = ()
+         else:
+-            instance._pre_region = tuple(
+-                intersect_ranges(_canonicalize(pre_region), bounds)
+-            )
++            # Folding (_from_specifier_set passes the region unfolded) makes
++            # ``>1.0a1`` and ``>=1.0a2.dev0`` carry the same region; clipping
++            # keeps the opt-in inside the range's own versions.
++            region = pre_region if canonical else _canonicalize(pre_region)
++            instance._pre_region = tuple(intersect_ranges(region, bounds))
+ 
+         return instance
+ 
+@@ -1105,8 +1373,7 @@ class VersionRange:
+         if not self._pre_region:
+             return other._pre_region
+ 
+-        # Both sides carry a region; merge them. _build re-canonicalizes and
+-        # clips, so the plain union is fine here.
++        # Both sides carry a region; a union of canonical regions is canonical.
+         return tuple(_union_ranges(self._pre_region, other._pre_region))
+ 
+     def _with_policy(
+@@ -1131,7 +1398,7 @@ class VersionRange:
+         >>> "1.0" in VersionRange.empty()
+         False
+         """
+-        return cls._build((), prereleases_configured=prereleases)
++        return cls._build((), prereleases_configured=prereleases, canonical=True)
+ 
+     @classmethod
+     def full(
+@@ -1156,6 +1423,7 @@ class VersionRange:
+             FULL_RANGE,
+             admit_arbitrary=admit_arbitrary,
+             prereleases_configured=prereleases,
++            canonical=True,
+         )
+ 
+     @classmethod
+@@ -1189,6 +1457,73 @@ class VersionRange:
              prereleases_configured=prereleases,
          )
  
@@ -3040,7 +3116,60 @@ index 4fbf48e..d52f359 100644
      def intersection(self, other: VersionRange) -> VersionRange:
          """Range containing exactly the versions in both self and other.
  
-@@ -1469,6 +1796,15 @@ class VersionRange:
+@@ -1219,6 +1554,7 @@ class VersionRange:
+                 admit_arbitrary=combined_arb,
+                 pre_region=new_region,
+                 prereleases_configured=configured,
++                canonical=True,
+             )
+ 
+         return self._combine_literals(
+@@ -1266,6 +1602,7 @@ class VersionRange:
+                 admit_arbitrary=combined_arb,
+                 pre_region=new_region,
+                 prereleases_configured=configured,
++                canonical=True,
+             )
+ 
+         return self._combine_literals(
+@@ -1309,6 +1646,7 @@ class VersionRange:
+             admit_arbitrary=self._admit_arbitrary,
+             pre_region=(),
+             prereleases_configured=self._prereleases_configured,
++            canonical=True,
+         )
+ 
+     def difference(self, other: VersionRange) -> VersionRange:
+@@ -1365,6 +1703,7 @@ class VersionRange:
+                 admit_arbitrary=combined_arb,
+                 pre_region=new_region,
+                 prereleases_configured=self._prereleases_configured,
++                canonical=True,
+             )
+ 
+         return self._combine_literals(
+@@ -1386,7 +1725,11 @@ class VersionRange:
+         pre_region: tuple[Interval, ...],
+         prereleases_configured: bool | None,
+     ) -> VersionRange:
+-        """Resolve admit/reject for ``self`` ``op`` ``other`` over their literals."""
++        """Resolve admit/reject for ``self`` ``op`` ``other`` over their literals.
++
++        Every caller is a set operation, so ``new_bounds`` and ``pre_region``
++        arrive folded.
++        """
+         admits: set[str] = set()
+         rejects: set[str] = set()
+ 
+@@ -1414,6 +1757,7 @@ class VersionRange:
+             admit_arbitrary=admit_arbitrary,
+             pre_region=pre_region,
+             prereleases_configured=prereleases_configured,
++            canonical=True,
+         )
+ 
+     def _matches_literal(self, literal: str) -> bool:
+@@ -1469,6 +1813,15 @@ class VersionRange:
          False
          >>> VersionRange.empty().is_subset(outer)
          True
@@ -3056,7 +3185,7 @@ index 4fbf48e..d52f359 100644
          """
          self._check_policy_compat(other)
  
-@@ -1479,12 +1815,52 @@ class VersionRange:
+@@ -1479,12 +1832,52 @@ class VersionRange:
  
          # Plain ranges: subset reduces to bounds containment, no algebra needed.
          if self._is_plain() and other._is_plain():
@@ -3110,7 +3239,7 @@ index 4fbf48e..d52f359 100644
      def is_superset(self, other: VersionRange) -> bool:
          """Return whether every member of other is also a member of self.
  
-@@ -1515,12 +1891,19 @@ class VersionRange:
+@@ -1515,12 +1908,19 @@ class VersionRange:
          True
          >>> a.is_disjoint(SpecifierSet(">=1.5,<2.5").to_range())
          False
@@ -3131,7 +3260,7 @@ index 4fbf48e..d52f359 100644
          return self.intersection(other).is_empty
  
      def _same_releases(self, other: VersionRange) -> bool:
-@@ -1539,6 +1922,8 @@ class VersionRange:
+@@ -1539,6 +1939,8 @@ class VersionRange:
          iterable: Iterable[UnparsedVersionVar],
          prereleases: bool | None = None,
          key: None = ...,
@@ -3140,7 +3269,7 @@ index 4fbf48e..d52f359 100644
      ) -> Iterator[UnparsedVersionVar]: ...
  
      @typing.overload
-@@ -1547,6 +1932,28 @@ class VersionRange:
+@@ -1547,6 +1949,28 @@ class VersionRange:
          iterable: Iterable[T],
          prereleases: bool | None = None,
          key: Callable[[T], UnparsedVersion] = ...,
@@ -3169,7 +3298,7 @@ index 4fbf48e..d52f359 100644
      ) -> Iterator[T]: ...
  
      def filter(
-@@ -1554,6 +1961,8 @@ class VersionRange:
+@@ -1554,6 +1978,8 @@ class VersionRange:
          iterable: Iterable[Any],
          prereleases: bool | None = None,
          key: Callable[[Any], Version | str] | None = None,
@@ -3178,7 +3307,7 @@ index 4fbf48e..d52f359 100644
      ) -> Iterator[Any]:
          """Yield items from iterable whose version falls inside the range.
  
-@@ -1564,13 +1973,56 @@ class VersionRange:
+@@ -1564,13 +1990,56 @@ class VersionRange:
          ``prereleases=True`` would yield it). A flushed buffer comes after
          every in-place yield, so the output is not version-sorted.
  
@@ -3236,7 +3365,7 @@ index 4fbf48e..d52f359 100644
          region: tuple[Interval, ...] = ()
          if prereleases is None:
              # The region applies only under the autodetect default; a configured
-@@ -1578,19 +2030,93 @@ class VersionRange:
+@@ -1578,19 +2047,93 @@ class VersionRange:
              prereleases = self._prereleases_configured
              region = self._pre_region
  
@@ -3335,7 +3464,7 @@ index 4fbf48e..d52f359 100644
      def _filter_with_admission(
          self,
          iterable: Iterable[Any],
-@@ -1678,6 +2204,123 @@ class VersionRange:
+@@ -1678,6 +2221,123 @@ class VersionRange:
          if not found_final:
              yield from all_nonfinal
  

--- a/tasks/vendoring/packaging.patch
+++ b/tasks/vendoring/packaging.patch
@@ -2638,7 +2638,7 @@ index 0000000..a5e2740
 +    def __repr__(self) -> str:
 +        return f"<{type(self).__name__} {_markersets.describe(self._tree)!r}>"
 diff --git a/nab-provider/src/nab_provider/_vendor/packaging/ranges.py b/nab-provider/src/nab_provider/_vendor/packaging/ranges.py
-index 4fbf48e..86a490c 100644
+index 4fbf48e..3f4ef78 100644
 --- a/nab-provider/src/nab_provider/_vendor/packaging/ranges.py
 +++ b/nab-provider/src/nab_provider/_vendor/packaging/ranges.py
 @@ -24,6 +24,7 @@ import typing
@@ -2804,9 +2804,9 @@ index 4fbf48e..86a490c 100644
 +    The predicate must be monotonic (false runs then true runs). Equivalent to
 +    ``bisect.bisect_left`` on the mapped booleans, done by hand because the
 +    ``key`` parameter for :mod:`bisect` only exists on Python 3.10 and later.
-+    ``project`` maps a probed item to the version it sorts by; ``None`` means
-+    the items sort by themselves, and a probe that is already a
-+    :class:`~packaging.version.Version` skips the call.
++    ``project`` maps a probed item to the version it sorts by; ``None`` maps it
++    with :func:`_project_plain`, skipping the call for a probe that is already a
++    :class:`~packaging.version.Version`.
 +    """
 +    low, high = 0, len(items)
 +    while low < high:
@@ -2855,9 +2855,9 @@ index 4fbf48e..86a490c 100644
 +def _project_plain(item: Any) -> Version:  # noqa: ANN401
 +    """The version a key-less entry of an ordered sequence sorts by.
 +
-+    An item that does not parse cannot sit in version order at all, which is a
-+    broken precondition rather than a non-match, so this raises rather than
-+    dropping the item the way :meth:`VersionRange.filter` drops it.
++    An item that does not parse cannot sit in version order at all, so this
++    raises on the broken precondition rather than dropping the item the way
++    :meth:`VersionRange.filter` drops a non-match.
 +    """
 +    parsed = item if isinstance(item, Version) else coerce_version(item)
 +    if parsed is None:
@@ -2874,8 +2874,8 @@ index 4fbf48e..86a490c 100644
 +    """Build the item-to-:class:`~packaging.version.Version` map for a sorted walk.
 +
 +    The bisections compare against bound predicates that only accept a
-+    :class:`~packaging.version.Version`, so a projected item is coerced.
-+    Without a ``key`` that map is :func:`_project_plain`.
++    :class:`~packaging.version.Version`, so the map coerces anything else.
++    Without a ``key`` it is :func:`_project_plain`.
 +    """
 +    if key is None:
 +        return _project_plain
@@ -3550,8 +3550,8 @@ index 4fbf48e..86a490c 100644
 +        """
 +        bounds = tuple(reversed(self._bounds)) if descending else self._bounds
 +
-+        # Without a key an entry is the version it sorts by, so the bisections
-+        # project only an entry that is not already one.
++        # Passing no projection lets the bisections skip the call for an entry
++        # that is already a Version.
 +        bisect_project = None if key is None else project
 +
 +        if prereleases is True:

--- a/tasks/vendoring/packaging.patch
+++ b/tasks/vendoring/packaging.patch
@@ -2638,7 +2638,7 @@ index 0000000..a5e2740
 +    def __repr__(self) -> str:
 +        return f"<{type(self).__name__} {_markersets.describe(self._tree)!r}>"
 diff --git a/nab-provider/src/nab_provider/_vendor/packaging/ranges.py b/nab-provider/src/nab_provider/_vendor/packaging/ranges.py
-index 4fbf48e..c92e4df 100644
+index 4fbf48e..a4a5912 100644
 --- a/nab-provider/src/nab_provider/_vendor/packaging/ranges.py
 +++ b/nab-provider/src/nab_provider/_vendor/packaging/ranges.py
 @@ -24,6 +24,7 @@ import typing
@@ -2790,7 +2790,7 @@ index 4fbf48e..c92e4df 100644
  def _complement_ranges(ranges: Sequence[Interval]) -> list[Interval]:
      """Complement a sorted, non-overlapping interval list.
  
-@@ -292,6 +414,142 @@ def _struct_admits(
+@@ -292,6 +414,163 @@ def _struct_admits(
      return matches_bounds_only(bounds, parsed)
  
  
@@ -2805,13 +2805,18 @@ index 4fbf48e..c92e4df 100644
 +    ``bisect.bisect_left`` on the mapped booleans, done by hand because the
 +    ``key`` parameter for :mod:`bisect` only exists on Python 3.10 and later.
 +    ``project`` maps a probed item to the version it sorts by; ``None`` means
-+    the items are already :class:`~packaging.version.Version` instances.
++    the items sort by themselves, and a probe that is already a
++    :class:`~packaging.version.Version` skips the call.
 +    """
 +    low, high = 0, len(items)
 +    while low < high:
 +        mid = (low + high) // 2
 +        item = items[mid]
-+        if predicate(item if project is None else project(item)):
++        if project is None:
++            version = item if item.__class__ is Version else _project_plain(item)
++        else:
++            version = project(item)
++        if predicate(version):
 +            high = mid
 +        else:
 +            low = mid + 1
@@ -2847,20 +2852,36 @@ index 4fbf48e..c92e4df 100644
 +    return start, stop
 +
 +
++def _project_plain(item: Any) -> Version:  # noqa: ANN401
++    """The version a key-less entry of an ordered sequence sorts by.
++
++    An item that does not parse cannot sit in version order at all, which is a
++    broken precondition rather than a non-match, so this raises rather than
++    dropping the item the way :meth:`VersionRange.filter` drops it.
++    """
++    parsed = item if isinstance(item, Version) else coerce_version(item)
++    if parsed is None:
++        raise ValueError(
++            f"{item!r} does not parse as a version, so the given sequence "
++            f"is not in version order"
++        )
++    return parsed
++
++
 +def _make_project(
 +    key: Callable[[Any], Version | str] | None,
 +) -> Callable[[Any], Version]:
 +    """Build the item-to-:class:`~packaging.version.Version` map for a sorted walk.
 +
 +    The bisections compare against bound predicates that only accept a
-+    :class:`~packaging.version.Version`, so every probed item is coerced. An
-+    item that does not parse cannot sit in version order at all, which is a
-+    broken precondition rather than a non-match, so this raises rather than
-+    dropping the item the way :meth:`VersionRange.filter` drops it.
++    :class:`~packaging.version.Version`, so a projected item is coerced.
++    Without a ``key`` that map is :func:`_project_plain`.
 +    """
++    if key is None:
++        return _project_plain
 +
 +    def project(item: Any) -> Version:  # noqa: ANN401
-+        raw: Version | str = item if key is None else key(item)
++        raw = key(item)
 +        parsed = raw if isinstance(raw, Version) else coerce_version(raw)
 +        if parsed is None:
 +            raise ValueError(
@@ -2933,7 +2954,7 @@ index 4fbf48e..c92e4df 100644
  # Repr helpers:
  
  
-@@ -904,7 +1162,8 @@ class VersionRange:
+@@ -904,7 +1183,8 @@ class VersionRange:
      :class:`~packaging.specifiers.SpecifierSet`.
  
      Construct via :meth:`~packaging.specifiers.SpecifierSet.to_range`, or with
@@ -2943,7 +2964,7 @@ index 4fbf48e..c92e4df 100644
      Compose with :meth:`intersection`, :meth:`union`, :meth:`complement`, and
      :meth:`difference` (or the ``&`` / ``|`` / ``~`` / ``-`` operators). Test
      membership with ``in`` or :meth:`contains`, filter an iterable with
-@@ -919,9 +1178,9 @@ class VersionRange:
+@@ -919,9 +1199,9 @@ class VersionRange:
      that opt-in scoped to those versions, so unrelated pre-releases are not
      admitted wholesale.
  
@@ -2956,7 +2977,7 @@ index 4fbf48e..c92e4df 100644
  
      >>> r = SpecifierSet(">=1.0,<2.0").to_range()
      >>> "1.5" in r
-@@ -997,7 +1256,8 @@ class VersionRange:
+@@ -997,7 +1277,8 @@ class VersionRange:
          raise TypeError(
              "cannot create 'VersionRange' instances directly; use "
              "SpecifierSet.to_range(), VersionRange.full(), "
@@ -2966,7 +2987,7 @@ index 4fbf48e..c92e4df 100644
          )
  
      @classmethod
-@@ -1010,6 +1270,7 @@ class VersionRange:
+@@ -1010,6 +1291,7 @@ class VersionRange:
          *,
          pre_region: tuple[Interval, ...] = (),
          prereleases_configured: bool | None = None,
@@ -2974,7 +2995,7 @@ index 4fbf48e..c92e4df 100644
      ) -> VersionRange:
          """Internal factory; bypasses :meth:`__new__`.
  
-@@ -1019,8 +1280,16 @@ class VersionRange:
+@@ -1019,8 +1301,16 @@ class VersionRange:
          pre-release policy is set here and never reassigned afterwards;
          ``pre_region`` is canonicalized like the bounds and clipped to them,
          or dropped when a configured policy makes it inert.
@@ -2992,7 +3013,7 @@ index 4fbf48e..c92e4df 100644
  
          if admit and reject:
              admit = admit - reject
-@@ -1044,16 +1313,15 @@ class VersionRange:
+@@ -1044,16 +1334,15 @@ class VersionRange:
          instance._admit_arbitrary = admit_arbitrary
          instance._prereleases_configured = prereleases_configured
  
@@ -3015,7 +3036,7 @@ index 4fbf48e..c92e4df 100644
  
          return instance
  
-@@ -1105,8 +1373,7 @@ class VersionRange:
+@@ -1105,8 +1394,7 @@ class VersionRange:
          if not self._pre_region:
              return other._pre_region
  
@@ -3025,7 +3046,7 @@ index 4fbf48e..c92e4df 100644
          return tuple(_union_ranges(self._pre_region, other._pre_region))
  
      def _with_policy(
-@@ -1131,7 +1398,7 @@ class VersionRange:
+@@ -1131,7 +1419,7 @@ class VersionRange:
          >>> "1.0" in VersionRange.empty()
          False
          """
@@ -3034,7 +3055,7 @@ index 4fbf48e..c92e4df 100644
  
      @classmethod
      def full(
-@@ -1156,6 +1423,7 @@ class VersionRange:
+@@ -1156,6 +1444,7 @@ class VersionRange:
              FULL_RANGE,
              admit_arbitrary=admit_arbitrary,
              prereleases_configured=prereleases,
@@ -3042,7 +3063,7 @@ index 4fbf48e..c92e4df 100644
          )
  
      @classmethod
-@@ -1189,6 +1457,73 @@ class VersionRange:
+@@ -1189,6 +1478,73 @@ class VersionRange:
              prereleases_configured=prereleases,
          )
  
@@ -3116,7 +3137,7 @@ index 4fbf48e..c92e4df 100644
      def intersection(self, other: VersionRange) -> VersionRange:
          """Range containing exactly the versions in both self and other.
  
-@@ -1219,6 +1554,7 @@ class VersionRange:
+@@ -1219,6 +1575,7 @@ class VersionRange:
                  admit_arbitrary=combined_arb,
                  pre_region=new_region,
                  prereleases_configured=configured,
@@ -3124,7 +3145,7 @@ index 4fbf48e..c92e4df 100644
              )
  
          return self._combine_literals(
-@@ -1266,6 +1602,7 @@ class VersionRange:
+@@ -1266,6 +1623,7 @@ class VersionRange:
                  admit_arbitrary=combined_arb,
                  pre_region=new_region,
                  prereleases_configured=configured,
@@ -3132,7 +3153,7 @@ index 4fbf48e..c92e4df 100644
              )
  
          return self._combine_literals(
-@@ -1309,6 +1646,7 @@ class VersionRange:
+@@ -1309,6 +1667,7 @@ class VersionRange:
              admit_arbitrary=self._admit_arbitrary,
              pre_region=(),
              prereleases_configured=self._prereleases_configured,
@@ -3140,7 +3161,7 @@ index 4fbf48e..c92e4df 100644
          )
  
      def difference(self, other: VersionRange) -> VersionRange:
-@@ -1365,6 +1703,7 @@ class VersionRange:
+@@ -1365,6 +1724,7 @@ class VersionRange:
                  admit_arbitrary=combined_arb,
                  pre_region=new_region,
                  prereleases_configured=self._prereleases_configured,
@@ -3148,7 +3169,7 @@ index 4fbf48e..c92e4df 100644
              )
  
          return self._combine_literals(
-@@ -1386,7 +1725,11 @@ class VersionRange:
+@@ -1386,7 +1746,11 @@ class VersionRange:
          pre_region: tuple[Interval, ...],
          prereleases_configured: bool | None,
      ) -> VersionRange:
@@ -3161,7 +3182,7 @@ index 4fbf48e..c92e4df 100644
          admits: set[str] = set()
          rejects: set[str] = set()
  
-@@ -1414,6 +1757,7 @@ class VersionRange:
+@@ -1414,6 +1778,7 @@ class VersionRange:
              admit_arbitrary=admit_arbitrary,
              pre_region=pre_region,
              prereleases_configured=prereleases_configured,
@@ -3169,7 +3190,7 @@ index 4fbf48e..c92e4df 100644
          )
  
      def _matches_literal(self, literal: str) -> bool:
-@@ -1469,6 +1813,15 @@ class VersionRange:
+@@ -1469,6 +1834,15 @@ class VersionRange:
          False
          >>> VersionRange.empty().is_subset(outer)
          True
@@ -3185,7 +3206,7 @@ index 4fbf48e..c92e4df 100644
          """
          self._check_policy_compat(other)
  
-@@ -1479,12 +1832,52 @@ class VersionRange:
+@@ -1479,12 +1853,52 @@ class VersionRange:
  
          # Plain ranges: subset reduces to bounds containment, no algebra needed.
          if self._is_plain() and other._is_plain():
@@ -3239,7 +3260,7 @@ index 4fbf48e..c92e4df 100644
      def is_superset(self, other: VersionRange) -> bool:
          """Return whether every member of other is also a member of self.
  
-@@ -1515,12 +1908,19 @@ class VersionRange:
+@@ -1515,12 +1929,19 @@ class VersionRange:
          True
          >>> a.is_disjoint(SpecifierSet(">=1.5,<2.5").to_range())
          False
@@ -3260,7 +3281,7 @@ index 4fbf48e..c92e4df 100644
          return self.intersection(other).is_empty
  
      def _same_releases(self, other: VersionRange) -> bool:
-@@ -1539,6 +1939,8 @@ class VersionRange:
+@@ -1539,6 +1960,8 @@ class VersionRange:
          iterable: Iterable[UnparsedVersionVar],
          prereleases: bool | None = None,
          key: None = ...,
@@ -3269,7 +3290,7 @@ index 4fbf48e..c92e4df 100644
      ) -> Iterator[UnparsedVersionVar]: ...
  
      @typing.overload
-@@ -1547,6 +1949,28 @@ class VersionRange:
+@@ -1547,6 +1970,28 @@ class VersionRange:
          iterable: Iterable[T],
          prereleases: bool | None = None,
          key: Callable[[T], UnparsedVersion] = ...,
@@ -3298,7 +3319,7 @@ index 4fbf48e..c92e4df 100644
      ) -> Iterator[T]: ...
  
      def filter(
-@@ -1554,6 +1978,8 @@ class VersionRange:
+@@ -1554,6 +1999,8 @@ class VersionRange:
          iterable: Iterable[Any],
          prereleases: bool | None = None,
          key: Callable[[Any], Version | str] | None = None,
@@ -3307,7 +3328,7 @@ index 4fbf48e..c92e4df 100644
      ) -> Iterator[Any]:
          """Yield items from iterable whose version falls inside the range.
  
-@@ -1564,13 +1990,56 @@ class VersionRange:
+@@ -1564,13 +2011,56 @@ class VersionRange:
          ``prereleases=True`` would yield it). A flushed buffer comes after
          every in-place yield, so the output is not version-sorted.
  
@@ -3365,7 +3386,7 @@ index 4fbf48e..c92e4df 100644
          region: tuple[Interval, ...] = ()
          if prereleases is None:
              # The region applies only under the autodetect default; a configured
-@@ -1578,19 +2047,93 @@ class VersionRange:
+@@ -1578,19 +2068,97 @@ class VersionRange:
              prereleases = self._prereleases_configured
              region = self._pre_region
  
@@ -3424,10 +3445,14 @@ index 4fbf48e..c92e4df 100644
 +        """
 +        bounds = tuple(reversed(self._bounds)) if descending else self._bounds
 +
++        # Without a key an entry is the version it sorts by, so the bisections
++        # project only an entry that is not already one.
++        bisect_project = None if key is None else project
++
 +        if prereleases is True:
 +            for lower, upper in bounds:
 +                start, stop = _partition_indexes(
-+                    versions, lower, upper, project, descending=descending
++                    versions, lower, upper, bisect_project, descending=descending
 +                )
 +                for index in range(start, stop):
 +                    yield versions[index]
@@ -3440,7 +3465,7 @@ index 4fbf48e..c92e4df 100644
 +
 +        for lower, upper in bounds:
 +            start, stop = _partition_indexes(
-+                versions, lower, upper, project, descending=descending
++                versions, lower, upper, bisect_project, descending=descending
 +            )
 +            for index in range(start, stop):
 +                item = versions[index]
@@ -3464,7 +3489,7 @@ index 4fbf48e..c92e4df 100644
      def _filter_with_admission(
          self,
          iterable: Iterable[Any],
-@@ -1678,6 +2221,123 @@ class VersionRange:
+@@ -1678,6 +2246,123 @@ class VersionRange:
          if not found_final:
              yield from all_nonfinal
  

--- a/tasks/vendoring/packaging.patch
+++ b/tasks/vendoring/packaging.patch
@@ -2638,7 +2638,7 @@ index 0000000..a5e2740
 +    def __repr__(self) -> str:
 +        return f"<{type(self).__name__} {_markersets.describe(self._tree)!r}>"
 diff --git a/nab-provider/src/nab_provider/_vendor/packaging/ranges.py b/nab-provider/src/nab_provider/_vendor/packaging/ranges.py
-index 4fbf48e..67b99ca 100644
+index 4fbf48e..86a490c 100644
 --- a/nab-provider/src/nab_provider/_vendor/packaging/ranges.py
 +++ b/nab-provider/src/nab_provider/_vendor/packaging/ranges.py
 @@ -24,6 +24,7 @@ import typing
@@ -3042,7 +3042,7 @@ index 4fbf48e..67b99ca 100644
      def _arbitrary_active(self) -> bool:
          """True when ``_admit_arbitrary`` actually admits non-version strings.
  
-@@ -1075,13 +1361,17 @@ class VersionRange:
+@@ -1075,7 +1361,8 @@ class VersionRange:
          bounds-only fast paths in :meth:`is_subset` and :meth:`is_disjoint`.
          """
          return (
@@ -3052,17 +3052,7 @@ index 4fbf48e..67b99ca 100644
              and not self._admit_arbitrary
              and self._prereleases_configured is not False
          )
- 
-     def _check_policy_compat(self, other: VersionRange) -> None:
--        """Refuse combining ranges with different pre-release policies."""
-+        """Refuse combining ranges with different pre-release policies.
-+
-+        Callers test compatibility inline and call this when that test fails.
-+        """
-         if not isinstance(other, VersionRange):
-             raise TypeError(f"expected VersionRange, got {type(other).__name__}")
-         if self._prereleases_configured != other._prereleases_configured:
-@@ -1105,8 +1395,7 @@ class VersionRange:
+@@ -1105,8 +1392,7 @@ class VersionRange:
          if not self._pre_region:
              return other._pre_region
  
@@ -3072,7 +3062,7 @@ index 4fbf48e..67b99ca 100644
          return tuple(_union_ranges(self._pre_region, other._pre_region))
  
      def _with_policy(
-@@ -1131,7 +1420,7 @@ class VersionRange:
+@@ -1131,7 +1417,7 @@ class VersionRange:
          >>> "1.0" in VersionRange.empty()
          False
          """
@@ -3081,7 +3071,7 @@ index 4fbf48e..67b99ca 100644
  
      @classmethod
      def full(
-@@ -1156,6 +1445,7 @@ class VersionRange:
+@@ -1156,6 +1442,7 @@ class VersionRange:
              FULL_RANGE,
              admit_arbitrary=admit_arbitrary,
              prereleases_configured=prereleases,
@@ -3089,7 +3079,7 @@ index 4fbf48e..67b99ca 100644
          )
  
      @classmethod
-@@ -1189,6 +1479,73 @@ class VersionRange:
+@@ -1189,6 +1476,73 @@ class VersionRange:
              prereleases_configured=prereleases,
          )
  
@@ -3163,7 +3153,7 @@ index 4fbf48e..67b99ca 100644
      def intersection(self, other: VersionRange) -> VersionRange:
          """Range containing exactly the versions in both self and other.
  
-@@ -1200,7 +1557,11 @@ class VersionRange:
+@@ -1200,7 +1554,11 @@ class VersionRange:
          >>> a.intersection(b) == SpecifierSet(">=1.0,<2.0").to_range()
          True
          """
@@ -3176,7 +3166,7 @@ index 4fbf48e..67b99ca 100644
  
          configured = self._prereleases_configured
          new_bounds = tuple(intersect_ranges(self._bounds, other._bounds))
-@@ -1213,12 +1574,13 @@ class VersionRange:
+@@ -1213,12 +1571,13 @@ class VersionRange:
              self._admit_arbitrary and other._admit_arbitrary and bool(new_bounds)
          )
  
@@ -3191,7 +3181,7 @@ index 4fbf48e..67b99ca 100644
              )
  
          return self._combine_literals(
-@@ -1243,7 +1605,11 @@ class VersionRange:
+@@ -1243,7 +1602,11 @@ class VersionRange:
          >>> "1.5" in a.union(b)
          False
          """
@@ -3204,7 +3194,7 @@ index 4fbf48e..67b99ca 100644
  
          configured = self._prereleases_configured
          new_bounds = tuple(_union_ranges(self._bounds, other._bounds))
-@@ -1260,12 +1626,13 @@ class VersionRange:
+@@ -1260,12 +1623,13 @@ class VersionRange:
              # Nothing widened, so keeping the flags keeps ``r | r == r``.
              combined_arb = self._admit_arbitrary or other._admit_arbitrary
  
@@ -3219,7 +3209,7 @@ index 4fbf48e..67b99ca 100644
              )
  
          return self._combine_literals(
-@@ -1309,6 +1676,7 @@ class VersionRange:
+@@ -1309,6 +1673,7 @@ class VersionRange:
              admit_arbitrary=self._admit_arbitrary,
              pre_region=(),
              prereleases_configured=self._prereleases_configured,
@@ -3227,7 +3217,7 @@ index 4fbf48e..67b99ca 100644
          )
  
      def difference(self, other: VersionRange) -> VersionRange:
-@@ -1334,7 +1702,11 @@ class VersionRange:
+@@ -1334,7 +1699,11 @@ class VersionRange:
          >>> a.difference(VersionRange.empty()) == a
          True
          """
@@ -3240,7 +3230,7 @@ index 4fbf48e..67b99ca 100644
  
          # Subtracting a nothing-admitting set is a no-op; return self unchanged.
          if not other._bounds and not other._admit:
-@@ -1359,12 +1731,13 @@ class VersionRange:
+@@ -1359,12 +1728,13 @@ class VersionRange:
          # admission neither operand had.
          combined_arb = self._admit_arbitrary and new_bounds == self._bounds
  
@@ -3255,7 +3245,7 @@ index 4fbf48e..67b99ca 100644
              )
  
          return self._combine_literals(
-@@ -1386,7 +1759,11 @@ class VersionRange:
+@@ -1386,7 +1756,11 @@ class VersionRange:
          pre_region: tuple[Interval, ...],
          prereleases_configured: bool | None,
      ) -> VersionRange:
@@ -3268,7 +3258,7 @@ index 4fbf48e..67b99ca 100644
          admits: set[str] = set()
          rejects: set[str] = set()
  
-@@ -1414,6 +1791,7 @@ class VersionRange:
+@@ -1414,6 +1788,7 @@ class VersionRange:
              admit_arbitrary=admit_arbitrary,
              pre_region=pre_region,
              prereleases_configured=prereleases_configured,
@@ -3276,7 +3266,7 @@ index 4fbf48e..67b99ca 100644
          )
  
      def _matches_literal(self, literal: str) -> bool:
-@@ -1469,8 +1847,21 @@ class VersionRange:
+@@ -1469,8 +1844,21 @@ class VersionRange:
          False
          >>> VersionRange.empty().is_subset(outer)
          True
@@ -3299,7 +3289,7 @@ index 4fbf48e..67b99ca 100644
  
          # A live arbitrary admission has non-version strings as members, which
          # no bounds cover; only another live admission contains them.
-@@ -1479,12 +1870,56 @@ class VersionRange:
+@@ -1479,12 +1867,56 @@ class VersionRange:
  
          # Plain ranges: subset reduces to bounds containment, no algebra needed.
          if self._is_plain() and other._is_plain():
@@ -3357,7 +3347,7 @@ index 4fbf48e..67b99ca 100644
      def is_superset(self, other: VersionRange) -> bool:
          """Return whether every member of other is also a member of self.
  
-@@ -1499,7 +1934,11 @@ class VersionRange:
+@@ -1499,7 +1931,11 @@ class VersionRange:
          True
          """
          # Type-guards a non-VersionRange other before delegating to is_subset.
@@ -3370,7 +3360,7 @@ index 4fbf48e..67b99ca 100644
          return other.is_subset(self)
  
      def is_disjoint(self, other: VersionRange) -> bool:
-@@ -1515,12 +1954,23 @@ class VersionRange:
+@@ -1515,12 +1951,23 @@ class VersionRange:
          True
          >>> a.is_disjoint(SpecifierSet(">=1.5,<2.5").to_range())
          False
@@ -3396,7 +3386,7 @@ index 4fbf48e..67b99ca 100644
          return self.intersection(other).is_empty
  
      def _same_releases(self, other: VersionRange) -> bool:
-@@ -1539,6 +1989,8 @@ class VersionRange:
+@@ -1539,6 +1986,8 @@ class VersionRange:
          iterable: Iterable[UnparsedVersionVar],
          prereleases: bool | None = None,
          key: None = ...,
@@ -3405,7 +3395,7 @@ index 4fbf48e..67b99ca 100644
      ) -> Iterator[UnparsedVersionVar]: ...
  
      @typing.overload
-@@ -1547,6 +1999,28 @@ class VersionRange:
+@@ -1547,6 +1996,28 @@ class VersionRange:
          iterable: Iterable[T],
          prereleases: bool | None = None,
          key: Callable[[T], UnparsedVersion] = ...,
@@ -3434,7 +3424,7 @@ index 4fbf48e..67b99ca 100644
      ) -> Iterator[T]: ...
  
      def filter(
-@@ -1554,6 +2028,8 @@ class VersionRange:
+@@ -1554,6 +2025,8 @@ class VersionRange:
          iterable: Iterable[Any],
          prereleases: bool | None = None,
          key: Callable[[Any], Version | str] | None = None,
@@ -3443,7 +3433,7 @@ index 4fbf48e..67b99ca 100644
      ) -> Iterator[Any]:
          """Yield items from iterable whose version falls inside the range.
  
-@@ -1564,13 +2040,56 @@ class VersionRange:
+@@ -1564,13 +2037,56 @@ class VersionRange:
          ``prereleases=True`` would yield it). A flushed buffer comes after
          every in-place yield, so the output is not version-sorted.
  
@@ -3501,7 +3491,7 @@ index 4fbf48e..67b99ca 100644
          region: tuple[Interval, ...] = ()
          if prereleases is None:
              # The region applies only under the autodetect default; a configured
-@@ -1578,19 +2097,97 @@ class VersionRange:
+@@ -1578,19 +2094,97 @@ class VersionRange:
              prereleases = self._prereleases_configured
              region = self._pre_region
  
@@ -3604,7 +3594,7 @@ index 4fbf48e..67b99ca 100644
      def _filter_with_admission(
          self,
          iterable: Iterable[Any],
-@@ -1678,6 +2275,123 @@ class VersionRange:
+@@ -1678,6 +2272,123 @@ class VersionRange:
          if not found_final:
              yield from all_nonfinal
  


### PR DESCRIPTION
Four instruction counts of a warm `pip:langchain-ml-course --resolution lowest` resolve, base and branch reaching the same 10,218 decisions every time, take 329,564,012 to 341,533,492 instructions off a base of about 22.9 billion: 1.4% to 1.5% of the run.

The call counts are exact; the timings are local.

| call | before | after |
| --- | ---: | ---: |
| `_check_policy_compat` | 61,096 | 0 |
| `_has_literals` | 122,192 | 0 |
| projection from `_bisect_predicate` | 106,275 | 0 |
| `_canonicalize` from `_build` | 75,230 | 18,719 |

All 61,096 guard calls returned without raising, and all 106,275 bisect probes were handed an item that was already a `Version`.

What changed:

- The three set operations and four relation queries test the operand's type and pre-release policy inline, so `_check_policy_compat` is called only to raise.
- `_has_literals` is gone; its callers test `_admit` and `_reject` directly.
- A key-less `filter` passes no projection, so `_bisect_predicate` coerces only a probe that is not already a `Version`. The `key=` path is unchanged.
- `_build` takes `canonical=True` from the set algebra, `full` and `empty`, whose bounds are folded already, and skips the fold.

On the clock the same scenario came out between about 0.6% and 4% faster (p=0.0015); a repeat run could not tell the two apart, and rules out a regression above about 2%. Peak memory sits inside about 0.2% either way.
