### PR TITLE
Prefetch only the listings a smoke scenario can reach, ~34% off the suite

### DIFF
--- a/nab-project/benchmarks/README.md
+++ b/nab-project/benchmarks/README.md
@@ -15,7 +15,7 @@ python nab-project/benchmarks/deterministic_smoke.py --lane performance --runs 5
 
 The scenarios use Nab's default highest resolution strategy and default cross-target alignment. `strategy-lowest`, `strategy-lowest-direct`, and `universal-independent` declare the only exceptions.
 
-Each resolve gets a fresh coordinator against the same prebuilt offline fixture. Warmups happen before measurement, and each recorded inner interval covers only the resolver call; fixture generation, coordinator lifecycle, semantic validation, and lock emission stay outside it. Timing samples are local diagnostics, not a reusable baseline or comparative result, and should be collected sequentially under controlled conditions.
+Each resolve gets a fresh coordinator against the same prebuilt offline fixture, and prefetches only the listings the scenario's own requirements and constraints can reach, so a new scenario adds no listing work to the existing ones. Warmups happen before measurement, and each recorded inner interval covers only the resolver call; fixture generation, coordinator lifecycle, semantic validation, and lock emission stay outside it. Metadata reads that the fetcher starts when a listing lands can still run inside the interval, so changing what a scenario prefetches moves its recorded time. Timing samples are local diagnostics, not a reusable baseline or comparative result, and should be collected sequentially under controlled conditions.
 
 ## Single-environment scenarios
 

--- a/nab-project/benchmarks/deterministic_smoke.py
+++ b/nab-project/benchmarks/deterministic_smoke.py
@@ -1379,21 +1379,64 @@ def prepare_scenario(scenario: Scenario, index_root: Path) -> PreparedScenario:
     )
 
 
-def _fixture_listing_packages(distributions: Sequence[Distribution]) -> tuple[str, ...]:
-    """Every canonical name in the fixture, in a stable order."""
-    return tuple(sorted({canonicalize_name(dist.name) for dist in distributions}))
+def _fixture_dependency_names(
+    distributions: Sequence[Distribution],
+) -> dict[str, frozenset[str]]:
+    """Map every fixture package to the package names its releases require.
+
+    Specifiers, extras and markers are dropped, so an edge stands whenever some
+    release of the package names the dependency under some environment.
+    """
+    edges: dict[str, set[str]] = {}
+    for dist in distributions:
+        edges.setdefault(canonicalize_name(dist.name), set()).update(
+            canonicalize_name(Requirement(dependency).name)
+            for dependency in dist.dependencies
+        )
+    return {name: frozenset(dependencies) for name, dependencies in edges.items()}
+
+
+def _scenario_root_names(prepared: PreparedScenario) -> tuple[str, ...]:
+    """Every canonical name the scenario itself declares, constraints included."""
+    constraints = (Requirement(text) for text in prepared.config.constraints)
+    return tuple(
+        canonicalize_name(requirement.name)
+        for requirement in (*prepared.requirements, *constraints)
+    )
+
+
+def _reachable_listing_packages(
+    dependencies: Mapping[str, frozenset[str]], roots: Sequence[str]
+) -> tuple[str, ...]:
+    """Every fixture package `roots` can reach, in a stable order.
+
+    The walk over-approximates the search: an edge ignores the specifier and
+    the marker that would rule the dependency out, so a dependency only one
+    environment activates still counts as reachable. A name the fixture does
+    not publish is dropped, since the offline index has no page to serve for
+    it.
+    """
+    reachable: set[str] = set()
+    pending = list(roots)
+    while pending:
+        name = pending.pop()
+        if name in reachable or name not in dependencies:
+            continue
+        reachable.add(name)
+        pending.extend(dependencies[name])
+    return tuple(sorted(reachable))
 
 
 def _await_listings(coordinator: FetchCoordinator, packages: Sequence[str]) -> None:
-    """Land every fixture listing before the caller starts timing.
+    """Land every named listing before the caller starts timing.
 
     The priority scan sorts a package whose listing is still in flight behind
     the ready ones, so a resolve racing its own fetches can decide in a
     different order run to run and reach the same pins by a different path.
