### PR TITLE
Take the relation gate's countdown off memo hits, ~0.8% off a resolve

### DIFF
--- a/nab-resolver/src/nab_resolver/propagate.py
+++ b/nab-resolver/src/nab_resolver/propagate.py
@@ -173,16 +173,16 @@ def _resample_relation_gate(resolver: Resolver[Any, Any]) -> None:
     off and drop the entries it collected.  While it is off, the window is only
     the wait before the memo is tried again.
     """
+    window = RELATION_GATE_WINDOW
     if not resolver.relation_cache_on:
         resolver.relation_cache_on = True
     elif resolver.relation_gate_hits < RELATION_GATE_MIN_HITS:
         resolver.relation_cache_on = False
         resolver.relation_cache.clear()
-        resolver.relation_gate_countdown = RELATION_GATE_RECHECK
-        return
+        window = RELATION_GATE_RECHECK
 
     resolver.relation_gate_hits = 0
-    resolver.relation_gate_countdown = RELATION_GATE_WINDOW
+    resolver.relation_gate_probes_left = window
 
 
 def term_relation(resolver: Resolver[Any, Any], term: Term[Any, Any]) -> SetRelation:
@@ -201,13 +201,6 @@ def term_relation(resolver: Resolver[Any, Any], term: Term[Any, Any]) -> SetRela
     positive = term.is_positive()
     constraint = term.constraint
 
-    countdown = resolver.relation_gate_countdown - 1
-    if countdown:
-        resolver.relation_gate_countdown = countdown
-    else:
-        _resample_relation_gate(resolver)
-
-    cache = resolver.relation_cache
     # key stays None while the memo is off, so a miss below stores nothing.
     key = None
     result = None
@@ -223,17 +216,28 @@ def term_relation(resolver: Resolver[Any, Any], term: Term[Any, Any]) -> SetRela
             constraint_token = _intern_range(resolver, constraint)
 
         key = (positive, assignment_token, constraint_token)
-        result = cache.get(key)
+        result = resolver.relation_cache.get(key)
 
     if result is None:
         relation = assignment.relation(constraint)
         result = classify_relation(
             term, subset=relation.is_subset, disjoint=relation.is_disjoint
         )
+
+        # A hit must not write this counter, so it is charged here and not above.
+        probes_left = resolver.relation_gate_probes_left - 1
+        resolver.relation_gate_probes_left = probes_left
+
         if key is not None:
+            cache = resolver.relation_cache
             if len(cache) >= RELATION_CACHE_MAX:
                 cache.clear()
             cache[key] = result
+
+        # Nothing hits while the memo is off, so the recheck wait runs its
+        # full length.
+        if probes_left <= resolver.relation_gate_hits:
+            _resample_relation_gate(resolver)
     else:
         resolver.relation_gate_hits += 1
 

--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -494,11 +494,12 @@ class Resolver(Generic[PackageType, VersionType]):
         self.relation_cache: dict[tuple[bool, int, int], SetRelation] = {}
 
         # relation_cache_on goes off while the memo's hit rate does not pay for
-        # the key it builds. relation_gate_countdown is the probes left in the
-        # window that rate is judged over, and relation_gate_hits its hits.
+        # the key it builds. A window of probes decides that: relation_gate_hits
+        # counts its hits, relation_gate_probes_left is the window less its
+        # misses, and a miss judges the window once the hits cover what is left.
         self.relation_cache_on = True
-        self.relation_gate_countdown = propagate.RELATION_GATE_WINDOW
         self.relation_gate_hits = 0
+        self.relation_gate_probes_left = propagate.RELATION_GATE_WINDOW
 
         # One token per distinct range, so a relation-cache probe compares ints
         # rather than bound structures. The counter never rewinds, so clearing
@@ -721,8 +722,8 @@ class Resolver(Generic[PackageType, VersionType]):
         self.priority_epoch = 0
         self.relation_cache.clear()
         self.relation_cache_on = True
-        self.relation_gate_countdown = propagate.RELATION_GATE_WINDOW
         self.relation_gate_hits = 0
+        self.relation_gate_probes_left = propagate.RELATION_GATE_WINDOW
         self.range_tokens.clear()
         self.range_token_by_id.clear()
         self.interned_ranges.clear()

--- a/nab-resolver/tests/test_resolver.py
+++ b/nab-resolver/tests/test_resolver.py
@@ -3097,10 +3097,18 @@ class TestRelationCache:
         assert self._token_key(resolver, term) == key
         assert resolver.relation_cache == {key: first}
 
+    @staticmethod
+    def _probe(resolver: Resolver[str, int], lower: int) -> None:
+        """Probe ``foo`` against ``>= lower``.
+
+        A ``lower`` not used before misses; a repeat hits while the memo is on.
+        """
+        term_relation(resolver, Term("foo", Range.at_least(lower), positive=True))
+
     def test_gate_switches_the_memo_off_when_probes_mostly_miss(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The window closes on probes alone, and the entries it collected go too."""
+        """Too few hits in a window switch the memo off and drop its entries."""
         monkeypatch.setattr(propagate, "RELATION_GATE_WINDOW", 3)
         resolver: Resolver[str, int] = Resolver(DictProvider({}))
         resolver.solution.decide("foo", 2)
