### PR TITLE
Walk the cached ascending listing under LOWEST, ~4.6% off a pandas resolve

### DIFF
--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -1488,6 +1488,20 @@ class TestPrereleaseAdmission:
         provider = self._provider(["1.0rc1", "1.0rc2"], ResolutionStrategy.LOWEST)
         assert provider.choose_version("foo", VersionRange.full()) == V("1.0rc1")
 
+    def test_lowest_picks_flushed_prerelease_over_admitted(self) -> None:
+        """With no final in range LOWEST reverses the newest-first walk.
+
+        ``>=1.0a1`` admits ``1.0a1`` in place while ``1.95a1`` arrives only
+        in the end-of-listing flush, so both walk directions end on
+        ``1.95a1`` and only the reversal puts it first.
+        """
+        provider = self._provider(["1.0a1", "1.95a1"], ResolutionStrategy.LOWEST)
+        version_range = (
+            SpecifierSet(">=1.0a1,<1.1").to_range()
+            | SpecifierSet(">1.9,<2.0").to_range()
+        )
+        assert provider.choose_version("foo", version_range) == V("1.95a1")
+
     def test_dependency_prerelease_admits_via_intersection(self) -> None:
         """A dep naming a pre-release propagates admission through ``&``."""
         provider = self._provider(["1.0", "2.0rc1"])

--- a/nab-provider/src/nab_provider/provider.py
+++ b/nab-provider/src/nab_provider/provider.py
@@ -12,6 +12,7 @@ import logging
 import operator
 from collections import defaultdict, deque
 from dataclasses import dataclass, fields
+from itertools import chain
 from typing import TYPE_CHECKING, TypeVar, cast
 
 from nab_provider._vendor.packaging.markers import prepare_environment
@@ -1235,7 +1236,9 @@ class Provider:
 
         version_list = self.fetch_versions(package)
         all_versions = self.versions_only(normalized, version_list)
-        candidates = self._ordered_candidates(normalized, version_range, all_versions)
+        candidates = self._ordered_candidates(
+            normalized, version_range, all_versions, version_list
+        )
         first = next(candidates, None)
         if first is None:
             self._record_no_versions_reason(
@@ -1263,16 +1266,34 @@ class Provider:
         normalized: str,
         version_range: VersionRange,
         all_versions: list[Version],
+        version_list: list[tuple[Version, DistFile]],
     ) -> Iterator[Version]:
         """Return the in-range versions in the order the strategy walks them.
 
-        ``VersionRange.filter`` yields newest-first, which is the order
-        HIGHEST wants; LOWEST has to read the whole listing to reverse it.
+        ``VersionRange.filter`` bisects a sorted listing lazily, so HIGHEST
+        walks the newest-first view and LOWEST the cached ascending one, and
+        the two reverse each other while a final release is in range. When
+        none is, each walk flushes its buffered pre-releases after the ones
+        it admitted in place, which is not a mirror image, so LOWEST falls
+        back to reversing the newest-first walk whenever its first match is
+        a pre-release.
         """
-        matches = version_range.filter(all_versions, assume_sorted="descending")
-        if self.wants_lowest(normalized):
-            return reversed(list(matches))
-        return matches
+        if not self.wants_lowest(normalized):
+            return version_range.filter(all_versions, assume_sorted="descending")
+
+        ascending = self._ascending_versions(normalized, version_list)
+        oldest_first = version_range.filter(ascending, assume_sorted="ascending")
+        first = next(oldest_first, None)
+        if first is None:
+            return iter(())
+
+        if first.is_prerelease:
+            newest_first = version_range.filter(
+                all_versions, assume_sorted="descending"
+            )
+            return reversed(list(newest_first))
+
+        return chain((first,), oldest_first)
 
     def _preferred_version(
         self,
@@ -2216,7 +2237,7 @@ class Provider:
         normalized: str,
         version_list: list[tuple[Version, DistFile]],
     ) -> list[Version]:
-        """Return the widening universe for ``normalized``: ascending, cached.
+        """Return the ascending version universe for ``normalized``, cached.
 
         The reversed ``versions_only`` view of the post-filter listing, so
         pre-release, dev, post, and local versions all fence widening.


### PR DESCRIPTION
Locally, `ecosystem:pandas-with-aws-s3 --resolution lowest` runs between about 2% and 6% faster, with a middle estimate near 4.6%. CPU follows; the run puts peak memory inside about 0.2% either way.

Under LOWEST, `Provider._ordered_candidates` built the whole in-range candidate list newest-first and reversed it, though everything past the first pick is read only if that pick is rejected. It now walks the ascending listing the provider already caches and stops at the first match.

Replayed over the arguments a real resolve hands it, the method and one `next()` go from about 99 microseconds a call to 5.4, over the 1,369 LOWEST calls a pandas resolve makes: 136 ms to 7.3 ms of a three-second run.

With both sides at 1383 decisions and 1081 conflicts, calls on that scenario drop from 44,768,637 to 40,276,473: `VersionRange._filter_sorted` 3,244,852 to 2,170,981, `Version.is_prerelease` 1,091,901 to 19,245. `pip:trustllm` lowest retires about 1.6% to 1.9% fewer instructions and `pip:google-bigquery-soda` lowest 0.33%; the timing runs on those two only rule out slowdowns above about 4% and 2.4%.

The two walks stop being mirror images when nothing in range is a final release, since each flushes its buffered pre-releases after those it admitted in place. LOWEST then falls back to reversing the newest-first walk, on 2 of those 1,369 pandas calls and 4 of 275 on trustllm.
