### PR TITLE
Snapshot the listing memo's counters with one attrgetter

### DIFF
--- a/nab-provider/src/nab_provider/provider.py
+++ b/nab-provider/src/nab_provider/provider.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import bisect
 import logging
+import operator
 from collections import defaultdict, deque
 from dataclasses import dataclass, fields
 from typing import TYPE_CHECKING, TypeVar, cast
@@ -152,10 +153,8 @@ class ProviderStats:
 
 _STAT_FIELDS = tuple(stat.name for stat in fields(ProviderStats))
 
-
-def _counters(stats: ProviderStats) -> tuple[int, ...]:
-    """Return every counter of ``stats``, in ``_STAT_FIELDS`` order."""
-    return tuple(getattr(stats, name) for name in _STAT_FIELDS)
+# Every counter of a ProviderStats, in _STAT_FIELDS order.
+_counters = operator.attrgetter(*_STAT_FIELDS)
 
 
 def _replay(stats: ProviderStats, delta: tuple[int, ...]) -> None:
@@ -167,12 +166,12 @@ def _replay(stats: ProviderStats, delta: tuple[int, ...]) -> None:
 
 def _since(before: tuple[int, ...], stats: ProviderStats) -> tuple[int, ...]:
     """Return how far each counter of ``stats`` rose since ``before``."""
-    return tuple(now - was for now, was in zip(_counters(stats), before, strict=True))
+    return tuple(map(operator.sub, _counters(stats), before))
 
 
 def _restore(stats: ProviderStats, before: tuple[int, ...]) -> None:
     """Take back every counter a bracketed pass bumped on ``stats``."""
-    _replay(stats, tuple(-count for count in _since(before, stats)))
+    _replay(stats, tuple(map(operator.sub, before, _counters(stats))))
 
 
 class ListingFilterCache:


### PR DESCRIPTION
Snapshotting the listing memo's counters costs about 17,300 instructions a miss instead of 49,300. A miss reads all 21 `ProviderStats` counters twice, before the filter and again in `_since`, so a later hit can replay the delta. One `operator.attrgetter` over `_STAT_FIELDS` reads them in C, and `map(operator.sub, ...)` subtracts.

A `--runs 1` pass of the `universal-aligned` smoke scenario, 576 four-target universal resolves, misses 6,912 times, so 290,304 `getattr` calls, 456,192 generator resumes and about 221 million instructions leave it. Importing `nab_provider.provider` costs 66,529 instructions more, on 351 million, paid whether or not a run builds a memo.

`canary.py` and `scenarios.py` build their provider without a memo, so no stored benchmark number moves; the single-target `pip-deep-backtracking` misses 72 times in the same pass.

No counter value changes. `_since` and `_restore` drop a strict `zip` for `map`, and both operands come from the one attrgetter; `_replay`, which reads a tuple stored earlier, keeps `strict=True`.