### PR TITLE
Inline the interval tests in Range's walks, ~8.5% off a backtracking resolve

### DIFF
--- a/nab-resolver/src/nab_resolver/ranges.py
+++ b/nab-resolver/src/nab_resolver/ranges.py
@@ -314,11 +314,17 @@ class Range(Generic[VersionType]):
                 left_interval, right_interval
             )
 
-            if not _interval_is_empty(
-                inter_lower,
-                lower_inclusive=inter_lower_inc,
-                upper=inter_upper,
-                upper_inclusive=inter_upper_inc,
+            # _interval_is_empty, written out.
+            if not (
+                inter_lower is not NEGATIVE_INFINITY
+                and inter_upper is not POSITIVE_INFINITY
+                and (
+                    inter_lower > inter_upper
+                    or (
+                        inter_lower == inter_upper
+                        and not (inter_lower_inc and inter_upper_inc)
+                    )
+                )
             ):
                 result.append(
                     (inter_lower, inter_lower_inc, inter_upper, inter_upper_inc)
@@ -414,6 +420,8 @@ class Range(Generic[VersionType]):
             lower, lower_inclusive, upper, upper_inclusive = left
 
             # A right interval below this one is below every later one too.
+            # Written out it would need an ``if`` to break on, which puts
+            # ``__sub__`` past ruff's C901 ceiling, so this one stays a call.
             while right_index < right_count and _ends_before(
                 right_intervals[right_index], left
             ):
@@ -423,21 +431,35 @@ class Range(Generic[VersionType]):
             scan = right_index
 
             while scan < right_count:
-                right = right_intervals[scan]
+                right_lower, right_lower_inc, right_upper, right_upper_inc = (
+                    right_intervals[scan]
+                )
 
-                # Carving moves the remainder's lower end only, so its upper end
-                # is still left's and this comparison can read left directly.
-                if _ends_before(left, right):
+                # _ends_before, written out.  Carving only moves the
+                # remainder's lower end, so ``upper`` is still left's own.
+                if (
+                    upper is not POSITIVE_INFINITY
+                    and right_lower is not NEGATIVE_INFINITY
+                    and (
+                        not (upper_inclusive and right_lower_inc)
+                        if upper == right_lower
+                        else upper < right_lower
+                    )
+                ):
                     break
 
-                right_lower, right_lower_inc, right_upper, right_upper_inc = right
-
-                # Whatever of the remainder sits below this right interval survives.
-                if right_lower is not NEGATIVE_INFINITY and not _interval_is_empty(
-                    lower,
-                    lower_inclusive=lower_inclusive,
-                    upper=right_lower,
-                    upper_inclusive=not right_lower_inc,
+                # Whatever of the remainder sits below this right interval
+                # survives.  _interval_is_empty, written out.
+                if right_lower is not NEGATIVE_INFINITY and not (
+                    lower is not NEGATIVE_INFINITY
+                    and right_lower is not POSITIVE_INFINITY
+                    and (
+                        lower > right_lower
+                        or (
+                            lower == right_lower
+                            and not (lower_inclusive and not right_lower_inc)
+                        )
+                    )
                 ):
                     result.append(
                         (lower, lower_inclusive, right_lower, not right_lower_inc)
@@ -447,24 +469,32 @@ class Range(Generic[VersionType]):
                     fully_covered = True
                     break
 
-                # Resume above this right interval.
+                # Resume above this right interval, stopping when nothing of
+                # it is left.  _interval_is_empty, written out.
                 lower, lower_inclusive = right_upper, not right_upper_inc
-                if _interval_is_empty(
-                    lower,
-                    lower_inclusive=lower_inclusive,
-                    upper=upper,
-                    upper_inclusive=upper_inclusive,
+                if (
+                    lower is not NEGATIVE_INFINITY
+                    and upper is not POSITIVE_INFINITY
+                    and (
+                        lower > upper
+                        or (
+                            lower == upper and not (lower_inclusive and upper_inclusive)
+                        )
+                    )
                 ):
                     fully_covered = True
                     break
 
                 scan += 1
 
-            if not fully_covered and not _interval_is_empty(
-                lower,
-                lower_inclusive=lower_inclusive,
-                upper=upper,
-                upper_inclusive=upper_inclusive,
+            # _interval_is_empty, written out.
+            if not fully_covered and not (
+                lower is not NEGATIVE_INFINITY
+                and upper is not POSITIVE_INFINITY
+                and (
+                    lower > upper
+                    or (lower == upper and not (lower_inclusive and upper_inclusive))
+                )
             ):
                 result.append((lower, lower_inclusive, upper, upper_inclusive))
 
@@ -483,9 +513,23 @@ class Range(Generic[VersionType]):
         right_index = 0
 
         for left in self._intervals:
-            while right_index < right_count and _ends_before(
-                right_intervals[right_index], left
-            ):
+            left_lower, left_lower_inclusive = left[0], left[1]
+
+            # Retire every right interval that finishes below this one:
+            # _ends_before, written out.
+            while right_index < right_count:
+                candidate = right_intervals[right_index]
+                candidate_upper = candidate[2]
+                if (
+                    candidate_upper is POSITIVE_INFINITY
+                    or left_lower is NEGATIVE_INFINITY
+                    or (
+                        (candidate[3] and left_lower_inclusive)
+                        if candidate_upper == left_lower
+                        else not candidate_upper < left_lower
+                    )
+                ):
+                    break
                 right_index += 1
 
             if right_index >= right_count:
@@ -523,11 +567,14 @@ class Range(Generic[VersionType]):
             lower, lower_inclusive = _max_lower_bound(left, right)
             upper, upper_inclusive = _min_upper_bound(left, right)
 
-            if not _interval_is_empty(
-                lower,
-                lower_inclusive=lower_inclusive,
-                upper=upper,
-                upper_inclusive=upper_inclusive,
+            # _interval_is_empty, written out.
+            if not (
+                lower is not NEGATIVE_INFINITY
+                and upper is not POSITIVE_INFINITY
+                and (
+                    lower > upper
+                    or (lower == upper and not (lower_inclusive and upper_inclusive))
+                )
             ):
                 return False
 
@@ -563,9 +610,23 @@ class Range(Generic[VersionType]):
         disjoint = True
 
         for left in self._intervals:
-            while right_index < right_count and _ends_before(
-                right_intervals[right_index], left
-            ):
+            left_lower, left_lower_inclusive = left[0], left[1]
+
+            # Retire every right interval that finishes below this one:
+            # _ends_before, written out.
+            while right_index < right_count:
+                candidate = right_intervals[right_index]
+                candidate_upper = candidate[2]
+                if (
+                    candidate_upper is POSITIVE_INFINITY
+                    or left_lower is NEGATIVE_INFINITY
+                    or (
+                        (candidate[3] and left_lower_inclusive)
+                        if candidate_upper == left_lower
+                        else not candidate_upper < left_lower
+                    )
+                ):
+                    break
                 right_index += 1
 
             if right_index >= right_count:
@@ -574,10 +635,22 @@ class Range(Generic[VersionType]):
                 subset = False
                 break
 
+            # _ends_before, written out, against the first right interval
+            # still standing.
             right = right_intervals[right_index]
-            if _ends_before(left, right):
-                # This interval meets nothing: the walk skipped everything below
-                # it, and right starts above it.  Leave right for the next one.
+            left_upper = left[2]
+            right_lower = right[0]
+            if (
+                left_upper is not POSITIVE_INFINITY
+                and right_lower is not NEGATIVE_INFINITY
+                and (
+                    not (left[3] and right[1])
+                    if left_upper == right_lower
+                    else left_upper < right_lower
+                )
+            ):
+                # It meets nothing: the walk skipped everything below it, and
+                # right starts above it.  Leave right for the next one.
                 subset = False
                 continue
 

--- a/nab-resolver/tests/test_ranges_contract.py
+++ b/nab-resolver/tests/test_ranges_contract.py
@@ -27,6 +27,7 @@ from nab_resolver.ranges import (
     POSITIVE_INFINITY,
     Interval,
     Range,
+    _interval_is_empty,
     _normalize_intervals,
 )
 from nab_resolver.types import RangeRelation
@@ -65,6 +66,28 @@ OUT_OF_CONTRACT_LISTS: tuple[tuple[Interval, ...], ...] = (
 )
 """One list per way the invariant can break: order, overlap, touch, empty,
 reversed, either inclusive infinity, and all of them at once."""
+
+AT_NEGATIVE_INFINITY: Interval = (
+    NEGATIVE_INFINITY,
+    True,
+    NEGATIVE_INFINITY,
+    False,
+)
+"""``[-inf, -inf)``, which puts ``-inf`` in the upper slot it is barred from."""
+
+AT_POSITIVE_INFINITY: Interval = (
+    POSITIVE_INFINITY,
+    True,
+    POSITIVE_INFINITY,
+    False,
+)
+"""``[+inf, +inf)``, the same for ``+inf`` and the lower slot."""
+
+STARTS_ABOVE_EVERYTHING: Interval = (POSITIVE_INFINITY, True, 1, True)
+"""``[+inf, 1]``: a finite upper bound over a ``+inf`` lower bound."""
+
+ENDS_BELOW_EVERYTHING: Interval = (1, True, NEGATIVE_INFINITY, True)
+"""``[1, -inf]``: a ``-inf`` upper bound under a finite lower bound."""
 
 
 def holds_no_version(interval: Interval) -> bool:
@@ -376,6 +399,28 @@ class TestNormalizeIntervals:
         )
 
 
+class TestTheEmptinessPredicate:
+    """``_interval_is_empty`` and ``holds_no_version`` state the same rule.
+
+    ``invariant_violations`` reads the test-side one, so the two agreeing is
+    what lets its verdicts stand for the module's own.
+    """
+
+    def test_they_agree_on_every_shape_of_bound(self) -> None:
+        """Both infinities, in both slots, against both flags."""
+        bounds = (NEGATIVE_INFINITY, 1, 2, POSITIVE_INFINITY)
+        combinations = itertools.product(bounds, (True, False), bounds, (True, False))
+
+        for lower, lower_inclusive, upper, upper_inclusive in combinations:
+            interval: Interval = (lower, lower_inclusive, upper, upper_inclusive)
+            assert _interval_is_empty(
+                lower,
+                lower_inclusive=lower_inclusive,
+                upper=upper,
+                upper_inclusive=upper_inclusive,
+            ) == holds_no_version(interval), interval
+
+
 class TestOutOfContractInputs:
     """Hand-built lists that break the invariant, and what ``Range`` does with them.
 
@@ -432,6 +477,122 @@ class TestOutOfContractInputs:
 
         assert oracle_is_subset(below_one, Range.full())
         assert not below_one.is_subset(Range.full()), WIDENING_CHANGES_THIS
+
+    def test_an_interval_at_an_infinity_holds_no_version(self) -> None:
+        """The scan finds nothing in either misplaced-sentinel interval.
+
+        Nothing sits at or beyond an infinity.  The walks below still carve and
+        compare these intervals, which is the asymmetry the rest of these tests
+        turn on.
+        """
+        assert all(probe not in Range((AT_NEGATIVE_INFINITY,)) for probe in PROBES)
+        assert all(probe not in Range((AT_POSITIVE_INFINITY,)) for probe in PROBES)
+
+    def test_the_carve_reads_a_misplaced_sentinel_as_an_infinity(self) -> None:
+        """``__sub__`` tests both ends for an infinity by identity before comparing.
+
+        Only a sentinel in a slot the invariant bars reaches those tests, and
+        each answer below changes if one of them goes.
+        """
+        assert (Range((AT_NEGATIVE_INFINITY,)) - Range.at_most(1)).is_empty, (
+            WIDENING_CHANGES_THIS
+        )
+        assert (
+            Range((AT_NEGATIVE_INFINITY,)) - Range((AT_NEGATIVE_INFINITY,))
+        )._intervals == (AT_NEGATIVE_INFINITY,), WIDENING_CHANGES_THIS
+
+        assert (Range.at_least(1) - Range((STARTS_ABOVE_EVERYTHING,)))._intervals == (
+            (1, True, POSITIVE_INFINITY, False),
+            (1, False, POSITIVE_INFINITY, False),
+        ), WIDENING_CHANGES_THIS
+
+        assert (
+            Range((AT_POSITIVE_INFINITY,)) - Range((AT_POSITIVE_INFINITY,))
+        )._intervals == (AT_POSITIVE_INFINITY,), WIDENING_CHANGES_THIS
+        assert (Range((AT_POSITIVE_INFINITY,)) - Range.singleton(1))._intervals == (
+            AT_POSITIVE_INFINITY,
+        ), WIDENING_CHANGES_THIS
+
+    def test_the_subset_walk_reads_a_misplaced_sentinel_as_an_infinity(self) -> None:
+        """``is_subset`` retires a right interval on the same two tests.
+
+        A ``+inf`` upper bound ends below nothing, and nothing ends below a
+        ``-inf`` lower bound, whichever slot the sentinel is sitting in.
+        """
+        assert Range((STARTS_ABOVE_EVERYTHING,)).is_subset(Range.at_least(1)), (
+            WIDENING_CHANGES_THIS
+        )
+        assert not Range.at_most(1).is_subset(
+            Range((AT_NEGATIVE_INFINITY, (NEGATIVE_INFINITY, False, 1, True)))
+        ), WIDENING_CHANGES_THIS
+
+    def test_relation_reads_a_misplaced_sentinel_as_an_infinity(self) -> None:
+        """``relation`` asks the same question in two places, in both directions.
+
+        Its advance loop and its ends-below test each carry both infinity
+        tests, so a pair answers one way round and not the other.
+        """
+        above_one: Range[int] = Range.at_least(1)
+        starts_above: Range[int] = Range((STARTS_ABOVE_EVERYTHING,))
+
+        assert starts_above.relation(above_one) is RangeRelation.SUBSET, (
+            WIDENING_CHANGES_THIS
+        )
+        assert above_one.relation(starts_above) is RangeRelation.OVERLAPPING, (
+            WIDENING_CHANGES_THIS
+        )
+
+        below_one: Range[int] = Range.at_most(1)
+        ends_below: Range[int] = Range((ENDS_BELOW_EVERYTHING,))
+
+        assert ends_below.relation(below_one) is RangeRelation.SUBSET, (
+            WIDENING_CHANGES_THIS
+        )
+        assert below_one.relation(ends_below) is RangeRelation.OVERLAPPING, (
+            WIDENING_CHANGES_THIS
+        )
+
+    def test_the_intersection_reads_a_misplaced_sentinel_as_an_infinity(self) -> None:
+        """``__and__`` and ``is_disjoint`` share the emptiness test on the overlap.
+
+        An overlap bounded by a misplaced sentinel is not empty, because that
+        test asks for the sentinel by identity before it compares.
+        """
+        assert (Range((AT_NEGATIVE_INFINITY,)) & Range.at_most(1))._intervals == (
+            (NEGATIVE_INFINITY, False, NEGATIVE_INFINITY, False),
+        ), WIDENING_CHANGES_THIS
+        assert not Range((AT_NEGATIVE_INFINITY,)).is_disjoint(Range.at_most(1)), (
+            WIDENING_CHANGES_THIS
+        )
+
+        assert (Range((AT_POSITIVE_INFINITY,)) & Range.at_least(1))._intervals == (
+            AT_POSITIVE_INFINITY,
+        ), WIDENING_CHANGES_THIS
+        assert not Range((AT_POSITIVE_INFINITY,)).is_disjoint(Range.at_least(1)), (
+            WIDENING_CHANGES_THIS
+        )
+
+    def test_a_shared_endpoint_belongs_to_both_sides_only_if_both_include_it(
+        self,
+    ) -> None:
+        """The walks decide that with ``and`` over the two flags.
+
+        Reaching it takes an interval that holds no version, since a canonical
+        list leaves a gap wherever two intervals could share an endpoint.
+        """
+        assert (
+            Range.at_most(1) - Range(((1, True, 1, True), (1, True, 1, False)))
+        )._intervals == Range.less_than(1)._intervals, WIDENING_CHANGES_THIS
+        assert (
+            Range(((1, True, 2, True),)) - Range(((2, False, 1, True),))
+        )._intervals == ((1, True, 2, True),), WIDENING_CHANGES_THIS
+
+        assert (Range(((1, True, 1, False),)) - Range.singleton(1)).is_empty, (
+            WIDENING_CHANGES_THIS
+        )
+        assert not Range(((1, True, 1, False),)).is_subset(
+            Range(((1, True, 1, False),))
+        ), WIDENING_CHANGES_THIS
 
     def test_an_empty_interval_defeats_the_relation_short_circuit(self) -> None:
         """``relation`` reads ``is_empty`` off the interval count, not off the versions."""


### PR DESCRIPTION
Writing `_ends_before` and `_interval_is_empty` out at the nine places where `__and__`, `__sub__`, `is_subset`, `is_disjoint` and `relation` walk two interval lists removes 104,455 of the 469,267 Python-level calls a `wrong-package-backtracking` resolve makes. On `satisfied-ceiling-fanin`, where every `relation` answers SUBSET, it removes 63,065 of 512,097. Both scenarios are in `nab-resolver/benchmarks/range_scenarios.py`.

| resolve | instructions | change |
| --- | ---: | ---: |
| `wrong-package-backtracking`, 64 releases | 752,971,194 -> 689,009,690 | -8.5% |
| `satisfied-ceiling-fanin`, 1000 dependents | 867,692,203 -> 826,385,223 | -4.8% |
| `conflict-free-fanout`, 120 packages | 250,268,126 -> 250,255,227 | -0.005% |

Callgrind under `PYTHONHASHSEED=0`, over a process that builds the graph and resolves it once; base and branch reach the same solution on all three. Timing the backtracking scenario agrees, between about 3% and 10% faster.

Every process importing `nab_resolver.ranges` pays about 13,000 more instructions of 80 million; the code object grows 762 bytes.

`__sub__`'s advance loop stays a call: inlining it needs an `if` to break on, which takes the method past ruff's C901 ceiling.