### PR TITLE
Answer Range.relation in one interval walk, ~18% off a backtracking resolve

### DIFF
--- a/nab-resolver/benchmarks/README.md
+++ b/nab-resolver/benchmarks/README.md
@@ -1,6 +1,6 @@
 # Benchmarks
 
-`range_scenarios.py` resolves two graph shapes through `nab_resolver.Resolver` with every
+`range_scenarios.py` resolves three graph shapes through `nab_resolver.Resolver` with every
 constructor argument left at its default, so the range type under test is this package's
 `Range`. nab-project's benchmark suites all pass packaging's `VersionRange`, which leaves
 `Range` unmeasured everywhere else even though it is what a consumer that supplies no
@@ -20,7 +20,13 @@ differences and intersections that fragment a range.
 conflicts, no range ever gains a second interval, and nearly all the work is membership
 tests during prioritization.
 
-A change to `Range` can win on one of those and lose on the other, so compare both. Each
+`satisfied-ceiling-fanin` builds one root over 1000 packages that all cap the same hub, one
+of them below the rest. That one is decided first, so every other requirement already holds
+when the resolver reaches it: all 1005 `relation` calls answer SUBSET, against a hub range
+the yanked releases leave in six intervals. The other two scenarios answer SUBSET 201 and 3
+times, so this is the one to read for a change that treats subset and disjoint differently.
+
+A change to `Range` can win on one of those and lose on another, so compare all three. Each
 scenario prints its Range call counts, `hash_misses` for the calls that found the hash memo
 empty, `intervals_max` and `intervals_mean` over the intervals per range that membership was
 tested against, a digest of the solution it reached, and process CPU. Everything but the
@@ -32,10 +38,11 @@ two runs whose digests differ as two different questions rather than as a compar
 Three things those numbers do not say. The digest identifies the solution, not the workload,
 and `wrong-package-backtracking` always resolves to the same four pins, so on that scenario
 the search counters and the interval census are what separate two runs. The interval census
-is a function of that scenario's size rather than a sample of anything: `intervals_max` is
-always the size. And every membership test in either scenario comes from `GraphProvider`
-scanning its own release lists, so a provider that indexed or cached its candidates would
-show almost none. All of it compares `Range` implementations against each other on a fixed
+is a function of the scenario's shape rather than a sample of anything: on the two fanned
+scenarios `intervals_max` is fixed by construction, and on `wrong-package-backtracking` it
+is the size. And every membership test in any of them comes from `GraphProvider` scanning
+its own release lists, so a provider that indexed or cached its candidates would show
+almost none. All of it compares `Range` implementations against each other on a fixed
 workload; none of it sizes `Range`'s share of a real resolve.
 
 Versions here are `int`, so a comparison inside `Range` costs a C-level int compare, while a

--- a/nab-resolver/benchmarks/range_scenarios.py
+++ b/nab-resolver/benchmarks/range_scenarios.py
@@ -8,10 +8,12 @@ Usage:
 ``Range`` is what ``Resolver`` and ``PartialSolution`` fall back to when a
 consumer passes no ``range_type``, and nab-project always passes packaging's
 ``VersionRange``, so nothing in nab's other benchmark suites runs it. A change
-to Range's algebra can win on one graph shape and lose on another, so both
+to Range's algebra can win on one graph shape and lose on another, so three
 regimes run here: ``wrong-package-backtracking`` drives the set predicates and
-the differences that fragment a range, and ``conflict-free-fanout`` is almost
-all membership tests against single-interval ranges.
+the differences that fragment a range, ``conflict-free-fanout`` is almost all
+membership tests against single-interval ranges, and
+``satisfied-ceiling-fanin`` puts every ``relation`` question the resolver asks
+on a requirement that already holds, so all of them answer SUBSET.
 
 Every scenario reports its Range call counts, how many ``__hash__`` calls found
 the memo empty, the intervals per range that membership was tested against, and
@@ -51,6 +53,14 @@ Graph = dict[str, dict[int, dict[str, Range[int]]]]
 
 FANOUT_RELEASES = 50
 DEFAULT_REPEATS = 5