-    Requesting the whole fixture up front and waiting takes that race out of
-    the measurement; it does not change what the resolver does with a listing
-    once it holds one.  Every request goes out before the first wait so they
-    still overlap.
+    Requesting the set up front and waiting takes that race out of the
+    measurement; it does not change what the resolver does with a listing once
+    it holds one.  Every request goes out before the first wait so they still
+    overlap.
     """
     for event in [coordinator.request_listing(package) for package in packages]:
         event.wait()
@@ -1680,7 +1723,10 @@ def run_scenario(scenario: Scenario, index_root: Path, runs: int) -> dict[str, A
     # index_root happens to hold; the digest check is what ties the two together.
     prepared = prepare_scenario(scenario, index_root)
     distributions, _fixture_manifest_digest = load_fixture()
-    listing_packages = _fixture_listing_packages(distributions)
+
+    listing_packages = _reachable_listing_packages(
+        _fixture_dependency_names(distributions), _scenario_root_names(prepared)
+    )
 
     # A semantic case is validated once and never timed, so it collapses to a
     # single unmeasured batch of one.

--- a/nab-project/tests/test_deterministic_smoke_core.py
+++ b/nab-project/tests/test_deterministic_smoke_core.py
@@ -6,6 +6,7 @@ import contextlib
 import importlib.util
 import json
 import sys
+import threading
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -571,7 +572,10 @@ def test_pins_hold_however_the_listings_arrive(smoke_index: Path) -> None:
         if scenario.id == "deep-backjump"
     )
     prepared = harness.prepare_scenario(backjump, smoke_index)
-    packages = harness._fixture_listing_packages(distributions)
+    packages = harness._reachable_listing_packages(
+        harness._fixture_dependency_names(distributions),
+        harness._scenario_root_names(prepared),
+    )
 
     observed: dict[str, dict[str, dict[str, str]]] = {}
     for label, landed in _listing_arrival_states(packages).items():
@@ -580,6 +584,128 @@ def test_pins_hold_however_the_listings_arrive(smoke_index: Path) -> None:
 
     expected = harness._expected(backjump)
     assert observed == dict.fromkeys(observed, expected)
+
+
+def test_a_scenario_prefetches_only_the_listings_it_can_reach(tmp_path: Path) -> None:
+    """The prefetch set follows the scenario's own graph, not the whole manifest.
+
+    The walk is blind to specifiers and markers, so a dependency only some
+    environment activates still counts as reachable.
+    """
+    harness = _harness()
+    distributions, _digest = harness.load_fixture()
+    dependencies = harness._fixture_dependency_names(distributions)
+
+    def prefetched(scenario_id: str) -> tuple[str, ...]:
+        scenario = next(
+            scenario
+            for scenario in harness.load_scenarios()
+            if scenario.id == scenario_id
+        )
+        prepared = harness.prepare_scenario(scenario, tmp_path)
+        return harness._reachable_listing_packages(
+            dependencies, harness._scenario_root_names(prepared)
+        )
+
+    # Every package the fixture publishes, so the sets below have a denominator.
+    assert len(dependencies) == 34
+
+    assert prefetched("pip-deep-backtracking") == (
+        "nab-smoke-pip-a",
+        "nab-smoke-pip-b",
+        "nab-smoke-pip-c",
+    )
+
+    # nab-smoke-extra-speed sits behind an extra and nab-smoke-marker-leaf
+    # behind a Python marker, and both are still reached.
+    assert prefetched("extra-and-python-marker") == (
+        "nab-smoke-extra-app",
+        "nab-smoke-extra-base",
+        "nab-smoke-extra-speed",
+        "nab-smoke-marker-leaf",
+    )
+
+
+def test_the_walk_seeds_constraints_and_unions_across_releases(tmp_path: Path) -> None:
+    """Two widenings the corpus does not exercise on its own.
+
+    The one scenario with constraints constrains a package it already
+    requires, and the one package whose dependencies vary across releases
+    omits a name another edge reaches anyway, so dropping either rule leaves
+    all 11 prefetch sets untouched. A scenario that needed one would
+    under-fetch in silence, so pin both directly.
+    """
+    harness = _harness()
+
+    releases = (
+        harness.Distribution(
+            name="Fixture_Pkg", version="1.0", dependencies=("early",)
+        ),
+        harness.Distribution(
+            name="fixture-pkg", version="2.0", dependencies=("late>=2",)
+        ),
+    )
+    assert harness._fixture_dependency_names(releases) == {
+        "fixture-pkg": frozenset({"early", "late"})
+    }
+
+    ceiling = next(
+        scenario
+        for scenario in harness.load_scenarios()
+        if scenario.id == "constraint-ceiling"
+    )
+    prepared = harness.prepare_scenario(ceiling, tmp_path)
+    widened = replace(
+        prepared,
+        config=replace(prepared.config, constraints=("nab-smoke-pip-a<2.0.0",)),
+    )
+
+    assert set(harness._scenario_root_names(widened)) == {
+        "nab-smoke-constrained",
+        "nab-smoke-pip-a",
+    }
+
+
+def test_no_scenario_asks_for_a_listing_its_prefetch_left_out(
+    smoke_index: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Every listing a resolve requests was already landed before it started.
+
+    Under-fetching does not fail loudly: the resolve blocks on the fetcher
+    instead, and the priority scan then orders packages by whichever listing
+    arrived first, which is what drifts the recorded search counters. So the
+    property is coverage, taken from what the resolver asks for rather than
+    from the walk that produced the set.
+    """
+    harness = _harness()
+    distributions, _digest = harness.load_fixture()
+    dependencies = harness._fixture_dependency_names(distributions)
+    requested: list[str] = []
+
+    class _RecordingCoordinator(harness.FetchCoordinator):
+        """A real coordinator that records the listings it is asked for."""
+
+        def request_listing(
+            self, package: str, *, speculative: bool = False
+        ) -> threading.Event:
+            requested.append(package)
+            return super().request_listing(package, speculative=speculative)
+
+    monkeypatch.setattr(harness, "FetchCoordinator", _RecordingCoordinator)
+
+    uncovered: dict[str, set[str]] = {}
+    for scenario in harness.load_scenarios():
+        prepared = harness.prepare_scenario(scenario, smoke_index)
+        packages = harness._reachable_listing_packages(
+            dependencies, harness._scenario_root_names(prepared)
+        )
+        requested.clear()
+        harness._resolve_once(prepared, packages)
+        missing = set(requested) - set(packages)
+        if missing:
+            uncovered[scenario.id] = missing
+
+    assert uncovered == {}
 
 
 def test_asyncio_wakeup_preflight_reports_restricted_execution() -> None:


### PR DESCRIPTION
Every smoke scenario prefetched all 34 fixture listings before every resolve, whatever it declared. It now walks the scenario's own requirements and constraints over the fixture's dependency edges, which reaches 1 to 14 of the 34.

A default `--runs 3` run of the 11-scenario suite does 1,087 resolves. Across them listing requests fall from 53,151 to 20,853, and wheel-metadata reads from 44,368 to 12,070. Locally the run takes about 30 s instead of about 45 s.

Instructions per resolve:

| scenario | listings | per resolve |
| --- | --- | ---: |
| `constraint-ceiling` | 34 to 1 | 93.3 M to 6.5 M |
| `universal-aligned` | 34 to 4 | 109 M to 25.2 M |
| `deep-backjump` | 34 to 14 | 154 M to 91.1 M |
| `pip-deep-backtracking-unsatisfiable` | 34 to 3 | 555 M to 488 M |

The other seven land inside that range. Unreachable listings cost 63 M to 87 M per resolve on all 11, so the shares differ only because the resolves do.

The 11 return the same search and per-target fetch counters. Recorded times do not carry over: landing a listing starts a metadata read inside the timed interval, and `universal-aligned` now does 7 of those per resolve rather than 37.

Under-fetching would not fail loudly, so the walk ignores specifiers, extras and markers, and a test pins that no resolve asks for a listing the walk left out.
