### PR TITLE
Fix README build-policy bullets omitting local-sources and archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,12 @@ but sometimes that is not possible and you have to build a package
 to extract the dependency metadata. There are three build policies:
 
  * never: Never builds a Python package
- * build-local (default): Builds only your local workspace packages
-   if they have dynamic versions or dependencies
- * build-remote: Builds packages sourced from indexes or VCS, it is
-   recommended that this only be turned on via per-package override
+ * build-local (default): Builds `[[tool.nab.local-sources]]` entries
+   and workspace members when their `pyproject.toml` cannot be read
+   statically
+ * build-remote: Also builds `[[tool.nab.vcs-sources]]` clones,
+   `[[tool.nab.archive-sources]]` trees, and sdists from an index. It
+   is recommended that this only be turned on via per-package override
 
 ## Indexes
 

--- a/nab-provider/src/nab_provider/policy.py
+++ b/nab-provider/src/nab_provider/policy.py
@@ -97,9 +97,10 @@ class BuildPolicy(enum.Enum):
     BUILD_LOCAL = "build-local"
     """Static metadata everywhere, plus PEP 517 builds on local checkouts (default).
 
-    Adds backend invocation for ``[[tool.nab.local-sources]]`` and workspace
-    members whose ``pyproject.toml`` cannot be read statically.  VCS clones,
-    archive sources, and remote PyPI sdists remain static-only.
+    Adds backend invocation for ``[[tool.nab.local-sources]]`` entries and
+    workspace members when their ``pyproject.toml`` cannot be read
+    statically.  VCS clones, archive sources, and remote PyPI sdists remain
+    static-only.
     """
 
     BUILD_REMOTE = "build-remote"

--- a/tests/test_readme_docs.py
+++ b/tests/test_readme_docs.py
@@ -1,4 +1,4 @@
-"""Check the README's VCS policy section against the admission code.
+"""Check the README's build and VCS policy sections against the code.
 
 The README is the ``nab`` distribution's PyPI description, so it states the
 default posture to readers who never open the documentation site.
@@ -12,22 +12,60 @@ from pathlib import Path
 import pytest
 import tomli
 
+from nab_project import _sources as sources
+from nab_project import build_backend
+from nab_project._testing.coordinator_fake import make_coordinator
 from nab_project.config_sources import OPTIONS
+from nab_provider._provider import build_remote, metadata_resolver
+from nab_provider._vendor.packaging.version import Version
+from nab_provider.errors import SourceBuildPolicyError, UnsupportedSdistError
+from nab_provider.metadata import WheelMetadata
+from nab_provider.policy import BuildPolicy
+from nab_provider.provider import Provider
+from nab_provider.records import SdistFile
 from nab_provider.vcs_admission import UnsupportedVcsError, VcsConfig, admit_vcs_url
 
 README = Path(__file__).resolve().parents[1] / "README.md"
 
 PINNED_URL = f"git+https://github.com/myorg/pkg.git@{'0' * 40}"
 
+# Every way of declaring a source, and the kind it reaches the build gate as.
+# Workspace discovery synthesises a LocalSource per member, so members and
+# local-sources entries arrive as the same kind.
+SOURCE_ROUTES = {
+    "[[tool.nab.local-sources]]": "local",
+    "workspace members": "local",
+    "[[tool.nab.vcs-sources]]": "vcs",
+    "[[tool.nab.archive-sources]]": "archive",
+}
 
