### PR TITLE
Share one version string per decoded release, ~2% off peak memory

### DIFF
--- a/nab-index/src/nab_index/parsed_listing.py
+++ b/nab-index/src/nab_index/parsed_listing.py
@@ -18,9 +18,9 @@ Wire form (UTF-8 JSON of ``[header, rows]``):
 * rows hold one entry per surviving record, in the order the wire parse
   returned them, so a downstream stable-sort tie-break stays identical. Each
   row is a flat list tagged wheel or sdist by its first element. Every field is
-  type-checked on the way back, and ``requires_python`` and hash-algorithm
-  names are re-interned via ``sys.intern`` so the round trip reproduces the
-  dedup the wire parse builds.
+  type-checked on the way back. ``requires_python`` and hash-algorithm names
+  are re-interned via ``sys.intern``, and consecutive rows of one release
+  share one ``version`` object.
 * the two integrity cells carry the index's own table, as a JSON object, when
   the record was built from one, and the parsed pairs otherwise. A rehydrated
   record defers the same way, so a listing pays the integrity parse only for
@@ -262,13 +262,25 @@ def _decode_zip_sdists(value: object) -> frozenset[str]:
 
 
 def _decode_rows(rows: object) -> list[WheelFile | SdistFile]:
-    """Rehydrate every row, raising :class:`_BadRowError` on the first bad one."""
+    """Rehydrate every row, raising :class:`_BadRowError` on the first bad one.
+
+    JSON gives every array cell its own str, so each row is offered the previous
+    row's version and reuses it when they match. An index lists a release's
+    files together, so no earlier row is worth checking.
+    """
     if not isinstance(rows, list):
         raise _BadRowError
-    return [_decode_row(row) for row in rows]
+
+    files: list[WheelFile | SdistFile] = []
+    prior_version = ""
+    for row in rows:
+        file = _decode_row(row, prior_version)
+        prior_version = file.version
+        files.append(file)
+    return files
 
 
-def _decode_row(row: object) -> WheelFile | SdistFile:
+def _decode_row(row: object, prior_version: str) -> WheelFile | SdistFile:
     """Rehydrate one row, dispatching on the tag its first element carries."""
     if not isinstance(row, list) or not row:
         raise _BadRowError
@@ -277,14 +289,14 @@ def _decode_row(row: object) -> WheelFile | SdistFile:
     if type(tag) is not int:
         raise _BadRowError
     if tag == _TAG_WHEEL:
-        return _decode_wheel(row)
+        return _decode_wheel(row, prior_version)
     if tag == _TAG_SDIST:
-        return _decode_sdist(row)
+        return _decode_sdist(row, prior_version)
     raise _BadRowError
 
 
-def _decode_wheel(row: Sequence[object]) -> WheelFile:
-    """Rehydrate a wheel row.
+def _decode_wheel(row: Sequence[object], prior_version: str) -> WheelFile:
+    """Rehydrate a wheel row, reusing ``prior_version`` when the row repeats it.
 
     An integrity cell holding the index's own table passes through unparsed,
     for the record to parse on first read; any other form is parsed here.
@@ -318,7 +330,7 @@ def _decode_wheel(row: Sequence[object]) -> WheelFile:
     return rehydrated_wheel(
         filename,
         url,
-        version,
+        prior_version if version == prior_version else version,
         None if requires_python is None else sys.intern(requires_python),
         has_metadata,
         upload_time,
@@ -330,7 +342,7 @@ def _decode_wheel(row: Sequence[object]) -> WheelFile:
     )
 
 
-def _decode_sdist(row: Sequence[object]) -> SdistFile:
+def _decode_sdist(row: Sequence[object], prior_version: str) -> SdistFile:
     """Rehydrate a source-distribution row; see :func:`_decode_wheel`."""
     _, filename, url, version, requires_python, upload_time, hashes, size = row
 
@@ -347,7 +359,7 @@ def _decode_sdist(row: Sequence[object]) -> SdistFile:
     return rehydrated_sdist(
         filename,
         url,
-        version,
+        prior_version if version == prior_version else version,
         None if requires_python is None else sys.intern(requires_python),
         upload_time,
         hashes if isinstance(hashes, dict) else _hashes(hashes),

--- a/nab-index/tests/test_parsed_listing_codec.py
+++ b/nab-index/tests/test_parsed_listing_codec.py
@@ -148,6 +148,24 @@ def test_requires_python_and_algo_reinterned_by_identity() -> None:
     assert decoded[2].requires_python is None
 
 
+def test_rows_of_one_release_share_a_version_object() -> None:
+    second_two_zero = dataclasses.replace(
+        WHEEL_BARE,
+        filename="pkg-2.0-py3-none-any.whl",
+        url="https://files.example/pkg-2.0-py3-none-any.whl",
+        version="2.0",
+    )
+    decoded = _roundtrip([*SAMPLE, second_two_zero])
+
+    one_zero = decoded[0].version
+    assert decoded[1].version is one_zero
+    assert decoded[2].version is one_zero
+
+    # The carried version advances with the rows, so 2.0 gets an object of its own.
+    assert decoded[3].version is not one_zero
+    assert decoded[4].version is decoded[3].version
+
+
 def test_empty_listing_roundtrips() -> None:
     assert _roundtrip([]) == []
 


### PR DESCRIPTION
Peak resident memory falls about 2% to 2.7% locally on three canary scenarios, over 12 runs of each: 6.8 MB off `pip:langchain-ml-course@lowest`, 3.4 MB off `airflow:airflow-3-0-2-awswrangler@lowest-direct`, 4.0 MB off `ai-stack:vllm-transformers-floor@highest`.

Decoding a listing back out of the parsed-listing cache gave every row its own version `str`, where the live parse returns one cached object per version string. A row now takes the previous row's version when the two match, and a release's files sit together in a listing, so the neighbour is the only row worth comparing. Over the 30 largest cached listings (147,090 records, 5,476 distinct versions) that leaves 8,930 version strings instead of 147,090, and 4.9% off the bytes those records hold.

The comparison costs instructions: +0.98% on an isolated decode of 102,873 cached rows, +0.57% on a whole awswrangler resolve, where two runs of the base itself differ by 0.15%.

The clock cannot see a cost that small. The timing runs rule out a wall regression above about 2.3% on vllm and about 6% on langchain; the awswrangler runs were too scattered to bound anything under 17%.