@@ -3109,46 +3117,84 @@ class TestRelationCache:
 
         # A distinct constraint each time, so no probe in the window hits.
         for lower in (1, 3, 5):
-            term_relation(resolver, Term("foo", Range.at_least(lower), positive=True))
+            self._probe(resolver, lower)
 
         assert resolver.relation_cache_on is False
         assert resolver.relation_cache == {}
-        assert resolver.relation_gate_countdown == propagate.RELATION_GATE_RECHECK
+        assert resolver.relation_gate_probes_left == propagate.RELATION_GATE_RECHECK
 
     def test_gate_keeps_the_memo_while_probes_hit(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A window that closes well starts the next one, so the count restarts.
+        """Enough hits keep the memo and its entries, and the next window opens.
 
-        The final hit count is the probe that closed the window, counted after
-        the reset rather than the one asserted before it.
+        A hit spends a probe of the window without recomputing anything, so the
+        third probe here closes a window of three on the second miss.
         """
+        monkeypatch.setattr(propagate, "RELATION_GATE_WINDOW", 3)
         monkeypatch.setattr(propagate, "RELATION_GATE_MIN_HITS", 1)
         resolver: Resolver[str, int] = Resolver(DictProvider({}))
         resolver.solution.decide("foo", 2)
-        term = Term("foo", Range.at_least(1), positive=True)
-        term_relation(resolver, term)
-        term_relation(resolver, term)
+
+        self._probe(resolver, 1)
+        self._probe(resolver, 1)
         assert resolver.relation_gate_hits == 1
 
-        resolver.relation_gate_countdown = 1
-        term_relation(resolver, term)
+        self._probe(resolver, 3)
 
         assert resolver.relation_cache_on is True
-        assert resolver.relation_gate_countdown == propagate.RELATION_GATE_WINDOW
-        assert resolver.relation_gate_hits == 1
+        assert len(resolver.relation_cache) == 2
 
-    def test_gate_tries_the_memo_again_after_the_recheck_window(self) -> None:
+        assert resolver.relation_gate_hits == 0
+        assert resolver.relation_gate_probes_left == propagate.RELATION_GATE_WINDOW
+
+    def test_a_hit_never_closes_the_window(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A hit fills a probe of the window but leaves the judging to a miss.
+
+        Two probes fill a window of two here, and it stays open because the
+        second of them was a hit.
+        """
+        monkeypatch.setattr(propagate, "RELATION_GATE_WINDOW", 2)
         resolver: Resolver[str, int] = Resolver(DictProvider({}))
         resolver.solution.decide("foo", 2)
-        resolver.relation_cache_on = False
-        resolver.relation_gate_countdown = 1
-        term = Term("foo", Range.at_least(1), positive=True)
 
-        result = term_relation(resolver, term)
+        self._probe(resolver, 1)
+        self._probe(resolver, 1)
 
+        assert resolver.relation_gate_probes_left == 1
+        assert resolver.relation_gate_hits == 1
+
+        # One hit is under the default threshold, so a window judged here would
+        # have switched the memo off.
         assert resolver.relation_cache_on is True
-        assert resolver.relation_gate_countdown == propagate.RELATION_GATE_WINDOW
+        assert len(resolver.relation_cache) == 1
+
+    def test_gate_tries_the_memo_again_after_the_recheck_window(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A switched-off memo comes back, and starts collecting again."""
+        monkeypatch.setattr(propagate, "RELATION_GATE_WINDOW", 2)
+        monkeypatch.setattr(propagate, "RELATION_GATE_RECHECK", 3)
+        resolver: Resolver[str, int] = Resolver(DictProvider({}))
+        resolver.solution.decide("foo", 2)
+
+        self._probe(resolver, 1)
+        self._probe(resolver, 3)
+        assert resolver.relation_cache_on is False
+
+        # The recheck window is longer than the one that judged the memo.
+        self._probe(resolver, 5)
+        self._probe(resolver, 7)
+        assert resolver.relation_cache_on is False
+
+        self._probe(resolver, 9)
+        assert resolver.relation_cache_on is True
+        assert resolver.relation_cache == {}
+
+        term = Term("foo", Range.at_least(11), positive=True)
+        result = term_relation(resolver, term)
         assert resolver.relation_cache == {self._token_key(resolver, term): result}
 
     def test_relation_is_unchanged_while_the_memo_is_off(self) -> None:


### PR DESCRIPTION
A memo hit no longer touches the relation gate's countdown: about 5.9 million instructions off a `wrong-package-backtracking` resolve of about 690 million in `nab-resolver/benchmarks/range_scenarios.py`, and about 170,000 off `conflict-free-fanout`'s 37 million. Callgrind under `PYTHONHASHSEED=0`.

The decrement ran ahead of the cache lookup in `term_relation`, so every probe paid it; only a probe that recomputes is charged now. The first graph makes 19,594 probes and recomputes on 4,348 of them, the second 484 with 3. Both reach the same solution by the same decisions.

Only a miss can close a window, so one can now run past its 4,096 probes: a window that keeps the memo on holds a hit rate of at least 1,024/5,120 rather than 1,024/4,096.

`Resolver.relation_gate_countdown` becomes `relation_gate_probes_left`, so a consumer reading the old name gets an `AttributeError` rather than a counter that changed meaning.