-def _vcs_section() -> str:
-    """The README body under ``## VCS policy``, up to the next heading.
+INDEX_SDIST_PHRASE = "sdists from an index"
+
+DYNAMIC_PYPROJECT = '[project]\nname = "pkg"\ndynamic = ["dependencies"]\n'
+
+INDEX_SDIST = SdistFile(
+    filename="pkg-1.0.tar.gz",
+    url="https://example.com/pkg-1.0.tar.gz",
+    version="1.0",
+    requires_python=None,
+    upload_time=None,
+)
+
+DYNAMIC_SDIST_METADATA = WheelMetadata(
+    name="pkg", version=Version("1.0"), dynamic=frozenset({"Requires-Dist"})
+)
+
+BUILT = WheelMetadata(name="pkg", version=Version("1.0"))
+
+
+def _section(title: str) -> str:
+    """The README body under ``## <title>``, up to the next heading.
 
     A heading only counts outside a fenced block, so a ``#`` comment in a
     toml example does not cut the section short.
     """
-    body = README.read_text(encoding="utf-8").partition("\n## VCS policy\n")[2]
-    assert body, "README.md has no VCS policy section"
+    body = README.read_text(encoding="utf-8").partition(f"\n## {title}\n")[2]
+    assert body, f"README.md has no {title} section"
 
     lines: list[str] = []
     fenced = False
@@ -42,8 +80,8 @@ def _vcs_section() -> str:
 
 
 def _documented_default() -> VcsConfig:
-    """The section's toml block, parsed by the registry's own ``vcs`` parser."""
-    block = re.search(r"```toml\n(.*?)\n```", _vcs_section(), re.DOTALL)
+    """The VCS section's toml block, parsed by the registry's own parser."""
+    block = re.search(r"```toml\n(.*?)\n```", _section("VCS policy"), re.DOTALL)
     assert block, "the VCS policy section has no toml block"
 
     spec = next(option for option in OPTIONS if option.key == "vcs")
@@ -59,3 +97,134 @@ def test_documented_default_refuses_a_pinned_url() -> None:
     """A commit-pinned URL is refused under the block, as the section says."""
     with pytest.raises(UnsupportedVcsError, match=r'vcs\.policy is "block"'):
         admit_vcs_url(PINNED_URL, _documented_default())
+
+
+def _build_policy_bullets() -> dict[BuildPolicy, str]:
+    """The Build policy section's bullets, keyed by the level each opens."""
+    bullets = re.findall(
+        r"^ \* ([a-z-]+)[^:\n]*:(.*?)(?=^ \*|\Z)",
+        _section("Build policy"),
+        re.MULTILINE | re.DOTALL,
+    )
+    documented = {BuildPolicy(token): body for token, body in bullets}
+    assert set(documented) == set(BuildPolicy), "a build policy has no bullet"
+    return documented
+
+
+def _documented_routes() -> dict[BuildPolicy, frozenset[str]]:
+    """The ways of declaring a source that each level's bullet names.
+
+    A bullet says what its level adds to the stricter one above it, so a
+    route counts for the bullet that first names it. Index sdists are not
+    declared in config and have a test of their own.
+    """
+    return {
+        policy: frozenset(phrase for phrase in SOURCE_ROUTES if phrase in body)
+        for policy, body in _build_policy_bullets().items()
+    }
+
+
+def _admitted_kinds(policy: BuildPolicy, tree: Path) -> frozenset[str]:
+    """The source kinds ``policy`` lets through to a backend, over ``tree``."""
+    kinds: set[str] = set()
+    for kind in sorted(set(SOURCE_ROUTES.values())):
+        try:
+            metadata = sources.extract_source_metadata(
+                tree,
+                descriptor=f"{kind} source 'pkg'",
+                policy=policy,
+                kind=kind,
+                offline=True,
+                build_config=None,
+            )
+        except SourceBuildPolicyError:
+            continue
+        assert metadata is BUILT
+        kinds.add(kind)
+    return frozenset(kinds)
+
+
+@pytest.fixture
+def admitted_additions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> dict[BuildPolicy, frozenset[str]]:
+    """Per level, the source kinds it starts sending to a backend.
+
+    Runs the gate over a tree whose static read yields nothing, once per
+    kind and level, and reports each level's gain over the one below it.
+    The backend is stubbed, so what is recorded is the policy decision and
+    not whether a real build would work.
+    """
+    (tmp_path / "pyproject.toml").write_text(DYNAMIC_PYPROJECT, encoding="utf-8")
+    monkeypatch.setattr(
+        build_backend, "extract_metadata", lambda *args, **kwargs: BUILT
+    )
+
+    admitted = {policy: _admitted_kinds(policy, tmp_path) for policy in BuildPolicy}
+
+    below: frozenset[str] = frozenset()
+    additions: dict[BuildPolicy, frozenset[str]] = {}
+    for policy, kinds in admitted.items():
+        assert kinds >= below, "the levels are declared strictest first and nest"
+        additions[policy] = kinds - below
+        below = kinds
+    return additions
+
+
+def test_build_policy_bullets_name_the_declared_sources_each_level_adds(
+    admitted_additions: dict[BuildPolicy, frozenset[str]],
+) -> None:
+    """Each bullet names every way of declaring the sources its level adds.
+
+    Naming the kind is not enough: local-sources entries and workspace
+    members share the ``local`` kind, so a bullet naming one of them reads
+    as a rule about that one alone.
+    """
+    expected = {
+        policy: frozenset(
+            phrase for phrase, kind in SOURCE_ROUTES.items() if kind in kinds
+        )
+        for policy, kinds in admitted_additions.items()
+    }
+    assert _documented_routes() == expected
+
+
+@pytest.fixture
+def index_sdist_builders(monkeypatch: pytest.MonkeyPatch) -> frozenset[BuildPolicy]:
+    """The levels whose gate sends an index sdist to a backend.
+
+    Reconciles a dynamic-deps sdist with no static fallback, once per level
+    and each on a fresh index, since the reconciled metadata is cached there
+    and the next level would read it back. The build is stubbed, so what is
+    recorded is the policy decision and not whether a real build would work.
+    """
+    monkeypatch.setattr(
+        build_remote, "build_remote_sdist", lambda *args, **kwargs: BUILT
+    )
+
+    building: set[BuildPolicy] = set()
+    for policy in BuildPolicy:
+        provider = Provider(
+            make_coordinator([INDEX_SDIST], package="pkg"), build_policy=policy
+        )
+        try:
+            metadata = metadata_resolver.resolve_dynamic_sdist(
+                provider, ("pkg", Version("1.0")), DYNAMIC_SDIST_METADATA
+            )
+        except UnsupportedSdistError:
+            continue
+        assert metadata is BUILT
+        building.add(policy)
+    return frozenset(building)
+
+
+def test_only_the_level_that_builds_index_sdists_names_them(
+    index_sdist_builders: frozenset[BuildPolicy],
+) -> None:
+    """The bullet naming index sdists is the level whose gate builds one."""
+    naming = {
+        policy
+        for policy, body in _build_policy_bullets().items()
+        if INDEX_SDIST_PHRASE in body
+    }
+    assert naming == index_sdist_builders

