### PR TITLE
Document that only a .tar.gz sdist keeps a version alive

### DIFF
--- a/docs/explanation/universal.md
+++ b/docs/explanation/universal.md
@@ -306,9 +306,9 @@ combination cannot be declared:
 The matrix also decides which wheels a tuple can install, computed from
 the python version, platform, and implementation without a live
 interpreter. A version whose only wheels are tag-incompatible with a
-tuple is dropped for that tuple; a version that also ships an sdist
-stays, subject to the build policy. Each tuple accepts three wheel-tag
-dimensions:
+tuple is dropped for that tuple; a version that also ships a `.tar.gz`
+sdist stays, subject to the build policy. Each tuple accepts three
+wheel-tag dimensions:
 
 * interpreter: `cpXY` for CPython, `ppXY` for PyPy, plus the
   interpreter-agnostic `py3` tags.

--- a/docs/reference/build-policy.md
+++ b/docs/reference/build-policy.md
@@ -10,6 +10,9 @@ from every source it admits; the difference is what is permitted
 to fall through to a backend invocation when the static read
 returns nothing usable.
 
+An sdist below means a `.tar.gz`.  nab drops every other format
+when it parses an index listing, so no policy sees one.
+
 The default is `build-local`: local checkouts and workspace
 members may invoke a backend, but remote sources (PyPI sdists,
 VCS clones, archive sources) are read statically only.  Lift

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -147,9 +147,13 @@ The target declares both halves of the environment: its PEP 508 markers
 gate every dependency, and its PEP 425 wheel tags gate every candidate.
 A version whose only wheels the target cannot install, and which ships no
 sdist, is not a candidate: the resolve fails on it rather than pinning a
-wheel that will not install (`pywin32` on Linux).  An sdist keeps a
-version alive whatever the build policy, so a pure-source package still
-resolves.  The lockfile records only the wheels the target can install.
+wheel that will not install (`pywin32` on Linux).  The lockfile records
+only the wheels the target can install.
+
+Tags gate wheels only, so a `.tar.gz` sdist keeps a version alive for any
+target.  nab drops every other sdist format when it parses the listing,
+so a version whose only sdist is a `.zip` and which ships no wheel is not
+a candidate either (`pyreadline==2.1`).
 
 The resolve is still for one environment.  A lock made for
 `linux_x86_64` is a lock for `linux_x86_64`; it says so in its PEP 751
@@ -550,6 +554,12 @@ considers and which end up in the lockfile.  The default
 | `wheel-or-sdist` (default) | yes | yes | both |
 | `sdist-only` | no | yes | sdist |
 | `sdist-install` | yes | yes | sdist |
+
+nab drops every sdist format but `.tar.gz` when it parses an index
+listing, before any policy sees it, so a version whose only sdist is a
+`.zip` counts as shipping none.  A wheel-admitting policy sees only its
+wheels, and `sdist-only` and `sdist-install` skip it, since both need an
+sdist to lock.
 
 `wheel-only` is the equivalent of pip's `--only-binary :all:` and
 `sdist-only` of `--no-binary :all:`, scoped per package or per index


### PR DESCRIPTION
`docs/reference/configuration.md` promised that an sdist keeps a version alive whatever the build policy. It does not: `_parse_sdist_filename` in `nab-index` accepts `.tar.gz` only, so every other format is dropped as the index listing is parsed, before any tag or policy check runs.

A version whose only sdist is a `.zip` and which ships no wheel is therefore not a candidate. `pyreadline` 2.1 is a live example: PyPI serves `pyreadline-2.1.zip` and two `.exe` installers, nothing else. `sdist-only` and `sdist-install` skip it too, with no sdist to lock.

nab already says this when the resolve fails on such a version:

    no PEP 658 metadata and the sdist is a .zip, a format nab drops

`configuration.md` loses the promise, and `build-policy.md` and `explanation/universal.md` now spell the format out as `.tar.gz`.
