### PR TITLE
Hand-write nab-provider's source value types, 2.6% off the CLI import

### DIFF
--- a/nab-provider/src/nab_provider/_value.py
+++ b/nab-provider/src/nab_provider/_value.py
@@ -1,0 +1,50 @@
+"""The shared base under the package's declared-source value types.
+
+Those types are written out by hand instead of declared with
+``@dataclass(slots=True)``, because applying the decorator is import-time work
+every ``nab`` invocation pays for.  The comparison, hash and repr all eight
+share live here; each type declares its own fields and constructor.
+"""
+
+from __future__ import annotations
+
+from typing_extensions import override
+
+__all__ = ["SlottedValue"]
+
+
+class SlottedValue:
+    """Comparison, hashing and repr over a subclass's declared fields.
+
+    A subclass lists its fields in ``__slots__`` and repeats them, in
+    declaration order, in ``__match_args__``, which is the order read here.
+    Comparison tests the exact class, so a subclass holding equal field
+    values is not equal.
+    """
+
+    __slots__ = ()
+    __match_args__: tuple[str, ...]
+
+    @override
+    def __eq__(self, other: object) -> bool:
+        """Compare every field against an instance of the same class."""
+        if other.__class__ is not self.__class__:
+            return NotImplemented
+
+        names = self.__match_args__
+        return tuple(getattr(self, name) for name in names) == tuple(
+            getattr(other, name) for name in names
+        )
+
+    @override
+    def __hash__(self) -> int:
+        """Hash every field together."""
+        return hash(tuple(getattr(self, name) for name in self.__match_args__))
+
+    @override
+    def __repr__(self) -> str:
+        """Return the class name and every field, in declaration order."""
+        fields = ", ".join(
+            f"{name}={getattr(self, name)!r}" for name in self.__match_args__
+        )
+        return f"{type(self).__qualname__}({fields})"

--- a/nab-provider/src/nab_provider/archive.py
+++ b/nab-provider/src/nab_provider/archive.py
@@ -11,8 +11,7 @@ own scheme; which archives are permitted is a policy decision in
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-
+from ._value import SlottedValue
 from .digest import is_hex_digest
 from .records import ACCEPTED_HASH_ALGORITHMS
 from .subdir import subdirectory_escapes
@@ -27,8 +26,7 @@ class ArchiveRequestError(Exception):
     """Raised when an archive URL cannot be parsed."""
 
 
-@dataclass(frozen=True, slots=True)
-class ArchiveRequest:
+class ArchiveRequest(SlottedValue):
     """Parsed representation of a direct-URL archive requirement.
 
     ``url`` is the archive URL with the ``#`` fragment stripped.
@@ -37,9 +35,19 @@ class ArchiveRequest:
     extracted tree, or ``""`` for the archive root.
     """
 
-    url: str
-    hashes: tuple[tuple[str, str], ...]
-    subdirectory: str = ""
+    __slots__ = ("hashes", "subdirectory", "url")
+    __match_args__ = ("url", "hashes", "subdirectory")
+
+    def __init__(
+        self,
+        url: str,
+        hashes: tuple[tuple[str, str], ...],
+        subdirectory: str = "",
+    ) -> None:
+        """Record one parsed archive URL."""
+        self.url = url
+        self.hashes = hashes
+        self.subdirectory = subdirectory
 
     @property
     def has_usable_hash(self) -> bool:

--- a/nab-provider/src/nab_provider/policy.py
+++ b/nab-provider/src/nab_provider/policy.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import enum
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
+
+from ._value import SlottedValue
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -137,8 +138,7 @@ class DecisionOrder(enum.Enum):
     """Wait for each listing, so the sort key cannot see arrival order."""
 
 
-@dataclass(frozen=True, slots=True)
-class LocalSource:
+class LocalSource(SlottedValue):
     """A source tree on disk used as the only candidate for a package.
 
     The package is pinned to the version the tree declares in
@@ -149,10 +149,22 @@ class LocalSource:
     layouts, and ``editable`` records an editable install in the lockfile.
     """
 
-    name: str
-    path: str
-    editable: bool = False
-    subdirectory: str | None = None
+    __slots__ = ("editable", "name", "path", "subdirectory")
+    __match_args__ = ("name", "path", "editable", "subdirectory")
+
+    def __init__(
+        self,
+        name: str,
+        path: str,
+        *,
+        editable: bool = False,
+        subdirectory: str | None = None,
+    ) -> None:
+        """Record the tree at ``path`` as the only candidate for ``name``."""
+        self.name = name
+        self.path = path
+        self.editable = editable
+        self.subdirectory = subdirectory
 
     @property
     def descriptor(self) -> str:
@@ -160,8 +172,7 @@ class LocalSource:
         return f"local source {self.name!r}"
 
 
-@dataclass(frozen=True, slots=True)
-class VcsSource:
+class VcsSource(SlottedValue):
     """A VCS reference used as the only candidate for a package.
 
     ``url`` is a pip-style VCS URL, e.g.
@@ -169,8 +180,13 @@ class VcsSource:
     read for metadata as a :class:`LocalSource` is.
     """
 
-    name: str
-    url: str
+    __slots__ = ("name", "url")
+    __match_args__ = ("name", "url")
+
+    def __init__(self, name: str, url: str) -> None:
+        """Record the repository at ``url`` as the only candidate for ``name``."""
+        self.name = name
+        self.url = url
 
     @property
     def descriptor(self) -> str:
@@ -178,8 +194,7 @@ class VcsSource:
         return f"vcs source {self.name!r}"
 
 
-@dataclass(frozen=True, slots=True)
-class ArchiveSource:
+class ArchiveSource(SlottedValue):
     """A direct-URL archive used as the only candidate for a package.
 
     ``url`` carries the archive's hash, and an optional subdirectory, in its
@@ -188,8 +203,13 @@ class ArchiveSource:
     :class:`LocalSource` is.
     """
 
-    name: str
-    url: str
+    __slots__ = ("name", "url")
+    __match_args__ = ("name", "url")
+
+    def __init__(self, name: str, url: str) -> None:
+        """Record the archive at ``url`` as the only candidate for ``name``."""
+        self.name = name
+        self.url = url
 
     @property
     def descriptor(self) -> str:
@@ -197,8 +217,7 @@ class ArchiveSource:
         return f"archive source {self.name!r}"
 
 
-@dataclass(frozen=True, slots=True)
-class SourceRequest:
+class SourceRequest(SlottedValue):
     """One declared source and everything a host needs to materialise it.
 
     ``build_policy`` is the source's effective policy, per-package overrides
@@ -206,16 +225,43 @@ class SourceRequest:
     demands a full commit sha.
     """
 
-    package: str
-    source: LocalSource | VcsSource | ArchiveSource
-    build_policy: BuildPolicy
-    vcs_cache_dir: Path | None
-    archive_cache_dir: Path | None
-    require_pin: bool
+    __slots__ = (
+        "archive_cache_dir",
+        "build_policy",
+        "package",
+        "require_pin",
+        "source",
+        "vcs_cache_dir",
+    )
+    __match_args__ = (
+        "package",
+        "source",
+        "build_policy",
+        "vcs_cache_dir",
+        "archive_cache_dir",
+        "require_pin",
+    )
+
+    def __init__(
+        self,
+        package: str,
+        source: LocalSource | VcsSource | ArchiveSource,
+        build_policy: BuildPolicy,
+        vcs_cache_dir: Path | None,
+        archive_cache_dir: Path | None,
+        *,
+        require_pin: bool,
+    ) -> None:
+        """Record what a host needs to materialise ``source`` for ``package``."""
+        self.package = package
+        self.source = source
+        self.build_policy = build_policy
+        self.vcs_cache_dir = vcs_cache_dir
+        self.archive_cache_dir = archive_cache_dir
+        self.require_pin = require_pin
 
 
-@dataclass(frozen=True, slots=True)
-class SourceMaterialization:
+class SourceMaterialization(SlottedValue):
     """What a host produced for one declared source.
 
     ``path`` is the directory the metadata was read from.  ``commit_sha`` is
@@ -223,6 +269,13 @@ class SourceMaterialization:
     an archive.
     """
 
-    path: Path
-    metadata: WheelMetadata
-    commit_sha: str | None
+    __slots__ = ("commit_sha", "metadata", "path")
+    __match_args__ = ("path", "metadata", "commit_sha")
+
+    def __init__(
+        self, path: Path, metadata: WheelMetadata, commit_sha: str | None
+    ) -> None:
+        """Record the tree at ``path`` and the metadata read out of it."""
+        self.path = path
+        self.metadata = metadata
+        self.commit_sha = commit_sha

--- a/nab-provider/src/nab_provider/vcs_request.py
+++ b/nab-provider/src/nab_provider/vcs_request.py
@@ -8,9 +8,9 @@ vocabulary.
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from ._value import SlottedValue
 from .subdir import subdirectory_escapes
 
 if TYPE_CHECKING:
