### PR TITLE
Drop the Python __hash__ on the root sentinel, ~0.3% off a fanout resolve

### DIFF
--- a/nab-resolver/src/nab_resolver/root.py
+++ b/nab-resolver/src/nab_resolver/root.py
@@ -18,15 +18,14 @@ class _RootPackage:
     """Singleton sentinel for the virtual root package.
 
     Uses object identity so it can never collide with user package names.
+    The resolver's package-keyed dicts hash it on every lookup, so it
+    defines no ``__hash__`` of its own and hashes through ``object``
+    without a Python frame.
     """
 
     @override
     def __repr__(self) -> str:
         return "<root>"
-
-    @override
-    def __hash__(self) -> int:
-        return hash("__nab_root__")
 
 
 ROOT = _RootPackage()

--- a/nab-resolver/tests/test_root.py
+++ b/nab-resolver/tests/test_root.py
@@ -1,0 +1,24 @@
+"""Contract for ``ROOT``, the virtual root package sentinel.
+
+The resolver's package-keyed dicts hash it on every lookup, so a Python
+``__hash__`` on it would cost a frame each time.
+"""
+
+from __future__ import annotations
+
+from nab_resolver.root import ROOT
+
+
+class TestRootSentinel:
+    def test_the_sentinel_hashes_through_object(self) -> None:
+        assert type(ROOT).__hash__ is object.__hash__
+
+    def test_the_sentinel_compares_by_identity(self) -> None:
+        """A second instance of the class is a distinct key, not an alias."""
+        other = type(ROOT)()
+
+        assert other != ROOT
+        assert {ROOT: "root", other: "other"}[ROOT] == "root"
+
+    def test_the_sentinel_reprs_as_root(self) -> None:
+        assert repr(ROOT) == "<root>"


### PR DESCRIPTION
Deleting `_RootPackage.__hash__` takes 118,475 instructions off the `conflict-free-fanout` resolve, 0.32% of it, and 813,739 off `wrong-package-backtracking`, 0.12%, the two graphs in `nab-resolver/benchmarks/range_scenarios.py`.

| graph | before | after | change |
| --- | ---: | ---: | ---: |
| `conflict-free-fanout`, 120 packages | 37,470,366 | 37,351,891 | -118,475 |
| `wrong-package-backtracking`, 64 releases | 693,132,070 | 692,318,331 | -813,739 |

Retired instructions in the resolve, under callgrind with `PYTHONHASHSEED=0`. Both graphs reach the same solution in the same rounds either way.

The method returned `hash("__nab_root__")`, so every lookup keyed on the virtual root paid a Python frame: 800 instructions, measured on a membership test against a one-element set. Fanout hashes the sentinel 150 times a resolve, backtracking 1,051. `_RootPackage` defines no `__eq__`, so equality was already identity and `object.__hash__` agrees with it.

`hash(ROOT)` now derives from the object's address rather than a str hash, and `nab_resolver.root.ROOT` is in the supported API: a host keying a set on the sentinel loses reproducible iteration order, even with `PYTHONHASHSEED` pinned.

Not additive with #1008, which drops the `undecided.discard(ROOT)` behind 122 of fanout's 150 hashes.