--- a/tests/test_readme_docs.py
+++ b/tests/test_readme_docs.py
@@ -112,16 +112,22 @@ def _build_policy_bullets() -> dict[BuildPolicy, str]:
 
 
 def _documented_routes() -> dict[BuildPolicy, frozenset[str]]:
-    """The ways of declaring a source that each level's bullet names.
+    """The ways of declaring a source each level's bullet is the first to name.
 
-    A bullet says what its level adds to the stricter one above it, so a
-    route counts for the bullet that first names it. Index sdists are not
-    declared in config and have a test of their own.
+    A bullet may restate a stricter level's sources to say what its own level
+    adds to them, so a route counts only for the first bullet that names it,
+    levels taken strictest first. Index sdists are not declared in config and
+    have a test of their own.
     """
-    return {
-        policy: frozenset(phrase for phrase in SOURCE_ROUTES if phrase in body)
-        for policy, body in _build_policy_bullets().items()
-    }
+    bullets = _build_policy_bullets()
+
+    routes: dict[BuildPolicy, frozenset[str]] = {}
+    named_above: set[str] = set()
+    for policy in BuildPolicy:
+        named = {phrase for phrase in SOURCE_ROUTES if phrase in bullets[policy]}
+        routes[policy] = frozenset(named - named_above)
+        named_above |= named
+    return routes
 
 
 def _admitted_kinds(policy: BuildPolicy, tree: Path) -> frozenset[str]:

--- a/tests/test_readme_docs.py
+++ b/tests/test_readme_docs.py
@@ -16,11 +16,12 @@ from nab_project import _sources as sources
 from nab_project import build_backend
 from nab_project._testing.coordinator_fake import make_coordinator
 from nab_project.config_sources import OPTIONS
+from nab_project.workspace import read_workspace_members
 from nab_provider._provider import build_remote, metadata_resolver
 from nab_provider._vendor.packaging.version import Version
 from nab_provider.errors import SourceBuildPolicyError, UnsupportedSdistError
 from nab_provider.metadata import WheelMetadata
-from nab_provider.policy import BuildPolicy
+from nab_provider.policy import BuildPolicy, SourceRequest
 from nab_provider.provider import Provider
 from nab_provider.records import SdistFile
 from nab_provider.vcs_admission import UnsupportedVcsError, VcsConfig, admit_vcs_url
@@ -29,14 +30,22 @@ README = Path(__file__).resolve().parents[1] / "README.md"
 
 PINNED_URL = f"git+https://github.com/myorg/pkg.git@{'0' * 40}"
 
-# Every way of declaring a source, and the kind it reaches the build gate as.
-# Workspace discovery synthesises a LocalSource per member, so members and
-# local-sources entries arrive as the same kind.
+# The kind each config source table's entries reach the build gate as.
+TABLE_KINDS = {
+    "local-sources": "local",
+    "vcs-sources": "vcs",
+    "archive-sources": "archive",
+}
+
+WORKSPACE_MEMBERS = "workspace members"
+
+# Every way of declaring a source, spelled as the README spells it, and the
+# kind it reaches the build gate as.  Declared, not derived: the table names
+# are checked against the registry below and the member row against discovery,
+# but each table's own kind is a literal in ``nab_project._sources``.
 SOURCE_ROUTES = {
-    "[[tool.nab.local-sources]]": "local",
-    "workspace members": "local",
-    "[[tool.nab.vcs-sources]]": "vcs",
-    "[[tool.nab.archive-sources]]": "archive",
+    **{f"[[tool.nab.{key}]]": kind for key, kind in TABLE_KINDS.items()},
+    WORKSPACE_MEMBERS: "local",
 }
 
 INDEX_SDIST_PHRASE = "sdists from an index"
@@ -193,6 +202,65 @@ def test_build_policy_bullets_name_the_declared_sources_each_level_adds(
         for policy, kinds in admitted_additions.items()
     }
     assert _documented_routes() == expected
+
+
+def test_every_source_table_the_registry_defines_has_a_route() -> None:
+    """Every ``*-sources`` table the config registry defines has a row above.
+
+    The bullets have to answer for each one, so a new table fails here rather
+    than going unnamed in the README.
+    """
+    assert set(TABLE_KINDS) == {
+        option.key for option in OPTIONS if option.key.endswith("-sources")
+    }
+
+
+def test_a_workspace_member_takes_the_route_its_row_records(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A discovered member reaches the build gate as the kind its row names.
+
+    Every other row is spelled as the table its entries parse from; a member
+    is declared by path, so the route from discovery to the gate is run here.
+    """
+    root = tmp_path / "pyproject.toml"
+    root.write_text(
+        '[project]\nname = "root"\n[tool.nab.workspace]\nmembers = ["member"]\n',
+        encoding="utf-8",
+    )
+    member = tmp_path / "member"
+    member.mkdir()
+    (member / "pyproject.toml").write_text(DYNAMIC_PYPROJECT, encoding="utf-8")
+
+    monkeypatch.setattr(
+        build_backend, "extract_metadata", lambda *args, **kwargs: BUILT
+    )
+
+    (source,) = read_workspace_members(root)
+    port = make_coordinator()
+
+    admitting: set[BuildPolicy] = set()
+    for policy in BuildPolicy:
+        request = SourceRequest(
+            package="pkg",
+            source=source,
+            build_policy=policy,
+            vcs_cache_dir=None,
+            archive_cache_dir=None,
+            require_pin=False,
+        )
+        try:
+            materialized = sources.materialize_source(port, request, None)
+        except SourceBuildPolicyError:
+            continue
+        assert materialized.metadata is BUILT
+        admitting.add(policy)
+
+    assert admitting == {
+        policy
+        for policy in BuildPolicy
+        if SOURCE_ROUTES[WORKSPACE_MEMBERS] in _admitted_kinds(policy, member)
+    }
 
 
 @pytest.fixture


### PR DESCRIPTION
The README's `build-local` bullet says the default builds "only your local workspace packages", so a `[[tool.nab.local-sources]]` entry reads as something the default will not build. It does: workspace discovery synthesises a local source per member, so a declared local source and a workspace member reach the build gate as the same kind, and both build at `build-local`.

`build-remote` has the gap the other way round. It names index sdists and VCS clones but not `[[tool.nab.archive-sources]]`, which builds at that level too, so an archive source with dynamic metadata reads as unbuildable at every policy.

The two bullets as they stood:

     * build-local (default): Builds only your local workspace packages
       if they have dynamic versions or dependencies
     * build-remote: Builds packages sourced from indexes or VCS, it is
       recommended that this only be turned on via per-package override

Each bullet now names every way of declaring a source its level starts building. `build-local` also drops "dynamic versions or dependencies" for "cannot be read statically", the condition the gate applies: a missing or malformed `[project]` falls through to a backend the same way a `dynamic` list does.

`tests/test_readme_docs.py` runs the gate over each source kind at each level and checks the bullets against what got through.