@@ -32,8 +32,7 @@ class VcsCloneError(Exception):
     """Raised when a clone or ref resolution fails."""
 
 
-@dataclass(frozen=True, slots=True)
-class VcsClone:
+class VcsClone(SlottedValue):
     """Result of :func:`nab_index.vcs.prepare_clone`.
 
     ``path`` is the absolute filesystem path to the (possibly
@@ -43,13 +42,17 @@ class VcsClone:
     pyproject.toml; ``""`` means the repo root.
     """
 
-    path: Path
-    commit_sha: str
-    subdirectory: str = ""
+    __slots__ = ("commit_sha", "path", "subdirectory")
+    __match_args__ = ("path", "commit_sha", "subdirectory")
+
+    def __init__(self, path: Path, commit_sha: str, subdirectory: str = "") -> None:
+        """Record a checkout of ``commit_sha`` at ``path``."""
+        self.path = path
+        self.commit_sha = commit_sha
+        self.subdirectory = subdirectory
 
 
-@dataclass(frozen=True, slots=True)
-class VcsRequest:
+class VcsRequest(SlottedValue):
     """Parsed representation of a ``git+https://repo.git@ref#...`` URL.
 
     ``ref`` may be a 40-char SHA or a branch / tag name.  ``ref`` of
@@ -58,10 +61,15 @@ class VcsRequest:
     if present.
     """
 
-    scheme: str
-    repo_url: str
-    ref: str
-    subdirectory: str
+    __slots__ = ("ref", "repo_url", "scheme", "subdirectory")
+    __match_args__ = ("scheme", "repo_url", "ref", "subdirectory")
+
+    def __init__(self, scheme: str, repo_url: str, ref: str, subdirectory: str) -> None:
+        """Record one parsed VCS URL."""
+        self.scheme = scheme
+        self.repo_url = repo_url
+        self.ref = ref
+        self.subdirectory = subdirectory
 
     @classmethod
     def parse(cls, url: str) -> VcsRequest:

