### PR TITLE
Load the lock emitter on first use, 6.7% off `nab --version`

### DIFF
--- a/nab-project/src/nab_project/_lockfile/builder.py
+++ b/nab-project/src/nab_project/_lockfile/builder.py
@@ -2,9 +2,7 @@
 
 The provider's caches still hold the listings the resolver consumed
 when this runs, so artefact hashes and per-file Requires-Python can
-be read directly without a second fetch.  This module also owns the
-``read_lockfile_anchor`` helper used by ``nab lock`` to keep
-``P<n>D`` durations stable across re-locks.
+be read directly without a second fetch.
 """
 
 from __future__ import annotations
@@ -16,9 +14,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Protocol, overload
 from urllib.parse import quote, urlsplit, urlunsplit
 
-import tomli
-
-from nab_provider._vendor.packaging.pylock import Pylock, PylockValidationError
 from nab_provider._vendor.packaging.specifiers import SpecifierSet
 from nab_provider._vendor.packaging.utils import canonicalize_name
 from nab_provider.extra_keys import split_extra
@@ -27,9 +22,19 @@ from nab_provider.metadata import validate_specifier_versions
 from nab_provider.policy import DistPolicy
 from nab_provider.records import SdistFile, WheelFile
 
-from .. import toml_io
-from .._toml import tool_nab_section
-from ..paths import path_state
+from ..lockfile import (
+    ACCEPTED_HASH_ALGORITHMS,
+    ArchivePin,
+    IndexPin,
+    LocalPin,
+    MissingHashError,
+    MissingSdistError,
+    MissingVcsCommitError,
+    SdistArtifact,
+    TargetLock,
+    VcsPin,
+    WheelArtifact,
+)
 from .groups import BASE_MEMBER
 
 if TYPE_CHECKING:
@@ -40,28 +45,14 @@ if TYPE_CHECKING:
     from nab_provider.records import IndexConfig
     from nab_provider.target import ResolveTarget
 
-    from ..lockfile import (
-        ArchivePin,
-        IndexPin,
-        LockInput,
-        PinShape,
-        SdistArtifact,
-        TargetLock,
-        VcsPin,
-        WheelArtifact,
-    )
+    from ..lockfile import LockInput, PinShape
 
 
 logger = logging.getLogger(__name__)
 
 
 __all__ = [
-    "MissingHashError",
-    "MissingSdistError",
-    "MissingVcsCommitError",
     "build_target_lock",
-    "read_lockfile_anchor",
-    "read_lockfile_packages",
     "require_artifact_hashes",
     "strip_userinfo",
 ]
@@ -146,99 +137,6 @@ class LockInputProvider(Protocol):
         ...
 
 
-class MissingHashError(ValueError):
-    """A distribution chosen by the resolver has no usable hash.
-
-    PEP 751 requires at least one hash per artefact.  When an index
-    serves a wheel or sdist without a ``hashes`` map (rare on PyPI,
-    common on file:// indexes), the lock writer cannot emit a
-    spec-compliant entry.  Surface the failure with the offending
-    package and filename so the user can either add a hash to their
-    local index or exclude the package.
-    """
-
-
-class MissingSdistError(ValueError):
-    """A ``sdist-install`` package's pinned version has no sdist.
-
-    Under :attr:`~nab_provider.provider.DistPolicy.SDIST_INSTALL` the
-    resolver may read a wheel's metadata but the lock must pin only the
-    sdist.  When the pinned version publishes wheels but no sdist, the
-    wheels are dropped and nothing is left to pin.  Surface the package
-    and version so the user can pick a version with an sdist or relax
-    the policy, rather than emitting an empty package the spec rejects.
-    """
-
-
-class MissingVcsCommitError(ValueError):
-    """A VCS source reached the lock writer without a resolved commit SHA.
-
-    PEP 751 requires ``packages.vcs.commit-id`` to be an immutable
-    identifier.  nab records the post-clone SHA on the provider during
-    materialisation, before any version can be pinned, so a missing SHA
-    here means a VCS source was pinned without being cloned.  Surface it
-    loudly rather than emit a branch name or empty string as the commit
-    id, which would silently produce a non-reproducible lock.
-    """
-
-
-def read_lockfile_anchor(path: Path) -> datetime | None:
-    """Return the ``[tool.nab].created-at`` timestamp from ``path`` if any.
-
-    Used by ``nab lock`` to keep ``P<n>D`` durations stable across
-    re-locks: the anchor used for the previous resolve is read back
-    and reused unless the user passes ``--upgrade``.
-
-    Returns ``None`` when ``path`` does not exist, cannot be read, is
-    not valid TOML, is not a PEP 751-shaped pylock, or is missing the
-    ``[tool.nab]`` block.  Naive timestamps (no offset) are coerced to UTC
-    for symmetry with the writer; this is informational provenance, so
-    a missing offset is recoverable rather than fatal.
-    """
-    if not path_state(path).should_read:
-        return None
-    try:
-        with path.open("rb") as f:
-            data = toml_io.load(f)
-    except (OSError, UnicodeDecodeError, tomli.TOMLDecodeError):
-        return None
-    nab = tool_nab_section(data)
-    raw = nab.get("created-at") if isinstance(nab, dict) else None
-    if isinstance(raw, datetime):
-        return raw if raw.tzinfo else raw.replace(tzinfo=timezone.utc)
-    if isinstance(raw, str):
-        try:
-            dt = parse_iso_datetime(raw)
-        except ValueError:
-            return None
-        return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
-    return None
-
-
-def read_lockfile_packages(path: Path) -> dict[str, Version] | None:
-    """Return the ``name -> version`` map from a prior pylock at ``path``.
-
-    Used by ``nab lock`` to diff a re-lock against the previous result.
-    Packages without a recorded version (direct-reference entries that
-    omit it) are skipped.
-
-    Returns ``None`` when ``path`` does not exist, cannot be read, is
-    not valid TOML, or is not a spec-compliant PEP 751 lockfile; the
-    caller falls back to a no-diff summary line.
-    """
-    if not path_state(path).should_read:
-        return None
-    try:
-        with path.open("rb") as f:
-            data = toml_io.load(f)
-        pylock = Pylock.from_dict(data)
-    except (OSError, UnicodeDecodeError, tomli.TOMLDecodeError, PylockValidationError):
-        return None
-    return {
-        str(pkg.name): pkg.version for pkg in pylock.packages if pkg.version is not None
-    }
-
-
 def strip_userinfo(url: str) -> str:
     """Return ``url`` with credential userinfo removed.
 
@@ -293,8 +191,6 @@ def build_target_lock(
     Every wheel the target can install, plus the sdist, is recorded for
     each pinned version.
     """
-    from ..lockfile import LocalPin, TargetLock
-
     if base_roots is None:
         if selector_roots:
             msg = (
@@ -521,7 +417,6 @@ def _index_pin_from_listing(
     artefact value.
     """
     from ..fetch import DEFAULT_INDEX_URL
-    from ..lockfile import IndexPin, SdistArtifact, WheelArtifact
 
     files = list(provider.dist_files_for(canonical, version))
     serving = provider.coordinator.index.get_listing_index(canonical)
@@ -631,8 +526,6 @@ def _filter_acceptable_hashes(
     can pick.  Unacceptable algorithms (e.g. md5) are dropped, so the
     result may be empty.
     """
-    from ..lockfile import ACCEPTED_HASH_ALGORITHMS
-
     return tuple(
         (algo, digest)
         for algo, digest in sorted(hashes)
@@ -647,8 +540,6 @@ def require_artifact_hashes(lock_input: LockInput) -> None:
     sha256/sha384/sha512 per artefact.  :func:`write_requirements_without_hashes`
     emits no ``--hash`` lines and does not call this.
     """
-    from ..lockfile import ACCEPTED_HASH_ALGORITHMS, IndexPin
-
     for lock in lock_input.targets.values():
         for pin in lock.pins.values():
             if not isinstance(pin, IndexPin):
@@ -723,8 +614,6 @@ def _vcs_pin_from_source(
     """
     from nab_provider.vcs_request import VcsRequest
 
-    from ..lockfile import VcsPin
-
     if resolved_sha is None:
         msg = (
             f"{canonical}: VCS source pinned without a resolved commit SHA;"
@@ -772,8 +661,6 @@ def _archive_pin_from_source(
     never carries a token.
     """
     from nab_provider.archive import ArchiveRequest
-
-    from ..lockfile import ArchivePin
 
     request = ArchiveRequest.parse(source.url)
     return ArchivePin(

--- a/nab-project/src/nab_project/_lockfile/pylock.py
+++ b/nab-project/src/nab_project/_lockfile/pylock.py
@@ -49,6 +49,7 @@ from nab_provider.conflict_kind import KIND_GROUP, MARKER_VARIABLE_FOR_KIND
 from nab_provider.marker_holds import intractable_as_error
 
 from ..config import conflict_exclusion_groups, conflict_member_groups
+from ..lockfile import LOCK_VERSION, ArchivePin, IndexPin, LocalPin, VcsPin
 from .builder import require_artifact_hashes
 from .coverage import validate_marker_coverage
 from .disjointness import validate_marker_disjointness
@@ -286,8 +287,6 @@ def build_pylock(lock_input: LockInput, *, lock_dir: Path | None = None) -> Pylo
     so the lockfile is portable.  It defaults to the current working
     directory when the caller has no path in mind (e.g. stdout).
     """
-    from ..lockfile import LOCK_VERSION
-
     lock_input = _name_base_group(lock_input)
 
     base = (lock_dir if lock_dir is not None else Path.cwd()).resolve()
@@ -443,8 +442,6 @@ def _pin_to_package(
     lock_dir: Path,
     dependencies: list[dict[str, str]] | None = None,
 ) -> Package:
-    from ..lockfile import ArchivePin, IndexPin, LocalPin, VcsPin
-
     if isinstance(pin, IndexPin):
         return Package(
             name=canonicalize_name(pin.name),
@@ -819,8 +816,6 @@ def _group_pins_by_pin(
 
 def _pin_discriminator(pin: PinShape) -> tuple:
     """Return a hashable key that identifies the source + version of ``pin``."""
-    from ..lockfile import ArchivePin, IndexPin, LocalPin, VcsPin
-
     if isinstance(pin, IndexPin):
         return ("index", pin.version, pin.index)
     if isinstance(pin, LocalPin):
@@ -860,8 +855,6 @@ def _merge_pins_in_group(pins: list[PinShape]) -> PinShape:
     Non-IndexPin shapes are already fully discriminated, so the first
     pin is returned unchanged.
     """
-    from ..lockfile import IndexPin
-
     head = pins[0]
     if not isinstance(head, IndexPin):
         return head

--- a/nab-project/src/nab_project/_lockfile/reader.py
+++ b/nab-project/src/nab_project/_lockfile/reader.py
@@ -1,0 +1,91 @@
+"""Read a committed pylock back for ``nab lock``.
+
+Kept out of the builder, which every command imports, so the vendored
+pylock model is loaded only when a lock is read.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+import tomli
+
+from nab_provider._vendor.packaging.pylock import Pylock, PylockValidationError
+from nab_provider.iso8601 import parse_iso_datetime
+
+from .. import toml_io
+from .._toml import tool_nab_section
+from ..paths import path_state
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from nab_provider._vendor.packaging.version import Version
+
+
+__all__ = [
+    "read_lockfile_anchor",
+    "read_lockfile_packages",
+]
+
+
+def read_lockfile_anchor(path: Path) -> datetime | None:
+    """Return the ``[tool.nab].created-at`` timestamp from ``path`` if any.
+
+    Used by ``nab lock`` to keep ``P<n>D`` durations stable across
+    re-locks: the anchor used for the previous resolve is read back
+    and reused unless the user passes ``--upgrade``.
+
+    Returns ``None`` when ``path`` does not exist, cannot be read, is
+    not valid TOML, is not a PEP 751-shaped pylock, or is missing the
+    ``[tool.nab]`` block.  Naive timestamps (no offset) are coerced to UTC
+    for symmetry with the writer; this is informational provenance, so
+    a missing offset is recoverable rather than fatal.
+    """
+    if not path_state(path).should_read:
+        return None
+
+    try:
+        with path.open("rb") as f:
+            data = toml_io.load(f)
+    except (OSError, UnicodeDecodeError, tomli.TOMLDecodeError):
+        return None
+
+    nab = tool_nab_section(data)
+    raw = nab.get("created-at") if isinstance(nab, dict) else None
+    if isinstance(raw, datetime):
+        return raw if raw.tzinfo else raw.replace(tzinfo=timezone.utc)
+    if isinstance(raw, str):
+        try:
+            dt = parse_iso_datetime(raw)
+        except ValueError:
+            return None
+        return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+    return None
+
+
+def read_lockfile_packages(path: Path) -> dict[str, Version] | None:
+    """Return the ``name -> version`` map from a prior pylock at ``path``.
+
+    Used by ``nab lock`` to diff a re-lock against the previous result.
+    Packages without a recorded version (direct-reference entries that
+    omit it) are skipped.
+
+    Returns ``None`` when ``path`` does not exist, cannot be read, is
+    not valid TOML, or is not a spec-compliant PEP 751 lockfile; the
+    caller falls back to a no-diff summary line.
+    """
+    if not path_state(path).should_read:
+        return None
+
+    try:
+        with path.open("rb") as f:
+            data = toml_io.load(f)
+        pylock = Pylock.from_dict(data)
+    except (OSError, UnicodeDecodeError, tomli.TOMLDecodeError, PylockValidationError):
+        return None
+
+    return {
+        str(pkg.name): pkg.version for pkg in pylock.packages if pkg.version is not None
+    }

--- a/nab-project/src/nab_project/_lockfile/requirements.py
+++ b/nab-project/src/nab_project/_lockfile/requirements.py
@@ -15,13 +15,14 @@ from urllib.parse import quote
 
 from nab_index.atomic import atomic_write_text
 
+from ..lockfile import ArchivePin, IndexPin, LocalPin, VcsPin
 from .builder import require_artifact_hashes
 
 if TYPE_CHECKING:
     import os
     from collections.abc import Mapping
 
-    from ..lockfile import IndexPin, LockInput, PinShape
+    from ..lockfile import LockInput, PinShape
 
 
 __all__ = [
@@ -101,8 +102,6 @@ def _render_requirements(
 
 def _render_pins(pins: Mapping[str, PinShape], *, with_hashes: bool) -> list[str]:
     """Render a flat ``{name: pin}`` mapping in alphabetical order."""
-    from ..lockfile import ArchivePin, IndexPin, LocalPin, VcsPin
-
     lines: list[str] = []
     for canonical in sorted(pins):
         pin = pins[canonical]

--- a/nab-project/src/nab_project/lockfile.py
+++ b/nab-project/src/nab_project/lockfile.py
@@ -8,6 +8,9 @@ emitters are :func:`write_lock` (PEP 751 ``pylock.toml``),
 collapses them into one ``Package`` per distinct ``(name, version,
 source)`` with a marker disjoining the targets that chose it, and drops
 the marker when every target agrees.
+
+The value types are defined here; the emitter and the reader are
+imported on first use, so importing this module does not load them.
 """
 
 from __future__ import annotations
@@ -15,41 +18,11 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field, replace
 from datetime import timezone
+from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
-from nab_provider._vendor.packaging.pylock import is_valid_pylock_path
 from nab_provider._vendor.packaging.utils import canonicalize_name
 from nab_provider._vendor.packaging.version import Version
-
-from ._lockfile.builder import (
-    MissingHashError,
-    MissingSdistError,
-    MissingVcsCommitError,
-    build_target_lock,
-    read_lockfile_anchor,
-    read_lockfile_packages,
-    strip_userinfo,
-)
-from ._lockfile.disjointness import DisjointnessError
-from ._lockfile.groups import BASE_MEMBER
-from ._lockfile.pylock import (
-    DivergentBaseDependencyError,
-    LockValidationError,
-    build_pylock,
-    render_lock,
-    write_lock,
-)
-from ._lockfile.requirements import (
-    write_requirements_with_hashes,
-    write_requirements_without_hashes,
-)
-from ._lockfile.validate import (
-    InvalidLockfileError,
-    LockDisqualification,
-    LockfileSyntaxError,
-    RootRequirement,
-    check_locked,
-)
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -57,8 +30,31 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from nab_provider._vendor.packaging.markers import Marker
+    from nab_provider._vendor.packaging.pylock import is_valid_pylock_path
     from nab_provider.target import ResolveTarget
 
+    from ._lockfile.builder import build_target_lock, strip_userinfo
+    from ._lockfile.disjointness import DisjointnessError
+    from ._lockfile.groups import BASE_MEMBER
+    from ._lockfile.pylock import (
+        DivergentBaseDependencyError,
+        LockValidationError,
+        build_pylock,
+        render_lock,
+        write_lock,
+    )
+    from ._lockfile.reader import read_lockfile_anchor, read_lockfile_packages
+    from ._lockfile.requirements import (
+        write_requirements_with_hashes,
+        write_requirements_without_hashes,
+    )
+    from ._lockfile.validate import (
+        InvalidLockfileError,
+        LockDisqualification,
+        LockfileSyntaxError,
+        RootRequirement,
+        check_locked,
+    )
     from .config import ConflictSet, PackageOverride
 
 
@@ -103,6 +99,50 @@ __all__ = [
 ]
 
 
+# Where each lazily bound name lives.  Importing them eagerly would load the
+# emitter, its vendored pylock model and tomli_w on every ``nab`` command,
+# when only ``lock`` writes or reads a lock.
+_LAZY_EXPORTS: dict[str, str] = {
+    "BASE_MEMBER": "._lockfile.groups",
+    "DisjointnessError": "._lockfile.disjointness",
+    "DivergentBaseDependencyError": "._lockfile.pylock",
+    "InvalidLockfileError": "._lockfile.validate",
+    "LockDisqualification": "._lockfile.validate",
+    "LockValidationError": "._lockfile.pylock",
+    "LockfileSyntaxError": "._lockfile.validate",
+    "RootRequirement": "._lockfile.validate",
+    "build_pylock": "._lockfile.pylock",
+    "build_target_lock": "._lockfile.builder",
+    "check_locked": "._lockfile.validate",
+    "is_valid_pylock_path": "nab_provider._vendor.packaging.pylock",
+    "read_lockfile_anchor": "._lockfile.reader",
+    "read_lockfile_packages": "._lockfile.reader",
+    "render_lock": "._lockfile.pylock",
+    "strip_userinfo": "._lockfile.builder",
+    "write_lock": "._lockfile.pylock",
+    "write_requirements_with_hashes": "._lockfile.requirements",
+    "write_requirements_without_hashes": "._lockfile.requirements",
+}
+
+
+def __getattr__(name: str) -> object:
+    """Bind a lazy export on first use, importing the module that defines it."""
+    try:
+        module_name = _LAZY_EXPORTS[name]
+    except KeyError:
+        msg = f"module {__name__!r} has no attribute {name!r}"
+        raise AttributeError(msg) from None
+
+    value = getattr(import_module(module_name, __package__), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    """List the public names, including those ``__getattr__`` has yet to bind."""
+    return sorted(__all__)
+
+
 logger = logging.getLogger(__name__)
 
 LOCK_VERSION = "1.0"
@@ -120,6 +160,42 @@ def _select_primary_digest(
         if algo in by_algo:
             return algo, by_algo[algo]
     return None
+
+
+class MissingHashError(ValueError):
+    """A distribution chosen by the resolver has no usable hash.
+
+    PEP 751 requires at least one hash per artefact.  When an index
+    serves a wheel or sdist without a ``hashes`` map (rare on PyPI,
+    common on file:// indexes), the lock writer cannot emit a
+    spec-compliant entry.  Surface the failure with the offending
+    package and filename so the user can either add a hash to their
+    local index or exclude the package.
+    """
+
+
+class MissingSdistError(ValueError):
+    """A ``sdist-install`` package's pinned version has no sdist.
+
+    Under :attr:`~nab_provider.provider.DistPolicy.SDIST_INSTALL` the
+    resolver may read a wheel's metadata but the lock must pin only the
+    sdist.  When the pinned version publishes wheels but no sdist, the
+    wheels are dropped and nothing is left to pin.  Surface the package
+    and version so the user can pick a version with an sdist or relax
+    the policy, rather than emitting an empty package the spec rejects.
+    """
+
+
+class MissingVcsCommitError(ValueError):
+    """A VCS source reached the lock writer without a resolved commit SHA.
+
+    PEP 751 requires ``packages.vcs.commit-id`` to be an immutable
+    identifier.  nab records the post-clone SHA on the provider during
+    materialisation, before any version can be pinned, so a missing SHA
+    here means a VCS source was pinned without being cloned.  Surface it
+    loudly rather than emit a branch name or empty string as the commit
+    id, which would silently produce a non-reproducible lock.
+    """
 
 
 @dataclass(frozen=True, slots=True)

--- a/nab-project/tests/test_lockfile.py
+++ b/nab-project/tests/test_lockfile.py
@@ -23,6 +23,8 @@ else:
 
 from nab_index.client import SdistFile, WheelFile, _parse_files
 from nab_index.multi_index import IndexConfig
+from nab_project import lockfile
+from nab_project._lockfile import pylock
 from nab_project._lockfile.builder import _common_requires_python
 from nab_project._lockfile.coverage import (
     CoverageError,
@@ -186,6 +188,20 @@ def _index_pin(
         wheels=(_wheel(name, version),),
         requires_python=">=3.10",
     )
+
+
+class TestLazyExports:
+    """:mod:`nab_project.lockfile` binds the emitter's names on first use."""
+
+    def test_first_use_binds_the_emitter_name(self) -> None:
+        assert lockfile.render_lock is pylock.render_lock
+        assert vars(lockfile)["render_lock"] is pylock.render_lock
+
+    def test_unknown_name_raises_attribute_error(self) -> None:
+        assert not hasattr(lockfile, "no_such_name")
+
+    def test_dir_lists_the_public_names(self) -> None:
+        assert dir(lockfile) == sorted(lockfile.__all__)
 
 
 class TestSingleTarget:

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -28,7 +28,7 @@ import tomli
 import tyro
 
 from nab._version import __version__
-from nab_project import toml_io
+from nab_project import lockfile, toml_io
 from nab_project.config import (
     ConfigError,
     NabProjectConfig,
@@ -36,27 +36,13 @@ from nab_project.config import (
     plan_targets,
 )
 from nab_project.lockfile import (
-    DisjointnessError,
-    DivergentBaseDependencyError,
-    InvalidLockfileError,
-    LockfileSyntaxError,
     LockInput,
-    LockValidationError,
     MissingHashError,
     Provenance,
-    RootRequirement,
     TargetLock,
-    check_locked,
     drop_workspace_pins,
-    is_valid_pylock_path,
     package_metadata_override_records,
-    read_lockfile_anchor,
-    read_lockfile_packages,
-    render_lock,
     summarize_lock,
-    write_lock,
-    write_requirements_with_hashes,
-    write_requirements_without_hashes,
 )
 from nab_project.paths import PathState, path_state
 from nab_project.pyproject_files import (
@@ -587,7 +573,7 @@ def _fast_fail_locked(
     resolve_target = _locked_resolve_target(retargeted)
 
     try:
-        disqualification = check_locked(
+        disqualification = lockfile.check_locked(
             target,
             requires_python=config.requires_python,
             extras=run.extras,
@@ -603,13 +589,13 @@ def _fast_fail_locked(
     except OSError as e:
         _cli.printer().error(f"--locked: cannot read lockfile {target}: {e}.")
         sys.exit(1)
-    except LockfileSyntaxError as e:
+    except lockfile.LockfileSyntaxError as e:
         _cli.printer().error(
             f"--locked: lockfile {target} is not valid TOML: {e};"
             f" re-run `{refresh}` to regenerate it."
         )
         sys.exit(1)
-    except InvalidLockfileError as e:
+    except lockfile.InvalidLockfileError as e:
         _cli.printer().error(
             f"--locked: lockfile {target} is not a valid PEP 751 lockfile: {e};"
             f" re-run `{refresh}` to regenerate it."
@@ -648,7 +634,7 @@ def _active_root_requirements(
     base_group: str | None = None,
     build_requirements: bool = False,
     build_group: str | None = None,
-) -> list[RootRequirement]:
+) -> list[lockfile.RootRequirement]:
     """Collect this run's active direct requirements with their source clause.
 
     Covers ``[project].dependencies`` plus the requirements each selected extra
@@ -664,12 +650,12 @@ def _active_root_requirements(
     """
     if build_requirements:
         return [
-            RootRequirement(requirement=req, source="[build-system].requires")
+            lockfile.RootRequirement(requirement=req, source="[build-system].requires")
             for req in read_pyproject_build_requires(path)
         ]
 
     roots = [
-        RootRequirement(requirement=req, source="[project].dependencies")
+        lockfile.RootRequirement(requirement=req, source="[project].dependencies")
         for req in read_pyproject_dependencies(path)
     ]
 
@@ -678,7 +664,7 @@ def _active_root_requirements(
         project_name = read_pyproject_name(path)
         for extra in extras:
             roots.extend(
-                RootRequirement(requirement=req, source=f"the {extra!r} extra")
+                lockfile.RootRequirement(requirement=req, source=f"the {extra!r} extra")
                 for req in expand_extra_requirements(optional, project_name, [extra])
             )
 
@@ -692,7 +678,7 @@ def _active_root_requirements(
             if group not in groups:
                 continue
             roots.extend(
-                RootRequirement(
+                lockfile.RootRequirement(
                     requirement=req, source=f"the {group!r} dependency group"
                 )
                 for req in requirements
@@ -700,7 +686,7 @@ def _active_root_requirements(
 
     if build_group is not None:
         roots.extend(
-            RootRequirement(requirement=req, source="[build-system].requires")
+            lockfile.RootRequirement(requirement=req, source="[build-system].requires")
             for req in read_pyproject_build_requires(path)
         )
 
@@ -716,7 +702,9 @@ def _check_locked(lock_input: LockInput, *, run: _LockRun) -> None:
     lock is never read back into the resolve.
     """
     target = _locked_target_path(run)
-    new_text = _render_or_exit(lambda: render_lock(lock_input, lock_dir=target.parent))
+    new_text = _render_or_exit(
+        lambda: lockfile.render_lock(lock_input, lock_dir=target.parent)
+    )
     committed = _packages_only(target.read_text(encoding="utf-8"))
     if _packages_only(new_text) == committed:
         _cli.printer().done(f"Lockfile {target} is up to date.")
@@ -738,7 +726,7 @@ def _emit_pylock(
 
     target = output if output is not None else default_output
     # Read the prior pins before the write overwrites the file.
-    prior = read_lockfile_packages(target)
+    prior = lockfile.read_lockfile_packages(target)
     # Pass the target so wheel/sdist/directory paths are written relative
     # to the lockfile's own directory, not the cwd.
     _write_lock_or_exit(lock_input, target=target)
@@ -747,17 +735,21 @@ def _emit_pylock(
 
 def _write_lock_or_exit(lock_input: LockInput, *, target: Path | None) -> str:
     """Write the lock, printing a render refusal as one error line and exiting 1."""
-    return _render_or_exit(lambda: write_lock(lock_input, output_path=target))
+    return _render_or_exit(lambda: lockfile.write_lock(lock_input, output_path=target))
 
 
 def _render_or_exit(render: Callable[[], str]) -> str:
     """Run a lock render, printing a refusal as one error line and exiting 1."""
     try:
         return render()
-    except (MissingHashError, LockValidationError, IntractableMarkerError) as e:
+    except (
+        MissingHashError,
+        lockfile.LockValidationError,
+        IntractableMarkerError,
+    ) as e:
         _cli.printer().error(f"cannot lock: {e}")
         sys.exit(1)
-    except (DisjointnessError, DivergentBaseDependencyError) as e:
+    except (lockfile.DisjointnessError, lockfile.DivergentBaseDependencyError) as e:
         _cli.printer().error(str(e))
         sys.exit(1)
 
@@ -1087,9 +1079,11 @@ def _render_requirements_or_exit(
     """
     try:
         if with_hashes:
-            text = write_requirements_with_hashes(lock_input, output_path=output_path)
+            text = lockfile.write_requirements_with_hashes(
+                lock_input, output_path=output_path
+            )
         else:
-            text = write_requirements_without_hashes(
+            text = lockfile.write_requirements_without_hashes(
                 lock_input, output_path=output_path
             )
     except MissingHashError as e:
@@ -1233,7 +1227,7 @@ def _reused_lock_anchor(
     if _cli.is_stdout(output) or format != "pylock":
         return None, None
     target = _default_output_path(format, build_requirements=build_requirements)
-    return None, read_lockfile_anchor(output if output is not None else target)
+    return None, lockfile.read_lockfile_anchor(output if output is not None else target)
 
 
 def _determine_lock_anchor(
@@ -1290,7 +1284,7 @@ def _validate_pylock_output_name(
     """
     if format != "pylock" or output is None or _cli.is_stdout(output):
         return
-    if is_valid_pylock_path(output):
+    if lockfile.is_valid_pylock_path(output):
         return
     if not output.name:
         _cli.printer().error(
@@ -1302,7 +1296,9 @@ def _validate_pylock_output_name(
     # Path(name), not output.with_name(name): with_name raises on names its
     # dotted form can produce, such as '.' from a bare '-'.
     dotted = output.name.replace("-", ".")
-    suggestion = dotted if is_valid_pylock_path(Path(dotted)) else "pylock.toml"
+    suggestion = (
+        dotted if lockfile.is_valid_pylock_path(Path(dotted)) else "pylock.toml"
+    )
     _cli.printer().error(
         f"output file name {output.name!r} must match 'pylock.toml'"
         " or 'pylock.<name>.toml' per PEP 751 (note the dot separator,"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2601,7 +2601,10 @@ class TestLockCommandUniversal:
                 "nab.cli.resolve_for_targets",
                 return_value=_universal_result(success=True),
             ),
-            patch("nab._lock.write_lock", side_effect=MissingHashError("no hash")),
+            patch(
+                "nab_project.lockfile.write_lock",
+                side_effect=MissingHashError("no hash"),
+            ),
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, output=tmp_path / "pylock.toml")
@@ -2626,7 +2629,9 @@ class TestLockCommandUniversal:
                 "nab.cli.resolve_for_targets",
                 return_value=_universal_result(success=True),
             ),
-            patch("nab._lock.write_lock", side_effect=DisjointnessError(hint)),
+            patch(
+                "nab_project.lockfile.write_lock", side_effect=DisjointnessError(hint)
+            ),
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, output=tmp_path / "pylock.toml")
@@ -2644,7 +2649,10 @@ class TestLockCommandUniversal:
                 "nab.cli.resolve_for_targets",
                 return_value=_universal_result(success=True),
             ),
-            patch("nab._lock.write_lock", side_effect=IntractableMarkerError(message)),
+            patch(
+                "nab_project.lockfile.write_lock",
+                side_effect=IntractableMarkerError(message),
+            ),
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, output=tmp_path / "pylock.toml")
@@ -2728,7 +2736,7 @@ class TestLockCommandUniversal:
                 return_value=_universal_result(success=True),
             ),
             patch(
-                "nab._lock.write_lock",
+                "nab_project.lockfile.write_lock",
                 side_effect=DivergentBaseDependencyError(message),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -3036,7 +3044,7 @@ class TestLockCommandUniversal:
                 return_value=_universal_result(success=True),
             ),
             patch(
-                "nab._lock.write_requirements_with_hashes",
+                "nab_project.lockfile.write_requirements_with_hashes",
                 side_effect=MissingHashError("no hash"),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -3559,7 +3567,7 @@ class TestLockCommandUniversal:
                 return_value=_universal_result(success=True),
             ),
             patch(
-                "nab._lock.write_requirements_with_hashes",
+                "nab_project.lockfile.write_requirements_with_hashes",
                 side_effect=MissingHashError("no hash"),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -4656,7 +4664,10 @@ class TestLockedFlag:
                 "nab.cli.resolve_for_targets",
                 return_value=_stub_resolve_result(pins={"foo": V("1.0")}),
             ),
-            patch("nab._lock.render_lock", side_effect=MissingHashError("no hash")),
+            patch(
+                "nab_project.lockfile.render_lock",
+                side_effect=MissingHashError("no hash"),
+            ),
             pytest.raises(SystemExit) as exc,
         ):
             app.cli(
@@ -4703,7 +4714,9 @@ class TestLockedFlag:
                 "nab.cli.resolve_for_targets",
                 return_value=_stub_resolve_result(pins={"foo": V("1.0")}),
             ),
-            patch("nab._lock.render_lock", side_effect=DisjointnessError(hint)),
+            patch(
+                "nab_project.lockfile.render_lock", side_effect=DisjointnessError(hint)
+            ),
             pytest.raises(SystemExit) as exc,
         ):
             app.cli(
@@ -4962,7 +4975,7 @@ class TestLockNonUtf8Text:
                 return_value=_multi_tuple_universal_result(),
             ),
             patch(
-                "nab._lock.write_requirements_without_hashes",
+                "nab_project.lockfile.write_requirements_without_hashes",
                 return_value="pkg @ file:///src-\udce9\n",
             ),
             pytest.raises(SystemExit) as exc,
@@ -5313,7 +5326,7 @@ class TestCacheFlags:
                 "nab.cli.resolve_for_targets",
                 return_value=_stub_resolve_result(pins={}),
             ) as mock_resolve,
-            patch("nab._lock.write_lock"),
+            patch("nab_project.lockfile.write_lock"),
         ):
             lock(pyproject, output=tmp_path / "pylock.toml")
         kwargs = mock_resolve.call_args.kwargs
@@ -5329,7 +5342,7 @@ class TestCacheFlags:
                 "nab.cli.resolve_for_targets",
                 return_value=_stub_resolve_result(pins={}),
             ) as mock_resolve,
-            patch("nab._lock.write_lock"),
+            patch("nab_project.lockfile.write_lock"),
         ):
             lock(pyproject, cache_dir=cache, output=tmp_path / "pylock.toml")
         assert mock_resolve.call_args.kwargs["cache_dir"] == cache
@@ -5342,7 +5355,7 @@ class TestCacheFlags:
                 "nab.cli.resolve_for_targets",
                 return_value=_stub_resolve_result(pins={}),
             ) as mock_resolve,
-            patch("nab._lock.write_lock"),
+            patch("nab_project.lockfile.write_lock"),
         ):
             lock(pyproject, cache=False, output=tmp_path / "pylock.toml")
         assert mock_resolve.call_args.kwargs["cache_dir"] is None
@@ -5355,7 +5368,7 @@ class TestCacheFlags:
                 "nab.cli.resolve_for_targets",
                 return_value=_stub_resolve_result(pins={}),
             ) as mock_resolve,
-            patch("nab._lock.write_lock"),
+            patch("nab_project.lockfile.write_lock"),
         ):
             lock(pyproject, offline=True, output=tmp_path / "pylock.toml")
         assert mock_resolve.call_args.kwargs["offline"] is True
@@ -5430,7 +5443,7 @@ class TestOfflineFlagContract:
                 "nab.cli.resolve_for_targets",
                 return_value=_stub_resolve_result(pins={}),
             ) as mock_resolve,
-            patch("nab._lock.write_lock"),
+            patch("nab_project.lockfile.write_lock"),
         ):
             app.cli(
                 args=[
@@ -5513,7 +5526,7 @@ class TestMainNormalizesOfflineFlag:
                 "nab.cli.resolve_for_targets",
                 return_value=_stub_resolve_result(pins={}),
             ) as mock_resolve,
-            patch("nab._lock.write_lock"),
+            patch("nab_project.lockfile.write_lock"),
         ):
             main()
         return mock_resolve.call_args.kwargs["offline"]
@@ -5576,7 +5589,7 @@ class TestLayeredRunKnobFlagContract:
                 "nab.cli.resolve_for_targets",
                 return_value=_stub_resolve_result(pins={}),
             ),
-            patch("nab._lock.write_lock"),
+            patch("nab_project.lockfile.write_lock"),
             patch("nab.cli._make_transport") as mock_transport,
         ):
             app.cli(
@@ -6026,7 +6039,7 @@ class TestMainWiresOutputOptions:
                 "nab.cli.resolve_for_targets",
                 return_value=_stub_resolve_result(pins={}),
             ),
-            patch("nab._lock.write_lock"),
+            patch("nab_project.lockfile.write_lock"),
         ):
             main()
 
@@ -6183,7 +6196,7 @@ class TestProgressReachesTheResolve:
         received, stderr = self._run_main(
             monkeypatch,
             ["nab", "lock", str(pyproject), "--output", str(tmp_path / "pylock.toml")],
-            patch("nab._lock.write_lock"),
+            patch("nab_project.lockfile.write_lock"),
         )
 
         assert len(received) == 1
@@ -6225,7 +6238,7 @@ class TestProgressReachesTheResolve:
                 "--output",
                 str(tmp_path / "pylock.toml"),
             ],
-            patch("nab._lock.write_lock"),
+            patch("nab_project.lockfile.write_lock"),
         )
 
         assert isinstance(received[0], ProgressReporter)
@@ -6267,7 +6280,7 @@ class TestProgressReachesTheResolve:
         _received, stderr = self._run_main(
             monkeypatch,
             ["nab", "lock", str(pyproject), "--output", "-"],
-            patch("nab._lock.write_lock", return_value=""),
+            patch("nab_project.lockfile.write_lock", return_value=""),
         )
 
         assert "Resolving... 1 fetched, 0 pinned" in stderr
@@ -6500,6 +6513,26 @@ assert not leaked, f"importing nab.cli loaded {leaked}"
 """
 
 
+_LOCK_EMITTER_PROBE = """
+import sys
+
+import nab.cli
+
+deferred = {
+    "nab_project._lockfile.coverage",
+    "nab_project._lockfile.disjointness",
+    "nab_project._lockfile.pylock",
+    "nab_project._lockfile.reader",
+    "nab_project._lockfile.requirements",
+    "nab_project._lockfile.validate",
+    "nab_provider._vendor.packaging.pylock",
+    "tomli_w",
+}
+leaked = sorted(deferred & sys.modules.keys())
+assert not leaked, f"importing nab.cli loaded {leaked}"
+"""
+
+
 class TestCliImportPath:
     """What importing :mod:`nab.cli` is allowed to pull in."""
 
@@ -6517,6 +6550,16 @@ class TestCliImportPath:
         """
         subprocess.run(  # noqa: S603 - the probe is this file's own source
             [sys.executable, "-c", _STDLIB_MODULE_PROBE], check=True
+        )
+
+    def test_lock_emitter_stays_unimported(self) -> None:
+        """The pylock writer and reader, their vendored model and tomli_w load lazily.
+
+        Only ``lock`` writes or reads a lock.  The ``LockInput`` builder is not
+        probed: the resolve engine imports it, so it loads with every command.
+        """
+        subprocess.run(  # noqa: S603 - the probe is this file's own source
+            [sys.executable, "-c", _LOCK_EMITTER_PROBE], check=True
         )
 
 

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -1061,7 +1061,7 @@ class TestProjectCliOverrides:
             patch(
                 "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
             ) as mock_resolve,
-            patch("nab._lock.write_lock"),
+            patch("nab_project.lockfile.write_lock"),
         ):
             app.cli(
                 args=["lock", str(proj), "--no-cache", "--output", str(out), *extra],
@@ -1184,7 +1184,7 @@ class TestProjectCliOverrides:
             patch(
                 "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
             ) as mock_resolve,
-            patch("nab._lock.write_lock"),
+            patch("nab_project.lockfile.write_lock"),
         ):
             app.cli(
                 args=[


### PR DESCRIPTION
`nab --version` costs 747,657,807 instructions instead of 801,685,461, 6.7% less, and `nab cache dir` 842,219,487 instead of 896,312,617, 6.0% less. Both are import cost: `import nab.cli` drops 56,415,231 of 837,147,383. Its `sys.modules` goes from 391 to 383, losing five `_lockfile` modules (`coverage`, `disjointness`, `pylock`, `requirements`, `validate`), the vendored `packaging.pylock` model, and `tomli_w` with its writer.

`nab_project.lockfile` keeps its value types and binds the emitter and reader names on first use through a module `__getattr__`. Two moves make that possible:

- `MissingHashError`, `MissingSdistError` and `MissingVcsCommitError` move into the facade, so `nab/cli.py` can catch them without importing the builder;
- `read_lockfile_anchor` and `read_lockfile_packages` move to a new `_lockfile/reader.py`, so the builder the resolve engine imports no longer needs the vendored pylock model or `tomli`.

Locking still loads the emitter: an offline two-package relock goes from 1,022,635,138 to 1,017,308,799 instructions, 0.5% less, because `--locked` and `--format requirements` now load `validate.py` and `requirements.py` only on demand.

Locally `nab cache dir` is between about 1% and 8% faster over 100 paired runs, middle estimate near 5%, medians 155 ms and 147 ms. The counts reproduce anywhere; the timing is off my machine.