+
+# The release the fan-in's anchor caps its hub at, leaving every other
+# dependent's cap above it and so already satisfied.
+FANIN_SUPPORTED = 200
+
+# Hub releases every dependent excludes, which is what leaves the hub's range
+# in several intervals rather than one.
+FANIN_YANKED = (3, 8, 13, 18, 23)
 
 # The Range methods worth counting: the set predicates, the operators an
 # implementation might answer them with, and the equality and hash a dict keyed
@@ -104,6 +114,43 @@ def conflict_free_fanout_graph(packages: int) -> Graph:
     return graph
 
 
+def _hub_ceiling(cap: int) -> Range[int]:
+    """Return ``hub <= cap`` with the yanked releases cut out of it."""
+    ceiling = Range.at_most(cap)
+    for yanked in FANIN_YANKED:
+        ceiling -= Range.singleton(yanked)
+    return ceiling
+
+
+def satisfied_ceiling_fanin_graph(dependents: int) -> Graph:
+    """Build one root over ``dependents`` packages that all cap a single hub.
+
+    ``anchor`` is the only package with one release, so the provider's
+    prioritization decides it first and the hub's range is settled before any
+    other dependent is looked at. Every remaining requirement caps the hub
+    above that, at its own release, so every ``relation`` the resolver asks
+    answers SUBSET, against a range the yanked releases have cut into
+    ``len(FANIN_YANKED) + 1`` intervals.
+    """
+    releases = FANIN_SUPPORTED + dependents
+    graph: Graph = {
+        "root": {1: {}},
+        "hub": {version: {} for version in range(1, releases + 1)},
+        "anchor": {1: {"hub": _hub_ceiling(FANIN_SUPPORTED)}},
+    }
+
+    root = graph["root"][1]
+    root["anchor"] = Range.at_least(1)
+
+    for index in range(dependents):
+        name = f"d{index}"
+        ceiling = _hub_ceiling(FANIN_SUPPORTED + 1 + index)
+        graph[name] = {version: {"hub": ceiling} for version in range(1, 3)}
+        root[name] = Range.at_least(1)
+
+    return graph
+
+
 @dataclass(frozen=True)
 class Scenario:
     """One graph shape and the size the standard run builds it at."""
@@ -116,6 +163,7 @@ class Scenario:
 SCENARIOS = (
     Scenario("wrong-package-backtracking", 64, wrong_package_backtracking_graph),
     Scenario("conflict-free-fanout", 120, conflict_free_fanout_graph),
+    Scenario("satisfied-ceiling-fanin", 1000, satisfied_ceiling_fanin_graph),
 )
 
 

--- a/nab-resolver/src/nab_resolver/ranges.py
+++ b/nab-resolver/src/nab_resolver/ranges.py
@@ -541,14 +541,56 @@ class Range(Generic[VersionType]):
     def relation(self, other: Range[VersionType]) -> RangeRelation:
         """Return how self's members sit against other's.
 
-        The empty range is both a subset and disjoint, so it is answered ahead
-        of the walks instead of by running both of them.
+        The empty range is both a subset and disjoint, so it is answered
+        before the walk rather than by it.
+
+        One walk answers subset and disjoint together, on the same invariant
+        :meth:`is_subset` relies on.  Each interval of self is decided by the
+        first interval of other that does not end below it: everything the
+        walk skipped ended below, and the invariant leaves a gap after the one
+        it stopped on, so nothing else can cover what that one leaves out.
         """
         if self.is_empty:
             return _EMPTY_REL
-        if self.is_subset(other):
+
+        right_intervals = other._intervals
+        right_count = len(right_intervals)
+        right_index = 0
+
+        # subset is cleared by an interval of self that other leaves
+        # uncovered, disjoint by one that meets other.
+        subset = True
+        disjoint = True
+
+        for left in self._intervals:
+            while right_index < right_count and _ends_before(
+                right_intervals[right_index], left
+            ):
+                right_index += 1
+
+            if right_index >= right_count:
+                # Every remaining interval of self sits above all of other, so
+                # none is covered and none meets anything.
+                subset = False
+                break
+
+            right = right_intervals[right_index]
+            if _ends_before(left, right):
+                # This interval meets nothing: the walk skipped everything below
+                # it, and right starts above it.  Leave right for the next one.
+                subset = False
+                continue
+
+            disjoint = False
+            lower, lower_inclusive = _max_lower_bound(left, right)
+            upper, upper_inclusive = _min_upper_bound(left, right)
+
+            if (lower, lower_inclusive, upper, upper_inclusive) != left:
+                return _OVERLAPPING_REL
+
+        if subset:
             return _SUBSET_REL
