### PR TITLE
Keep a decision key while its listing is in flight, ~2% fewer instructions

### DIFF
--- a/nab-provider/src/nab_provider/provider.py
+++ b/nab-provider/src/nab_provider/provider.py
@@ -2552,13 +2552,29 @@ class Provider:
         self._package_parts[package] = result
         return result
 
-    def begin_decision_scan(self) -> None:
+    def begin_decision_scan(self) -> Callable[[str], bool] | None:
         """Open a decision scan, expiring the last one's in-flight answers.
 
         The coming scan re-reads the index, then holds any name it finds still
         in flight that way until the next call.
+
+        Offers no probe under :attr:`DecisionOrder.STABLE`, where a scan waits
+        for a listing instead of ranking its absence and so has nothing to wait
+        on between scans.
         """
         self._scan_generation += 1
+        return None if self.settle_listings else self._listing_landed
+
+    def _listing_landed(self, package: str) -> bool:
+        """Return whether the listing ``package``'s key waits on has arrived.
+
+        Asked of the base package: an extras proxy's own ``is_ready`` reads the
+        base's ``versions_cache`` entry, which ``prioritize`` fills only once
+        the listing has landed, so it would hold the proxy past the arrival it
+        is waiting for.
+        """
+        base, _, _ = self.split_and_normalize(package)
+        return self.is_ready(base)
 
     def arrived_listing(self, normalized: str) -> list[DistFile] | None:
         """Return ``normalized``'s listing, or None while it is in flight.

--- a/nab-provider/tests/test_decision_scan.py
+++ b/nab-provider/tests/test_decision_scan.py
@@ -287,6 +287,63 @@ class TestOneKeyHoldsTogether:
         assert provider.prioritize("foo", rng, {})[1] == 2
 
 
+class TestTheArrivalProbe:
+    """The probe ``begin_decision_scan`` hands back for in-flight keys."""
+
+    def test_a_name_still_in_flight_denies_the_probe(self) -> None:
+        provider = Provider(_coordinator({"foo": [_wheel("foo")]}))
+
+        probe = provider.begin_decision_scan()
+
+        assert probe is not None
+        assert probe("foo") is False
+
+    def test_the_next_scan_probes_the_arrival(self) -> None:
+        provider = Provider(_coordinator({"foo": [_wheel("foo")]}))
+        provider.begin_decision_scan()
+        assert provider.is_ready("foo") is False
+
+        probe = provider.begin_decision_scan()
+
+        assert probe is not None
+        assert probe("foo") is True
+
+    def test_an_extras_proxy_lands_with_the_listing_not_the_cache(self) -> None:
+        """Why the probe asks about the base rather than the proxy.
+
+        A proxy's own ``is_ready`` reads its base's ``versions_cache`` entry,
+        and ``prioritize`` writes that only once the listing lands, so a probe
+        reading it would hold the proxy past the arrival it waits on.
+        """
+        provider = Provider(_coordinator({"foo": [_wheel("foo")]}))
+        provider.begin_decision_scan()
+        assert provider.is_ready("foo") is False
+
+        probe = provider.begin_decision_scan()
+
+        assert probe is not None
+        assert probe("foo[socks]") is True
+        assert provider.is_ready("foo[socks]") is False
+
+    def test_a_cached_base_lands_without_the_index(self) -> None:
+        provider = Provider(_coordinator({}))
+        provider.versions_cache["foo"] = [(Version("1.0"), _wheel("foo"))]
+
+        probe = provider.begin_decision_scan()
+
+        assert probe is not None
+        assert probe("foo[socks]") is True
+
+    def test_settling_listings_offers_no_probe(self) -> None:
+        """A scan that waits for the listing has nothing to wait on between scans."""
+        provider = Provider(
+            _coordinator({"foo": [_wheel("foo")]}),
+            decision_order=DecisionOrder.STABLE,
+        )
+
+        assert provider.begin_decision_scan() is None
+
+
 class TestScanKeysShareOneView:
     """Every key a scan compares is built against one view of what has landed."""
 

--- a/nab-resolver/src/nab_resolver/decide.py
+++ b/nab-resolver/src/nab_resolver/decide.py
@@ -31,9 +31,10 @@ def choose_package_to_decide(resolver: Resolver[Any, Any]) -> Any | None:
     Prefers ``is_ready`` packages so resolution keeps making progress while
     other listings/metadata are still in flight.  ``begin_decision_scan`` marks
     the start of the scan so a provider fed by another thread can hold the
-    state behind its sort key still. The queue keeps that key across scans, so
-    one that moves without the solution or ``priority_epoch`` moving is never
-    read again.
+    state behind its sort key still, and may hand back a probe that lets the
+    queue leave a still-waiting package's key alone. The queue keeps that key
+    across scans, so one that moves without the solution or ``priority_epoch``
+    moving is never read again.
 
     ``ROOT`` never turns up in the undecided set: it is decided at level 1, a
     targeted backtrack never aims lower, and conflict resolution raises rather
@@ -43,7 +44,7 @@ def choose_package_to_decide(resolver: Resolver[Any, Any]) -> Any | None:
     if not undecided:
         return None
 
-    resolver.provider.begin_decision_scan()
+    key_inputs_arrived = resolver.provider.begin_decision_scan()
 
     conflict_counts = resolver.stats.package_conflict_counts
     culprit_counts = resolver.stats.package_culprit_counts
@@ -75,6 +76,7 @@ def choose_package_to_decide(resolver: Resolver[Any, Any]) -> Any | None:
         sort_key,
         resolver.solution.take_changed_packages(),
         resolver.priority_epoch,
+        key_inputs_arrived,
     )
 
 

--- a/nab-resolver/src/nab_resolver/decision_queue.py
+++ b/nab-resolver/src/nab_resolver/decision_queue.py
@@ -30,8 +30,10 @@ class DecisionQueue(Generic[PackageType]):
     A key is re-evaluated when the partial solution reports the package's range
     or decided state as moved, when the caller passes a new ``epoch``, and on
     every scan while the package is not ready, since a listing lands without the
-    solution seeing it. Superseded heap entries stay in place until they reach
-    the top, or until a rebuild drops the ones that never do.
+    solution seeing it. A caller that supplies a probe narrows that last case
+    to the scan the package's key inputs arrive on. Superseded heap entries
+    stay in place until they reach the top, or until a rebuild drops the ones
+    that never do.
     """
 
     def __init__(self) -> None:
