### PR TITLE
Compile the specifier pattern once, 1.26% off a one-dependency lock

### DIFF
--- a/nab-provider/src/nab_provider/_vendor/packaging/PROVENANCE.md
+++ b/nab-provider/src/nab_provider/_vendor/packaging/PROVENANCE.md
@@ -47,6 +47,10 @@ most one checked-in patch.
     quotes when that body is ASCII and holds no backslash, newline, carriage
     return or NUL, and calls `ast.literal_eval` otherwise. The `QUOTED_STRING`
     rule admits no string prefix, so a token takes the same value either way.
+  - `specifiers.py` and `_tokenizer.py`: `Specifier._regex` compiles the
+    specifier pattern without the surrounding `\s*`, and `Specifier.__init__`
+    strips the string before matching it, so `DEFAULT_RULES["SPECIFIER"]` can be
+    that same compiled object instead of a second compile of the same pattern.
 
   Upstream PRs are planned for the bound ordering, the direct subset and
   disjoint walks, `filter`'s `assume_sorted` fast path,

--- a/nab-provider/src/nab_provider/_vendor/packaging/_tokenizer.py
+++ b/nab-provider/src/nab_provider/_vendor/packaging/_tokenizer.py
@@ -77,10 +77,8 @@ DEFAULT_RULES: dict[str, re.Pattern[str]] = {
         """,
         re.VERBOSE,
     ),
-    "SPECIFIER": re.compile(
-        Specifier._specifier_regex_str,
-        re.VERBOSE | re.IGNORECASE,
-    ),
+    # Shared with Specifier so the pattern compiles once.
+    "SPECIFIER": Specifier._regex,
     "AT": re.compile(r"\@"),
     "URL": re.compile(r"[^ \t]+"),
     "IDENTIFIER": re.compile(r"\b[a-zA-Z0-9][a-zA-Z0-9._-]*\b"),

--- a/nab-provider/src/nab_provider/_vendor/packaging/specifiers.py
+++ b/nab-provider/src/nab_provider/_vendor/packaging/specifiers.py
@@ -329,9 +329,8 @@ class Specifier(BaseSpecifier):
         )
         """
 
-    _regex = re.compile(
-        r"\s*" + _specifier_regex_str + r"\s*", re.VERBOSE | re.IGNORECASE
-    )
+    # No surrounding \s*, so _tokenizer can share this object; __init__ strips first.
+    _regex = re.compile(_specifier_regex_str, re.VERBOSE | re.IGNORECASE)
 
     # Legacy unused attribute, kept for backward compatibility
     _operators: Final = {
@@ -358,10 +357,11 @@ class Specifier(BaseSpecifier):
         :raises InvalidSpecifier:
             If the given specifier is invalid (i.e. bad syntax).
         """
-        if not self._regex.fullmatch(spec):
+        stripped = spec.strip()
+        if not self._regex.fullmatch(stripped):
             raise InvalidSpecifier(f"Invalid specifier: {spec!r}")
 
-        spec = spec.strip()
+        spec = stripped
         if spec.startswith("==="):
             operator, version = spec[:3], spec[3:].strip()
         elif spec.startswith(("~=", "==", "!=", "<=", ">=")):

--- a/nab-provider/tests/test_vendor_specifier_pattern_shared.py
+++ b/nab-provider/tests/test_vendor_specifier_pattern_shared.py
@@ -1,0 +1,64 @@
+"""Tests for the vendored patch that shares one compiled specifier pattern.
+
+The tokenizer rule is ``Specifier._regex`` itself, and that pattern matches no
+surrounding whitespace, so ``Specifier.__init__`` strips before matching. Both
+are pinned: ``re`` caches on the pattern text, so the identity assertion alone
+would still hold if the tokenizer compiled the string a second time.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from nab_provider._vendor.packaging._tokenizer import DEFAULT_RULES
+from nab_provider._vendor.packaging.requirements import Requirement
+from nab_provider._vendor.packaging.specifiers import InvalidSpecifier, Specifier
+
+# Padding ``Specifier`` accepts, with the operator and version it parses to.
+# ``str.strip()`` and ``\s`` have to accept the same characters, hence ``\xa0``.
+PADDED = [
+    (" ==1.0", ("==", "1.0")),
+    ("==1.0 ", ("==", "1.0")),
+    ("\t==1.0\n", ("==", "1.0")),
+    ("\x0b==1.0\x0c", ("==", "1.0")),
+    ("\xa0==1.0\xa0", ("==", "1.0")),
+    ("  ===  ", ("===", "")),
+]
+
+# Strings the pattern refuses however they are padded.
+REFUSED = ["", " ", "=1.0", "== ", "==1.0 2.0", "~=1"]
+
+
+def test_the_tokenizer_rule_is_the_specifier_pattern_object() -> None:
+    assert DEFAULT_RULES["SPECIFIER"] is Specifier._regex
+
+
+def test_the_pattern_carries_no_surrounding_whitespace() -> None:
+    assert Specifier._regex.pattern == Specifier._specifier_regex_str
+
+
+@pytest.mark.parametrize(("spec", "expected"), PADDED)
+def test_padding_is_stripped_before_the_operator_split(
+    spec: str, expected: tuple[str, str]
+) -> None:
+    parsed = Specifier(spec)
+
+    assert (parsed.operator, parsed.version) == expected
+
+
+@pytest.mark.parametrize("spec", REFUSED)
+def test_a_refused_specifier_is_reported_with_its_padding(spec: str) -> None:
+    padded = f" {spec}\t"
+    message = re.escape(f"Invalid specifier: {padded!r}")
+
+    with pytest.raises(InvalidSpecifier, match=message):
+        Specifier(padded)
+
+
+def test_the_tokenizer_reads_a_specifier_out_of_a_requirement() -> None:
+    requirement = Requirement('foo >=1.0,<2.0; python_version >= "3.9"')
+
+    assert str(requirement.specifier) == "<2.0,>=1.0"
+    assert str(requirement.marker) == 'python_version >= "3.9"'

--- a/tasks/vendoring/packaging.patch
+++ b/tasks/vendoring/packaging.patch
@@ -2098,6 +2098,23 @@ index e312a1f..29c32bc 100644
      def __hash__(self) -> int:
          return hash((self.version, self.inclusive))
  
+diff --git a/nab-provider/src/nab_provider/_vendor/packaging/_tokenizer.py b/nab-provider/src/nab_provider/_vendor/packaging/_tokenizer.py
+index 7158421..6384493 100644
+--- a/nab-provider/src/nab_provider/_vendor/packaging/_tokenizer.py
++++ b/nab-provider/src/nab_provider/_vendor/packaging/_tokenizer.py
+@@ -77,10 +77,8 @@ DEFAULT_RULES: dict[str, re.Pattern[str]] = {
+         """,
+         re.VERBOSE,
+     ),
+-    "SPECIFIER": re.compile(
+-        Specifier._specifier_regex_str,
+-        re.VERBOSE | re.IGNORECASE,
+-    ),
++    # Shared with Specifier so the pattern compiles once.
++    "SPECIFIER": Specifier._regex,
+     "AT": re.compile(r"\@"),
+     "URL": re.compile(r"[^ \t]+"),
+     "IDENTIFIER": re.compile(r"\b[a-zA-Z0-9][a-zA-Z0-9._-]*\b"),
 diff --git a/nab-provider/src/nab_provider/_vendor/packaging/markers.py b/nab-provider/src/nab_provider/_vendor/packaging/markers.py
 index 609099c..07c7d81 100644
 --- a/nab-provider/src/nab_provider/_vendor/packaging/markers.py
@@ -3505,3 +3522,33 @@ index 4fbf48e..d52f359 100644
      @classmethod
      def _from_specifier_set(cls, specifier_set: SpecifierSet) -> VersionRange:
          """Build the range accepted by ``specifier_set``.
+diff --git a/nab-provider/src/nab_provider/_vendor/packaging/specifiers.py b/nab-provider/src/nab_provider/_vendor/packaging/specifiers.py
+index dd46b56..6f02085 100644
+--- a/nab-provider/src/nab_provider/_vendor/packaging/specifiers.py
++++ b/nab-provider/src/nab_provider/_vendor/packaging/specifiers.py
+@@ -329,9 +329,8 @@ class Specifier(BaseSpecifier):
+         )
+         """
+ 
+-    _regex = re.compile(
+-        r"\s*" + _specifier_regex_str + r"\s*", re.VERBOSE | re.IGNORECASE
+-    )
++    # No surrounding \s*, so _tokenizer can share this object; __init__ strips first.
++    _regex = re.compile(_specifier_regex_str, re.VERBOSE | re.IGNORECASE)
+ 
+     # Legacy unused attribute, kept for backward compatibility
+     _operators: Final = {
+@@ -358,10 +357,11 @@ class Specifier(BaseSpecifier):
+         :raises InvalidSpecifier:
+             If the given specifier is invalid (i.e. bad syntax).
+         """
+-        if not self._regex.fullmatch(spec):
++        stripped = spec.strip()
++        if not self._regex.fullmatch(stripped):
+             raise InvalidSpecifier(f"Invalid specifier: {spec!r}")
+ 
+-        spec = spec.strip()
++        spec = stripped
+         if spec.startswith("==="):
+             operator, version = spec[:3], spec[3:].strip()
+         elif spec.startswith(("~=", "==", "!=", "<=", ">=")):


### PR DESCRIPTION
Compiling the specifier pattern once instead of twice takes 14,319,301 instructions off a one-dependency offline `nab lock`, 1.26% of that run's 1,133,665,216. The same saving shows on a bare `import nab.cli`, so every `nab` invocation gets it.

| workload | base | branch | saved |
| --- | ---: | ---: | ---: |
| one-dependency offline `nab lock` | 1,133,665,216 | 1,119,345,915 | 14,319,301 (1.26%) |
| `import nab.cli` | 918,874,848 | 904,607,522 | 14,267,326 (1.55%) |

That import now compiles 87 patterns rather than 88, and 9,779 characters of pattern text rather than 13,637.

`Specifier._regex` compiles without the surrounding `\s*` and `__init__` strips the string before matching, so `_tokenizer.DEFAULT_RULES["SPECIFIER"]` can be that same object instead of a second compile of the same 3,852-character pattern. Padding, refusals, and the string quoted in `InvalidSpecifier` are unchanged; no code point exists where `str.strip()` and `\s` disagree.

This is a local divergence in the vendored packaging tree, declared in `tasks/vendoring/packaging.patch` and the vendored `PROVENANCE.md`.

Timing the same lock 40 times a side rules out a wall regression above about 3.8%. The clock cannot see an effect this small.
