### PR TITLE
Intern marker atoms so equality is identity, ~1% off a universal lock

### DIFF
--- a/nab-provider/src/nab_provider/_vendor/packaging/_markersets.py
+++ b/nab-provider/src/nab_provider/_vendor/packaging/_markersets.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import re
 import sys
 import threading
+import weakref
 from functools import lru_cache
 from itertools import pairwise, product
 from typing import TYPE_CHECKING, NamedTuple, cast
@@ -178,19 +179,30 @@ def _oversized_numeric(text: str) -> bool:
 # ---------------------------------------------------------------------------- atoms
 
 
+# A strong table would keep an entry for every distinct atom the process ever
+# built, so values are weak and an entry lives only while its atom does. The lock
+# stops two threads minting rival atoms for one key, which the algebra would then
+# treat as two leaves rather than one.
+_INTERNED: weakref.WeakValueDictionary[
+    tuple[str, str, str, str, str, bool, bool, bool], Atom
+] = weakref.WeakValueDictionary()
+_INTERN_LOCK = threading.Lock()
+
+
 class Atom:
     """A normalised leaf whose ``holds`` gives its denotation on one point.
 
-    Immutable once constructed, apart from the version pool a version atom mints
-    lazily from its own literal. Equality and hashing run off a field tuple
-    precomputed at construction. A decision re-reads the same atom on the same point
-    across partitions of one axis; that memo belongs to the operation, not here, so
-    ``holds`` recomputes. The comparison it runs is memoised in :func:`_apply`.
+    Interned on its fields, so two equal atoms are one object and equality is
+    identity. The only mutation after construction is the version pool it mints
+    lazily, a pure function of those same fields, so sharing it is sound.
+
+    A decision re-reads the same atom on the same point across partitions of one
+    axis; that memo belongs to the operation, not here, so ``holds`` recomputes.
+    The comparison it runs is memoised in :func:`_apply`.
     """
 
     __slots__ = (
-        "_hash",
-        "_key",
+        "__weakref__",
         "_pool_entries",
         "derive_mm",
         "kind",
@@ -211,12 +223,10 @@ class Atom:
     positive: bool
     derive_mm: bool  # A1: evaluate on the major.minor of the point
 
-    _key: tuple[str, str, str, str, str, bool, bool, bool]
-    _hash: int
     _pool_entries: tuple[tuple[Version, str], ...] | None
 
-    def __init__(
-        self,
+    def __new__(
+        cls,
         kind: str,
         variable: str,
         origin: str,
@@ -226,29 +236,30 @@ class Atom:
         swapped: bool = False,
         positive: bool = True,
         derive_mm: bool = False,
-    ) -> None:
-        self.kind = kind
-        self.variable = variable
-        self.origin = origin
-        self.op = op
-        self.literal = literal
-        self.swapped = swapped
-        self.positive = positive
-        self.derive_mm = derive_mm
-        self._key = (kind, variable, origin, op, literal, swapped, positive, derive_mm)
-        self._hash = hash(self._key)
-        self._pool_entries = None
+    ) -> Atom:
+        """Return the interned atom for these fields, building one if none is live."""
+        key = (kind, variable, origin, op, literal, swapped, positive, derive_mm)
+        with _INTERN_LOCK:
+            interned = _INTERNED.get(key)
+            if interned is not None:
+                return interned
 
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, Atom):
-            return NotImplemented
-        return self._key == other._key
+            self = super().__new__(cls)
+            self.kind = kind
+            self.variable = variable
+            self.origin = origin
+            self.op = op
+            self.literal = literal
+            self.swapped = swapped
+            self.positive = positive
+            self.derive_mm = derive_mm
+            self._pool_entries = None
 
-    def __hash__(self) -> int:
-        return self._hash
+            _INTERNED[key] = self
+            return self
 
     def replaced(self, *, op: str | None = None, positive: bool | None = None) -> Atom:
