### PR TITLE
Drop dataclasses from nab-resolver, 56% off its import

### DIFF
--- a/nab-resolver/src/nab_resolver/partial_solution.py
+++ b/nab-resolver/src/nab_resolver/partial_solution.py
@@ -17,8 +17,7 @@ from __future__ import annotations
 import operator
 from collections import defaultdict
 from collections.abc import Mapping
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Any, Final, Generic, TypeVar, cast, overload
 from weakref import ref
 
 from ._compat import override
@@ -174,9 +173,39 @@ def _detach_snapshots(
             snapshot.detach()
 
 
-@dataclass(slots=True)
+# Every field in declaration order.  ``__slots__`` holds the same names sorted,
+# so equality, the repr and ``__match_args__`` read this one instead.
+_ASSIGNMENT_FIELDS: Final = (
+    "package",
+    "accumulated_range",
+    "decision_level",
+    "is_decision",
+    "trail_index",
+    "version",
+    "cause",
+    "positive",
+    "cum_positive",
+    "cum_negative",
+)
+
+
 class Assignment(Generic[PackageType, VersionType]):
     """A single entry in the partial solution trail."""
+
+    __slots__ = (
+        "accumulated_range",
+        "cause",
+        "cum_negative",
+        "cum_positive",
+        "decision_level",
+        "is_decision",
+        "package",
+        "positive",
+        "trail_index",
+        "version",
+    )
+
+    __match_args__ = _ASSIGNMENT_FIELDS
 
     package: PackageType
     """Which package this assignment constrains."""
@@ -190,23 +219,68 @@ class Assignment(Generic[PackageType, VersionType]):
     is_decision: bool
     """True if this is a version choice; False if derived by propagation."""
 
-    trail_index: int = 0
+    trail_index: int
     """Chronological position in the assignment trail."""
 
-    version: VersionType | None = None
+    version: VersionType | None
     """The chosen version (only set for decisions)."""
 
-    cause: Incompatibility[PackageType, VersionType] | None = None
+    cause: Incompatibility[PackageType, VersionType] | None
     """The incompatibility that forced this derivation (only for derivations)."""
 
-    positive: bool = True
+    positive: bool
     """Whether this constrains the package positively or negatively."""
 
-    cum_positive: RangeProtocol[VersionType] | None = None
+    cum_positive: RangeProtocol[VersionType] | None
     """Latest positive accumulated range for the package as of this entry."""
 
-    cum_negative: RangeProtocol[VersionType] | None = None
+    cum_negative: RangeProtocol[VersionType] | None
     """Latest negative accumulated range for the package as of this entry."""
+
+    def __init__(  # noqa: PLR0913, PLR0917 - one parameter per field
+        self,
+        package: PackageType,
+        accumulated_range: RangeProtocol[VersionType],
+        decision_level: int,
+        is_decision: bool,  # noqa: FBT001
+        trail_index: int = 0,
+        version: VersionType | None = None,
+        cause: Incompatibility[PackageType, VersionType] | None = None,
+        positive: bool = True,  # noqa: FBT001, FBT002
+        cum_positive: RangeProtocol[VersionType] | None = None,
+        cum_negative: RangeProtocol[VersionType] | None = None,
+    ) -> None:
+        """Record one trail entry."""
+        self.package = package
+        self.accumulated_range = accumulated_range
+        self.decision_level = decision_level
+        self.is_decision = is_decision
+
+        self.trail_index = trail_index
+        self.version = version
+        self.cause = cause
+        self.positive = positive
+        self.cum_positive = cum_positive
+        self.cum_negative = cum_negative
+
+    @override
+    def __eq__(self, other: object) -> bool:
+        """Compare every field."""
+        if not isinstance(other, Assignment):
+            return NotImplemented
+        return tuple(getattr(self, name) for name in _ASSIGNMENT_FIELDS) == tuple(
+            getattr(other, name) for name in _ASSIGNMENT_FIELDS
+        )
+
+    __hash__ = None  # type: ignore[assignment]
+
+    @override
+    def __repr__(self) -> str:
+        """Return a debug representation, fields in declaration order."""
+        fields = ", ".join(
+            f"{name}={getattr(self, name)!r}" for name in _ASSIGNMENT_FIELDS
+        )
+        return f"{type(self).__qualname__}({fields})"
 
 
 class PartialSolution(Generic[PackageType, VersionType]):

--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -22,10 +22,10 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Callable, Mapping, Sequence
-from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Generic, Protocol
+from typing import TYPE_CHECKING, Any, Final, Generic, Protocol
 
 from . import conflict, decide, incompat_index, propagate
+from ._compat import override
 from .decision_queue import DecisionQueue
 from .errors import ResolutionError
 from .partial_solution import PartialSolution
@@ -67,7 +67,6 @@ __all__ = [
 DEFAULT_MAX_ITERATIONS = 200_000
 
 
-@dataclass(frozen=True)
 class Solution(Generic[PackageType, VersionType]):
     """Pins and dependency relationships from a finished resolution.
 
@@ -76,11 +75,67 @@ class Solution(Generic[PackageType, VersionType]):
     breadth-first order from ``roots``.  Both endpoints of each edge are
     keys of ``pins``.  ``roots`` are the packages the caller required
     directly, in requirement order.
+
+    Immutable.  No ``__slots__``: pickle and ``copy`` restore a slotted
+    instance by assignment, which :meth:`__setattr__` refuses.
     """
+
+    __match_args__ = ("pins", "edges", "roots")
 
     pins: dict[PackageType, VersionType]
     edges: tuple[tuple[PackageType, PackageType], ...]
     roots: tuple[PackageType, ...]
+
+    def __init__(
+        self,
+        pins: dict[PackageType, VersionType],
+        edges: tuple[tuple[PackageType, PackageType], ...],
+        roots: tuple[PackageType, ...],
+    ) -> None:
+        """Record the pins, edges and roots of a finished resolution."""
+        object.__setattr__(self, "pins", pins)
+        object.__setattr__(self, "edges", edges)
+        object.__setattr__(self, "roots", roots)
+
+    @override
+    def __setattr__(self, name: str, value: object) -> None:
+        """Refuse the write."""
+        message = f"cannot assign to field {name!r}"
+        raise AttributeError(message)
+
+    @override
+    def __delattr__(self, name: str) -> None:
+        """Refuse the deletion."""
+        message = f"cannot delete field {name!r}"
+        raise AttributeError(message)
+
+    @override
+    def __eq__(self, other: object) -> bool:
+        """Compare pins, edges and roots."""
+        if not isinstance(other, Solution):
+            return NotImplemented
+        return (self.pins, self.edges, self.roots) == (
+            other.pins,
+            other.edges,
+            other.roots,
+        )
+
+    @override
+    def __hash__(self) -> int:
+        """Hash pins, edges and roots together.
+
+        Immutable and comparable, so it declares a hash; the ``pins`` dict
+        makes the call itself raise :exc:`TypeError`.
+        """
+        return hash((self.pins, self.edges, self.roots))
+
+    @override
+    def __repr__(self) -> str:
+        """Return a debug representation."""
+        return (
+            f"{type(self).__qualname__}(pins={self.pins!r}, "
+            f"edges={self.edges!r}, roots={self.roots!r})"
+        )
 
 
 class ResolverProvider(Protocol[PackageType, VersionType]):
@@ -325,7 +380,22 @@ def _provider_with_inherited_hint(
     return None
 
 
-@dataclass
+# Every counter in declaration order.  ``__slots__`` holds the same names
+# sorted, so equality, the repr and ``__match_args__`` read this one instead.
+_STAT_FIELDS: Final = (
+    "rounds",
+    "decisions",
+    "conflicts",
+    "derivations",
+    "backjumps",
+    "restarts",
+    "targeted_backtracks",
+    "incompatibilities_learned",
+    "package_conflict_counts",
+    "package_culprit_counts",
+)
+
+
 class ResolverStats(Generic[PackageType]):
     """Running statistics for resolution observability.
 
@@ -334,20 +404,78 @@ class ResolverStats(Generic[PackageType]):
     See: https://minisat.se/MiniSat.html
     """
 
-    rounds: int = 0
-    decisions: int = 0
-    conflicts: int = 0
-    derivations: int = 0
-    backjumps: int = 0
-    restarts: int = 0
-    targeted_backtracks: int = 0
-    incompatibilities_learned: int = 0
-    package_conflict_counts: defaultdict[PackageType, int] = field(
-        default_factory=lambda: defaultdict(int)
+    __slots__ = (
+        "backjumps",
+        "conflicts",
+        "decisions",
+        "derivations",
+        "incompatibilities_learned",
+        "package_conflict_counts",
+        "package_culprit_counts",
+        "restarts",
+        "rounds",
+        "targeted_backtracks",
     )
-    package_culprit_counts: defaultdict[PackageType, int] = field(
-        default_factory=lambda: defaultdict(int)
-    )
+
+    __match_args__ = _STAT_FIELDS
+
+    rounds: int
+    decisions: int
+    conflicts: int
+    derivations: int
+    backjumps: int
+    restarts: int
+    targeted_backtracks: int
+    incompatibilities_learned: int
+    package_conflict_counts: defaultdict[PackageType, int]
+    package_culprit_counts: defaultdict[PackageType, int]
+
+    def __init__(  # noqa: PLR0913, PLR0917 - one parameter per counter
+        self,
+        rounds: int = 0,
+        decisions: int = 0,
+        conflicts: int = 0,
+        derivations: int = 0,
+        backjumps: int = 0,
+        restarts: int = 0,
+        targeted_backtracks: int = 0,
+        incompatibilities_learned: int = 0,
+        package_conflict_counts: defaultdict[PackageType, int] | None = None,
+        package_culprit_counts: defaultdict[PackageType, int] | None = None,
+    ) -> None:
+        """Start every counter at the value given, zero and empty by default."""
+        self.rounds = rounds
+        self.decisions = decisions
+        self.conflicts = conflicts
+        self.derivations = derivations
+        self.backjumps = backjumps
+        self.restarts = restarts
+        self.targeted_backtracks = targeted_backtracks
+        self.incompatibilities_learned = incompatibilities_learned
+
+        if package_conflict_counts is None:
+            package_conflict_counts = defaultdict(int)
+        if package_culprit_counts is None:
+            package_culprit_counts = defaultdict(int)
+        self.package_conflict_counts = package_conflict_counts
+        self.package_culprit_counts = package_culprit_counts
+
+    @override
+    def __eq__(self, other: object) -> bool:
+        """Compare every counter."""
+        if not isinstance(other, ResolverStats):
+            return NotImplemented
+        return tuple(getattr(self, name) for name in _STAT_FIELDS) == tuple(
+            getattr(other, name) for name in _STAT_FIELDS
+        )
+
+    __hash__ = None  # type: ignore[assignment]
+
+    @override
+    def __repr__(self) -> str:
+        """Return a debug representation."""
+        counters = ", ".join(f"{name}={getattr(self, name)!r}" for name in _STAT_FIELDS)
+        return f"{type(self).__qualname__}({counters})"
 
 
 class ResolverObserver(Generic[PackageType, VersionType]):

--- a/nab-resolver/src/nab_resolver/types.py
+++ b/nab-resolver/src/nab_resolver/types.py
@@ -12,7 +12,6 @@ Reference: https://github.com/dart-lang/pub/blob/master/doc/solver.md#definition
 from __future__ import annotations
 
 import enum
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar
 
 from ._compat import override
@@ -263,10 +262,6 @@ class RelationProtocol(Protocol):
         ...
 
 
-# No ``slots=True``: on 3.10 a frozen slotted dataclass raises TypeError when
-# ``typing._GenericAlias.__call__`` sets ``__orig_class__``, which the
-# subscripted construction in ``resolver._as_root_requirements`` triggers.
-@dataclass(frozen=True)
 class RootRequirement(Generic[PackageType, VersionType]):
     """One requirement as the caller wrote it, kept as its own clause.
 
@@ -279,11 +274,63 @@ class RootRequirement(Generic[PackageType, VersionType]):
     incompatibility, so a caller's own error reporter can identify the
     requirement behind a clause.  Two requirements on one package can share a
     range, so the range alone cannot tell them apart.
+
+    Immutable.  No ``__slots__``: pickle and ``copy`` restore a slotted
+    instance by assignment, which :meth:`__setattr__` refuses.
     """
+
+    __match_args__ = ("package", "constraint", "origin")
 
     package: PackageType
     constraint: RangeProtocol[VersionType]
-    origin: Any = None
+    origin: Any
+
+    def __init__(
+        self,
+        package: PackageType,
+        constraint: RangeProtocol[VersionType],
+        origin: Any = None,
+    ) -> None:
+        """Record one requirement on ``package``."""
+        object.__setattr__(self, "package", package)
+        object.__setattr__(self, "constraint", constraint)
+        object.__setattr__(self, "origin", origin)
+
+    @override
+    def __setattr__(self, name: str, value: object) -> None:
+        """Refuse the write."""
+        message = f"cannot assign to field {name!r}"
+        raise AttributeError(message)
+
+    @override
+    def __delattr__(self, name: str) -> None:
+        """Refuse the deletion."""
+        message = f"cannot delete field {name!r}"
+        raise AttributeError(message)
+
+    @override
+    def __eq__(self, other: object) -> bool:
+        """Compare package, constraint and origin."""
+        if not isinstance(other, RootRequirement):
+            return NotImplemented
+        return (self.package, self.constraint, self.origin) == (
+            other.package,
+            other.constraint,
+            other.origin,
+        )
+
+    @override
+    def __hash__(self) -> int:
+        """Hash package, constraint and origin together."""
+        return hash((self.package, self.constraint, self.origin))
+
+    @override
+    def __repr__(self) -> str:
+        """Return a debug representation."""
+        return (
+            f"{type(self).__qualname__}(package={self.package!r}, "
+            f"constraint={self.constraint!r}, origin={self.origin!r})"
+        )
 
 
 class SetRelation(enum.Enum):

--- a/nab-resolver/tests/test_import_footprint.py
+++ b/nab-resolver/tests/test_import_footprint.py
@@ -1,0 +1,33 @@
+"""nab_resolver must not pull ``dataclasses`` into an importing interpreter.
+
+Importing it also loads ``inspect``, ``ast``, ``dis``, ``tokenize``,
+``linecache``, ``opcode``, ``token`` and ``copy``, which a consumer that wants
+only the resolver pays for at startup.  The package's value types are written
+out by hand so that none of it arrives.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+_PROBE = """
+import importlib
+import pkgutil
+import sys
+
+# A None entry makes ``import dataclasses`` raise ImportError.
+sys.modules["dataclasses"] = None
+
+import nab_resolver
+
+names = sorted(module.name for module in pkgutil.iter_modules(nab_resolver.__path__))
+assert names, "found no nab_resolver submodules to import"
+for name in names:
+    importlib.import_module(f"nab_resolver.{name}")
+"""
+
+
+def test_imports_without_dataclasses() -> None:
+    """Every submodule imports with dataclasses blocked."""
+    subprocess.run([sys.executable, "-c", _PROBE], check=True)  # noqa: S603

--- a/nab-resolver/tests/test_partial_solution.py
+++ b/nab-resolver/tests/test_partial_solution.py
@@ -3,13 +3,20 @@
 from __future__ import annotations
 
 import gc
+from typing import Any
 
 import pytest
 
 from nab_resolver import partial_solution
-from nab_resolver.partial_solution import PartialSolution
+from nab_resolver.partial_solution import Assignment, PartialSolution
 from nab_resolver.ranges import Range
 from nab_resolver.types import Incompatibility, IncompatibilityCause, Term
+
+# Incompatibility declares no __eq__, so entries that have to compare equal
+# share one cause object.
+_CAUSE: Incompatibility[str, int] = Incompatibility(
+    [Term("foo", Range.at_least(2))], cause=IncompatibilityCause.NO_VERSIONS
+)
 
 
 class TestAssignments:
@@ -611,3 +618,105 @@ class TestRangeOperationMemo:
         assert effective is not None
         assert 5 in effective
         assert 9 not in effective
+
+
+class TestAssignmentEntries:
+    def _entry(self, **overrides: Any) -> Assignment[str, int]:
+        """A derivation entry with every field set, ``overrides`` applied."""
+        fields: dict[str, Any] = {
+            "package": "foo",
+            "accumulated_range": Range.at_least(2),
+            "decision_level": 1,
+            "is_decision": False,
+            "trail_index": 4,
+            "version": 7,
+            "cause": _CAUSE,
+            "positive": True,
+            "cum_positive": Range.at_least(2),
+            "cum_negative": Range.full(),
+        }
+        return Assignment(**{**fields, **overrides})
+
+    def test_the_optional_fields_default(self) -> None:
+        entry = Assignment("foo", Range.at_least(2), 1, is_decision=True)
+
+        assert (entry.trail_index, entry.version, entry.cause) == (0, None, None)
+        assert entry.positive
+        assert (entry.cum_positive, entry.cum_negative) == (None, None)
+
+    def test_entries_carry_no_instance_dict(self) -> None:
+        """One lives per trail step, so the layout is the point."""
+        with pytest.raises(AttributeError):
+            _ = self._entry().__dict__
+
+    def test_equality_covers_every_field_and_declines_other_types(self) -> None:
+        """Vary one field at a time, so no field can drop out of __eq__."""
+        others: dict[str, Any] = {
+            "package": "bar",
+            "accumulated_range": Range.at_least(3),
+            "decision_level": 2,
+            "is_decision": True,
+            "trail_index": 5,
+            "version": 8,
+            "cause": None,
+            "positive": False,
+            "cum_positive": Range.at_least(3),
+            "cum_negative": Range.at_least(4),
+        }
+        assert tuple(sorted(others)) == Assignment.__slots__
+
+        entry = self._entry()
+
+        assert entry == self._entry()
+        for name, value in others.items():
+            assert entry != self._entry(**{name: value}), name
+
+        assert entry.__eq__("foo") is NotImplemented
+
+    def test_a_mutable_trail_entry_is_unhashable(self) -> None:
+        assert Assignment.__hash__ is None
+
+    def test_repr_names_the_class_and_every_field_in_declaration_order(self) -> None:
+        """A property test formats an entry into its failure message."""
+        entry = Assignment(
+            "foo", Range.at_least(2), 1, is_decision=False, trail_index=4
+        )
+
+        assert repr(entry) == (
+            "Assignment(package='foo',"
+            " accumulated_range=Range(((2, True, +inf, False),)), decision_level=1,"
+            " is_decision=False, trail_index=4, version=None, cause=None,"
+            " positive=True, cum_positive=None, cum_negative=None)"
+        )
+
+    def test_pattern_matching_reads_every_field_positionally(self) -> None:
+        """Ten sub-patterns, in declaration order rather than slot order."""
+        match self._entry():
+            case Assignment(
+                package,
+                accumulated_range,
+                decision_level,
+                is_decision,
+                trail_index,
+                version,
+                cause,
+                positive,
+                cum_positive,
+                cum_negative,
+            ):
+                assert (package, accumulated_range, decision_level) == (
+                    "foo",
+                    Range.at_least(2),
+                    1,
+                )
+                assert (is_decision, trail_index, version, cause) == (
+                    False,
+                    4,
+                    7,
+                    _CAUSE,
+                )
+                assert (positive, cum_positive, cum_negative) == (
+                    True,
+                    Range.at_least(2),
+                    Range.full(),
+                )

--- a/nab-resolver/tests/test_resolver.py
+++ b/nab-resolver/tests/test_resolver.py
@@ -4,6 +4,7 @@ and end-to-end resolution with a simple in-memory provider."""
 from __future__ import annotations
 
 import sys
+from collections import defaultdict
 from collections.abc import Mapping
 from typing import Any
 
@@ -40,6 +41,7 @@ from nab_resolver.resolver import (
     ResolutionError,
     Resolver,
     ResolverObserver,
+    ResolverStats,
     Solution,
 )
 from nab_resolver.root import ROOT
@@ -3432,3 +3434,104 @@ class TestSettledClauseSkip:
 
         assert restarted
         assert resolver.solution.contradiction_epoch > before
+
+
+class TestResolverStats:
+    def test_a_fresh_bag_starts_at_zero_with_its_own_counters(self) -> None:
+        """The two count maps are per-instance, not shared class state."""
+        stats: ResolverStats[str] = ResolverStats()
+        other: ResolverStats[str] = ResolverStats()
+
+        assert stats.rounds == 0
+        assert stats.incompatibilities_learned == 0
+        assert stats.package_conflict_counts == {}
+        assert stats.package_culprit_counts == {}
+
+        stats.package_conflict_counts["a"] += 1
+        assert other.package_conflict_counts == {}
+
+    def test_counters_can_be_supplied(self) -> None:
+        stats: ResolverStats[str] = ResolverStats(
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            defaultdict(int, {"a": 1}),
+            defaultdict(int, {"b": 2}),
+        )
+
+        assert (stats.rounds, stats.decisions, stats.conflicts) == (1, 2, 3)
+        assert (stats.derivations, stats.backjumps, stats.restarts) == (4, 5, 6)
+        assert (stats.targeted_backtracks, stats.incompatibilities_learned) == (7, 8)
+        assert stats.package_conflict_counts == {"a": 1}
+        assert stats.package_culprit_counts == {"b": 2}
+
+    def test_equality_covers_every_counter_and_declines_other_types(self) -> None:
+        """Vary one counter at a time, so none can drop out of __eq__."""
+        counters: dict[str, Any] = {
+            "rounds": 1,
+            "decisions": 2,
+            "conflicts": 3,
+            "derivations": 4,
+            "backjumps": 5,
+            "restarts": 6,
+            "targeted_backtracks": 7,
+            "incompatibilities_learned": 8,
+            "package_conflict_counts": defaultdict(int, {"a": 1}),
+            "package_culprit_counts": defaultdict(int, {"b": 2}),
+        }
+        assert tuple(sorted(counters)) == ResolverStats.__slots__
+
+        stats: ResolverStats[str] = ResolverStats(**counters)
+
+        assert stats == ResolverStats(**counters)
+        for name, value in counters.items():
+            other = value + 1 if isinstance(value, int) else defaultdict(int, {"z": 9})
+            assert stats != ResolverStats(**{**counters, name: other}), name
+
+        assert stats.__eq__("stats") is NotImplemented
+
+    def test_a_mutable_bag_of_counters_is_unhashable(self) -> None:
+        assert ResolverStats.__hash__ is None
+
+    def test_a_bag_of_counters_carries_no_instance_dict(self) -> None:
+        """The ten slots are the whole layout."""
+        stats: ResolverStats[str] = ResolverStats()
+
+        with pytest.raises(AttributeError):
+            _ = stats.__dict__
+
+    def test_pattern_matching_reads_every_counter_positionally(self) -> None:
+        """Ten sub-patterns, in declaration order rather than slot order."""
+        stats: ResolverStats[str] = ResolverStats(rounds=2, conflicts=5)
+
+        match stats:
+            case ResolverStats(
+                rounds,
+                decisions,
+                conflicts,
+                derivations,
+                backjumps,
+                restarts,
+                targeted_backtracks,
+                learned,
+                conflict_counts,
+                culprit_counts,
+            ):
+                assert (rounds, decisions, conflicts) == (2, 0, 5)
+                assert (derivations, backjumps, restarts) == (0, 0, 0)
+                assert (targeted_backtracks, learned) == (0, 0)
+                assert (conflict_counts, culprit_counts) == ({}, {})
+
+    def test_repr_names_the_class_and_every_counter(self) -> None:
+        assert repr(ResolverStats(rounds=2)) == (
+            "ResolverStats(rounds=2, decisions=0, conflicts=0, derivations=0,"
+            " backjumps=0, restarts=0, targeted_backtracks=0,"
+            " incompatibilities_learned=0,"
+            " package_conflict_counts=defaultdict(<class 'int'>, {}),"
+            " package_culprit_counts=defaultdict(<class 'int'>, {}))"
+        )

--- a/nab-resolver/tests/test_result.py
+++ b/nab-resolver/tests/test_result.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import pickle
 from itertools import permutations
 from typing import Any
@@ -64,6 +65,55 @@ class TestPublicSolution:
         assert not hasattr(result_module, "Solution")
         assert b"cnab_resolver.resolver\nSolution\n" in serialized
         assert restored == solution
+
+    def test_a_solution_survives_copying_and_the_default_pickle(self) -> None:
+        solution = solve({"a": {1: {"b": Range.full()}}, "b": {1: {}}}, a=Range.full())
+
+        assert copy.copy(solution) == solution
+        assert copy.deepcopy(solution) == solution
+        assert pickle.loads(pickle.dumps(solution)) == solution  # noqa: S301
+
+    def test_equality_reads_every_field_and_declines_other_types(self) -> None:
+        fields: dict[str, Any] = {
+            "pins": {"a": 1},
+            "edges": (("a", "b"),),
+            "roots": ("a",),
+        }
+        others: dict[str, Any] = {"pins": {"a": 2}, "edges": (), "roots": ("b",)}
+        solution: Solution[str, int] = Solution(**fields)
+
+        assert solution == Solution(**fields)
+        for name, other in others.items():
+            assert solution != Solution(**{**fields, name: other}), name
+
+        assert solution.__eq__("a") is NotImplemented
+
+    def test_repr_names_the_class_and_every_field(self) -> None:
+        solution = Solution(pins={"a": 1}, edges=(("a", "b"),), roots=("a",))
+
+        assert repr(solution) == (
+            "Solution(pins={'a': 1}, edges=(('a', 'b'),), roots=('a',))"
+        )
+
+    def test_hash_is_declared_but_the_pins_dict_defeats_it(self) -> None:
+        solution = Solution(pins={"a": 1}, edges=(), roots=("a",))
+
+        assert Solution.__hash__ is not None
+        with pytest.raises(TypeError):
+            hash(solution)
+
+    def test_fields_cannot_be_reassigned_or_deleted(self) -> None:
+        solution = solve({"a": {1: {}}}, a=Range.full())
+
+        with pytest.raises(AttributeError, match="cannot assign to field 'pins'"):
+            solution.pins = {}
+        with pytest.raises(AttributeError, match="cannot delete field 'pins'"):
+            del solution.pins
+
+    def test_pattern_matching_reads_the_three_fields_positionally(self) -> None:
+        match Solution(pins={"a": 1}, edges=(("a", "b"),), roots=("a",)):
+            case Solution(pins, edges, roots):
+                assert (pins, edges, roots) == ({"a": 1}, (("a", "b"),), ("a",))
 
 
 class TestRoots:

--- a/nab-resolver/tests/test_types.py
+++ b/nab-resolver/tests/test_types.py
@@ -2,8 +2,19 @@
 
 from __future__ import annotations
 
+import copy
+import pickle
+from typing import Any
+
+import pytest
+
 from nab_resolver.ranges import Range
-from nab_resolver.types import Incompatibility, IncompatibilityCause, Term
+from nab_resolver.types import (
+    Incompatibility,
+    IncompatibilityCause,
+    RootRequirement,
+    Term,
+)
 
 
 class TestTerm:
@@ -102,3 +113,85 @@ class TestIncompatibility:
         t = Term("foo", Range.at_least(99))
         inc = Incompatibility([t], cause=IncompatibilityCause.NO_VERSIONS)
         assert len(inc.terms) == 1
+
+
+class TestRootRequirement:
+    def test_origin_defaults_to_none_and_fields_are_readable(self) -> None:
+        bare = RootRequirement("foo", Range.at_least(2))
+        tagged = RootRequirement("foo", Range.at_least(2), origin="foo>=2 (line 3)")
+
+        assert (bare.package, bare.constraint, bare.origin) == (
+            "foo",
+            Range.at_least(2),
+            None,
+        )
+        assert tagged.origin == "foo>=2 (line 3)"
+
+    def test_equality_reads_every_field_and_declines_other_types(self) -> None:
+        fields: dict[str, Any] = {
+            "package": "foo",
+            "constraint": Range.at_least(2),
+            "origin": "from the lockfile",
+        }
+        others: dict[str, Any] = {
+            "package": "bar",
+            "constraint": Range.at_least(3),
+            "origin": "from the command line",
+        }
+        requirement: RootRequirement[str, int] = RootRequirement(**fields)
+
+        assert requirement == RootRequirement(**fields)
+        for name, other in others.items():
+            assert requirement != RootRequirement(**{**fields, name: other}), name
+
+        assert requirement.__eq__("foo") is NotImplemented
+
+    def test_equal_requirements_hash_alike(self) -> None:
+        requirement = RootRequirement("foo", Range.at_least(2), "origin")
+        twin = RootRequirement("foo", Range.at_least(2), "origin")
+
+        assert len({requirement, twin}) == 1
+
+    def test_repr_names_the_class_and_every_field(self) -> None:
+        requirement = RootRequirement("foo", Range.singleton(2), "origin")
+
+        assert repr(requirement) == (
+            "RootRequirement(package='foo', constraint=Range(((2, True, 2, True),)),"
+            " origin='origin')"
+        )
+
+    def test_fields_cannot_be_reassigned_or_deleted(self) -> None:
+        """A requirement is hashable, so a write after use as a key is a bug."""
+        requirement = RootRequirement("foo", Range.at_least(2))
+
+        with pytest.raises(AttributeError, match="cannot assign to field 'package'"):
+            requirement.package = "bar"
+        with pytest.raises(AttributeError, match="cannot delete field 'package'"):
+            del requirement.package
+
+    def test_a_requirement_survives_copying_and_pickling(self) -> None:
+        requirement = RootRequirement("foo", Range.at_least(2), "origin")
+
+        assert copy.copy(requirement) == requirement
+        assert copy.deepcopy(requirement) == requirement
+        assert pickle.loads(pickle.dumps(requirement)) == requirement  # noqa: S301
+
+    def test_subscripted_construction_keeps_working(self) -> None:
+        """``resolver._as_root_requirements`` builds these subscripted.
+
+        Subscripted construction tries to set ``__orig_class__``, which
+        ``__setattr__`` refuses.
+        """
+        requirement = RootRequirement[str, int]("foo", Range.at_least(2))
+
+        assert requirement.package == "foo"
+        assert not hasattr(requirement, "__orig_class__")
+
+    def test_pattern_matching_reads_the_three_fields_positionally(self) -> None:
+        match RootRequirement("foo", Range.at_least(2), "origin"):
+            case RootRequirement(package, constraint, origin):
+                assert (package, constraint, origin) == (
+                    "foo",
+                    Range.at_least(2),
+                    "origin",
+                )


### PR DESCRIPTION
`import nab_resolver.resolver, nab_resolver.ranges` costs 40,926,303 instructions over a bare interpreter instead of 92,001,438, 56% off, and loads 34 modules instead of 50: `dataclasses` and the `inspect` / `ast` / `dis` subtree behind it stop loading. Instruction counts here are callgrind under `PYTHONHASHSEED=0`.

The four types `Assignment`, `Solution`, `ResolverStats` and `RootRequirement` are written out by hand. `Solution` and `RootRequirement` stay immutable, through `__setattr__` rather than the decorator.

nab's other four packages still import `dataclasses` from 30 modules, so a `nab` command drops four class bodies rather than the subtree: `nab --version` applies `@dataclass` 98 times instead of 102, and costs 12.3 million instructions less, 1.3%. Resolving is cheaper too, by 0.35% on a `conflict-free-fanout` resolve and 0.05% on a `wrong-package-backtracking` one, the two scenarios in `nab-resolver/benchmarks/range_scenarios.py`.

For a consumer of these types:

| | before | after |
|---|---|---|
| `is_dataclass` | `True` | `False` |
| `fields`, `asdict`, `replace` | work | `TypeError` |
| write to a `Solution` or `RootRequirement` field | `FrozenInstanceError` | `AttributeError`, its superclass |
| `ResolverStats` instance `__dict__`, weak references, pickle protocols 0 and 1 | yes | no |