-        if self.is_disjoint(other):
+        if disjoint:
             return _DISJOINT_REL
         return _OVERLAPPING_REL
 

--- a/nab-resolver/tests/property/test_ranges_relation.py
+++ b/nab-resolver/tests/property/test_ranges_relation.py
@@ -1,0 +1,127 @@
+"""Differential property test for ``Range.relation``.
+
+``relation`` answers "subset" and "disjoint" in one pass over the two interval
+lists.  One oracle composes ``is_subset`` and ``is_disjoint`` instead, so a walk
+that disagrees with either predicate fails here.  A second oracle reads
+``__contains__`` alone, and catches a fault ``relation`` shares with
+``is_subset``.
+
+Every generated interval list satisfies the invariant ``Range.__init__``
+documents, which is what the walks assume.
+"""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from nab_resolver.ranges import (
+    NEGATIVE_INFINITY,
+    POSITIVE_INFINITY,
+    Interval,
+    Range,
+)
+from nab_resolver.types import RangeRelation
+
+from .strategies import PROPERTY_SETTINGS
+
+pytestmark = pytest.mark.property
+
+MAX_INTERVALS = 3
+BLOCK_WIDTH = 4
+"""Distance between the blocks successive intervals are cut from."""
+
+BLOCK_SPAN = 2
+"""How far above its block an interval's bounds may reach.  Below
+``BLOCK_WIDTH``, so consecutive intervals always leave a gap."""
+
+PROBES = tuple(step / 2 for step in range(-2, 2 * BLOCK_WIDTH * MAX_INTERVALS))
+"""Membership probes at half steps, so every interval the generator can draw
+holds one.  The pool reaches past both ends of the blocks."""
+
+
+@st.composite
+def canonical_ranges(draw: st.DrawFn) -> Range[int]:
+    """Generate a ``Range[int]`` whose interval list satisfies the invariant.
+
+    Each interval is cut from its own block of values, which is what keeps the
+    list sorted and leaves a gap between neighbours.  A degenerate ``[v, v]``
+    is drawn inclusive at both ends, the only way it holds a version.  The
+    outer bound at either end may be replaced by its infinity sentinel, which
+    is how ``Range.full()`` is reached.
+    """
+    count = draw(st.integers(min_value=0, max_value=MAX_INTERVALS))
+    intervals: list[Interval] = []
+
+    for block in range(count):
+        base = block * BLOCK_WIDTH
+        lower = base + draw(st.integers(min_value=0, max_value=BLOCK_SPAN))
+        upper = draw(st.integers(min_value=lower, max_value=base + BLOCK_SPAN))
+        if lower == upper:
+            intervals.append((lower, True, upper, True))
+        else:
+            intervals.append((lower, draw(st.booleans()), upper, draw(st.booleans())))
+
+    if intervals and draw(st.booleans()):
+        _, _, upper_bound, upper_inclusive = intervals[0]
+        intervals[0] = (NEGATIVE_INFINITY, False, upper_bound, upper_inclusive)
+    if intervals and draw(st.booleans()):
+        lower_bound, lower_inclusive, _, _ = intervals[-1]
+        intervals[-1] = (lower_bound, lower_inclusive, POSITIVE_INFINITY, False)
+
+    return Range(tuple(intervals))
+
+
+def composed_relation(left: Range[int], right: Range[int]) -> RangeRelation:
+    """Return the relation composed from ``is_empty``, ``is_subset`` and ``is_disjoint``."""
+    if left.is_empty:
+        return RangeRelation.EMPTY
+    if left.is_subset(right):
+        return RangeRelation.SUBSET
+    if left.is_disjoint(right):
+        return RangeRelation.DISJOINT
+    return RangeRelation.OVERLAPPING
+
+
+def membership_relation(left: Range[int], right: Range[int]) -> RangeRelation:
+    """Return the relation from :data:`PROBES` and ``__contains__`` alone.
+
+    Sound on generated ranges because every finite bound is an integer inside
+    the probe pool's span and the probes are half steps, so every non-empty
+    interval those bounds can build holds a probe.
+    """
+    held = [probe for probe in PROBES if probe in left]
+    if not held:
+        return RangeRelation.EMPTY
+    if all(probe in right for probe in held):
+        return RangeRelation.SUBSET
+    if any(probe in right for probe in held):
+        return RangeRelation.OVERLAPPING
+    return RangeRelation.DISJOINT
+
+
+class TestRelationMatchesTheSeparatePredicates:
+    """``relation`` agrees with ``is_subset`` and ``is_disjoint``, and with membership."""
+
+    @given(left=canonical_ranges(), right=canonical_ranges())
+    @PROPERTY_SETTINGS
+    def test_relation_matches_the_composition(
+        self, left: Range[int], right: Range[int]
+    ) -> None:
+        assert left.relation(right) is composed_relation(left, right)
+
+    @given(left=canonical_ranges(), right=canonical_ranges())
+    @PROPERTY_SETTINGS
+    def test_relation_matches_membership(
+        self, left: Range[int], right: Range[int]
+    ) -> None:
+        assert left.relation(right) is membership_relation(left, right)
+
+    @given(range_=canonical_ranges())
+    @PROPERTY_SETTINGS
+    def test_a_generated_range_is_empty_exactly_when_no_probe_lands_in_it(
+        self, range_: Range[int]
+    ) -> None:
+        """Pins what the emptiness leg of :func:`membership_relation` leans on."""
+        assert range_.is_empty == all(probe not in range_ for probe in PROBES)

