### PR TITLE
Bound the range token table, which grew with every distinct range

### DIFF
--- a/nab-resolver/src/nab_resolver/propagate.py
+++ b/nab-resolver/src/nab_resolver/propagate.py
@@ -44,10 +44,11 @@ RELATION_GATE_WINDOW = 4_096
 RELATION_GATE_MIN_HITS = 1_024
 RELATION_GATE_RECHECK = 65_536
 
-# Upper bound on the address-keyed token memo, cleared on overflow together
-# with the range objects it holds alive.  A larger cap wipes less often and so
-# holds on to more ranges, which costs peak memory.
+# Upper bounds on the two token memos.  Both hold ranges alive, the value memo
+# as its own keys and the address memo through interned_ranges, so a larger cap
+# wipes less often and holds on to more ranges, which costs peak memory.
 RANGE_ID_MEMO_MAX = 8_192
+RANGE_TOKEN_MEMO_MAX = 8_192
 
 
 def unit_propagation(
@@ -152,13 +153,23 @@ def _intern_range(resolver: Resolver[Any, Any], range_: RangeProtocol[Any]) -> i
     """Return the token for ``range_``, minting one the first time it is seen.
 
     Equal ranges share a token, so the relation cache keys on range value
-    rather than on identity.  The address memo the caller reads first is only
-    sound while the object it answers for is alive, so ``interned_ranges``
-    holds on to every range that memo records.
+    rather than on identity.  A wipe frees ranges only if ``interned_ranges``,
+    which holds them alive too, goes with the value memo.  The address memo
+    then has to go as well: a reused address would answer with the freed
+    range's token.
+
+    A range seen again after a wipe is minted a second, higher token.
+    ``next_range_token`` never rewinds, so relation-cache entries under a
+    retired token, including a key that mixes one token from each side of a
+    wipe, become unreachable rather than wrong.
     """
     tokens = resolver.range_tokens
     token = tokens.get(range_)
     if token is None:
+        if len(tokens) >= RANGE_TOKEN_MEMO_MAX:
+            tokens.clear()
+            resolver.range_token_by_id.clear()
+            resolver.interned_ranges.clear()
         token = resolver.next_range_token
         resolver.next_range_token = token + 1
         tokens[range_] = token

--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -690,9 +690,9 @@ class Resolver(Generic[PackageType, VersionType]):
         self.relation_gate_probes_left = propagate.RELATION_GATE_WINDOW
 
         # One token per distinct range, so a relation-cache probe compares ints
-        # rather than bound structures. The counter never rewinds, so clearing
-        # this table alone only strands relation_cache entries; it can never
-        # point a live one at a different range.
+        # rather than bound structures. The table holds every key alive, which is
+        # why it is capped; the counter never rewinds, so a wipe strands
+        # relation_cache entries rather than pointing a live one at another range.
         self.range_tokens: dict[RangeProtocol[Any], int] = {}
         self.next_range_token = 0
 

--- a/nab-resolver/tests/test_resolver.py
+++ b/nab-resolver/tests/test_resolver.py
@@ -3146,6 +3146,97 @@ class TestRelationCache:
         """
         term_relation(resolver, Term("foo", Range.at_least(lower), positive=True))
 
+    @classmethod
+    def _probe_distinct_ranges(cls, resolver: Resolver[str, int], count: int) -> int:
+        """Probe ``>= 1`` through ``>= count``, returning the value memo's peak size.
+
+        The peak is sampled after every probe: a length read only at the end
+        cannot see a table that overshot its cap and was then wiped.
+        """
+        peak = 0
+        for lower in range(1, count + 1):
+            cls._probe(resolver, lower)
+            peak = max(peak, len(resolver.range_tokens))
+        return peak
+
+    def test_value_memo_never_grows_past_its_cap(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The value memo holds its keys alive, so it needs a cap of its own."""
+        monkeypatch.setattr(propagate, "RANGE_TOKEN_MEMO_MAX", 4)
+        resolver: Resolver[str, int] = Resolver(DictProvider({}))
+        resolver.solution.decide("foo", 2)
+
+        peak = self._probe_distinct_ranges(resolver, 39)
+
+        assert peak == propagate.RANGE_TOKEN_MEMO_MAX
+
+    def test_an_overflow_releases_the_ranges_the_memo_held(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The cap exists to free ranges nothing else holds.
+
+        ``Range`` sets ``__slots__`` without ``__weakref__``, so a weak reference
+        cannot watch one go and the reference count is the next best witness.
+        """
+        monkeypatch.setattr(propagate, "RANGE_TOKEN_MEMO_MAX", 4)
+        resolver: Resolver[str, int] = Resolver(DictProvider({}))
+        resolver.solution.decide("foo", 2)
+
+        constraint = Range.at_least(99)
+        baseline = sys.getrefcount(constraint)
+        term_relation(resolver, Term("foo", constraint, positive=True))
+
+        assert sys.getrefcount(constraint) > baseline
+
+        self._probe_distinct_ranges(resolver, 39)
+
+        assert sys.getrefcount(constraint) == baseline
+
+    def test_equal_ranges_share_a_token_after_an_overflow(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Equal ranges still land on one token: no address outlives the wipe."""
+        monkeypatch.setattr(propagate, "RANGE_TOKEN_MEMO_MAX", 4)
+        resolver: Resolver[str, int] = Resolver(DictProvider({}))
+        resolver.solution.decide("foo", 2)
+
+        self._probe_distinct_ranges(resolver, 39)
+
+        live_tokens = set(resolver.range_tokens.values())
+        assert set(resolver.range_token_by_id.values()) <= live_tokens
+
+        term = Term("foo", Range.at_least(99), positive=True)
+        equal_term = Term("foo", Range.at_least(99), positive=True)
+        assert equal_term.constraint is not term.constraint
+
+        term_relation(resolver, term)
+        term_relation(resolver, equal_term)
+        tokens_by_address = resolver.range_token_by_id
+
+        assert (
+            tokens_by_address[id(term.constraint)]
+            == tokens_by_address[id(equal_term.constraint)]
+        )
+
+    def test_bounded_memo_reaches_the_same_solution(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A cap that wipes on all but the first mint must not change the answer."""
+        packages = {
+            "root": {1: {"left": Range.at_least(1), "right": Range.at_least(1)}},
+            "left": {v: {"shared": Range.singleton(v)} for v in (1, 2, 3)},
+            "right": {v: {"shared": Range.singleton(max(1, v - 1))} for v in (1, 2, 3)},
+            "shared": {1: {}, 2: {}, 3: {}},
+        }
+        at_default_cap: Resolver[str, int] = Resolver(DictProvider(packages))
+        expected = at_default_cap.resolve({"root": Range.at_least(1)})
+
+        monkeypatch.setattr(propagate, "RANGE_TOKEN_MEMO_MAX", 1)
+        at_cap_of_one: Resolver[str, int] = Resolver(DictProvider(packages))
+
+        assert at_cap_of_one.resolve({"root": Range.at_least(1)}) == expected
+
     def test_gate_switches_the_memo_off_when_probes_mostly_miss(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
`Resolver.range_tokens` has no cap. It gains an entry for every distinct range and holds each one alive until the resolve ends, so nothing bounds it but the shape of the graph.

No workload measured here reaches that point, so the change buys no saving. Across 63 resolves the table never overflowed:

| workload | peak entries |
| --- | --- |
| `ecosystem:pandas-with-aws-s3 --resolution lowest` | 3,206 to 4,494 (8 runs) |
| `pip:langchain-ml-course --resolution lowest`, highest of the 19-case canary set | 1,900 to 1,909 (7 runs) |
| the other 16 canary scenarios | 2 to 508 (48 runs) |

The worst of those holds 3,898,758 bytes against a cap of 8,192, so it sits at 55% of the bound rather than an order of magnitude under it. What the change buys is bounded growth, for one integer comparison per mint. Only the synthetic `satisfied-ceiling-fanin` at 8,200 dependents crosses the cap.

`RANGE_TOKEN_MEMO_MAX = 8_192` is checked in `_intern_range`, beside the existing `RANGE_ID_MEMO_MAX`. An overflow wipes three tables at once, because keeping any one would make the others wrong: `interned_ranges` holds the same ranges, and `range_token_by_id` would answer for a reused address. `next_range_token` only increments, so relation-cache entries under a retired token go unreachable rather than stale.

8,192 is a bound, not a tuned value. Nothing measured picks it.
