### PR TITLE
Skip the hash-name re-intern on cached rows, ~0.8% off a warm resolve

### DIFF
--- a/nab-provider/src/nab_provider/records.py
+++ b/nab-provider/src/nab_provider/records.py
@@ -117,6 +117,21 @@ def _compact_table(table: dict[object, object]) -> object:
     return table
 
 
+def _compact_shared_table(table: dict[object, object]) -> object:
+    """Compact ``table`` for a caller whose rows already share one name object.
+
+    One cached listing's rows are decoded together and get a single object for
+    a repeated name, and :func:`parse_hash_table` interns whatever a reader
+    parses out of the pair, so :func:`_compact_table`'s per-row intern buys
+    nothing here.
+    """
+    if len(table) == 1:
+        ((algo, digest),) = table.items()
+        if type(algo) is str:
+            return (algo, digest)
+    return table
+
+
 def _expand_table(held: object) -> object:
     """Return ``held`` as the index served it, undoing :func:`_compact_table`."""
     if isinstance(held, tuple):
@@ -358,12 +373,12 @@ def rehydrated_wheel(  # noqa: PLR0913, PLR0917 - the record's fields, in its ow
     _set_wheel_local_path(wheel, None)
 
     if isinstance(hashes, dict):
-        _set_wheel_raw_hashes(wheel, _compact_table(hashes))
+        _set_wheel_raw_hashes(wheel, _compact_shared_table(hashes))
     else:
         _set_wheel_hashes(wheel, hashes)
 
     if isinstance(metadata_hash, dict):
-        _set_wheel_raw_metadata(wheel, _compact_table(metadata_hash))
+        _set_wheel_raw_metadata(wheel, _compact_shared_table(metadata_hash))
     else:
         _set_wheel_metadata_hash(wheel, metadata_hash)
 
@@ -445,7 +460,7 @@ def rehydrated_sdist(
     _set_sdist_local_path(sdist, None)
 
     if isinstance(hashes, dict):
-        _set_sdist_raw_hashes(sdist, _compact_table(hashes))
+        _set_sdist_raw_hashes(sdist, _compact_shared_table(hashes))
     else:
         _set_sdist_hashes(sdist, hashes)
 

--- a/nab-provider/tests/test_record_deferral.py
+++ b/nab-provider/tests/test_record_deferral.py
@@ -7,7 +7,13 @@ import threading
 import pytest
 
 from nab_provider import records
-from nab_provider.records import SdistFile, WheelFile, defer_hashes, defer_sidecar_hash
+from nab_provider.records import (
+    SdistFile,
+    WheelFile,
+    defer_hashes,
+    defer_sidecar_hash,
+    rehydrated_wheel,
+)
 
 DIGEST = "a" * 64
 SHA256 = "sha256"
@@ -27,6 +33,21 @@ def _deferred_wheel(hashes: object, *, sidecar: object) -> WheelFile:
     defer_hashes(wheel, hashes)
     defer_sidecar_hash(wheel, sidecar)
     return wheel
+
+
+def _rehydrated_wheel(table: dict[object, str]) -> WheelFile:
+    """A wheel rebuilt from a cached listing row that holds ``table`` for both fields."""
+    return rehydrated_wheel(
+        filename="pkg-1.0-py3-none-any.whl",
+        url="https://files.example/pkg-1.0-py3-none-any.whl",
+        version="1.0",
+        requires_python=None,
+        has_metadata=True,
+        upload_time=None,
+        hashes=table,
+        size=None,
+        metadata_hash=table,
+    )
 
 
 def _deferred_sdist(hashes: object) -> SdistFile:
@@ -70,6 +91,38 @@ def test_a_many_algorithm_table_is_held_as_it_stands() -> None:
     table = {"sha256": DIGEST, "sha512": "f" * 128}
 
     wheel = _deferred_wheel(table, sidecar=table)
+
+    assert wheel._raw_hashes == table
+    assert wheel._raw_metadata == table
+
+
+def test_a_rehydrated_one_algorithm_table_keeps_the_name_the_row_carried() -> None:
+    """One blob decodes to one name object, so re-interning it per row buys nothing."""
+    algo = b"sha256".decode()
+    assert algo is not SHA256
+
+    wheel = _rehydrated_wheel({algo: DIGEST})
+    hashes, metadata = wheel._raw_hashes, wheel._raw_metadata
+    assert isinstance(hashes, tuple)
+    assert isinstance(metadata, tuple)
+
+    assert hashes == (algo, DIGEST)
+    assert hashes[0] is algo
+    assert metadata[0] is algo
+
+    # Reading the field parses and interns, so the pair a caller sees is unchanged.
+    assert wheel.hashes == ((SHA256, DIGEST),)
+    assert wheel.hashes[0][0] is SHA256
+
+
+@pytest.mark.parametrize(
+    "table", [{"sha256": DIGEST, "sha512": "f" * 128}, {7: DIGEST}]
+)
+def test_a_rehydrated_table_the_pair_form_cannot_hold_is_kept_whole(
+    table: dict[object, str],
+) -> None:
+    """Several algorithms, or a name that is not a string, is held as it stands."""
+    wheel = _rehydrated_wheel(table)
 
     assert wheel._raw_hashes == table
     assert wheel._raw_metadata == table


### PR DESCRIPTION
About 32 million instructions off a warm `pip:google-bigquery-soda --resolution lowest` resolve, 0.79% to 0.82% of roughly 3.99 billion over two callgrind pairs on the same 240-decision search.

Rebuilding a record from a cached listing row re-interned its hash-algorithm name, once per integrity table. A blob's rows are decoded together and already share one name object, and `parse_hash_table` interns whatever a reader parses out of the pair, so that intern buys nothing here. `rehydrated_wheel` and `rehydrated_sdist` now compact without it; the wire-parse path still goes through `_compact_table`.

| metric | main | branch |
| --- | ---: | ---: |
| `sys.intern` calls, that resolve | 106,713 | 31,413 |
| instructions, that resolve | 3,985,080,332 | 3,953,424,014 |
| instructions per compaction, over 75,300 calls | 2,046 | 1,616 |

The cost is retention: the held name becomes one object per cached listing rather than one per process, 100 instead of 1 across the benchmark cache's 100 listings, about 4.7 KB.

A resolve with no parsed cache never reaches the new helper: 108,548 interns on both sides. Fourteen interleaved pairs rule out a wall regression above about 1.7% and leave peak RSS inside about 0.3% either way.