--- a/nab-resolver/tests/test_range_benchmark.py
+++ b/nab-resolver/tests/test_range_benchmark.py
@@ -1,11 +1,11 @@
 """Tests for the Range benchmark under ``nab-resolver/benchmarks``.
 
-The benchmark exists to catch a change to ``Range`` that helps a backtracking
-resolve and hurts a wide one, so what has to hold is that its two scenarios
-really are those two regimes, that both go through the resolver's default range
-type, and that the traffic each reports is the traffic it reported before. Each
-scenario runs here shrunk to ``SUITE_SIZES``; the sizes the standard run
-declares are pinned on their own.
+The benchmark exists to catch a change to ``Range`` that helps one graph shape
+and hurts another, so what has to hold is that its three scenarios really are
+the three regimes it claims, that all of them go through the resolver's default
+range type, and that the traffic each reports is the traffic it reported
+before. Each scenario runs here shrunk to ``SUITE_SIZES``; the sizes the
+standard run declares are pinned on their own.
 
 These carry the ``benchmark`` marker, so they run under ``nox -s benchmarks``
 rather than in the resolver workspace.
@@ -26,6 +26,7 @@ from typing import Any, NamedTuple
 import pytest
 
 from nab_resolver.ranges import Range
+from nab_resolver.types import RangeRelation
 
 pytestmark = pytest.mark.benchmark
 
@@ -34,7 +35,11 @@ MODULE_NAME = "_nab_range_scenarios"
 
 # Small enough to run in a fraction of a second, large enough to backtrack and
 # to fan out.
-SUITE_SIZES = {"wrong-package-backtracking": 8, "conflict-free-fanout": 6}
+SUITE_SIZES = {
+    "wrong-package-backtracking": 8,
+    "conflict-free-fanout": 6,
+    "satisfied-ceiling-fanin": 6,
+}
 
 
 class Profile(NamedTuple):
@@ -77,6 +82,16 @@ SUITE_PROFILE = {
         hash_misses=5,
         equality_calls=22,
     ),
+    "satisfied-ceiling-fanin": Profile(
+        rounds=10,
+        decisions=10,
+        conflicts=0,
+        membership_tests=235,
+        intervals_seen=1300,
+        largest_range=6,
+        hash_misses=19,
+        equality_calls=52,
+    ),
 }
 
 
@@ -117,8 +132,11 @@ def test_standard_run_declares_the_full_scale_sizes(benchmark: ModuleType) -> No
     assert {s.id: s.size for s in benchmark.SCENARIOS} == {
         "wrong-package-backtracking": 64,
         "conflict-free-fanout": 120,
+        "satisfied-ceiling-fanin": 1000,
     }
     assert benchmark.FANOUT_RELEASES == 50
+    assert benchmark.FANIN_SUPPORTED == 200
+    assert benchmark.FANIN_YANKED == (3, 8, 13, 18, 23)
     assert benchmark.DEFAULT_REPEATS == 5
 
 
@@ -159,6 +177,34 @@ def test_fanout_scenario_stays_conflict_free_and_single_interval(
 
     assert measurement.traffic.census.largest == 1
     assert measurement.traffic.census.mean == 1.0
+
+
+def test_fanin_scenario_answers_every_relation_with_subset(
+    benchmark: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The regime the other two leave out: a requirement that already holds.
+
+    The answers are read off what ``relation`` returns rather than off the
+    predicates it calls, because which of those it goes through is what a
+    change to ``Range`` is free to alter.
+    """
+    answers: list[RangeRelation] = []
+    relation = Range.relation
+
+    def tallied(self: Range[int], other: Range[int]) -> RangeRelation:
+        answer = relation(self, other)
+        answers.append(answer)
+        return answer
+
+    monkeypatch.setattr(Range, "relation", tallied)
+    measurement = measure_small(benchmark, "satisfied-ceiling-fanin")
+
+    assert measurement.resolution.stats.conflicts == 0
+    assert set(answers) == {RangeRelation.SUBSET}
+
+    # Only the hub's range fragments, into one more interval than there are
+    # yanked releases, so it is the widest membership is tested against.
+    assert measurement.traffic.census.largest == len(benchmark.FANIN_YANKED) + 1
 
 
 @pytest.mark.parametrize("scenario_id", list(SUITE_SIZES))