@@ -57,6 +59,7 @@ class DecisionQueue(Generic[PackageType]):
         sort_key: Callable[[PackageType], tuple[Any, ...]],
         changed: set[PackageType],
         epoch: int,
+        key_inputs_arrived: Callable[[PackageType], bool] | None = None,
     ) -> PackageType:
         """Return the undecided package with the smallest sort key.
 
@@ -69,9 +72,18 @@ class DecisionQueue(Generic[PackageType]):
 
         ``sort_key`` must lead with the ready penalty: a truthy first field
         keeps the package on the re-evaluate list until it clears.
+
+        ``key_inputs_arrived`` answers whether the state behind a package's key
+        has landed. A caller that supplies one promises the unready key it
+        already gave stands until that answer turns true, which lets the scan
+        keep the key instead of building it again.
         """
+        # _stale_packages overwrites the stored epoch, so compare before it
+        # runs: a new epoch re-evaluates every key, probe or not.
+        probe = key_inputs_arrived if epoch == self._epoch else None
+
         stale = self._stale_packages(undecided, changed, epoch)
-        self._refresh(undecided, stale, sort_key)
+        self._refresh(undecided, stale, sort_key, changed, probe)
         self._compact()
         return self._live_top()
 
@@ -106,12 +118,19 @@ class DecisionQueue(Generic[PackageType]):
         undecided: AbstractSet[PackageType],
         stale: set[PackageType],
         sort_key: Callable[[PackageType], tuple[Any, ...]],
+        changed: set[PackageType],
+        key_inputs_arrived: Callable[[PackageType], bool] | None,
     ) -> None:
         """Re-evaluate the stale keys, pushing an entry for each one that moved.
 
         Walks ``undecided`` rather than ``stale`` so which packages are stale
         cannot change the order ``sort_key`` is called in, since a provider can
         fetch while answering one.
+
+        Given ``key_inputs_arrived``, an unready package the solution left
+        alone reaches ``sort_key`` only once its key's inputs have landed. The
+        probe runs at that package's own place in the walk, so a listing
+        landing mid-scan is still seen by the packages after it.
         """
         keys = self._keys
         heap = self._heap
@@ -120,6 +139,14 @@ class DecisionQueue(Generic[PackageType]):
 
         for package in undecided:
             if package not in stale:
+                continue
+
+            if (
+                key_inputs_arrived is not None
+                and package in unready
+                and package not in changed
+                and not key_inputs_arrived(package)
+            ):
                 continue
 
             key = sort_key(package)

