### PR TITLE
Release 0.0.15

### DIFF
--- a/nab-index/pyproject.toml
+++ b/nab-index/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nab-index"
-version = "0.0.15.dev0"
+version = "0.0.15"
 description = "PyPI Simple-API client and on-disk cache for nab"
 readme = "README.md"
 license = "MIT"
@@ -20,7 +20,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "nab-provider==0.0.15.dev0",
+    "nab-provider==0.0.15",
     "packaging>=24.0",
     "truststore>=0.10",
     "typing_extensions>=4.6",

--- a/nab-index/pyproject.toml
+++ b/nab-index/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nab-index"
-version = "0.0.15"
+version = "0.0.16.dev0"
 description = "PyPI Simple-API client and on-disk cache for nab"
 readme = "README.md"
 license = "MIT"
@@ -20,7 +20,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "nab-provider==0.0.15",
+    "nab-provider==0.0.16.dev0",
     "packaging>=24.0",
     "truststore>=0.10",
     "typing_extensions>=4.6",

--- a/nab-project/pyproject.toml
+++ b/nab-project/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nab-project"
-version = "0.0.15.dev0"
+version = "0.0.15"
 description = "Index-backed provider, lockfile emitter, and downloader for nab"
 readme = "README.md"
 license = "MIT"
@@ -20,9 +20,9 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "nab-provider==0.0.15.dev0",
-    "nab-resolver==0.0.15.dev0",
-    "nab-index==0.0.15.dev0",
+    "nab-provider==0.0.15",
+    "nab-resolver==0.0.15",
+    "nab-index==0.0.15",
     # toml_io builds TOMLDecodeError(msg, doc, pos), a signature 2.2 added.
     "tomli>=2.2",
     "tomli_w>=1.2",

--- a/nab-project/pyproject.toml
+++ b/nab-project/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nab-project"
-version = "0.0.15"
+version = "0.0.16.dev0"
 description = "Index-backed provider, lockfile emitter, and downloader for nab"
 readme = "README.md"
 license = "MIT"
@@ -20,9 +20,9 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "nab-provider==0.0.15",
-    "nab-resolver==0.0.15",
-    "nab-index==0.0.15",
+    "nab-provider==0.0.16.dev0",
+    "nab-resolver==0.0.16.dev0",
+    "nab-index==0.0.16.dev0",
     # toml_io builds TOMLDecodeError(msg, doc, pos), a signature 2.2 added.
     "tomli>=2.2",
     "tomli_w>=1.2",

--- a/nab-provider/pyproject.toml
+++ b/nab-provider/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nab-provider"
-version = "0.0.15.dev0"
+version = "0.0.15"
 description = "IO-free resolution core for nab"
 readme = "README.md"
 license = "MIT"
@@ -23,7 +23,7 @@ classifiers = [
 # a config file. A host that supplies its own IO can vendor this and the solver
 # without taking nab's HTTP client, cache, or build machinery with it.
 dependencies = [
-    "nab-resolver==0.0.15.dev0",
+    "nab-resolver==0.0.15",
     "typing_extensions>=4.6",
 ]
 

--- a/nab-provider/pyproject.toml
+++ b/nab-provider/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nab-provider"
-version = "0.0.15"
+version = "0.0.16.dev0"
 description = "IO-free resolution core for nab"
 readme = "README.md"
 license = "MIT"
@@ -23,7 +23,7 @@ classifiers = [
 # a config file. A host that supplies its own IO can vendor this and the solver
 # without taking nab's HTTP client, cache, or build machinery with it.
 dependencies = [
-    "nab-resolver==0.0.15",
+    "nab-resolver==0.0.16.dev0",
     "typing_extensions>=4.6",
 ]
 

--- a/nab-resolver/pyproject.toml
+++ b/nab-resolver/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nab-resolver"
-version = "0.0.15.dev0"
+version = "0.0.15"
 description = "Generic PubGrub dependency-resolver core"
 readme = "README.md"
 license = "MIT"

--- a/nab-resolver/pyproject.toml
+++ b/nab-resolver/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nab-resolver"
-version = "0.0.15"
+version = "0.0.16.dev0"
 description = "Generic PubGrub dependency-resolver core"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nab"
-version = "0.0.15"
+version = "0.0.16.dev0"
 description = "PubGrub-based dependency resolver for Python packages"
 readme = "README.md"
 license = "MIT"
@@ -20,16 +20,16 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "nab-resolver==0.0.15",
-    "nab-provider==0.0.15",
-    "nab-project==0.0.15",
-    "nab-index==0.0.15",
+    "nab-resolver==0.0.16.dev0",
+    "nab-provider==0.0.16.dev0",
+    "nab-project==0.0.16.dev0",
+    "nab-index==0.0.16.dev0",
     "tyro>=1.0",
     "typing_extensions>=4.6",
 ]
 
 [project.optional-dependencies]
-httpx = ["nab-index[httpx]==0.0.15"]
+httpx = ["nab-index[httpx]==0.0.16.dev0"]
 
 [project.urls]
 Homepage = "https://github.com/notatallshaw/nab"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nab"
-version = "0.0.15.dev0"
+version = "0.0.15"
 description = "PubGrub-based dependency resolver for Python packages"
 readme = "README.md"
 license = "MIT"
@@ -20,16 +20,16 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "nab-resolver==0.0.15.dev0",
-    "nab-provider==0.0.15.dev0",
-    "nab-project==0.0.15.dev0",
-    "nab-index==0.0.15.dev0",
+    "nab-resolver==0.0.15",
+    "nab-provider==0.0.15",
+    "nab-project==0.0.15",
+    "nab-index==0.0.15",
     "tyro>=1.0",
     "typing_extensions>=4.6",
 ]
 
 [project.optional-dependencies]
-httpx = ["nab-index[httpx]==0.0.15.dev0"]
+httpx = ["nab-index[httpx]==0.0.15"]
 
 [project.urls]
 Homepage = "https://github.com/notatallshaw/nab"


### PR DESCRIPTION
Lockstep version bump for 0.0.15 across the five packages, then back to `0.0.16.dev0`.

206 PRs since v0.0.14 (2026-08-14): mostly resolver and index cost, a large batch of crash fixes that turn tracebacks into exit codes, and diagnostics that name the real cause.

Merge with a merge commit, not a squash, so the `Release 0.0.15` commit and the `v0.0.15` tag stay in history. Publishing the tag's GitHub release is what triggers PyPI.