-        """Return a copy with ``op`` or ``positive`` swapped out, for complements."""
+        """Return the atom with ``op`` or ``positive`` swapped out, for complements."""
         return Atom(
             self.kind,
             self.variable,

--- a/nab-provider/tests/test_marker_algebra.py
+++ b/nab-provider/tests/test_marker_algebra.py
@@ -7,8 +7,10 @@ decision, restriction, serialisation, witness, and guard surfaces.
 
 from __future__ import annotations
 
+import gc
 import sys
 import traceback
+import weakref
 
 import pytest
 
@@ -264,6 +266,79 @@ def test_direct_construction_is_refused() -> None:
     # The op-tree is private; a set is built only through the factories.
     with pytest.raises(TypeError, match="from_marker"):
         MarkerSet()  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------- interning
+
+
+_CONSTRUCTION_PATHS = (
+    'python_full_version >= "3.10"',  # a plain value atom
+    'python_version < "3.12"',  # A1-lowered onto python_full_version
+    '"x" in platform_release',  # an opaque contains atom
+    'platform_release in "5.10"',  # the exact-substring direction
+    'extra == "dev"',  # a set atom
+    '"linux" == sys_platform',  # a swapped value atom
+)
+
+
+def _atoms(text: str) -> list[_markersets.Atom]:
+    return _markersets.collect_atoms(_markersets.parse(text))
+
+
+@pytest.mark.parametrize("text", _CONSTRUCTION_PATHS)
+def test_every_construction_path_returns_the_interned_atom(text: str) -> None:
+    """A second parse of a clause reaches the atom the first parse built.
+
+    Atoms compare and hash by identity, so a construction path that skipped the
+    table would leave the algebra carrying one leaf as two.
+    """
+    (first,) = _atoms(text)
+    (second,) = _atoms(text)
+
+    assert second is first
+
+
+def test_reversed_operands_do_not_collapse_onto_one_atom() -> None:
+    """The intern key carries every field, ``swapped`` included.
+
+    Only ``swapped`` separates these two leaves, and sharing one atom between
+    them would read the literal as the same operand in both, making two
+    disjoint sets equal.
+    """
+    (below,) = _atoms('python_full_version < "3.10"')
+    (above,) = _atoms('"3.10" < python_full_version')
+
+    assert below is not above
+
+    lower = ms('python_full_version < "3.10"')
+    upper = ms('"3.10" < python_full_version')
+
+    assert lower.is_disjoint(upper)
+
+
+def test_a_complement_interns_back_to_the_atom_it_negates() -> None:
+    """``replaced`` interns too, so complementing twice returns the original."""
+    (atom,) = _atoms('sys_platform == "linux"')
+
+    assert atom.replaced(op="!=").replaced(op="==") is atom
+
+    (contains,) = _atoms('"x" in platform_release')
+
+    assert contains.replaced(positive=False).replaced(positive=True) is contains
+
+
+def test_an_atom_leaves_the_table_with_the_last_tree_holding_it() -> None:
+    """Nothing prunes this table, so a strong one would only ever grow."""
+    tree = _markersets.parse('extra == "nab-intern-probe"')
+    (atom,) = _markersets.collect_atoms(tree)
+    probe = weakref.ref(atom)
+
+    assert atom in _markersets._INTERNED.values()
+
+    del tree, atom
+    gc.collect()
+
+    assert probe() is None
 
 
 # ----------------------------------------------------------------- algebra

--- a/tasks/vendoring/packaging.patch
+++ b/tasks/vendoring/packaging.patch
@@ -1,9 +1,9 @@
 diff --git a/nab-provider/src/nab_provider/_vendor/packaging/_markersets.py b/nab-provider/src/nab_provider/_vendor/packaging/_markersets.py
 new file mode 100644
-index 0000000..04c833a
+index 0000000..9e908b1
 --- /dev/null
 +++ b/nab-provider/src/nab_provider/_vendor/packaging/_markersets.py
-@@ -0,0 +1,1934 @@
+@@ -0,0 +1,1945 @@
 +"""Marker algebra engine: reason about PEP 508 markers as sets of environments.
 +
 +The private engine behind :class:`~packaging.markersets.MarkerSet`. Parses a
@@ -23,6 +23,7 @@ index 0000000..04c833a
 +import re
 +import sys
 +import threading
++import weakref
 +from functools import lru_cache
 +from itertools import pairwise, product
 +from typing import TYPE_CHECKING, NamedTuple, cast
@@ -184,19 +185,30 @@ index 0000000..04c833a
 +# ---------------------------------------------------------------------------- atoms
 +
 +
++# A strong table would keep an entry for every distinct atom the process ever
++# built, so values are weak and an entry lives only while its atom does. The lock
++# stops two threads minting rival atoms for one key, which the algebra would then
++# treat as two leaves rather than one.
++_INTERNED: weakref.WeakValueDictionary[
++    tuple[str, str, str, str, str, bool, bool, bool], Atom
++] = weakref.WeakValueDictionary()
++_INTERN_LOCK = threading.Lock()
++
++
 +class Atom:
 +    """A normalised leaf whose ``holds`` gives its denotation on one point.
 +
-+    Immutable once constructed, apart from the version pool a version atom mints
-+    lazily from its own literal. Equality and hashing run off a field tuple
-+    precomputed at construction. A decision re-reads the same atom on the same point
-+    across partitions of one axis; that memo belongs to the operation, not here, so
-+    ``holds`` recomputes. The comparison it runs is memoised in :func:`_apply`.
++    Interned on its fields, so two equal atoms are one object and equality is
++    identity. The only mutation after construction is the version pool it mints
++    lazily, a pure function of those same fields, so sharing it is sound.
++
++    A decision re-reads the same atom on the same point across partitions of one
++    axis; that memo belongs to the operation, not here, so ``holds`` recomputes.
++    The comparison it runs is memoised in :func:`_apply`.
 +    """
 +
 +    __slots__ = (
-+        "_hash",
-+        "_key",
++        "__weakref__",
 +        "_pool_entries",
 +        "derive_mm",
 +        "kind",
@@ -217,12 +229,10 @@ index 0000000..04c833a
 +    positive: bool
 +    derive_mm: bool  # A1: evaluate on the major.minor of the point
 +
-+    _key: tuple[str, str, str, str, str, bool, bool, bool]
-+    _hash: int
 +    _pool_entries: tuple[tuple[Version, str], ...] | None
 +
-+    def __init__(
-+        self,
++    def __new__(
++        cls,
 +        kind: str,
 +        variable: str,
 +        origin: str,
@@ -232,29 +242,30 @@ index 0000000..04c833a
 +        swapped: bool = False,
 +        positive: bool = True,
 +        derive_mm: bool = False,
-+    ) -> None:
-+        self.kind = kind
-+        self.variable = variable
-+        self.origin = origin
-+        self.op = op
-+        self.literal = literal
-+        self.swapped = swapped
-+        self.positive = positive
-+        self.derive_mm = derive_mm
-+        self._key = (kind, variable, origin, op, literal, swapped, positive, derive_mm)
-+        self._hash = hash(self._key)
-+        self._pool_entries = None
++    ) -> Atom:
++        """Return the interned atom for these fields, building one if none is live."""
++        key = (kind, variable, origin, op, literal, swapped, positive, derive_mm)
++        with _INTERN_LOCK:
++            interned = _INTERNED.get(key)
++            if interned is not None:
++                return interned
 +
-+    def __eq__(self, other: object) -> bool:
-+        if not isinstance(other, Atom):
-+            return NotImplemented
-+        return self._key == other._key
++            self = super().__new__(cls)
++            self.kind = kind
++            self.variable = variable
++            self.origin = origin
++            self.op = op
++            self.literal = literal
++            self.swapped = swapped
++            self.positive = positive
++            self.derive_mm = derive_mm
++            self._pool_entries = None
 +
-+    def __hash__(self) -> int:
-+        return self._hash
++            _INTERNED[key] = self
++            return self
 +
 +    def replaced(self, *, op: str | None = None, positive: bool | None = None) -> Atom:
-+        """Return a copy with ``op`` or ``positive`` swapped out, for complements."""
++        """Return the atom with ``op`` or ``positive`` swapped out, for complements."""
 +        return Atom(
 +            self.kind,
 +            self.variable,


### PR DESCRIPTION
`universal-aligned`, a smoke run of 576 universal resolves each locking four targets, retires 1.5 billion fewer instructions under callgrind, 1.1% of its 141 billion. All 681,408 `Atom.__hash__` and 156,672 `Atom.__eq__` calls go with it.

`Atom`, the marker-algebra leaf in nab-provider's vendored `packaging/_markersets.py`, is interned on its eight fields in a module-level `weakref.WeakValueDictionary`, so equal atoms are one object and `__eq__` and `__hash__` are deleted. Its 43,776 constructions, 76 a resolve, each take a lock and a table lookup instead of hashing the field tuple. Sharing an atom shares the version pool it mints lazily, so `Version.__init__` loses 43,776 calls and `_parse_letter_version` 76,032.

`pip-deep-backtracking` builds 10 atoms a resolve against that 76, and callgrind puts it about 3 million instructions higher over its 24 resolves, on a run of 9.3 billion. `import nab.cli` pays 33,189 more.

`_markersets.py` is nab's own file rather than upstream code; `tasks/vendoring/packaging.patch` is regenerated with it.