--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -179,8 +179,8 @@ class ResolverProvider(Protocol[PackageType, VersionType]):
         """
         ...
 
-    def begin_decision_scan(self) -> None:
-        """Announce the start of one decision scan.
+    def begin_decision_scan(self) -> Callable[[PackageType], bool] | None:
+        """Announce the start of one decision scan, and offer an arrival probe.
 
         The scan reads sort keys from ``prioritize`` and ``is_ready``, so both
         must answer from state that does not move until the next call.
@@ -193,6 +193,16 @@ class ResolverProvider(Protocol[PackageType, VersionType]):
         for a reason only the provider can see fits none of those and may go
         unread, so a provider whose priority is still settling returns False
         from ``is_ready`` until it has.
+
+        A returned probe replaces that every-scan re-read, and is a promise:
+        while it answers False for a package, and that package's range and the
+        counts you were last passed are unchanged, ``prioritize`` and
+        ``is_ready`` must answer what they last answered.  Neither is called
+        for the package meanwhile, over any number of consecutive scans, so a
+        provider that starts its fetch inside ``prioritize`` would wait on a
+        fetch it never begins.  Answering True is always safe.  Return ``None``
+        to decline the probe and keep the every-scan re-read; a provider
+        wrapping another returns the inner probe.
         """
         ...
 
@@ -220,7 +230,9 @@ class ResolverProvider(Protocol[PackageType, VersionType]):
 
         Returning False also holds the package on the scan's re-read list, so a
         provider whose ``prioritize`` key is still moving keeps returning False
-        until it settles.
+        until it settles.  A provider that returns a probe from
+        ``begin_decision_scan`` gives that re-read up: while the probe answers
+        False the key is not read at all.
         """
         ...
 
@@ -318,8 +330,9 @@ class BaseProvider(Generic[PackageType, VersionType]):
     ``from nab_resolver.resolver import BaseProvider``.
     """
 
-    def begin_decision_scan(self) -> None:
-        """Freeze nothing: no state moves between scans."""
+    def begin_decision_scan(self) -> Callable[[PackageType], bool] | None:
+        """Freeze nothing and offer no probe: no state moves between scans."""
+        return None
 
     def is_ready(self, package: PackageType) -> bool:
         """Report every package ready, since answers do not wait on a fetch."""

--- a/nab-resolver/tests/property/providers.py
+++ b/nab-resolver/tests/property/providers.py
@@ -9,7 +9,7 @@ provider implementations can be shared across files.
 from __future__ import annotations
 
 import itertools
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 
 from nab_resolver.ranges import Range
 from nab_resolver.types import Incompatibility, RangeProtocol
@@ -51,8 +51,9 @@ class FuzzProvider:
         """Return dependencies for a specific version."""
         return self._graph.get(package, {}).get(version, {})
 