--- a/nab-provider/tests/test_source_value_types.py
+++ b/nab-provider/tests/test_source_value_types.py
@@ -1,0 +1,281 @@
+"""What the declared-source value types promise.
+
+Each names its fields three times, in ``__slots__``, in ``__match_args__`` and
+in its own constructor, and :class:`SlottedValue` reads ``__match_args__`` for
+comparison, hashing and repr.  A field missing from one of the three is
+otherwise silent.  The cases below drive every field of every type through all
+of them, and through the defaults, copying and pickling.
+"""
+
+from __future__ import annotations
+
+import copy
+import dataclasses
+import inspect
+import pickle
+from pathlib import Path
+from typing import Any, NamedTuple
+
+import pytest
+
+from nab_provider._value import SlottedValue
+from nab_provider._vendor.packaging.version import Version
+from nab_provider.archive import ArchiveRequest
+from nab_provider.metadata import WheelMetadata
+from nab_provider.policy import (
+    ArchiveSource,
+    BuildPolicy,
+    LocalSource,
+    SourceMaterialization,
+    SourceRequest,
+    VcsSource,
+)
+from nab_provider.vcs_request import VcsClone, VcsRequest
+
+SHA = "0" * 40
+OTHER_SHA = "1" * 40
+
+# SourceMaterialization's metadata field needs two values that differ.
+METADATA = WheelMetadata(name="pkg", version=Version("1.0"))
+OTHER_METADATA = WheelMetadata(name="other", version=Version("2.0"))
+
+
+class Case(NamedTuple):
+    """One value type and the field values the tests drive it through.
+
+    ``alt`` differs from ``base`` in every field, so varying one field at a
+    time reaches a field that a comparison or a hash left out.  ``defaults``
+    is every constructor parameter that carries one, and ``keyword_only``
+    every one a caller cannot pass positionally.
+    """
+
+    cls: type[SlottedValue]
+    base: tuple[Any, ...]
+    alt: tuple[Any, ...]
+    defaults: dict[str, Any]
+    keyword_only: frozenset[str] = frozenset()
+    hashable: bool = True
+
+
+CASES = [
+    Case(
+        LocalSource,
+        ("pkg", "/a/b", False, None),
+        ("other", "/c/d", True, "sub"),
+        {"editable": False, "subdirectory": None},
+        keyword_only=frozenset({"editable", "subdirectory"}),
+    ),
+    Case(
+        VcsSource,
+        ("pkg", "git+https://e/x.git"),
+        ("other", "git+https://e/y.git"),
+        {},
+    ),
+    Case(
+        ArchiveSource,
+        ("pkg", "https://e/x.tar.gz"),
+        ("other", "https://e/y.tar.gz"),
+        {},
+    ),
+    Case(
+        SourceRequest,
+        (
+            "pkg",
+            LocalSource("pkg", "/a/b"),
+            BuildPolicy.NEVER,
+            Path("/vcs"),
+            Path("/archive"),
+            True,
+        ),
+        (
+            "other",
+            VcsSource("other", "git+https://e/y.git"),
+            BuildPolicy.BUILD_REMOTE,
+            Path("/vcs2"),
+            Path("/archive2"),
+            False,
+        ),
+        {},
+        keyword_only=frozenset({"require_pin"}),
+    ),
+    Case(
+        SourceMaterialization,
+        (Path("/tree"), METADATA, None),
+        (Path("/other"), OTHER_METADATA, SHA),
+        {},
+        hashable=False,
+    ),
+    Case(
+        VcsClone,
+        (Path("/tree"), SHA, ""),
+        (Path("/other"), OTHER_SHA, "sub"),
+        {"subdirectory": ""},
+    ),
+    Case(
+        VcsRequest,
+        ("git", "https://e/x.git", "main", ""),
+        ("hg", "https://e/y.git", "v1", "sub"),
+        {},
+    ),
+    Case(
+        ArchiveRequest,
+        ("https://e/x.tar.gz", (("sha256", "ab"),), ""),
+        ("https://e/y.tar.gz", (("sha512", "cd"),), "sub"),
+        {"subdirectory": ""},
+    ),
+]
+
+VALUE_TYPES = [pytest.param(case, id=case.cls.__name__) for case in CASES]
+
+
+def _build(case: Case, values: tuple[Any, ...]) -> Any:
+    """Construct ``case.cls`` from ``values``, every field passed by name."""
+    return case.cls(**dict(zip(case.cls.__match_args__, values, strict=True)))
+
+
+def _build_positionally(case: Case, values: tuple[Any, ...]) -> Any:
+    """Construct ``case.cls`` positionally, naming only its keyword-only fields."""
+    fields = dict(zip(case.cls.__match_args__, values, strict=True))
+    leading = [value for name, value in fields.items() if name not in case.keyword_only]
+
+    return case.cls(*leading, **{name: fields[name] for name in case.keyword_only})
+
+
+def _vary(base: tuple[Any, ...], alt: tuple[Any, ...], index: int) -> tuple[Any, ...]:
+    """Return ``base`` with field ``index`` taken from ``alt``."""
+    return (*base[:index], alt[index], *base[index + 1 :])
+
+
+@pytest.mark.parametrize("case", VALUE_TYPES)
+def test_init_takes_the_declared_fields_in_order(case: Case) -> None:
+    parameters = inspect.signature(case.cls.__init__).parameters
+    names = list(parameters)
+
+    assert names[0] == "self"
+    assert tuple(names[1:]) == case.cls.__match_args__
+
+    instance = _build(case, case.base)
+    for name, value in zip(case.cls.__match_args__, case.base, strict=True):
+        assert getattr(instance, name) == value
+
+    assert _build_positionally(case, case.base) == instance
+
+
+@pytest.mark.parametrize("case", VALUE_TYPES)
+def test_the_fields_a_caller_must_name_are_the_expected_ones(case: Case) -> None:
+    """Pins the keyword-only set, which is where both boolean fields sit."""
+    parameters = inspect.signature(case.cls.__init__).parameters
+    keyword_only = {
+        name
+        for name, parameter in parameters.items()
+        if parameter.kind is inspect.Parameter.KEYWORD_ONLY
+    }
+
+    assert keyword_only == case.keyword_only
+
+
+@pytest.mark.parametrize("case", VALUE_TYPES)
+def test_init_carries_exactly_the_expected_defaults(case: Case) -> None:
+    parameters = inspect.signature(case.cls.__init__).parameters
+    declared = {
+        name: parameter.default
+        for name, parameter in parameters.items()
+        if parameter.default is not inspect.Parameter.empty
+    }
+
+    assert declared == case.defaults
+
+
+@pytest.mark.parametrize("case", VALUE_TYPES)
+def test_equality_reads_every_field(case: Case) -> None:
+    assert _build(case, case.base) == _build(case, case.base)
+
+    for index in range(len(case.base)):
+        varied = _build(case, _vary(case.base, case.alt, index))
+        assert _build(case, case.base) != varied, case.cls.__match_args__[index]
+
+
+@pytest.mark.parametrize("case", VALUE_TYPES)
+def test_equality_defers_to_an_unrelated_type(case: Case) -> None:
+    assert case.cls.__eq__(_build(case, case.base), object()) is NotImplemented
+    assert _build(case, case.base) != object()
+
+
+@pytest.mark.parametrize("case", VALUE_TYPES)
+def test_equality_rejects_a_subclass_holding_the_same_values(case: Case) -> None:
+    subclass = type(f"{case.cls.__name__}Subclass", (case.cls,), {"__slots__": ()})
+    same = subclass(**dict(zip(case.cls.__match_args__, case.base, strict=True)))
+
+    assert _build(case, case.base) != same
+    assert same != _build(case, case.base)
+
+
+@pytest.mark.parametrize("case", VALUE_TYPES)
+def test_hash_is_the_field_tuple(case: Case) -> None:
+    instance = _build(case, case.base)
+    if not case.hashable:
+        # One field is itself unhashable, so hashing the field tuple raises.
+        with pytest.raises(TypeError):
+            hash(instance)
+        return
+
+    assert hash(instance) == hash(case.base)
+    assert len({instance, _build(case, case.base)}) == 1
+
+    for index in range(len(case.base)):
+        assert hash(instance) != hash(_build(case, _vary(case.base, case.alt, index)))
+
+
+@pytest.mark.parametrize("case", VALUE_TYPES)
+def test_repr_names_every_field_in_order(case: Case) -> None:
+    body = ", ".join(
+        f"{name}={value!r}"
+        for name, value in zip(case.cls.__match_args__, case.base, strict=True)
+    )
+
+    assert repr(_build(case, case.base)) == f"{case.cls.__qualname__}({body})"
+
+
+@pytest.mark.parametrize("case", VALUE_TYPES)
+def test_a_write_reaches_only_a_declared_field(case: Case) -> None:
+    instance = _build(case, case.base)
+    first = case.cls.__match_args__[0]
+
+    setattr(instance, first, case.alt[0])
+    assert getattr(instance, first) == case.alt[0]
+
+    with pytest.raises(AttributeError):
+        instance.not_a_field = 1  # type: ignore[attr-defined]
+
+    assert not hasattr(instance, "__dict__")
+    assert tuple(sorted(case.cls.__match_args__)) == tuple(sorted(case.cls.__slots__))
+
+
+@pytest.mark.parametrize("clone", [copy.copy, copy.deepcopy])
+@pytest.mark.parametrize("case", VALUE_TYPES)
+def test_copying_restores_every_field(case: Case, clone: Any) -> None:
+    instance = _build(case, case.base)
+
+    assert clone(instance) == instance
+
+
+@pytest.mark.parametrize("case", VALUE_TYPES)
+def test_pickling_restores_every_field(case: Case) -> None:
+    instance = _build(case, case.base)
+
+    assert pickle.loads(pickle.dumps(instance)) == instance  # noqa: S301
+
+
+@pytest.mark.parametrize("case", VALUE_TYPES)
+def test_the_type_is_not_a_dataclass(case: Case) -> None:
+    # Re-decorating one puts back the import cost they are written out to avoid.
+    assert not dataclasses.is_dataclass(case.cls)
+
+
+def test_a_positional_pattern_binds_the_declared_order() -> None:
+    bound: tuple[object, ...] = ()
+    match LocalSource("pkg", "/a/b", editable=True, subdirectory="sub"):
+        case LocalSource(name, path, editable, subdirectory):
+            bound = (name, path, editable, subdirectory)
+
+    assert bound == ("pkg", "/a/b", True, "sub")


### PR DESCRIPTION
`import nab.cli` costs 25,784,745 fewer instructions, 2.6% of the 984,003,171 it costs on main. Callgrind, pinned hash seed, ASLR off; the count repeats to the digit.

Eight `@dataclass(frozen=True, slots=True)` classes in `nab_provider.policy`, `archive` and `vcs_request`, 27 fields between them, become plain `__slots__` classes with `self.field = field` constructors over a shared `SlottedValue` base that reads `__match_args__` for comparison, hashing and repr.

Reading `__match_args__` costs at runtime. Per call on `LocalSource`, `==` goes from 1,694 instructions to 11,956 and `hash()` from 1,669 to 6,862, while construction falls from 6,953 to 2,895. nab builds one per declared source and never compares or hashes one; a host that puts a `SourceRequest` in a set pays the difference.

They are no longer frozen or dataclasses, so a field write succeeds and `dataclasses.fields`, `replace` and `asdict` raise. `LocalSource`'s `editable` and `subdirectory` and `SourceRequest`'s `require_pin` are now keyword-only, and every call site already passed them by name.