### PR TITLE
Bind propagation's enum members to module globals, ~1.8% off a resolve

### DIFF
--- a/nab-resolver/src/nab_resolver/propagate.py
+++ b/nab-resolver/src/nab_resolver/propagate.py
@@ -19,6 +19,13 @@ if TYPE_CHECKING:
     from .resolver import Resolver
     from .types import Incompatibility, RangeProtocol
 
+# Bound once so the hot paths load a module global instead of a class attribute.
+_SATISFIED_REL = SetRelation.SATISFIED
+_CONTRADICTED_REL = SetRelation.CONTRADICTED
+_UNDETERMINED_REL = SetRelation.UNDETERMINED
+_CONTRADICTED_STATE = IncompatibilityState.CONTRADICTED
+_CONFLICT_STATE = IncompatibilityState.CONFLICT
+
 __all__ = [
     "classify_relation",
     "evaluate_incompatibility",
@@ -77,11 +84,11 @@ def unit_propagation(
             incompatibility = resolver.incompatibilities[incompatibility_index]
             evaluation = evaluate_incompatibility(resolver, incompatibility)
 
-            if evaluation is IncompatibilityState.CONTRADICTED:
+            if evaluation is _CONTRADICTED_STATE:
                 contradicted_at[incompatibility_index] = epoch
                 continue
 
-            if evaluation is IncompatibilityState.CONFLICT:
+            if evaluation is _CONFLICT_STATE:
                 return incompatibility
 
             if isinstance(evaluation, Term):
@@ -128,17 +135,17 @@ def evaluate_incompatibility(
 
     for term in incompatibility.terms:
         relation = term_relation(resolver, term)
-        if relation is SetRelation.SATISFIED:
+        if relation is _SATISFIED_REL:
             continue
-        if relation is SetRelation.CONTRADICTED:
-            return IncompatibilityState.CONTRADICTED
+        if relation is _CONTRADICTED_REL:
+            return _CONTRADICTED_STATE
         if undetermined_term is not None:
             return None
         undetermined_term = term
 
     if undetermined_term is not None:
         return undetermined_term
-    return IncompatibilityState.CONFLICT
+    return _CONFLICT_STATE
 
 
 def _intern_range(resolver: Resolver[Any, Any], range_: RangeProtocol[Any]) -> int:
@@ -196,7 +203,7 @@ def term_relation(resolver: Resolver[Any, Any], term: Term[Any, Any]) -> SetRela
     """
     assignment = resolver.solution.get(term.package)
     if assignment is None:
-        return SetRelation.UNDETERMINED
+        return _UNDETERMINED_REL
 
     positive = term.is_positive()
     constraint = term.constraint
@@ -237,11 +244,11 @@ def term_relation(resolver: Resolver[Any, Any], term: Term[Any, Any]) -> SetRela
     else:
         resolver.relation_gate_hits += 1
 
-    needs_positive = (positive and result is SetRelation.SATISFIED) or (
-        not positive and result is SetRelation.CONTRADICTED
+    needs_positive = (positive and result is _SATISFIED_REL) or (
+        not positive and result is _CONTRADICTED_REL
     )
     if needs_positive and not resolver.solution.has_positive_constraint(term.package):
-        return SetRelation.UNDETERMINED
+        return _UNDETERMINED_REL
 
     return result
 
@@ -268,7 +275,7 @@ def classify_relation(
         satisfied, contradicted = disjoint, subset
 
     if satisfied:
-        return SetRelation.SATISFIED
+        return _SATISFIED_REL
     if contradicted:
-        return SetRelation.CONTRADICTED
-    return SetRelation.UNDETERMINED
+        return _CONTRADICTED_REL
+    return _UNDETERMINED_REL

--- a/nab-resolver/tests/test_resolver.py
+++ b/nab-resolver/tests/test_resolver.py
@@ -26,7 +26,7 @@ from nab_resolver.incompat_index import (
     maybe_merge_dependency,
 )
 from nab_resolver.partial_solution import Assignment, PartialSolution
-from nab_resolver.propagate import term_relation
+from nab_resolver.propagate import classify_relation, term_relation
 from nab_resolver.ranges import Range
 from nab_resolver.report import (
     explain_incompatibility,
@@ -3012,6 +3012,45 @@ class TestHashOrderIndependence:
         forward = self._culprit_queue_order(list(range(8)))
         backward = self._culprit_queue_order(list(range(7, -1, -1)))
         assert forward == backward
+
+
+class TestClassifyRelation:
+    @pytest.mark.parametrize(
+        ("positive", "subset", "disjoint", "expected"),
+        [
+            (True, True, False, SetRelation.SATISFIED),
+            (True, False, True, SetRelation.CONTRADICTED),
+            (True, False, False, SetRelation.UNDETERMINED),
+            (False, False, True, SetRelation.SATISFIED),
+            (False, True, False, SetRelation.CONTRADICTED),
+            (False, False, False, SetRelation.UNDETERMINED),
+        ],
+    )
+    def test_maps_each_relation_to_its_member(
+        self,
+        *,
+        positive: bool,
+        subset: bool,
+        disjoint: bool,
+        expected: SetRelation,
+    ) -> None:
+        term = Term("foo", Range.at_least(1), positive=positive)
+
+        result = classify_relation(term, subset=subset, disjoint=disjoint)
+
+        assert result is expected
+
+    @pytest.mark.parametrize("positive", [True, False])
+    def test_an_empty_assignment_reads_as_satisfied(self, *, positive: bool) -> None:
+        """An empty assignment is both a subset of and disjoint from anything.
+
+        Satisfied is tested first, so it wins for a term of either sign.
+        """
+        term = Term("foo", Range.at_least(1), positive=positive)
+
+        result = classify_relation(term, subset=True, disjoint=True)
+
+        assert result is SetRelation.SATISFIED
 
 
 class TestRelationCache:


### PR DESCRIPTION
One `wrong-package-backtracking` resolve from `nab-resolver/benchmarks/range_scenarios.py` retires 12,516,964 fewer instructions, 1.81% of it, and `conflict-free-fanout` 229,364 fewer, 0.61%. Both reach the same solution by the same search, still 332 rounds, 206 decisions and 126 conflicts on the backtracking graph.

| graph | before | after |
| --- | ---: | ---: |
| `wrong-package-backtracking`, 64 releases | 693,036,384 | 680,519,420 |
| `conflict-free-fanout`, 120 packages | 37,445,125 | 37,215,761 |

Counted with callgrind under `PYTHONHASHSEED=0`.

`propagate.py` reads `SetRelation` and `IncompatibilityState` members off their classes at thirteen sites, 98,833 times in the first resolve and 1,697 in the second. CPython 3.12 specialises a module global read and leaves the `LOAD_ATTR` on an `EnumType` unspecialised, so binding the five members at module level, as `ranges.py` already does for `RangeRelation`, removes them all. Importing the module costs 13,601 instructions more, paid once.