### PR TITLE
Fix docs calling requirements-without-hashes a hash-free name==version list

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ dependencies = [
 nab lock pyproject.toml
 ```
 
-Writes `pylock.toml` next to the project. For a sorted
-`name==version` list instead, use
+Writes `pylock.toml` next to the project. For a pip-style
+requirements list instead, use
 `nab lock --format requirements-without-hashes --output -`.
 
 # Security

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -35,10 +35,14 @@ Resolve and emit a lockfile or pin list. Three formats:
 
 * `--format pylock` (default) writes a [PEP 751] `pylock.toml`.
 * `--format requirements` writes a pip-compatible
-  `requirements.txt` with one `--hash=<algo>:<digest>` line per
-  recorded digest.
-* `--format requirements-without-hashes` writes a sorted
-  `name==version` list with no hashes.
+  `requirements.txt`, sorted by name. An index pin is
+  `name==version` with one `--hash=<algo>:<digest>` line per
+  recorded digest; a local, VCS or archive pin renders as a URL
+  line.
+* `--format requirements-without-hashes` writes the same output
+  with the `--hash` lines dropped, so an index pin is a bare
+  `name==version`. Local, VCS and archive pins are unchanged, so
+  an archive pin still carries its digest in the URL fragment.
 
 Dependency-group selection (PEP 735):
 

--- a/docs/reference/lockfile.md
+++ b/docs/reference/lockfile.md
@@ -9,10 +9,14 @@ install elsewhere.
 result:
 
 * `--format pylock` (default): a [PEP 751] `pylock.toml`.
-* `--format requirements`: a pip-compatible `requirements.txt`
-  with one `--hash=<algo>:<digest>` line per recorded digest.
-* `--format requirements-without-hashes`: a sorted
-  `name==version` list with no hashes.
+* `--format requirements`: a pip-compatible `requirements.txt`,
+  sorted by name. An index pin is `name==version` with one
+  `--hash=<algo>:<digest>` line per recorded digest; a local, VCS
+  or archive pin renders as a URL line.
+* `--format requirements-without-hashes`: the same output with
+  the `--hash` lines dropped, so an index pin is a bare
+  `name==version`. Local, VCS and archive pins are unchanged, so
+  an archive pin still carries its digest in the URL fragment.
 
 Pass `--output -` to write to stdout instead of a file.
 

--- a/nab-project/src/nab_project/_lockfile/builder.py
+++ b/nab-project/src/nab_project/_lockfile/builder.py
@@ -642,8 +642,8 @@ def require_artifact_hashes(lock_input: LockInput) -> None:
     """Raise :class:`MissingHashError` if a pinned artefact has no hash.
 
     PEP 751 and pip's hash-checking mode each need at least one of
-    sha256/sha384/sha512 per artefact.  The plain ``name==version``
-    writer records no hash and does not call this.
+    sha256/sha384/sha512 per artefact.  :func:`write_requirements_without_hashes`
+    emits no ``--hash`` lines and does not call this.
     """
     from ..lockfile import ACCEPTED_HASH_ALGORITHMS, IndexPin
 

--- a/nab-project/src/nab_project/_lockfile/requirements.py
+++ b/nab-project/src/nab_project/_lockfile/requirements.py
@@ -1,10 +1,10 @@
 """Pip-compatible ``requirements.txt`` rendering for a finished resolve.
 
 Produces text that pip's hash-checking mode can install (with
-``--hash=sha256:...`` lines) or a plain ``name==version`` list when
-hashes are not required.  Per-tuple resolves render as commented
-sections; pip cannot install a single requirements.txt across
-multiple ``(python, platform)`` tuples in hash-checking mode.
+``--hash=sha256:...`` lines on index pins) or the same text without
+those lines.  Per-tuple resolves render as commented sections; pip
+cannot install a single requirements.txt across multiple
+``(python, platform)`` tuples in hash-checking mode.
 """
 
 from __future__ import annotations
@@ -35,7 +35,7 @@ def write_requirements_with_hashes(
 ) -> str:
     """Render ``lock_input`` as a pip-compatible requirements.txt.
 
-    Each line is ``name==version`` followed by one ``--hash=<algo>:<digest>``
+    An index pin is ``name==version`` followed by one ``--hash=<algo>:<digest>``
     per recorded digest, in the format pip's hash-checking mode accepts.  The
     hash lines are sorted, so the output does not depend on artefact order.
     Local and VCS pins are emitted as ``name @ <url>`` lines without hashes
@@ -53,12 +53,12 @@ def write_requirements_with_hashes(
 def write_requirements_without_hashes(
     lock_input: LockInput, *, output_path: str | os.PathLike[str] | None = None
 ) -> str:
-    """Render ``lock_input`` as a plain ``name==version`` list.
+    """Render ``lock_input`` without the ``--hash=sha256:...`` lines.
 
-    Same shape as :func:`write_requirements_with_hashes` but without
-    the ``--hash=sha256:...`` lines.  Local, VCS, and archive pins render
-    the same in both variants.  Returns the text and, when ``output_path``
-    is provided, atomically writes it.
+    Same shape as :func:`write_requirements_with_hashes`, so an index pin
+    is a bare ``name==version``; local, VCS, and archive pins render the
+    same in both variants.  Returns the text and, when ``output_path`` is
+    provided, atomically writes it.
     """
     return _render_requirements(lock_input, with_hashes=False, output_path=output_path)
 

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -148,10 +148,11 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
 ) -> None:
     """Resolve dependencies and emit a lockfile or pin list.
 
-    Formats: ``pylock`` (PEP 751), ``requirements`` (pip-style with
-    ``--hash`` lines), ``requirements-without-hashes`` (plain
-    ``name==version``).  ``--output`` defaults to ``pylock.toml`` or
-    ``requirements.txt``; ``--output -`` writes to stdout.
+    Formats: ``pylock`` (PEP 751), ``requirements`` (pip-style, with
+    ``--hash`` lines on index pins), ``requirements-without-hashes``
+    (the same without those lines).  ``--output`` defaults to
+    ``pylock.toml`` or ``requirements.txt``; ``--output -`` writes to
+    stdout.
 
     ``--groups`` / ``--all-groups`` select PEP 735 dependency groups;
     ``--extras`` / ``--all-extras`` select entries from

--- a/tests/test_cli_docs.py
+++ b/tests/test_cli_docs.py
@@ -1,7 +1,9 @@
 """Check the published CLI pages against what the CLI does.
 
-The reference page lists each subcommand's flags, env vars and statuses; the
-conflicts page quotes refusal lines verbatim.
+The reference page lists each subcommand's flags, env vars and statuses, and
+the conflicts page quotes refusal lines verbatim. The reference and lockfile
+pages, ``nab lock --help`` and the README each summarise the lock formats, so
+those are checked against the emitters.
 
 These tests read ``docs/``, which the umbrella sdist does not ship, so the
 module is on that sdist's exclude list in pyproject.toml.
@@ -13,7 +15,7 @@ import inspect
 import io
 import logging
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 
@@ -24,10 +26,26 @@ from nab._lock import lock
 from nab.cli import app
 from nab.output import ColorChoice, Verbosity, parse_output_options
 from nab_project.config_sources import OPTIONS
+from nab_project.lockfile import (
+    ArchivePin,
+    IndexPin,
+    LocalPin,
+    LockInput,
+    PinShape,
+    TargetLock,
+    VcsPin,
+    WheelArtifact,
+    write_requirements_with_hashes,
+    write_requirements_without_hashes,
+)
+from nab_provider.tags import PlatformSpec
+from nab_provider.target import ResolveTarget
 
 _DOCS = Path(__file__).resolve().parents[1] / "docs"
 _CLI_REFERENCE = _DOCS / "reference" / "cli.md"
+_LOCKFILE_REFERENCE = _DOCS / "reference" / "lockfile.md"
 _CONFLICTS_DOC = _DOCS / "explanation" / "conflicts.md"
+_README = Path(__file__).resolve().parents[1] / "README.md"
 
 _SUBCOMMANDS = ("lock", "download", "config", "cache")
 
@@ -68,6 +86,11 @@ def _names_flag(text: str, flag: str) -> bool:
     if flag.startswith("--project-"):
         forms.append("--project-*")
     return any(re.search(rf"`{re.escape(form)}(?![\w-])", text) for form in forms)
+
+
+def _unwrapped(text: str) -> str:
+    """``text`` with its line wrapping removed, so a claim matches on one line."""
+    return " ".join(text.split())
 
 
 def _doc_paragraph(text: str, needle: str) -> str:
@@ -471,7 +494,7 @@ class TestConflictsDocForkingPolicies:
     def _unwrapped_claim(self, needle: str) -> str:
         """The page's paragraph holding ``needle``, unwrapped so a claim matches."""
         doc = _CONFLICTS_DOC.read_text(encoding="utf-8")
-        return " ".join(_doc_paragraph(doc, needle).split())
+        return _unwrapped(_doc_paragraph(doc, needle))
 
     def test_exactly_one_forks_co_selected_members(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -496,3 +519,163 @@ class TestConflictsDocForkingPolicies:
 
         claim = self._unwrapped_claim("The require-one policies")
         assert "`at-least-one` permits it" in claim
+
+
+_WITHOUT_HASHES = "requirements-without-hashes"
+_ARCHIVE_URL = "https://example.com/my-archive-1.0.tar.gz"
+_ARCHIVE_DIGEST = "c" * 64
+_COMMIT = "d" * 40
+_WHEEL_DIGEST = "a" * 64
+_TARGET = ResolveTarget.for_declared(
+    python_version="3.11", spec=PlatformSpec("linux_x86_64")
+)
+_NAME_EQUALS_VERSION = re.compile(r"[^\s@]+==\S+")
+
+
+def _pins_by_shape(directory: Path) -> dict[str, PinShape]:
+    """One pin per source shape, keyed by the name the docs give the shape."""
+    return {
+        "index": IndexPin(
+            name="fastapi",
+            version="0.109.1",
+            index="pypi",
+            wheels=(
+                WheelArtifact(
+                    filename="fastapi-0.109.1-py3-none-any.whl",
+                    url="https://example.com/fastapi-0.109.1-py3-none-any.whl",
+                    hashes=(("sha256", _WHEEL_DIGEST),),
+                ),
+            ),
+        ),
+        "archive": ArchivePin(
+            name="my-archive",
+            version="1.0",
+            url=_ARCHIVE_URL,
+            hashes=(("sha256", _ARCHIVE_DIGEST),),
+        ),
+        "local": LocalPin(name="my-fork", version="2.0", path=str(directory)),
+        "vcs": VcsPin(
+            name="some-pkg",
+            version="0.0.0+vcs",
+            repo_url=f"git+https://github.com/me/x.git@{_COMMIT}",
+            bare_repo_url="https://github.com/me/x.git",
+            commit_id=_COMMIT,
+        ),
+    }
+
+
+def _requirements_lines(pins: Iterable[PinShape], *, with_hashes: bool) -> list[str]:
+    """The requirements lines ``pins`` produce in one of the two formats."""
+    lock_input = LockInput(
+        targets={
+            _TARGET.label: TargetLock(
+                target=_TARGET, pins={pin.name: pin for pin in pins}
+            )
+        }
+    )
+    write = (
+        write_requirements_with_hashes
+        if with_hashes
+        else write_requirements_without_hashes
+    )
+    return write(lock_input).splitlines()
+
+
+def _format_bullets(section: str) -> str:
+    """The ``--format`` bullets of a reference section, joined into one string."""
+    return " ".join(
+        chunk for chunk in _prose_chunks(section) if chunk.startswith("* `--format")
+    )
+
+
+def _format_summaries() -> dict[str, str]:
+    """The user-facing ``nab lock --format`` summaries, keyed by where each lives.
+
+    Each reference page carries a bullet per format, ``nab lock``'s docstring is
+    its ``--help`` text, and the README is the distribution's PyPI description.
+    """
+    preamble = _LOCKFILE_REFERENCE.read_text(encoding="utf-8").partition("\n## ")[0]
+    readme = _README.read_text(encoding="utf-8")
+
+    summaries = {
+        "cli.md": _format_bullets(_reference_section("## `nab lock`")),
+        "lockfile.md": _format_bullets(preamble),
+        "nab lock --help": _unwrapped(
+            _doc_paragraph(inspect.getdoc(lock) or "", "Formats:")
+        ),
+        "README.md": _unwrapped(_doc_paragraph(readme, _WITHOUT_HASHES)),
+    }
+
+    for source, summary in summaries.items():
+        assert _WITHOUT_HASHES in summary, f"{source} no longer names the format"
+
+    return summaries
+
+
+class TestLockFormatSummaries:
+    """The ``nab lock --format`` summaries describe what the emitters print.
+
+    Only an index pin renders as ``name==version``; a local, VCS or archive
+    pin is a URL line, and an archive pin's URL carries its digest in both
+    formats.
+    """
+
+    def test_only_an_index_pin_renders_name_equals_version(
+        self, tmp_path: Path
+    ) -> None:
+        """One pin of each shape gives one pinned line and three URL lines."""
+        shapes = _pins_by_shape(tmp_path)
+        assert _requirements_lines(shapes.values(), with_hashes=False) == [
+            "fastapi==0.109.1",
+            f"my-archive @ {_ARCHIVE_URL}#sha256={_ARCHIVE_DIGEST}",
+            f"my-fork @ {tmp_path.resolve().as_uri()}",
+            f"some-pkg @ git+https://github.com/me/x.git@{_COMMIT}",
+        ]
+
+    def test_dropping_the_hash_lines_leaves_the_url_lines_alone(
+        self, tmp_path: Path
+    ) -> None:
+        """Only the index pin's line differs between the two formats."""
+        shapes = _pins_by_shape(tmp_path)
+        hashed = _requirements_lines(shapes.values(), with_hashes=True)
+        plain = _requirements_lines(shapes.values(), with_hashes=False)
+
+        assert hashed[:2] == [
+            "fastapi==0.109.1 \\",
+            f"    --hash=sha256:{_WHEEL_DIGEST}",
+        ]
+        assert hashed[2:] == plain[1:]
+
+    def test_no_summary_calls_a_format_hash_free(self, tmp_path: Path) -> None:
+        """An archive pin keeps its digest, so neither format drops every hash."""
+        plain = _requirements_lines(
+            _pins_by_shape(tmp_path).values(), with_hashes=False
+        )
+        assert any(f"sha256={_ARCHIVE_DIGEST}" in line for line in plain)
+
+        for source, summary in _format_summaries().items():
+            assert "no hashes" not in summary.lower(), source
+
+    def test_a_summary_naming_name_equals_version_says_which_pins(self) -> None:
+        """The phrase covers index pins only, so a summary using it says so."""
+        for source, summary in _format_summaries().items():
+            if "name==version" in summary.replace("`", ""):
+                assert "index pin" in summary.lower(), source
+
+    def test_reference_pages_name_every_shape_that_renders_as_a_url(
+        self, tmp_path: Path
+    ) -> None:
+        """Every shape whose line is a URL is named on both reference pages."""
+        url_shapes = {
+            shape
+            for shape, pin in _pins_by_shape(tmp_path).items()
+            if not _NAME_EQUALS_VERSION.fullmatch(
+                _requirements_lines([pin], with_hashes=False)[0]
+            )
+        }
+        assert url_shapes == {"archive", "local", "vcs"}
+
+        summaries = _format_summaries()
+        for source in ("cli.md", "lockfile.md"):
+            for shape in sorted(url_shapes):
+                assert shape in summaries[source].lower(), f"{source} omits {shape}"


### PR DESCRIPTION
`--format requirements-without-hashes` was documented as "a sorted `name==version` list with no hashes". Only an index pin renders that way, and the archive line still carries a digest:

```
my-archive @ https://example.com/my-archive-1.0.tar.gz#sha256=<digest>
my-fork @ file:///home/me/my-fork
some-pkg @ git+https://github.com/me/x.git@<commit>
```

`--format requirements` was documented as one `--hash=<algo>:<digest>` line per recorded digest. `_render_index_pin` is the only branch that emits them; local, VCS and archive pins render identically in both formats.

Corrected on `docs/reference/formats.md`, `docs/reference/lockfile.md`, `nab lock --help` and the README, plus the `_lockfile` docstrings that repeated it.

`TestLockFormatSummaries` renders one pin of each shape through both writers and checks all four summaries against the lines that come out: none may call a format hash-free, one using `name==version` has to say which pins, and a shape whose line is a URL has to be named on both reference pages.