-    def begin_decision_scan(self) -> None:
-        """No-op: nothing in this stub moves under a scan."""
+    def begin_decision_scan(self) -> Callable[[str], bool] | None:
+        """Offer no probe: nothing in this stub moves under a scan."""
+        return None
 
     def prioritize(
         self,

--- a/nab-resolver/tests/test_decision_queue.py
+++ b/nab-resolver/tests/test_decision_queue.py
@@ -199,13 +199,13 @@ def test_the_heap_is_rebuilt_once_superseded_entries_pile_up() -> None:
 
 
 class ConflictSensitiveProvider(FuzzProvider):
-    """A provider whose sort keys move with no assignment behind them.
+    """A provider whose sort keys move with and without the solution.
 
-    Two of the things a sort key reads sit outside the partial solution, and
-    this drives both. ``prioritize`` ranks a package by how far its culprit
-    count trails the leading one, so crediting the leading culprit moves every
-    other package's key; ``is_ready`` holds one package back for the first
-    scans, the way a listing still in flight does.
+    ``prioritize`` ranks on how far a package's culprit count trails the
+    leading one and then on how many versions its range leaves, so a key moves
+    both when crediting a culprit leaves the solution alone and when the
+    solution narrows the range. ``is_ready`` holds one package back for the
+    first scans, the way a listing still in flight does.
     """
 
     def __init__(
@@ -221,9 +221,10 @@ class ConflictSensitiveProvider(FuzzProvider):
         self._ready_scan = ready_scan
         self.scans = 0
 
-    def begin_decision_scan(self) -> None:
-        """Count the scan, which is what ``is_ready`` answers from."""
+    def begin_decision_scan(self) -> Callable[[str], bool]:
+        """Count the scan, then offer ``is_ready``: nothing else moves it here."""
         self.scans += 1
+        return self.is_ready
 
     def prioritize(
         self,
@@ -232,10 +233,17 @@ class ConflictSensitiveProvider(FuzzProvider):
         conflict_counts: Mapping[str, int],
         culprit_counts: Mapping[str, int] | None = None,
     ) -> int:
-        """Rank the package by how far its culprit count trails the leading one."""
-        del version_range, conflict_counts
+        """Rank on the culprit gap, then on how many versions the range leaves.
+
+        Scaling the gap orders the two the way a tuple would, since no package
+        in this graph has more than two versions.
+        """
         counts = culprit_counts or {}
-        return max(counts.values(), default=0) - counts.get(package, 0)
+        trailing = max(counts.values(), default=0) - counts.get(package, 0)
+        matching = super().prioritize(
+            package, version_range, conflict_counts, culprit_counts
+        )
+        return trailing * 4 + matching
 
     def is_ready(self, package: str) -> bool:
         """Report every package ready but the held-back one, until its scan."""
@@ -247,13 +255,15 @@ class RecheckingDecisionQueue(DecisionQueue[str]):
 
     The cached keys are what the resolver decides on, so a move the queue is
     never told about shows up here as a key the scan's own ``sort_key`` no
-    longer agrees with.
+    longer agrees with. Also counts the keys the probe held back, so a resolve
+    that never took the skip cannot pass as a check of it.
     """
 
     def __init__(self) -> None:
-        """Start empty, with no scan yet seen holding an unready package."""
+        """Start empty, with no unready package seen and no key held back."""
         super().__init__()
         self.unready_picks = 0
+        self.held_keys = 0
 
     def pick(
         self,
@@ -261,12 +271,24 @@ class RecheckingDecisionQueue(DecisionQueue[str]):
         sort_key: Callable[[str], tuple[Any, ...]],
         changed: set[str],
         epoch: int,
+        key_inputs_arrived: Callable[[str], bool] | None = None,
     ) -> str:
         """Pick as usual, then check the cached keys against a fresh scan."""
-        picked = super().pick(undecided, sort_key, changed, epoch)
+        evaluated: set[str] = set()
+
+        def watched(package: str) -> tuple[Any, ...]:
+            """Return the package's key, recording that the scan built it."""
+            evaluated.add(package)
+            return sort_key(package)
+
+        picked = super().pick(undecided, watched, changed, epoch, key_inputs_arrived)
 
         if self._unready:
             self.unready_picks += 1
+
+        # Every unready package is stale, so one the scan never evaluated is
+        # one the probe held back.
+        self.held_keys += len(self._unready - evaluated)
 
         assert self._keys.keys() == undecided
         for package in undecided:
@@ -291,9 +313,11 @@ def test_a_resolve_that_backjumps_keeps_every_cached_key_current() -> None:
     ``a@2`` and ``d@2`` both dead-end, so the resolve backjumps and credits
     culprits, and ``c`` arrives unready. Both move sort keys of packages the
     partial solution reports as unchanged, so a queue that misses either
-    signal decides on a stale key and resolves somewhere else in silence.
+    signal decides on a stale key and resolves somewhere else in silence. The
+    provider hands back a probe, so ``c``'s key is one the queue keeps across
+    scans rather than rebuilds.
     """
-    provider = ConflictSensitiveProvider(BACKJUMPING_GRAPH, unready="c", ready_scan=3)
+    provider = ConflictSensitiveProvider(BACKJUMPING_GRAPH, unready="c", ready_scan=12)
     resolver: Resolver[str, int] = Resolver(provider)
     queue = RecheckingDecisionQueue()
     resolver.decision_queue = queue
@@ -307,3 +331,106 @@ def test_a_resolve_that_backjumps_keeps_every_cached_key_current() -> None:
     assert resolver.stats.backjumps > 0
     assert resolver.priority_epoch > 0
     assert queue.unready_picks > 0
+    assert queue.held_keys > 0
+
+
+class Landings:
+    """A probe over packages whose listings land on cue."""
+
+    def __init__(self) -> None:
+        """Start with nothing landed and nothing probed."""
+        self.landed: set[str] = set()
+        self.probed: list[str] = []
+
+    def probe(self, package: str) -> bool:
+        """Report whether the package's listing has landed, recording the ask."""
+        self.probed.append(package)
+        return package in self.landed
+
+
+def test_a_probe_that_stays_false_leaves_the_unready_key_unread() -> None:
+    """An in-flight package's key is not rebuilt while its probe stays false."""
+    book = KeyBook({"a": (1, 0, "a"), "b": (0, 2, "b")})
+    queue: DecisionQueue[str] = DecisionQueue()
+    landings = Landings()
+    queue.pick({"a", "b"}, book.sort_key, {"a", "b"}, 0, landings.probe)
+    book.take_read()
+
+    picked = queue.pick({"a", "b"}, book.sort_key, set(), 0, landings.probe)
+
+    assert picked == "b"
+    assert book.take_read() == set()
+    assert landings.probed == ["a"]
+
+
+def test_a_probe_turning_true_rebuilds_the_key_it_held() -> None:
+    book = KeyBook({"a": (1, 0, "a"), "b": (0, 2, "b")})
+    queue: DecisionQueue[str] = DecisionQueue()
+    landings = Landings()
+    queue.pick({"a", "b"}, book.sort_key, {"a", "b"}, 0, landings.probe)
+    queue.pick({"a", "b"}, book.sort_key, set(), 0, landings.probe)
+    book.take_read()
+
+    landings.landed.add("a")
+    book.keys["a"] = (0, 1, "a")
+
+    picked = queue.pick({"a", "b"}, book.sort_key, set(), 0, landings.probe)
+
+    assert picked == "a"
+    assert book.take_read() == {"a"}
+
+
+def test_a_changed_package_is_re_evaluated_while_its_probe_is_false() -> None:
+    """A moved range changes the key of a package still waiting on a listing."""
+    book = KeyBook({"a": (1, 0, "a"), "b": (0, 2, "b")})
+    queue: DecisionQueue[str] = DecisionQueue()
+    landings = Landings()
+    queue.pick({"a", "b"}, book.sort_key, {"a", "b"}, 0, landings.probe)
+    book.take_read()
+
+    book.keys["a"] = (1, 5, "a")
+    queue.pick({"a", "b"}, book.sort_key, {"a"}, 0, landings.probe)
+
+    assert book.take_read() == {"a"}
+    assert landings.probed == []
+
+
+def test_a_new_epoch_re_evaluates_an_unready_key_the_probe_denies() -> None:
+    """A new epoch stands for a count move the probe knows nothing about."""
+    book = KeyBook({"a": (1, 0, "a"), "b": (0, 2, "b")})
+    queue: DecisionQueue[str] = DecisionQueue()
+    landings = Landings()
+    queue.pick({"a", "b"}, book.sort_key, {"a", "b"}, 0, landings.probe)
+    book.take_read()
+
+    queue.pick({"a", "b"}, book.sort_key, set(), 1, landings.probe)
+
+    assert book.take_read() == {"a", "b"}
+    assert landings.probed == []
+
+
+def test_a_listing_landing_mid_scan_reaches_the_package_behind_it() -> None:
+    """The probe runs at the package's own place in the walk.
+
+    One snapshot taken at the head of the scan would hold every later arrival
+    back a whole scan, and could pick a different package.
+    """
+    book = KeyBook({"a": (1, 0, "a"), "b": (1, 0, "b")})
+    queue: DecisionQueue[str] = DecisionQueue()
+    landings = Landings()
+    queue.pick({"a", "b"}, book.sort_key, {"a", "b"}, 0, landings.probe)
+    book.take_read()
+
+    def land_the_others(package: str) -> bool:
+        """Publish every other package's listing, then answer for this one."""
+        for other in ("a", "b"):
+            if other != package:
+                landings.landed.add(other)
+                book.keys[other] = (0, 1, other)
+        return landings.probe(package)
+
+    picked = queue.pick({"a", "b"}, book.sort_key, set(), 0, land_the_others)
+
+    _, second = landings.probed
+    assert book.take_read() == {second}
+    assert picked == second


### PR DESCRIPTION
A warm `pip:langchain-ml-course --resolution lowest` resolve builds 18,528 decision sort keys instead of 62,136 over the same 10,261 scans: 740,308 fewer Python calls, 3.5% of that run, and 2.0% to 2.7% of its instructions over three callgrind pairs.

While a listing is in flight `prioritize` scores a placeholder version count that only the arrival can change, so the scan rebuilt every waiting package's key on every pass. `begin_decision_scan` now offers the queue a probe, and a package that is not ready, was not touched by the solution and is still waiting keeps the key it has. The probe runs at each package's own place in the walk, so a listing landing mid-scan still reaches the packages behind it.

`ResolverProvider.begin_decision_scan` widens from `-> None` to returning that probe or `None`, so existing implementations stay valid and keep the behaviour they have.

Over 12 interleaved pairs CPU is down about 2%, between roughly 1% and 3%. Those runs rule out a wall slowdown above about 0.7% and put peak memory inside 0.2% either way. On a 25-tuple universal matrix, which waits on no listing, the two sides land within 350 of the same 2.0 million calls.
