### PR TITLE
Spell look-ahead blocker ranges only when the resolve fails

### DIFF
--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -100,7 +100,12 @@ from nab_provider.target import ResolveTarget
 from nab_provider.testing import pkg_override
 from nab_resolver.errors import ResolutionError
 from nab_resolver.resolver import Resolver
-from nab_resolver.types import Incompatibility, IncompatibilityCause, Term
+from nab_resolver.types import (
+    Incompatibility,
+    IncompatibilityCause,
+    RangeProtocol,
+    Term,
+)
 
 V = Version
 
@@ -1135,7 +1140,10 @@ class TestHasSatisfyingVersion:
         provider = Provider(coordinator)
         provider._no_versions_reasons["foo"] = _blocker_reason(
             diagnosis_mod.Blocker(
-                diagnosis_mod.BlockerKind.DECIDED, "bar", "==2.0", "1.0"
+                diagnosis_mod.BlockerKind.DECIDED,
+                "bar",
+                (SpecifierSet("==2.0").to_range(),),
+                V("1.0"),
             )
         )
         assert not provider.has_satisfying_version(
@@ -2210,7 +2218,10 @@ class TestNoVersionsReasons:
         provider = Provider(coordinator)
         provider._no_versions_reasons["foo"] = _blocker_reason(
             diagnosis_mod.Blocker(
-                diagnosis_mod.BlockerKind.HELD, "bar", "==2.0", "<2.0"
+                diagnosis_mod.BlockerKind.HELD,
+                "bar",
+                (SpecifierSet("==2.0").to_range(),),
+                SpecifierSet("<2.0").to_range(),
             )
         )
 
@@ -2341,6 +2352,53 @@ class TestNoVersionsReasons:
         assert "AFTER_LOCALS" not in reason
         assert "needs bar in ==2.0, but the resolve holds bar in <2.0" in reason
         assert "disjoint with current solution range" not in reason
+
+    def test_a_rejected_scan_spells_no_range_until_the_report(self) -> None:
+        """A capture keeps the ranges; the report is where they get spelled.
+
+        An ask that returns nothing is ordinary backtracking, so a resolve
+        that goes on to succeed reads none of what the scan recorded.  The
+        three ``foo`` versions are rejected down the three capture paths, so
+        the count covers all of them.
+        """
+
+        class CountsSpelledRanges(Provider):
+            spelled = 0
+
+            def format_range(self, constraint: RangeProtocol[Version]) -> str:
+                self.spelled += 1
+                return super().format_range(constraint)
+
+        coordinator = make_coordinator(
+            listings={"foo": [make_wheel(v) for v in ("1.0", "2.0", "3.0")]},
+            metadata_by_version={
+                "1.0": make_metadata("foo", "1.0", "qux==2.0"),
+                "2.0": make_metadata("foo", "2.0", "baz==2.0"),
+                "3.0": make_metadata("foo", "3.0", "bar==2.0"),
+            },
+        )
+        provider = CountsSpelledRanges(
+            coordinator,
+            target=_PY312,
+            root_requirements={
+                "foo": VersionRange.full(admit_arbitrary=False),
+                "bar": SpecifierSet("==1.0").to_range(),
+            },
+        )
+        provider.solution_decisions["baz"] = V("1.0")
+        provider.solution_ranges["qux"] = SpecifierSet("<2.0").to_range()
+
+        assert provider.choose_version("foo", VersionRange.full()) is None
+        assert provider.spelled == 0
+
+        reason = rendered_reason(provider, "foo")
+        assert "needs bar in ==2.0, but your project requires bar ==1.0" in reason
+        assert "needs baz in ==2.0, but the resolve chose baz 1.0" in reason
+        assert "needs qux in ==2.0, but the resolve holds qux in <2.0" in reason
+
+        # One declared range each, plus a held range for the two blockers
+        # standing in one; the decided blocker's side is a version.
+        assert provider.spelled == 5
 
     @pytest.mark.parametrize("cache_listing", [True, False])
     def test_range_block_rejection_spells_each_declared_range(

--- a/nab-provider/src/nab_provider/_provider/listing_diagnosis.py
+++ b/nab-provider/src/nab_provider/_provider/listing_diagnosis.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Final
 
+from nab_provider._vendor.packaging.version import Version
 from nab_provider.diagnostics import Diagnostic
 from nab_provider.records import SdistFile, WheelFile
 
@@ -36,7 +37,7 @@ if TYPE_CHECKING:
     from typing import Literal, TypeAlias
 
     from nab_provider._vendor.packaging.ranges import VersionRange
-    from nab_provider._vendor.packaging.version import Version
+    from nab_resolver.types import RangeProtocol
 
     from ..provider import DistFile, Provider
     from .listing import Cause, ListingPolicy
@@ -263,12 +264,27 @@ class ListingDiagnosis:
 
 
 class Blocker:
-    """One dependency the look-ahead found no candidate could satisfy."""
+    """One dependency the look-ahead found no candidate could satisfy.
+
+    Neither side is rendered here.  A scan that exhausts its candidates is
+    ordinary backtracking, so nothing reads them unless the resolve then
+    fails, and the report spells them when it is built.
+    """
 
     __slots__ = ("declared", "held", "kind", "package")
 
-    def __init__(self, kind: Blocked, package: str, declared: str, held: str) -> None:
-        """Record that ``package`` is wanted in ``declared`` but stands at ``held``."""
+    def __init__(
+        self,
+        kind: Blocked,
+        package: str,
+        declared: tuple[RangeProtocol[Version], ...],
+        held: Version | RangeProtocol[Version],
+    ) -> None:
+        """Record that ``package`` is wanted in ``declared`` but stands at ``held``.
+
+        ``held`` is the version a decided blocker was pinned to, and the range
+        a held or root blocker stands in.
+        """
         self.kind = kind
         self.package = package
         self.declared = declared
@@ -1221,24 +1237,49 @@ def blockers_diagnostic(
     One rejection states its ranges on the line, and gets no ``-v`` body:
     the detail would be that same pair of ranges again.  Several name their
     packages and leave the ranges to ``-v``, since two pairs do not fit.
-    ``provider`` and ``normalized`` are read only where the one rejection is
-    a metadata failure the walk can say more about.
+    ``provider`` spells every range, and ``normalized`` is read only where
+    the one rejection is a metadata failure the walk can say more about.
     """
     if len(blockers) + bool(metadata) == 1:
         if not blockers:
             return metadata_diagnostic(provider, normalized, metadata)
-        return Diagnostic(f"every version {_blocker_clause(blockers[0])}")
+        return Diagnostic(f"every version {_blocker_clause(provider, blockers[0])}")
 
-    detail = [_blocker_clause(blocker) for blocker in blockers]
+    detail = [_blocker_clause(provider, blocker) for blocker in blockers]
     detail.extend(block.message for block in metadata)
     return Diagnostic(_several_blockers_short(blockers, metadata), tuple(detail))
 
 
-def _blocker_clause(blocker: Blocker) -> str:
+def _blocker_clause(provider: Provider, blocker: Blocker) -> str:
     """Say what one rejection wanted and what stands in its way."""
+    declared, held = _render_blocker(provider, blocker)
     return _BLOCKER_CLAUSES[blocker.kind].format(
-        package=blocker.package, declared=blocker.declared, held=blocker.held
+        package=blocker.package, declared=declared, held=held
     )
+
+
+def _render_blocker(provider: Provider, blocker: Blocker) -> tuple[str, str]:
+    """Spell one look-ahead rejection's two sides for the failure report.
+
+    Returns what the rejected candidates asked of the blocker, and where the
+    blocker stands: a decided one at a version, a held or root one over a
+    range.
+    """
+    declared = " or ".join(_blocker_side(provider, part) for part in blocker.declared)
+    held = blocker.held
+    if isinstance(held, Version):
+        return declared, str(held)
+    return declared, _blocker_side(provider, held)
+
+
+def _blocker_side(provider: Provider, constraint: RangeProtocol[Version]) -> str:
+    """Render one side of a blocker clause, naming an unconstrained range.
+
+    :meth:`~nab_provider.provider.Provider.format_range` spells an
+    unconstrained range as nothing, which would end the clause on a
+    dangling ``in``.
+    """
+    return provider.format_range(constraint) or "any version"
 
 
 def _several_blockers_short(

--- a/nab-provider/src/nab_provider/provider.py
+++ b/nab-provider/src/nab_provider/provider.py
@@ -340,6 +340,17 @@ _EXTRA_KINDS = frozenset(
 _MAX_EXCLUSIONS = 3
 
 
+def _declared_ranges(
+    recorded: _lookahead.DepRangeUnion,
+) -> tuple[RangeProtocol[Version], ...]:
+    """Return the ranges a blocker's rejected candidates declared on it.
+
+    Stating them one by one keeps the line spellable where their union is
+    not; a group that recorded no range falls back to its union.
+    """
+    return recorded.declared or (recorded.union,)
+
+
 def _requirement_over_listing(
     constraint: VersionRange,
     universe: Sequence[Version],
@@ -1746,41 +1757,39 @@ class Provider:
 
         Returns one record per dependency the scan found holding every
         candidate out, plus the metadata failures recorded against them.
-        Both queues reset at the next flush, so what the report will need
-        is taken now and rendered only if the resolve fails.
+        The queues reset at the next flush, so the ranges are taken now and
+        spelled only if the resolve fails.
         """
         out: list[_diagnosis.Blocker] = []
 
         for cand, blocker_pkg, blocker_version in self.pending_blocks:
             if cand != normalized:
                 continue
-            declared = self._format_declared_ranges(
-                self.pending_decision_dep_ranges[(cand, blocker_pkg, blocker_version)]
-            )
+            recorded = self.pending_decision_dep_ranges[
+                (cand, blocker_pkg, blocker_version)
+            ]
 
-            # The blocker is decided, so the record names that version rather
+            # The blocker is decided, so the record keeps that version rather
             # than a singleton range, which has no specifier spelling.
             out.append(
                 _diagnosis.Blocker(
                     _diagnosis.BlockerKind.DECIDED,
                     blocker_pkg,
-                    declared,
-                    str(blocker_version),
+                    _declared_ranges(recorded),
+                    blocker_version,
                 )
             )
 
         for cand, blocker_pkg, pos_range in self.pending_range_blocks:
             if cand != normalized:
                 continue
-            declared = self._format_declared_ranges(
-                self.pending_range_dep_ranges[(cand, blocker_pkg, pos_range)]
-            )
+            recorded = self.pending_range_dep_ranges[(cand, blocker_pkg, pos_range)]
             out.append(
                 _diagnosis.Blocker(
                     _diagnosis.BlockerKind.HELD,
                     blocker_pkg,
-                    declared,
-                    self._format_blocker_range(pos_range),
+                    _declared_ranges(recorded),
+                    pos_range,
                 )
             )
 
@@ -1796,8 +1805,8 @@ class Provider:
                 _diagnosis.Blocker(
                     _diagnosis.BlockerKind.ROOT,
                     blocker_pkg,
-                    self._format_blocker_range(dep_range),
-                    self._format_blocker_range(root_range),
+                    (dep_range,),
+                    root_range,
                 )
             )
 
@@ -2357,15 +2366,6 @@ class Provider:
         would end the line on a dangling ``in``.
         """
         return self.format_range(constraint) or "any version"
-
-    def _format_declared_ranges(self, recorded: _lookahead.DepRangeUnion) -> str:
-        """Render the ranges a blocker's rejected candidates declared on it.
-
-        Stating them one by one keeps the line spellable where their union is
-        not; a group that recorded no range falls back to its union.
-        """
-        declared = recorded.declared or (recorded.union,)
-        return " or ".join(self._format_blocker_range(part) for part in declared)
 
     def get_dependencies(
         self, package: str, version: Version

--- a/nab-provider/tests/test_listing_diagnosis.py
+++ b/nab-provider/tests/test_listing_diagnosis.py
@@ -44,6 +44,7 @@ from nab_provider.testing import make_coordinator, pkg_override
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from nab_provider._vendor.packaging.ranges import VersionRange
     from nab_provider.provider import DistFile
 
 CUTOFF = datetime(2026, 5, 1, tzinfo=timezone.utc)
@@ -1610,8 +1611,19 @@ class TestSharedPredicates:
 
 
 def blocker(package: str, kind: diagnosis_mod.BlockerKind) -> diagnosis_mod.Blocker:
-    """A look-ahead record wanting ``package`` in ``==2.0``, held at ``1.0``."""
-    return diagnosis_mod.Blocker(kind, package, "==2.0", "1.0")
+    """A look-ahead record wanting ``package`` in ``==2.0``, blocked at 1.0.
+
+    Only a decided blocker stands at a version; a held or root one stands in
+    a range, which is what the capture records for them.
+    """
+    held: Version | VersionRange = (
+        Version("1.0")
+        if kind is diagnosis_mod.BlockerKind.DECIDED
+        else SpecifierSet("==1.0").to_range()
+    )
+    return diagnosis_mod.Blocker(
+        kind, package, (SpecifierSet("==2.0").to_range(),), held
+    )
 
 
 class TestBlockerLines:
@@ -1625,8 +1637,8 @@ class TestBlockerLines:
     ) -> Diagnostic:
         """Render a look-ahead rejection for ``pkg``.
 
-        The provider is only read where a metadata block carries the ladder's
-        marker, so the blocker cases hand over a listing that resolves.
+        The provider spells every blocker's ranges, so the default hands over
+        a listing that resolves; a marked metadata block passes its own.
         """
         return diagnosis_mod.blockers_diagnostic(
             build([wheel("1.0")]) if provider is None else provider,
@@ -1647,13 +1659,13 @@ class TestBlockerLines:
     def test_one_held_blocker(self) -> None:
         held = blocker("bar", diagnosis_mod.BlockerKind.HELD)
         assert self._diagnostic([held]).short == (
-            "every version needs bar in ==2.0, but the resolve holds bar in 1.0"
+            "every version needs bar in ==2.0, but the resolve holds bar in ==1.0"
         )
 
     def test_one_root_blocker(self) -> None:
         root = blocker("bar", diagnosis_mod.BlockerKind.ROOT)
         assert self._diagnostic([root]).short == (
-            "every version needs bar in ==2.0, but your project requires bar 1.0"
+            "every version needs bar in ==2.0, but your project requires bar ==1.0"
         )
 
     def test_two_blockers_name_their_packages_and_stop(self) -> None:


### PR DESCRIPTION
The look-ahead records a blocker whenever a dependency holds every candidate out. That is ordinary backtracking, and only the failure report reads it, from inside an `except ResolutionError`. So `Blocker` keeps the ranges and the report spells them.

A `pip-deep-backtracking` smoke run of 24 resolves, all of which succeed, spells 1,104 dependency ranges and throws every one away. That goes to 0, and the run costs 9.11 billion instructions under callgrind rather than 9.32 billion, 2.2% less. The all-fail `pip-deep-backtracking-unsatisfiable` lane drops 1.2% of its instructions.

All 552 captures still happen and a failure prints the same text, later; two test strings move because their fixture built a blocker shape the capture never produces.

The smoke lane is dense in look-ahead exhaustion and real workloads are not: archived canary call counts have the capture spelling 11 ranges on `pip:apache-airflow-311-full --resolution lowest` and 1 on `pip:google-bigquery-soda --resolution lowest`.