### PR TITLE
Hand-write the config layer's value types, 3.4% off the CLI import

### DIFF
--- a/nab-project/src/nab_project/_value.py
+++ b/nab-project/src/nab_project/_value.py
@@ -1,0 +1,53 @@
+"""The base this package's hand-written value types share.
+
+``@dataclass`` compiles ``__init__``, ``__eq__`` and ``__repr__`` with
+``exec`` every time it is applied, and every ``nab`` invocation pays that
+at import.  :class:`ValueType` carries the equality, hashing and repr
+these types share, leaving each class its own fields and its own
+constructor.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from typing_extensions import override
+
+__all__ = ["ValueType"]
+
+
+class ValueType:
+    """A value type whose field names live in ``__match_args__``.
+
+    A subclass names its fields once, in declaration order, as both
+    ``__slots__`` and ``__match_args__``, annotates them, and assigns them
+    in its own ``__init__``.  Equality, hashing and repr read that tuple.
+    """
+
+    # Without this a subclass carries a __dict__ alongside its slots.
+    __slots__ = ()
+
+    __match_args__: ClassVar[tuple[str, ...]] = ()
+
+    @override
+    def __eq__(self, other: object) -> bool:
+        """Compare every field against an instance of the same class."""
+        if other.__class__ is not self.__class__:
+            return NotImplemented
+        names = self.__match_args__
+        return tuple(getattr(self, name) for name in names) == tuple(
+            getattr(other, name) for name in names
+        )
+
+    @override
+    def __hash__(self) -> int:
+        """Hash every field together."""
+        return hash(tuple(getattr(self, name) for name in self.__match_args__))
+
+    @override
+    def __repr__(self) -> str:
+        """Return the qualified class name and every field, in declaration order."""
+        fields = ", ".join(
+            f"{name}={getattr(self, name)!r}" for name in self.__match_args__
+        )
+        return f"{type(self).__qualname__}({fields})"

--- a/nab-project/src/nab_project/config.py
+++ b/nab-project/src/nab_project/config.py
@@ -64,6 +64,7 @@ from nab_provider.target import (
 from nab_provider.vcs_admission import VcsConfig, VcsPolicy, known_vcs_schemes
 
 from ._toml import tool_nab_section
+from ._value import ValueType
 from .config_sources import (
     ConfigError,
     EffectiveValue,
@@ -157,15 +158,37 @@ _TOOL_NAB_REQUIRES_PYTHON = "requires-python"
 _PROJECT_REQUIRES_PYTHON = "[project] requires-python"
 
 
-@dataclass(frozen=True, slots=True)
-class MatrixConfig:
+class MatrixConfig(ValueType):
     """User-declared matrix axes for universal resolution."""
+
+    __slots__ = __match_args__ = (
+        "python",
+        "platforms",
+        "python_order",
+        "python_patches",
+        "implementations",
+    )
 
     python: str
     platforms: tuple[PlatformSpec, ...]
-    python_order: str = "asc"
-    python_patches: Mapping[str, str] | None = None
-    implementations: tuple[str, ...] = ("cpython",)
+    python_order: str
+    python_patches: Mapping[str, str] | None
+    implementations: tuple[str, ...]
+
+    def __init__(
+        self,
+        python: str,
+        platforms: tuple[PlatformSpec, ...],
+        python_order: str = "asc",
+        python_patches: Mapping[str, str] | None = None,
+        implementations: tuple[str, ...] = ("cpython",),
+    ) -> None:
+        """Record the axes ``[tool.nab.matrix]`` declared."""
+        self.python = python
+        self.platforms = platforms
+        self.python_order = python_order
+        self.python_patches = python_patches
+        self.implementations = implementations
 
 
 @dataclass(frozen=True, slots=True)
@@ -212,8 +235,7 @@ class ConflictKind(enum.Enum):
     GROUP = KIND_GROUP
 
 
-@dataclass(frozen=True, slots=True)
-class ConflictMember:
+class ConflictMember(ValueType):
     """One side of a conflict: a named extra or dependency group.
 
     ``name`` is stored canonicalised (PEP 685 for extras, PEP 735 for
@@ -222,8 +244,15 @@ class ConflictMember:
     members, matching uv's package-qualified model.
     """
 
+    __slots__ = __match_args__ = ("kind", "name")
+
     kind: ConflictKind
     name: str
+
+    def __init__(self, kind: ConflictKind, name: str) -> None:
+        """Record an extra or group ``name`` the caller has canonicalised."""
+        self.kind = kind
+        self.name = name
 
     @override
     def __str__(self) -> str:
@@ -231,12 +260,22 @@ class ConflictMember:
         return f"{self.kind.value} {self.name!r}"
 
 
-@dataclass(frozen=True, slots=True)
-class ConflictSet:
+class ConflictSet(ValueType):
     """A set of mutually-exclusive members with an exclusivity policy."""
 
+    __slots__ = __match_args__ = ("members", "policy")
+
     members: tuple[ConflictMember, ...]
-    policy: ConflictPolicy = ConflictPolicy.AT_MOST_ONE
+    policy: ConflictPolicy
+
+    def __init__(
+        self,
+        members: tuple[ConflictMember, ...],
+        policy: ConflictPolicy = ConflictPolicy.AT_MOST_ONE,
+    ) -> None:
+        """Record the members ``policy`` makes exclusive."""
+        self.members = members
+        self.policy = policy
 
     @override
     def __str__(self) -> str:
@@ -281,8 +320,7 @@ def conflict_member_groups(
     )
 
 
-@dataclass(frozen=True, slots=True)
-class ConflictFork:
+class ConflictFork(ValueType):
     """One fork of a conflict-driven universal resolve.
 
     ``selection`` is the active conflicting members as ``(kind, name)``
@@ -293,13 +331,33 @@ class ConflictFork:
     unforked resolve is a single fork with an empty ``selection``.
     """
 
+    __slots__ = __match_args__ = (
+        "selection",
+        "active_extras",
+        "active_groups",
+        "active_configured",
+    )
+
     selection: tuple[tuple[str, str], ...]
     active_extras: tuple[str, ...]
     active_groups: tuple[str, ...]
-    active_configured: tuple[str, ...] = ()
+    active_configured: tuple[str, ...]
     """The configured group names (``base-group``, ``build-group``) this
     fork carries.  Their requirements come from a pyproject table rather
     than from ``[dependency-groups]``."""
+
+    def __init__(
+        self,
+        selection: tuple[tuple[str, str], ...],
+        active_extras: tuple[str, ...],
+        active_groups: tuple[str, ...],
+        active_configured: tuple[str, ...] = (),
+    ) -> None:
+        """Record one fork of a conflict-driven resolve."""
+        self.selection = selection
+        self.active_extras = active_extras
+        self.active_groups = active_groups
+        self.active_configured = active_configured
 
 
 # Two active selections engage the set's exclusivity, forcing a fork.

--- a/nab-project/src/nab_project/config_sources.py
+++ b/nab-project/src/nab_project/config_sources.py
@@ -32,7 +32,6 @@ import logging
 import types
 from contextlib import contextmanager
 from contextvars import ContextVar
-from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -57,6 +56,7 @@ from nab_provider.serialization import SimpleSerialization
 from nab_provider.vcs_admission import VcsConfig
 
 from ._toml import tool_nab_section
+from ._value import ValueType
 from .fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL
 from .paths import PathState, is_usable_path_name, path_state
 
@@ -235,8 +235,7 @@ _ALLOWED_TOML_SOURCES: dict[Scope, frozenset[SourceKind]] = {
 }
 
 
-@dataclass(frozen=True, slots=True)
-class OptionSpec:
+class OptionSpec(ValueType):
     """One row of the registry: the full definition of a layered option.
 
     ``key`` is the TOML/`nab config` key.  ``scope`` gates which sources
@@ -251,6 +250,18 @@ class OptionSpec:
     ``nab config``.
     """
 
+    __slots__ = __match_args__ = (
+        "key",
+        "scope",
+        "type_label",
+        "default",
+        "env_var",
+        "cli_flag",
+        "cli_param",
+        "parse",
+        "render",
+    )
+
     key: str
     scope: Scope
     type_label: str
@@ -260,6 +271,29 @@ class OptionSpec:
     cli_param: str | None
     parse: Callable[[Any, str], Any]
     render: Callable[[Any], str]
+
+    def __init__(  # noqa: PLR0913, PLR0917 - the type's own fields, in its own order
+        self,
+        key: str,
+        scope: Scope,
+        type_label: str,
+        default: Any,
+        env_var: str | None,
+        cli_flag: str | None,
+        cli_param: str | None,
+        parse: Callable[[Any, str], Any],
+        render: Callable[[Any], str],
+    ) -> None:
+        """Record one registry row."""
+        self.key = key
+        self.scope = scope
+        self.type_label = type_label
+        self.default = default
+        self.env_var = env_var
+        self.cli_flag = cli_flag
+        self.cli_param = cli_param
+        self.parse = parse
+        self.render = render
 
     def allowed_in_toml(self, kind: SourceKind) -> bool:
         """Whether a TOML source of ``kind`` may set this option.
@@ -1179,12 +1213,18 @@ def reject_user_keys_in_pyproject(raw: Mapping[str, Any]) -> None:
             raise SourceConfigError(msg)
 
 
-@dataclass(frozen=True, slots=True)
-class Origin:
+class Origin(ValueType):
     """Where a value came from: a source kind plus a display label."""
+
+    __slots__ = __match_args__ = ("kind", "label")
 
     kind: SourceKind
     label: str
+
+    def __init__(self, kind: SourceKind, label: str) -> None:
+        """Record the source a value came from."""
+        self.kind = kind
+        self.label = label
 
     @property
     def scope(self) -> str:
@@ -1216,16 +1256,21 @@ def _scope_label(kind: SourceKind) -> str:
     return "project" if kind is SourceKind.PYPROJECT else kind.value
 
 
-@dataclass(frozen=True, slots=True)
-class Layer:
+class Layer(ValueType):
     """A set of (key -> value) bindings discovered from one source."""
+
+    __slots__ = __match_args__ = ("origin", "values")
 
     origin: Origin
     values: Mapping[str, Any]
 
+    def __init__(self, origin: Origin, values: Mapping[str, Any]) -> None:
+        """Record the bindings ``origin`` supplied."""
+        self.origin = origin
+        self.values = values
 
-@dataclass(frozen=True, slots=True)
-class RejectedLayer:
+
+class RejectedLayer(ValueType):
     """A source refused by the registry: a key outside its scope, or unknown.
 
     Captured (not raised) by :func:`discover_layers` for the TOML sources and
@@ -1234,14 +1279,23 @@ class RejectedLayer:
     load path raises :class:`SourceConfigError` for TOML and warns for env.
     """
 
+    __slots__ = __match_args__ = ("origin", "key", "reason")
+
     origin: Origin
     key: str
     reason: str
 
+    def __init__(self, origin: Origin, key: str, reason: str) -> None:
+        """Record why ``origin``'s ``key`` was refused."""
+        self.origin = origin
+        self.key = key
+        self.reason = reason
 
-@dataclass(frozen=True, slots=True)
-class EffectiveValue:
+
+class EffectiveValue(ValueType):
     """One option's winning value plus its full shadowed stack."""
+
+    __slots__ = __match_args__ = ("spec", "value", "origin", "stack", "rejected")
 
     spec: OptionSpec
     value: Any
@@ -1249,11 +1303,25 @@ class EffectiveValue:
     # Every binding for this key in precedence order (low -> high),
     # the last of which is the winner.
     stack: tuple[tuple[Origin, Any], ...]
-    rejected: tuple[RejectedLayer, ...] = ()
+    rejected: tuple[RejectedLayer, ...]
+
+    def __init__(
+        self,
+        spec: OptionSpec,
+        value: Any,
+        origin: Origin,
+        stack: tuple[tuple[Origin, Any], ...],
+        rejected: tuple[RejectedLayer, ...] = (),
+    ) -> None:
+        """Record the value ``origin`` bound for ``spec``."""
+        self.spec = spec
+        self.value = value
+        self.origin = origin
+        self.stack = stack
+        self.rejected = rejected
 
 
-@dataclass(frozen=True, slots=True)
-class SourceRoots:
+class SourceRoots(ValueType):
     """Injectable search roots so config discovery is hermetic in tests.
 
     ``system_toml`` and ``user_toml`` point at the system/user
@@ -1267,10 +1335,30 @@ class SourceRoots:
     pyproject only.
     """
 
-    system_toml: Path | None = None
-    user_toml: Path | None = None
-    project_dir: Path | None = None
-    pyproject: Path | None = None
+    __slots__ = __match_args__ = (
+        "system_toml",
+        "user_toml",
+        "project_dir",
+        "pyproject",
+    )
+
+    system_toml: Path | None
+    user_toml: Path | None
+    project_dir: Path | None
+    pyproject: Path | None
+
+    def __init__(
+        self,
+        system_toml: Path | None = None,
+        user_toml: Path | None = None,
+        project_dir: Path | None = None,
+        pyproject: Path | None = None,
+    ) -> None:
+        """Record the roots config discovery may read."""
+        self.system_toml = system_toml
+        self.user_toml = user_toml
+        self.project_dir = project_dir
+        self.pyproject = pyproject
 
 
 def _load_toml_layer(

--- a/nab-project/tests/test_value_types.py
+++ b/nab-project/tests/test_value_types.py
@@ -1,0 +1,400 @@
+"""The hand-written value types in config and config_sources.
+
+:mod:`nab_project.config` and :mod:`nab_project.config_sources` write
+their value types against :class:`nab_project._value.ValueType` rather
+than applying ``@dataclass(slots=True)``.  Field order, equality,
+hashing, repr and the defaults are what the rest of nab reads off them,
+so each one is pinned here instead of being left to the decorator.
+"""
+
+from __future__ import annotations
+
+import copy
+import pickle
+from pathlib import Path
+from typing import Any, NamedTuple
+
+import pytest
+
+from nab_project import config, config_sources
+from nab_project._value import ValueType
+from nab_project.config import (
+    ConflictFork,
+    ConflictKind,
+    ConflictMember,
+    ConflictPolicy,
+    ConflictSet,
+    MatrixConfig,
+)
+from nab_project.config_sources import (
+    EffectiveValue,
+    Layer,
+    OptionSpec,
+    Origin,
+    RejectedLayer,
+    Scope,
+    SourceKind,
+    SourceRoots,
+)
+from nab_provider.tags import PlatformSpec
+
+
+def _parse(value: Any, where: str) -> Any:
+    return value
+
+
+def _render(value: Any) -> str:
+    return str(value)
+
+
+def _round_trip_pickle(instance: Any) -> Any:
+    """A pickled and restored copy of ``instance``."""
+    return pickle.loads(pickle.dumps(instance))  # noqa: S301
+
+
+ORIGIN = Origin(SourceKind.PYPROJECT, "/p/pyproject.toml")
+OTHER_ORIGIN = Origin(SourceKind.USER_TOML, "/u/nab.toml")
+SPEC = OptionSpec(
+    key="mode",
+    scope=Scope.PROJECT,
+    type_label="enum(specific|universal)",
+    default="specific",
+    env_var="NAB_MODE",
+    cli_flag="--project-mode",
+    cli_param="project_mode",
+    parse=_parse,
+    render=_render,
+)
+
+
+class Case(NamedTuple):
+    """One value type, a full set of field values, and a different value each.
+
+    ``fields`` is in declaration order, which is what ``__match_args__``
+    and ``__slots__`` are checked against.  ``alternates`` supplies one
+    differing value per field so equality can be varied a field at a
+    time.  ``hashable`` is False where one of the field values is
+    itself unhashable.
+    """
+
+    cls: type[ValueType]
+    fields: dict[str, Any]
+    alternates: dict[str, Any]
+    hashable: bool = True
+
+    @property
+    def id(self) -> str:
+        return self.cls.__name__
+
+    def build(self, **overrides: Any) -> ValueType:
+        return self.cls(**{**self.fields, **overrides})
+
+
+CASES = [
+    Case(
+        MatrixConfig,
+        {
+            "python": "3.12",
+            "platforms": (PlatformSpec("linux_x86_64"),),
+            "python_order": "asc",
+            "python_patches": None,
+            "implementations": ("cpython",),
+        },
+        {
+            "python": "3.13",
+            "platforms": (PlatformSpec("macos_arm64"),),
+            "python_order": "desc",
+            "python_patches": {"3.12": "3.12.4"},
+            "implementations": ("pypy",),
+        },
+    ),
+    Case(
+        ConflictMember,
+        {"kind": ConflictKind.EXTRA, "name": "cpu"},
+        {"kind": ConflictKind.GROUP, "name": "gpu"},
+    ),
+    Case(
+        ConflictSet,
+        {
+            "members": (ConflictMember(ConflictKind.EXTRA, "cpu"),),
+            "policy": ConflictPolicy.AT_MOST_ONE,
+        },
+        {
+            "members": (ConflictMember(ConflictKind.GROUP, "cpu"),),
+            "policy": ConflictPolicy.EXACTLY_ONE,
+        },
+    ),
+    Case(
+        ConflictFork,
+        {
+            "selection": (("extra", "cpu"),),
+            "active_extras": ("cpu",),
+            "active_groups": ("dev",),
+            "active_configured": ("base",),
+        },
+        {
+            "selection": (("extra", "gpu"),),
+            "active_extras": ("gpu",),
+            "active_groups": ("docs",),
+            "active_configured": ("build",),
+        },
+    ),
+    Case(
+        OptionSpec,
+        {
+            "key": "mode",
+            "scope": Scope.PROJECT,
+            "type_label": "enum(specific|universal)",
+            "default": "specific",
+            "env_var": "NAB_MODE",
+            "cli_flag": "--project-mode",
+            "cli_param": "project_mode",
+            "parse": _parse,
+            "render": _render,
+        },
+        {
+            "key": "resolution",
+            "scope": Scope.USER,
+            "type_label": "str",
+            "default": "universal",
+            "env_var": None,
+            "cli_flag": None,
+            "cli_param": None,
+            "parse": _render,
+            "render": _parse,
+        },
+    ),
+    Case(
+        Origin,
+        {"kind": SourceKind.PYPROJECT, "label": "/p/pyproject.toml"},
+        {"kind": SourceKind.USER_TOML, "label": "/u/nab.toml"},
+    ),
+    Case(
+        Layer,
+        {"origin": ORIGIN, "values": {"mode": "specific"}},
+        {"origin": OTHER_ORIGIN, "values": {"mode": "universal"}},
+        hashable=False,
+    ),
+    Case(
+        RejectedLayer,
+        {"origin": ORIGIN, "key": "mode", "reason": "not allowed here"},
+        {"origin": OTHER_ORIGIN, "key": "resolution", "reason": "unknown"},
+    ),
+    Case(
+        EffectiveValue,
+        {
+            "spec": SPEC,
+            "value": "specific",
+            "origin": ORIGIN,
+            "stack": ((ORIGIN, "specific"),),
+            "rejected": (RejectedLayer(ORIGIN, "mode", "unknown"),),
+        },
+        {
+            "spec": OptionSpec(
+                key="resolution",
+                scope=Scope.USER,
+                type_label="str",
+                default="highest",
+                env_var=None,
+                cli_flag=None,
+                cli_param=None,
+                parse=_parse,
+                render=_render,
+            ),
+            "value": "universal",
+            "origin": OTHER_ORIGIN,
+            "stack": (),
+            "rejected": (),
+        },
+    ),
+    Case(
+        SourceRoots,
+        {
+            "system_toml": Path("/etc/nab.toml"),
+            "user_toml": Path("/u/nab.toml"),
+            "project_dir": Path("/p"),
+            "pyproject": Path("/p/pyproject.toml"),
+        },
+        {
+            "system_toml": None,
+            "user_toml": None,
+            "project_dir": Path("/q"),
+            "pyproject": None,
+        },
+    ),
+]
+
+BY_ID = pytest.mark.parametrize("case", CASES, ids=[c.id for c in CASES])
+
+DEFAULTS = [
+    (
+        MatrixConfig,
+        {"python": "3.12", "platforms": ()},
+        {
+            "python_order": "asc",
+            "python_patches": None,
+            "implementations": ("cpython",),
+        },
+    ),
+    (ConflictSet, {"members": ()}, {"policy": ConflictPolicy.AT_MOST_ONE}),
+    (
+        ConflictFork,
+        {"selection": (), "active_extras": (), "active_groups": ()},
+        {"active_configured": ()},
+    ),
+    (
+        EffectiveValue,
+        {"spec": SPEC, "value": 1, "origin": ORIGIN, "stack": ()},
+        {"rejected": ()},
+    ),
+    (
+        SourceRoots,
+        {},
+        {
+            "system_toml": None,
+            "user_toml": None,
+            "project_dir": None,
+            "pyproject": None,
+        },
+    ),
+]
+
+
+def test_the_cases_cover_every_value_type() -> None:
+    """A subclass added later and left out of ``CASES`` would go unchecked."""
+    declared = {
+        obj
+        for module in (config, config_sources)
+        for obj in vars(module).values()
+        if isinstance(obj, type) and issubclass(obj, ValueType) and obj is not ValueType
+    }
+
+    assert declared == {case.cls for case in CASES}
+
+
+@BY_ID
+def test_the_field_names_are_declared_once_in_order(case: Case) -> None:
+    """``__slots__`` and ``__match_args__`` are the one field tuple."""
+    names = tuple(case.fields)
+
+    assert case.cls.__match_args__ == names
+    assert case.cls.__slots__ == names
+
+
+@BY_ID
+def test_instances_carry_no_dict(case: Case) -> None:
+    with pytest.raises(AttributeError):
+        _ = case.build().__dict__
+
+
+@BY_ID
+def test_positional_construction_binds_the_declared_order(case: Case) -> None:
+    """A signature binding in a different order than the field tuple shows up here."""
+    assert case.cls(*case.fields.values()) == case.build()
+
+
+@BY_ID
+def test_repr_names_every_field_in_order(case: Case) -> None:
+    rendered = ", ".join(f"{name}={value!r}" for name, value in case.fields.items())
+
+    assert repr(case.build()) == f"{case.cls.__qualname__}({rendered})"
+
+
+def test_repr_leads_with_the_qualified_name() -> None:
+    """All ten are module-level, so only a nested class separates the two names."""
+
+    class Nested(ValueType):
+        __slots__ = __match_args__ = ("value",)
+
+        value: int
+
+        def __init__(self, value: int) -> None:
+            self.value = value
+
+    assert "." in Nested.__qualname__
+    assert repr(Nested(1)) == f"{Nested.__qualname__}(value=1)"
+
+
+@BY_ID
+def test_equality_varies_with_every_field(case: Case) -> None:
+    """One field at a time, so no field can drop out of ``__eq__``."""
+    assert case.alternates.keys() == case.fields.keys()
+
+    instance = case.build()
+    assert instance == case.build()
+
+    for name, value in case.alternates.items():
+        assert instance != case.build(**{name: value}), name
+
+
+@BY_ID
+def test_equality_declines_another_type(case: Case) -> None:
+    assert case.build().__eq__("not a value type") is NotImplemented
+
+
+@BY_ID
+def test_a_subclass_holding_the_same_fields_is_not_equal(case: Case) -> None:
+    """Equality is by exact class, so a subclass never compares equal."""
+
+    class Subclass(case.cls):  # type: ignore[misc, name-defined]
+        __slots__ = ()
+
+    assert case.build() != Subclass(**case.fields)
+
+
+@BY_ID
+def test_hashing_follows_equality(case: Case) -> None:
+    instance = case.build()
+    if not case.hashable:
+        with pytest.raises(TypeError):
+            hash(instance)
+        return
+
+    assert hash(instance) == hash(case.build())
+    assert {instance, case.build()} == {instance}
+
+
+@BY_ID
+def test_an_undeclared_name_cannot_be_set(case: Case) -> None:
+    """Without ``__slots__ = ()`` on the base every instance would carry a dict."""
+    with pytest.raises(AttributeError):
+        case.build().unknown = 1  # type: ignore[attr-defined]
+
+
+@BY_ID
+def test_copying_and_unpickling_restore_every_field(case: Case) -> None:
+    """All three rebuild an instance from its slots, with no state hook of its own."""
+    instance = case.build()
+    restored = [
+        copy.copy(instance),
+        copy.deepcopy(instance),
+        _round_trip_pickle(instance),
+    ]
+
+    for other in restored:
+        assert other is not instance
+        assert type(other) is case.cls
+        assert other == instance
+
+
+@pytest.mark.parametrize(
+    ("cls", "required", "expected"),
+    DEFAULTS,
+    ids=[cls.__name__ for cls, _, _ in DEFAULTS],
+)
+def test_the_optional_fields_keep_their_defaults(
+    cls: type[ValueType], required: dict[str, Any], expected: dict[str, Any]
+) -> None:
+    instance = cls(**required)
+
+    assert {name: getattr(instance, name) for name in expected} == expected
+
+
+def test_a_conflict_member_deduplicates_by_canonical_identity() -> None:
+    """``_check_conflict_member_uniqueness`` holds members in a set."""
+    member = ConflictMember(ConflictKind.EXTRA, "cpu")
+    same = ConflictMember(ConflictKind.EXTRA, "cpu")
+    other_kind = ConflictMember(ConflictKind.GROUP, "cpu")
+
+    assert same in {member}
+    assert other_kind not in {member}


### PR DESCRIPTION
`import nab.cli` costs 33,912,797 fewer instructions, 3.4% of the base run, and `python -m nab --version` 33,754,933. Callgrind under `PYTHONHASHSEED=0`.

| run | main `db95ba50d` | branch |
| --- | ---: | ---: |
| `python -c "import nab.cli"` | 983,839,045 | 949,926,248 |
| `python -m nab --version` | 984,360,051 | 950,605,118 |

Ten `@dataclass(frozen=True, slots=True)` classes in `nab_project.config` and `nab_project.config_sources`, 38 fields between them, become plain `__slots__` classes over a shared `ValueType` base carrying `__eq__`, `__hash__` and `__repr__`. `dataclasses._create_fn` runs 598 times during that import instead of 658: the 60 methods it compiled with `exec` for those ten are gone.

`ValueType` reads fields by `getattr` over `__match_args__`, slower per call than the loads `dataclasses` emitted. The only shipped code that hashes one of the ten is two config-parse validators, over the conflict members a project declares.

The ten stop being dataclasses, so `fields`, `replace`, `asdict` and `astuple` raise `TypeError`, and a field write succeeds where `FrozenInstanceError` was raised. Copies round-trip, but a pickle written before this change does not load after it. `NabProjectConfig` and `EnvironmentConfig` stay dataclasses because callers pass them to `replace`.