### PR TITLE
Fix RecursionError traceback from an over-nested JSON cache entry

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,4 @@
-"""Top-level conftest: hypothesis profiles and the ``cap_writes`` fixture.
+"""Top-level conftest: hypothesis profiles and the simulated-failure fixtures.
 
 Three hypothesis profiles, selectable via the ``HYPOTHESIS_PROFILE`` env var:
 
@@ -15,15 +15,16 @@ The property suite under ``nab-*/tests/property*/`` uses explicit
 ``PROPERTY_SETTINGS``/``DEEP_SETTINGS``/``BRUTE_FORCE_SETTINGS``
 decorators so its example budget is independent of the profile.
 
-``cap_writes``, ``deny_access`` and ``oversized_integer`` are here rather than
-in one suite's conftest because both the ``nab-project`` suite and the CLI
-suite use them.
+``cap_writes``, ``deny_access``, ``oversized_integer`` and
+``refuse_over_nested`` are here rather than in one suite's conftest because
+the ``nab-index``, ``nab-project`` and CLI suites all use them.
 """
 
 from __future__ import annotations
 
 import errno
 import io
+import json
 import os
 import sys
 from contextlib import contextmanager
@@ -114,6 +115,20 @@ def _cap_writes(budget: int) -> Iterator[None]:
 
 
 @contextmanager
+def _refuse_over_nested(payload: bytes) -> Iterator[None]:
+    real_loads = json.loads
+
+    def refusing_loads(raw: Any, *args: Any, **kwargs: Any) -> Any:
+        if raw == payload:
+            msg = "maximum recursion depth exceeded while decoding a JSON array"
+            raise RecursionError(msg)
+        return real_loads(raw, *args, **kwargs)
+
+    with patch.object(json, "loads", refusing_loads):
+        yield
+
+
+@contextmanager
 def _deny_access(target: Path) -> Iterator[None]:
     real_os_stat, real_path_stat, real_open = os.stat, Path.stat, Path.open
     denied = os.fspath(target)
@@ -140,6 +155,19 @@ def _deny_access(target: Path) -> Iterator[None]:
         patch.object(Path, "open", denying_open),
     ):
         yield
+
+
+@pytest.fixture
+def refuse_over_nested() -> Callable[[bytes], AbstractContextManager[None]]:
+    """Simulate a JSON body the decoder refuses as nested too deeply.
+
+    Inside ``refuse_over_nested(b)`` decoding ``b`` raises ``RecursionError``
+    and every other body decodes as usual. The depth that provokes one belongs
+    to the interpreter version and to the C stack left to the running thread
+    rather than to the document, so a literal deep enough to trigger it here
+    decodes cleanly on the next machine.
+    """
+    return _refuse_over_nested
 
 
 @pytest.fixture

--- a/nab-index/src/nab_index/_json_decode.py
+++ b/nab-index/src/nab_index/_json_decode.py
@@ -1,0 +1,25 @@
+"""One JSON decode for the cache and Simple-API read paths.
+
+``json.loads`` reports most bad input as a :class:`ValueError`, but a document
+nested past the decoder's recursion limit raises :class:`RecursionError`, which
+a handler written for the first kind does not catch.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+__all__ = ["decode_json"]
+
+
+def decode_json(raw: bytes) -> Any:
+    """Decode ``raw``, or raise :class:`ValueError` naming the fault."""
+    try:
+        return json.loads(raw)
+    except ValueError as exc:
+        msg = "not valid JSON"
+        raise ValueError(msg) from exc
+    except RecursionError as exc:
+        msg = "nested too deeply to decode"
+        raise ValueError(msg) from exc

--- a/nab-index/src/nab_index/cache.py
+++ b/nab-index/src/nab_index/cache.py
@@ -54,6 +54,7 @@ from typing import TYPE_CHECKING, Protocol
 
 from nab_provider.serialization import SimpleSerialization
 
+from ._json_decode import decode_json
 from .atomic import atomic_write
 from .parsed_listing import corruption_reason as _parsed_corruption
 
@@ -577,9 +578,9 @@ class OnDiskCache:
 
     def _read_json_reason(self, path: Path, raw: bytes) -> str | None:
         try:
-            doc = json.loads(raw)
-        except ValueError:
-            return "not valid JSON"
+            doc = decode_json(raw)
+        except ValueError as exc:
+            return str(exc)
         bucket = self._bucket_of(path)
         if bucket.startswith("sdist-") and not (
             isinstance(doc, dict) and "pkg_info" in doc and "pyproject" in doc
@@ -632,7 +633,7 @@ def _decode_json_sdist_record(raw: bytes) -> tuple[str | None, str | None] | Non
     into the current bucket.
     """
     try:
-        doc = json.loads(raw)
+        doc = decode_json(raw)
         pkg_info, pyproject = doc["pkg_info"], doc["pyproject"]
     except (ValueError, KeyError, TypeError):
         return None
@@ -790,7 +791,7 @@ def _decode_policy(policy_bytes: bytes) -> CachePolicy | None:
     :class:`ValueError`.
     """
     try:
-        doc = json.loads(policy_bytes)
+        doc = decode_json(policy_bytes)
         return CachePolicy(
             fetched_at=int(doc["fetched_at"]),
             max_age=int(doc["max_age"]),

--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -10,7 +10,6 @@ treated as immutable (cached forever; never revalidated).
 from __future__ import annotations
 
 import hashlib
-import json
 import logging
 import re
 import time
@@ -22,6 +21,7 @@ from typing import TYPE_CHECKING
 from nab_provider.records import select_artifact_hash
 from nab_provider.serialization import SimpleSerialization, simple_accept_header
 
+from ._json_decode import decode_json
 from .cache import CacheBackend, CachePolicy, OfflineError, is_sendable_etag
 from .client import (
     _HTTP_NOT_FOUND,
@@ -572,13 +572,14 @@ class CachedAsyncSimpleClient:
         raises there, the same as on the wire path.
         """
         try:
-            decoded: object = json.loads(body)
-        except ValueError:
+            decoded: object = decode_json(body)
+        except ValueError as exc:
             logger.warning(
-                "Corrupt cached Simple-API body for %r from %s: not valid JSON; "
+                "Corrupt cached Simple-API body for %r from %s: %s; "
                 "treating as a miss and re-fetching",
                 package,
                 self._index_url,
+                exc,
             )
             return None
         return decoded
@@ -588,18 +589,16 @@ class CachedAsyncSimpleClient:
     ) -> list[WheelFile | SdistFile]:
         """Parse a Simple-API listing body served from ``page_url``.
 
-        A body that is not valid JSON raises the same
+        A body that will not decode raises the same
         :class:`MalformedSimpleResponseError` as a valid-JSON body of the
-        wrong shape, not a raw decode error. ``json.loads`` raises a
-        :class:`ValueError` for every body it rejects, including non-UTF-8
-        bytes and an integer literal past CPython's conversion limit.
+        wrong shape, not a raw decode error.
         """
         try:
-            data = json.loads(body)
+            data = decode_json(body)
         except ValueError as exc:
             msg = (
                 f"{self._index_url} served a malformed Simple-API response for "
-                f"{package!r}: body is not valid JSON"
+                f"{package!r}: body is {exc}"
             )
             raise MalformedSimpleResponseError(msg) from exc
         return self._parse_body(data, package, page_url=page_url)

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import hashlib
 import io
-import json
 import re
 import sys
 import tarfile
@@ -38,6 +37,7 @@ from nab_provider.records import (
 )
 from nab_provider.serialization import SimpleSerialization, simple_accept_header
 
+from ._json_decode import decode_json
 from ._pep503 import json_listing
 from .transport import IDENTITY_HEADERS, raise_unless_ok
 
@@ -399,7 +399,7 @@ class AsyncSimpleClient:
     async def get_files(self, package: str) -> list[WheelFile | SdistFile]:
         """Fetch all distribution files for a package.
 
-        A body ``json.loads`` rejects becomes a
+        A body that will not decode becomes a
         :class:`MalformedSimpleResponseError`, not a raw decode error.
         """
         url = f"{self._index_url}{package}/"
@@ -413,11 +413,11 @@ class AsyncSimpleClient:
         )
 
         try:
-            data = json.loads(body)
+            data = decode_json(body)
         except ValueError as exc:
             msg = (
                 f"{self._index_url} served a malformed Simple-API response for "
-                f"{package!r}: body is not valid JSON"
+                f"{package!r}: body is {exc}"
             )
             raise MalformedSimpleResponseError(msg) from exc
         return _parse_files(data, self._index_url, package, page_url=response.url)

--- a/nab-index/src/nab_index/parsed_listing.py
+++ b/nab-index/src/nab_index/parsed_listing.py
@@ -43,6 +43,8 @@ from nab_provider.records import (
     rehydrated_wheel,
 )
 
+from ._json_decode import decode_json
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
@@ -146,7 +148,7 @@ def decode(blob: bytes, policy: CachePolicy) -> list[WheelFile | SdistFile] | No
     matches a fresh parse.
     """
     try:
-        loaded = json.loads(blob)
+        loaded = decode_json(blob)
     except ValueError:
         return None
     if not (isinstance(loaded, list) and len(loaded) == _TOP_LEN):
@@ -184,9 +186,9 @@ def corruption_reason(blob: bytes) -> str | None:
     for every miss reason alike.
     """
     try:
-        loaded = json.loads(blob)
-    except ValueError:
-        return "not valid JSON"
+        loaded = decode_json(blob)
+    except ValueError as exc:
+        return str(exc)
     if not (isinstance(loaded, list) and len(loaded) == _TOP_LEN):
         return "unexpected top-level shape"
     header, rows = loaded

--- a/nab-index/tests/test_index_parsed_cache.py
+++ b/nab-index/tests/test_index_parsed_cache.py
@@ -41,6 +41,9 @@ _SIMPLE_BUCKET = f"simple-{CACHE_VERSION_SIMPLE}"
 
 _FRESH = CachePolicy(fetched_at=0, max_age=600, etag=None)
 
+# Well-formed JSON nested far past the decoder's recursion guard.
+_OVER_NESTED = ("[" * 100_000 + "]" * 100_000).encode()
+
 _T = TypeVar("_T")
 
 # Constructor form and the trailing-slash form the client normalizes to and
@@ -702,6 +705,22 @@ class TestReadPathRebuild:
         assert result is not None
         _, policy = result
         assert decode(cache.get_simple_parsed("pkg"), policy) == files
+
+    def test_over_nested_blob_warns_and_reparses(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        cache = _cache(tmp_path)
+        files, _ = _warm_bound(cache)
+        cache.put_simple_parsed("pkg", _OVER_NESTED)
+        transport = _FakeTransport([])
+        client = CachedAsyncSimpleClient(transport, cache, _INDEX)
+
+        with caplog.at_level(logging.WARNING):
+            got = _run(client.get_files("pkg"))
+
+        assert got == files
+        assert "Corrupt parsed-listing" in caplog.text
+        assert "nested too deeply to decode" in caplog.text
 
     def test_truncated_blob_warns_and_reparses(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture

--- a/nab-index/tests/test_index_parsed_cache.py
+++ b/nab-index/tests/test_index_parsed_cache.py
@@ -15,7 +15,8 @@ import asyncio
 import hashlib
 import json
 import logging
-from collections.abc import Coroutine, Mapping
+from collections.abc import Callable, Coroutine, Mapping
+from contextlib import AbstractContextManager
 from pathlib import Path
 from typing import Any, TypeVar
 
@@ -41,8 +42,8 @@ _SIMPLE_BUCKET = f"simple-{CACHE_VERSION_SIMPLE}"
 
 _FRESH = CachePolicy(fetched_at=0, max_age=600, etag=None)
 
-# Well-formed JSON nested far past the decoder's recursion guard.
-_OVER_NESTED = ("[" * 100_000 + "]" * 100_000).encode()
+# Stands in for a body nested past the decoder's guard (``refuse_over_nested``).
+_OVER_NESTED = b"[[[]]]"
 
 _T = TypeVar("_T")
 
@@ -707,7 +708,10 @@ class TestReadPathRebuild:
         assert decode(cache.get_simple_parsed("pkg"), policy) == files
 
     def test_over_nested_blob_warns_and_reparses(
-        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+        refuse_over_nested: Callable[[bytes], AbstractContextManager[None]],
     ) -> None:
         cache = _cache(tmp_path)
         files, _ = _warm_bound(cache)
@@ -715,7 +719,7 @@ class TestReadPathRebuild:
         transport = _FakeTransport([])
         client = CachedAsyncSimpleClient(transport, cache, _INDEX)
 
-        with caplog.at_level(logging.WARNING):
+        with refuse_over_nested(_OVER_NESTED), caplog.at_level(logging.WARNING):
             got = _run(client.get_files("pkg"))
 
         assert got == files

--- a/nab-index/tests/test_parsed_listing_codec.py
+++ b/nab-index/tests/test_parsed_listing_codec.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 import dataclasses
 import json
 import sys
+from collections.abc import Callable
+from contextlib import AbstractContextManager
 
 import pytest
 
@@ -34,8 +36,8 @@ from nab_provider.records import defer_hashes, defer_sidecar_hash
 
 DIGEST = "a" * 64
 
-# Well-formed JSON nested far past the decoder's recursion guard.
-OVER_NESTED = ("[" * 100_000 + "]" * 100_000).encode()
+# Stands in for a body nested past the decoder's guard (``refuse_over_nested``).
+OVER_NESTED = b"[[[]]]"
 
 SHA256 = sys.intern("sha256")
 SHA512 = sys.intern("sha512")
@@ -333,16 +335,25 @@ def test_absent_optional_fields_decode_as_none() -> None:
     assert wheel.metadata_hash is None
 
 
-def test_over_nested_blob_is_miss() -> None:
+def test_over_nested_blob_is_miss(
+    refuse_over_nested: Callable[[bytes], AbstractContextManager[None]],
+) -> None:
     """A blob nested past the JSON decoder's guard is a miss, not a raise."""
-    assert decode(OVER_NESTED, _policy()) is None
+    with refuse_over_nested(OVER_NESTED):
+        assert decode(OVER_NESTED, _policy()) is None
+
+
+def test_over_nested_blob_names_its_depth(
+    refuse_over_nested: Callable[[bytes], AbstractContextManager[None]],
+) -> None:
+    with refuse_over_nested(OVER_NESTED):
+        assert corruption_reason(OVER_NESTED) == "nested too deeply to decode"
 
 
 @pytest.mark.parametrize(
     ("blob", "reason"),
     [
         (b"not json", "not valid JSON"),
-        pytest.param(OVER_NESTED, "nested too deeply to decode", id="over-nested"),
         (json.dumps(7).encode(), "unexpected top-level shape"),
         (json.dumps(["bad-header", []]).encode(), "unexpected header shape"),
     ],

--- a/nab-index/tests/test_parsed_listing_codec.py
+++ b/nab-index/tests/test_parsed_listing_codec.py
@@ -34,6 +34,9 @@ from nab_provider.records import defer_hashes, defer_sidecar_hash
 
 DIGEST = "a" * 64
 
+# Well-formed JSON nested far past the decoder's recursion guard.
+OVER_NESTED = ("[" * 100_000 + "]" * 100_000).encode()
+
 SHA256 = sys.intern("sha256")
 SHA512 = sys.intern("sha512")
 RP = sys.intern(">=3.8")
@@ -330,10 +333,16 @@ def test_absent_optional_fields_decode_as_none() -> None:
     assert wheel.metadata_hash is None
 
 
+def test_over_nested_blob_is_miss() -> None:
+    """A blob nested past the JSON decoder's guard is a miss, not a raise."""
+    assert decode(OVER_NESTED, _policy()) is None
+
+
 @pytest.mark.parametrize(
     ("blob", "reason"),
     [
         (b"not json", "not valid JSON"),
+        pytest.param(OVER_NESTED, "nested too deeply to decode", id="over-nested"),
         (json.dumps(7).encode(), "unexpected top-level shape"),
         (json.dumps(["bad-header", []]).encode(), "unexpected header shape"),
     ],

--- a/nab-index/tests/test_read_fresh_parsed_listing.py
+++ b/nab-index/tests/test_read_fresh_parsed_listing.py
@@ -52,6 +52,9 @@ _LISTING = {
 _LISTING_BYTES = json.dumps(_LISTING).encode()
 _PARSED = _parse_files(json.loads(_LISTING_BYTES), _INDEX_NORM, "pkg")
 
+# Well-formed JSON nested far past the decoder's recursion guard.
+_OVER_NESTED = ("[" * 100_000 + "]" * 100_000).encode()
+
 # A page of only formats nab does not read, so it parses to zero files.
 _ZIP_ONLY_BYTES = json.dumps(
     {
@@ -169,6 +172,7 @@ class TestReadFreshParsedListing:
             b"not json",
             b'{"fetched_at": Infinity, "max_age": 99999, "etag": null}',
             b'{"fetched_at": 2000000000, "max_age": 1e400, "etag": null}',
+            pytest.param(_OVER_NESTED, id="over-nested"),
         ],
     )
     def test_corrupt_policy_returns_none(self, tmp_path: Path, raw: bytes) -> None:
@@ -198,7 +202,15 @@ class TestReadFreshParsedListing:
         cache.put_simple_parsed("pkg", encode(files, "f" * 64))
         assert read_fresh_parsed_listing(cache, "pkg", offline=False) is None
 
-    @pytest.mark.parametrize("blob", [b"\xff\xfe not json", b"", b"\x00\x01\x02"])
+    @pytest.mark.parametrize(
+        "blob",
+        [
+            b"\xff\xfe not json",
+            b"",
+            b"\x00\x01\x02",
+            pytest.param(_OVER_NESTED, id="over-nested"),
+        ],
+    )
     def test_corrupt_blob_returns_none(self, tmp_path: Path, blob: bytes) -> None:
         cache = _cache(tmp_path)
         _warm_bound(cache)

--- a/nab-index/tests/test_read_fresh_parsed_listing.py
+++ b/nab-index/tests/test_read_fresh_parsed_listing.py
@@ -12,7 +12,8 @@ from __future__ import annotations
 
 import asyncio
 import json
-from collections.abc import Coroutine, Mapping
+from collections.abc import Callable, Coroutine, Mapping
+from contextlib import AbstractContextManager
 from pathlib import Path
 from typing import Any, TypeVar
 
@@ -52,8 +53,8 @@ _LISTING = {
 _LISTING_BYTES = json.dumps(_LISTING).encode()
 _PARSED = _parse_files(json.loads(_LISTING_BYTES), _INDEX_NORM, "pkg")
 
-# Well-formed JSON nested far past the decoder's recursion guard.
-_OVER_NESTED = ("[" * 100_000 + "]" * 100_000).encode()
+# Stands in for a body nested past the decoder's guard (``refuse_over_nested``).
+_OVER_NESTED = b"[[[]]]"
 
 # A page of only formats nab does not read, so it parses to zero files.
 _ZIP_ONLY_BYTES = json.dumps(
@@ -172,7 +173,6 @@ class TestReadFreshParsedListing:
             b"not json",
             b'{"fetched_at": Infinity, "max_age": 99999, "etag": null}',
             b'{"fetched_at": 2000000000, "max_age": 1e400, "etag": null}',
-            pytest.param(_OVER_NESTED, id="over-nested"),
         ],
     )
     def test_corrupt_policy_returns_none(self, tmp_path: Path, raw: bytes) -> None:
@@ -180,6 +180,17 @@ class TestReadFreshParsedListing:
         _warm_bound(cache)
         tmp_path.joinpath(*_POLICY_PATH_PARTS).write_bytes(raw)
         assert read_fresh_parsed_listing(cache, "pkg", offline=False) is None
+
+    def test_over_nested_policy_returns_none(
+        self,
+        tmp_path: Path,
+        refuse_over_nested: Callable[[bytes], AbstractContextManager[None]],
+    ) -> None:
+        cache = _cache(tmp_path)
+        _warm_bound(cache)
+        tmp_path.joinpath(*_POLICY_PATH_PARTS).write_bytes(_OVER_NESTED)
+        with refuse_over_nested(_OVER_NESTED):
+            assert read_fresh_parsed_listing(cache, "pkg", offline=False) is None
 
     def test_stale_online_returns_none(self, tmp_path: Path) -> None:
         cache = _cache(tmp_path)
@@ -202,20 +213,23 @@ class TestReadFreshParsedListing:
         cache.put_simple_parsed("pkg", encode(files, "f" * 64))
         assert read_fresh_parsed_listing(cache, "pkg", offline=False) is None
 
-    @pytest.mark.parametrize(
-        "blob",
-        [
-            b"\xff\xfe not json",
-            b"",
-            b"\x00\x01\x02",
-            pytest.param(_OVER_NESTED, id="over-nested"),
-        ],
-    )
+    @pytest.mark.parametrize("blob", [b"\xff\xfe not json", b"", b"\x00\x01\x02"])
     def test_corrupt_blob_returns_none(self, tmp_path: Path, blob: bytes) -> None:
         cache = _cache(tmp_path)
         _warm_bound(cache)
         cache.put_simple_parsed("pkg", blob)
         assert read_fresh_parsed_listing(cache, "pkg", offline=False) is None
+
+    def test_over_nested_blob_returns_none(
+        self,
+        tmp_path: Path,
+        refuse_over_nested: Callable[[bytes], AbstractContextManager[None]],
+    ) -> None:
+        cache = _cache(tmp_path)
+        _warm_bound(cache)
+        cache.put_simple_parsed("pkg", _OVER_NESTED)
+        with refuse_over_nested(_OVER_NESTED):
+            assert read_fresh_parsed_listing(cache, "pkg", offline=False) is None
 
     def test_empty_listing_returns_none(self, tmp_path: Path) -> None:
         # A page of formats nab does not read parses to zero files; the blob

--- a/nab-project/tests/test_async_transports.py
+++ b/nab-project/tests/test_async_transports.py
@@ -13,7 +13,7 @@ import sys
 import tarfile
 import threading
 from collections.abc import Callable, Iterator, Mapping, Sequence
-from contextlib import contextmanager
+from contextlib import AbstractContextManager, contextmanager
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
@@ -1783,17 +1783,22 @@ class TestAsyncSimpleClient:
             asyncio.run(go())
         assert isinstance(caught.value, HttpError)
 
-    def test_get_files_over_nested_raises_clean(self) -> None:
+    def test_get_files_over_nested_raises_clean(
+        self, refuse_over_nested: Callable[[bytes], AbstractContextManager[None]]
+    ) -> None:
         """A body past the JSON decoder's recursion guard must not escape raw."""
-        body = ("[" * 100_000 + "]" * 100_000).encode()
+        body = b"[[[]]]"
         transport = self._FakeTransport(body)
 
         async def go() -> list:
             async with AsyncSimpleClient(transport, "https://pypi.org/simple/") as c:
                 return await c.get_files("pkg")
 
-        with pytest.raises(
-            MalformedSimpleResponseError, match="nested too deeply to decode"
+        with (
+            refuse_over_nested(body),
+            pytest.raises(
+                MalformedSimpleResponseError, match="nested too deeply to decode"
+            ),
         ):
             asyncio.run(go())
 

--- a/nab-project/tests/test_async_transports.py
+++ b/nab-project/tests/test_async_transports.py
@@ -1783,6 +1783,20 @@ class TestAsyncSimpleClient:
             asyncio.run(go())
         assert isinstance(caught.value, HttpError)
 
+    def test_get_files_over_nested_raises_clean(self) -> None:
+        """A body past the JSON decoder's recursion guard must not escape raw."""
+        body = ("[" * 100_000 + "]" * 100_000).encode()
+        transport = self._FakeTransport(body)
+
+        async def go() -> list:
+            async with AsyncSimpleClient(transport, "https://pypi.org/simple/") as c:
+                return await c.get_files("pkg")
+
+        with pytest.raises(
+            MalformedSimpleResponseError, match="nested too deeply to decode"
+        ):
+            asyncio.run(go())
+
     def test_get_files_404_returns_empty(self) -> None:
         transport = self._FakeTransport(b"not found", status=404)
 

--- a/nab-project/tests/test_cache.py
+++ b/nab-project/tests/test_cache.py
@@ -10,6 +10,8 @@ import re
 import stat
 import subprocess
 import time
+from collections.abc import Callable
+from contextlib import AbstractContextManager
 from dataclasses import replace
 from pathlib import Path
 from unittest.mock import patch
@@ -46,8 +48,8 @@ METADATA_BUCKET = f"metadata-{CACHE_VERSION_METADATA}"
 SDIST_BUCKET = f"sdist-{CACHE_VERSION_SDIST}"
 PARSED_BUCKET = f"simple-parsed-{CACHE_VERSION_SIMPLE_PARSED}"
 
-# Well-formed JSON nested far past the decoder's recursion guard.
-OVER_NESTED = ("[" * 100_000 + "]" * 100_000).encode()
+# Stands in for a body nested past the decoder's guard (``refuse_over_nested``).
+OVER_NESTED = b"[[[]]]"
 
 # Two wheels of one version, each with its own PEP 658 sidecar.
 METADATA_URLS = (
@@ -733,27 +735,39 @@ class TestCorruptEntryLogging:
         assert str(path) in warnings[0].getMessage()
 
     def test_over_nested_policy_logs_one_warning(
-        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+        refuse_over_nested: Callable[[bytes], AbstractContextManager[None]],
     ) -> None:
         cache = self._make(tmp_path)
         body_path, policy_path = cache._simple_paths("foo")
         body_path.parent.mkdir(parents=True, exist_ok=True)
         body_path.write_bytes(b"{}")
         policy_path.write_bytes(OVER_NESTED)
-        with caplog.at_level(logging.WARNING, logger="nab_index.cache"):
+        with (
+            refuse_over_nested(OVER_NESTED),
+            caplog.at_level(logging.WARNING, logger="nab_index.cache"),
+        ):
             assert cache.get_simple("foo") is None
         warnings = _warnings(caplog)
         assert len(warnings) == 1
         assert str(policy_path) in warnings[0].getMessage()
 
-    def test_over_nested_sdist_record_logs_one_warning(
-        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    def test_over_nested_sdist_json_record_logs_one_warning(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+        refuse_over_nested: Callable[[bytes], AbstractContextManager[None]],
     ) -> None:
         cache = self._make(tmp_path)
-        path = cache._sdist_path("foo", "1.0")
+        path = cache._sdist_json_path("foo", "1.0")
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_bytes(OVER_NESTED)
-        with caplog.at_level(logging.WARNING, logger="nab_index.cache"):
+        with (
+            refuse_over_nested(OVER_NESTED),
+            caplog.at_level(logging.WARNING, logger="nab_index.cache"),
+        ):
             assert cache.get_sdist_files("foo", "1.0") is None
         warnings = _warnings(caplog)
         assert len(warnings) == 1
@@ -948,26 +962,41 @@ class TestReadCacheEntry:
         path.write_bytes(b"{not json")
         assert cache.read_cache_entry(path) == "not valid JSON"
 
-    def test_over_nested_simple_json(self, tmp_path: Path) -> None:
+    def test_over_nested_simple_json(
+        self,
+        tmp_path: Path,
+        refuse_over_nested: Callable[[bytes], AbstractContextManager[None]],
+    ) -> None:
         cache = self._cache(tmp_path)
         path = tmp_path / SIMPLE_BUCKET / "pypi" / "foo.json"
         path.parent.mkdir(parents=True)
         path.write_bytes(OVER_NESTED)
-        assert cache.read_cache_entry(path) == "nested too deeply to decode"
+        with refuse_over_nested(OVER_NESTED):
+            assert cache.read_cache_entry(path) == "nested too deeply to decode"
 
-    def test_over_nested_policy(self, tmp_path: Path) -> None:
+    def test_over_nested_policy(
+        self,
+        tmp_path: Path,
+        refuse_over_nested: Callable[[bytes], AbstractContextManager[None]],
+    ) -> None:
         cache = self._cache(tmp_path)
         path = tmp_path / SIMPLE_BUCKET / "pypi" / "foo.policy"
         path.parent.mkdir(parents=True)
         path.write_bytes(OVER_NESTED)
-        assert cache.read_cache_entry(path) == "policy not decodable"
+        with refuse_over_nested(OVER_NESTED):
+            assert cache.read_cache_entry(path) == "policy not decodable"
 
-    def test_over_nested_parsed_blob(self, tmp_path: Path) -> None:
+    def test_over_nested_parsed_blob(
+        self,
+        tmp_path: Path,
+        refuse_over_nested: Callable[[bytes], AbstractContextManager[None]],
+    ) -> None:
         cache = self._cache(tmp_path)
         path = tmp_path / PARSED_BUCKET / "pypi" / "foo.parsed"
         path.parent.mkdir(parents=True)
         path.write_bytes(OVER_NESTED)
-        assert cache.read_cache_entry(path) == "nested too deeply to decode"
+        with refuse_over_nested(OVER_NESTED):
+            assert cache.read_cache_entry(path) == "nested too deeply to decode"
 
     def test_valid_simple_json_is_clean(self, tmp_path: Path) -> None:
         cache = self._cache(tmp_path)

--- a/nab-project/tests/test_cache.py
+++ b/nab-project/tests/test_cache.py
@@ -23,6 +23,7 @@ from nab_index.cache import (
     CACHE_VERSION_SDIST,
     CACHE_VERSION_SIMPLE,
     CACHE_VERSION_SIMPLE_NEG,
+    CACHE_VERSION_SIMPLE_PARSED,
     SOURCE_BUCKETS,
     VCS_BUCKET,
     CachePolicy,
@@ -43,6 +44,10 @@ SIMPLE_BUCKET = f"simple-{CACHE_VERSION_SIMPLE}"
 NEG_BUCKET = f"simple-neg-{CACHE_VERSION_SIMPLE_NEG}"
 METADATA_BUCKET = f"metadata-{CACHE_VERSION_METADATA}"
 SDIST_BUCKET = f"sdist-{CACHE_VERSION_SDIST}"
+PARSED_BUCKET = f"simple-parsed-{CACHE_VERSION_SIMPLE_PARSED}"
+
+# Well-formed JSON nested far past the decoder's recursion guard.
+OVER_NESTED = ("[" * 100_000 + "]" * 100_000).encode()
 
 # Two wheels of one version, each with its own PEP 658 sidecar.
 METADATA_URLS = (
@@ -727,6 +732,33 @@ class TestCorruptEntryLogging:
         assert len(warnings) == 1
         assert str(path) in warnings[0].getMessage()
 
+    def test_over_nested_policy_logs_one_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        cache = self._make(tmp_path)
+        body_path, policy_path = cache._simple_paths("foo")
+        body_path.parent.mkdir(parents=True, exist_ok=True)
+        body_path.write_bytes(b"{}")
+        policy_path.write_bytes(OVER_NESTED)
+        with caplog.at_level(logging.WARNING, logger="nab_index.cache"):
+            assert cache.get_simple("foo") is None
+        warnings = _warnings(caplog)
+        assert len(warnings) == 1
+        assert str(policy_path) in warnings[0].getMessage()
+
+    def test_over_nested_sdist_record_logs_one_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        cache = self._make(tmp_path)
+        path = cache._sdist_path("foo", "1.0")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(OVER_NESTED)
+        with caplog.at_level(logging.WARNING, logger="nab_index.cache"):
+            assert cache.get_sdist_files("foo", "1.0") is None
+        warnings = _warnings(caplog)
+        assert len(warnings) == 1
+        assert str(path) in warnings[0].getMessage()
+
     def test_non_utf8_sdist_record_is_logged_miss(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
@@ -915,6 +947,27 @@ class TestReadCacheEntry:
         path.parent.mkdir(parents=True)
         path.write_bytes(b"{not json")
         assert cache.read_cache_entry(path) == "not valid JSON"
+
+    def test_over_nested_simple_json(self, tmp_path: Path) -> None:
+        cache = self._cache(tmp_path)
+        path = tmp_path / SIMPLE_BUCKET / "pypi" / "foo.json"
+        path.parent.mkdir(parents=True)
+        path.write_bytes(OVER_NESTED)
+        assert cache.read_cache_entry(path) == "nested too deeply to decode"
+
+    def test_over_nested_policy(self, tmp_path: Path) -> None:
+        cache = self._cache(tmp_path)
+        path = tmp_path / SIMPLE_BUCKET / "pypi" / "foo.policy"
+        path.parent.mkdir(parents=True)
+        path.write_bytes(OVER_NESTED)
+        assert cache.read_cache_entry(path) == "policy not decodable"
+
+    def test_over_nested_parsed_blob(self, tmp_path: Path) -> None:
+        cache = self._cache(tmp_path)
+        path = tmp_path / PARSED_BUCKET / "pypi" / "foo.parsed"
+        path.parent.mkdir(parents=True)
+        path.write_bytes(OVER_NESTED)
+        assert cache.read_cache_entry(path) == "nested too deeply to decode"
 
     def test_valid_simple_json_is_clean(self, tmp_path: Path) -> None:
         cache = self._cache(tmp_path)

--- a/nab-project/tests/test_cached_client.py
+++ b/nab-project/tests/test_cached_client.py
@@ -13,7 +13,8 @@ import sys
 import tarfile
 import time
 import zipfile
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
+from contextlib import AbstractContextManager
 from dataclasses import replace
 from email.utils import formatdate
 from pathlib import Path
@@ -87,8 +88,8 @@ ZIP_ONLY_BYTES = json.dumps(ZIP_ONLY_LISTING).encode()
 # A digit run just past CPython's int-from-string limit.
 OVERSIZED_DIGITS = "9" * (sys.get_int_max_str_digits() + 1)
 
-# Well-formed JSON nested far past the decoder's recursion guard.
-OVER_NESTED = ("[" * 100_000 + "]" * 100_000).encode()
+# Stands in for a body nested past the decoder's guard (``refuse_over_nested``).
+OVER_NESTED = b"[[[]]]"
 
 
 class _FakeResponse:
@@ -2223,13 +2224,18 @@ class TestNonJsonListingBody:
         assert cache.get_simple("foo") is None
 
     def test_cold_over_nested_body_raises_clean_and_skips_cache(
-        self, tmp_path: Path
+        self,
+        tmp_path: Path,
+        refuse_over_nested: Callable[[bytes], AbstractContextManager[None]],
     ) -> None:
         cache = _make_cache(tmp_path)
         transport = _FakeTransport([_FakeResponse(OVER_NESTED, status=200)])
 
-        with pytest.raises(
-            MalformedSimpleResponseError, match="nested too deeply to decode"
+        with (
+            refuse_over_nested(OVER_NESTED),
+            pytest.raises(
+                MalformedSimpleResponseError, match="nested too deeply to decode"
+            ),
         ):
             _run_get_files(transport, cache, "foo")
         assert cache.get_simple("foo") is None
@@ -4391,13 +4397,19 @@ class TestCorruptCachedListing:
         assert len(_cached_warnings(caplog)) == 1
 
     def test_over_nested_cached_body_self_heals_online(
-        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+        refuse_over_nested: Callable[[bytes], AbstractContextManager[None]],
     ) -> None:
         cache = _make_cache(tmp_path)
         cache.put_simple("pkg", OVER_NESTED, self._fresh())
         transport = _FakeTransport([_FakeResponse(LISTING_BYTES, status=200)])
 
-        with caplog.at_level(logging.WARNING, logger="nab_index.cached_client"):
+        with (
+            refuse_over_nested(OVER_NESTED),
+            caplog.at_level(logging.WARNING, logger="nab_index.cached_client"),
+        ):
             files = _run_get_files(transport, cache, "pkg")
 
         assert len(files) == 1

--- a/nab-project/tests/test_cached_client.py
+++ b/nab-project/tests/test_cached_client.py
@@ -87,6 +87,9 @@ ZIP_ONLY_BYTES = json.dumps(ZIP_ONLY_LISTING).encode()
 # A digit run just past CPython's int-from-string limit.
 OVERSIZED_DIGITS = "9" * (sys.get_int_max_str_digits() + 1)
 
+# Well-formed JSON nested far past the decoder's recursion guard.
+OVER_NESTED = ("[" * 100_000 + "]" * 100_000).encode()
+
 
 class _FakeResponse:
     def __init__(
@@ -2217,6 +2220,18 @@ class TestNonJsonListingBody:
 
         with pytest.raises(MalformedSimpleResponseError, match="malformed Simple-API"):
             asyncio.run(go())
+        assert cache.get_simple("foo") is None
+
+    def test_cold_over_nested_body_raises_clean_and_skips_cache(
+        self, tmp_path: Path
+    ) -> None:
+        cache = _make_cache(tmp_path)
+        transport = _FakeTransport([_FakeResponse(OVER_NESTED, status=200)])
+
+        with pytest.raises(
+            MalformedSimpleResponseError, match="nested too deeply to decode"
+        ):
+            _run_get_files(transport, cache, "foo")
         assert cache.get_simple("foo") is None
 
     def test_poisoned_cache_not_reproduced_offline(self, tmp_path: Path) -> None:
@@ -4374,6 +4389,25 @@ class TestCorruptCachedListing:
         assert healed is not None
         assert healed[0] == LISTING_BYTES
         assert len(_cached_warnings(caplog)) == 1
+
+    def test_over_nested_cached_body_self_heals_online(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        cache = _make_cache(tmp_path)
+        cache.put_simple("pkg", OVER_NESTED, self._fresh())
+        transport = _FakeTransport([_FakeResponse(LISTING_BYTES, status=200)])
+
+        with caplog.at_level(logging.WARNING, logger="nab_index.cached_client"):
+            files = _run_get_files(transport, cache, "pkg")
+
+        assert len(files) == 1
+        assert len(transport.calls) == 1
+        healed = cache.get_simple("pkg")
+        assert healed is not None
+        assert healed[0] == LISTING_BYTES
+
+        (warning,) = _cached_warnings(caplog)
+        assert "nested too deeply to decode" in warning.getMessage()
 
     def test_corrupt_cached_body_offline_raises(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture

--- a/nab-provider/src/nab_provider/errors.py
+++ b/nab-provider/src/nab_provider/errors.py
@@ -147,8 +147,8 @@ class UnserveableUrlError(HttpError):
 class MalformedSimpleResponseError(HttpError):
     """The index served a 200 response that is not a usable Simple-API body.
 
-    Covers a listing that is neither valid JSON nor decodable HTML, and a
-    PEP 658 metadata sidecar that is not valid UTF-8.
+    Covers a listing body that neither the JSON nor the HTML decoder will
+    take, and a PEP 658 metadata sidecar that is not valid UTF-8.
     """
 
 

--- a/tests/test_cache_cmd.py
+++ b/tests/test_cache_cmd.py
@@ -23,6 +23,9 @@ SDIST_BUCKET = f"sdist-{CACHE_VERSION_SDIST}"
 
 _FRESH = CachePolicy(fetched_at=0, max_age=600, etag=None)
 
+# Well-formed JSON nested far past the decoder's recursion guard.
+_OVER_NESTED = ("[" * 100_000 + "]" * 100_000).encode()
+
 
 # Relative to tmp_path, which the fixture below points discovery at.
 _USER_TOML = Path("usr") / "nab.toml"
@@ -296,6 +299,18 @@ class TestCacheVerify:
         err = capsys.readouterr().err
         assert str(parsed_path) in err
         assert "not valid JSON" in err
+
+    def test_reports_over_nested_parsed_entry(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        root = tmp_path / "cache"
+        _populate(root)
+        parsed_path = root / "simple-parsed-v0" / "pypi" / "foo.parsed"
+        parsed_path.write_bytes(_OVER_NESTED)
+        _run_cache(["verify", "--cache-dir", str(root)])
+        err = capsys.readouterr().err
+        assert str(parsed_path) in err
+        assert "nested too deeply to decode" in err
 
     def test_does_not_read_through_symlinked_bucket(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]

--- a/tests/test_cache_cmd.py
+++ b/tests/test_cache_cmd.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from contextlib import AbstractContextManager
 from pathlib import Path
 
 import pytest
@@ -23,8 +25,8 @@ SDIST_BUCKET = f"sdist-{CACHE_VERSION_SDIST}"
 
 _FRESH = CachePolicy(fetched_at=0, max_age=600, etag=None)
 
-# Well-formed JSON nested far past the decoder's recursion guard.
-_OVER_NESTED = ("[" * 100_000 + "]" * 100_000).encode()
+# Stands in for a body nested past the decoder's guard (``refuse_over_nested``).
+_OVER_NESTED = b"[[[]]]"
 
 
 # Relative to tmp_path, which the fixture below points discovery at.
@@ -301,13 +303,17 @@ class TestCacheVerify:
         assert "not valid JSON" in err
 
     def test_reports_over_nested_parsed_entry(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        refuse_over_nested: Callable[[bytes], AbstractContextManager[None]],
     ) -> None:
         root = tmp_path / "cache"
         _populate(root)
         parsed_path = root / "simple-parsed-v0" / "pypi" / "foo.parsed"
         parsed_path.write_bytes(_OVER_NESTED)
-        _run_cache(["verify", "--cache-dir", str(root)])
+        with refuse_over_nested(_OVER_NESTED):
+            _run_cache(["verify", "--cache-dir", str(root)])
         err = capsys.readouterr().err
         assert str(parsed_path) in err
         assert "nested too deeply to decode" in err


### PR DESCRIPTION
A cache entry holding JSON nested past the decoder's recursion guard crashes with a raw traceback instead of being reported as corrupt. `nab cache verify` dies on the entry it was asked to check, and a resolve reading that entry dies with it.

Poison one blob in a warm cache and re-run the lock that wrote it:

    $ nab lock --cache-dir ./cache
    Traceback (most recent call last):
    ...
    RecursionError: maximum recursion depth exceeded while decoding a JSON array from a unicode string

`json.loads` reports a bad body as a `ValueError`, but a document nested past the scanner's guard raises `RecursionError`, which is a `RuntimeError`. So it goes straight past the `except ValueError` behind all eight JSON decodes on nab_index's read paths:

- the parsed-listing blob, in `parsed_listing.decode` and `corruption_reason`
- the `.policy` and `.neg` sidecars, in `cache._decode_policy`
- the retired JSON sdist record in `cache._decode_json_sdist_record`, and every `.json` entry in `OnDiskCache._read_json_reason`
- the Simple-API listing body, in `CachedAsyncSimpleClient._decode_cached_listing` and `_parse_listing`, and off the wire in `AsyncSimpleClient.get_files`

`read_fresh_parsed_listing` documents that it never raises so a caller's pending is never stranded, and the warm read path relies on that.

All eight now decode through one helper that raises `ValueError` for either refusal, naming the fault: "not valid JSON" or "nested too deeply to decode". Every body the old handlers already caught keeps the message it had. The poisoned lock above heals itself:

    warning: Corrupt parsed-listing cache blob for 'six' from https://pypi.org/simple/: nested too deeply to decode; ignoring it
    Wrote pylock.toml (1 packages)

Supersedes #1007, which covers three of these eight decodes.