--- a/nab-resolver/tests/test_ranges_contract.py
+++ b/nab-resolver/tests/test_ranges_contract.py
@@ -441,6 +441,22 @@ class TestOutOfContractInputs:
         assert oracle_relation(degenerate, other) is RangeRelation.EMPTY
         assert degenerate.relation(other) is RangeRelation.SUBSET, WIDENING_CHANGES_THIS
 
+    def test_a_reversed_interval_splits_relation_from_the_subset_walk(self) -> None:
+        """``[2, 1]`` is a subset for ``is_subset`` and disjoint for ``relation``.
+
+        ``relation`` asks whether the left interval ends below the right one
+        before rebuilding the intersection.  A reversed interval both ends
+        below and rebuilds to itself, so the two walks disagree.
+        """
+        reversed_bounds: Range[int] = Range(((2, True, 1, True),))
+        other: Range[int] = Range(((2, True, 3, False),))
+
+        assert oracle_relation(reversed_bounds, other) is RangeRelation.EMPTY
+        assert reversed_bounds.is_subset(other), WIDENING_CHANGES_THIS
+        assert reversed_bounds.relation(other) is RangeRelation.DISJOINT, (
+            WIDENING_CHANGES_THIS
+        )
+
 
 class TestMembershipDoesNotNeedTheInvariant:
     """``__contains__`` scans every interval, so it defines membership on any list.


### PR DESCRIPTION
Answering subset and disjoint in one interval walk instead of two takes a resolve of the 64-release `wrong-package-backtracking` graph in `nab-resolver/benchmarks/range_scenarios.py` from 690,579,418 instructions to 563,011,058, about 18%, same solution. nab-project passes `VersionRange`, so this class is what a consumer passing no `range_type` gets.

A SUBSET answer costs more, and `satisfied-ceiling-fanin`, added here, prices it: 1,005 of them against a six-interval range put that resolve up 7,300,563 on 528,624,533, +1.4%, or 7,264 instructions an answer. Cut the yanked releases so the range is one interval and it is 818 an answer, +0.18%.

A resolve that mostly answers SUBSET is also one that asks little: a warm `pip:google-bigquery-soda` resolve asks `relation` 133 times and answers SUBSET on 119, where this backtracking graph asks 4,348 and answers SUBSET on 201. `propagate.py:229`, the only caller in shipped code, reads both flags, so nothing can ask for one.

Two behaviour changes:

- A subclass overriding `is_subset` or `is_disjoint` no longer changes what `relation` answers.
- On an interval list that breaks the invariant `Range.__init__` documents, the answers differ: `Range(((2, True, 1, True),)).relation(Range(((2, True, 3, False),)))` answered SUBSET and now answers DISJOINT.