### PR TITLE
Decide three shapes the marker algebra read wrong

### DIFF
--- a/nab-project/tests/test_lockfile.py
+++ b/nab-project/tests/test_lockfile.py
@@ -2759,15 +2759,15 @@ class TestMarkerDisjointness:
         )
 
     def test_contains_over_approximation_reports_without_witness(self) -> None:
-        # A ``contains`` atom is an opaque, over-approximating boolean.
-        # ``"ab" in v`` implies ``"a" in v``, so no realisable
-        # platform_version satisfies ``"ab" in v and "a" not in v``; the
-        # algebra cannot rule the pair out (over-approximates to
+        # A ``contains`` atom on a version-dispatch variable is an opaque,
+        # over-approximating boolean.  ``"ab" in v`` implies ``"a" in v``, so no
+        # realisable implementation_version satisfies ``"ab" in v and "a" not in
+        # v``; the algebra cannot rule the pair out (over-approximates to
         # non-disjoint) and no concrete witness exists.  The gate stays
-        # conservative and reports the pair without a point.  A declared
-        # env supplying platform_version would fold the atoms away, so
-        # this uses an env that omits it.
-        marker = "'ab' in platform_version and 'a' not in platform_version"
+        # conservative and reports the pair without a point.  A declared env
+        # supplying implementation_version would fold the atoms away, so this
+        # uses an env that omits it.
+        marker = "'ab' in implementation_version and 'a' not in implementation_version"
         with pytest.raises(DisjointnessError, match="not disjoint"):
             validate_marker_disjointness(
                 [

--- a/nab-provider/src/nab_provider/_vendor/packaging/_markersets.py
+++ b/nab-provider/src/nab_provider/_vendor/packaging/_markersets.py
@@ -1,16 +1,11 @@
-"""Marker algebra engine: reason about PEP 508 markers as sets of environments.
+"""Marker algebra engine behind :class:`~packaging.markersets.MarkerSet`.
 
-The private engine behind :class:`~packaging.markersets.MarkerSet`. Parses a
-marker string (or :class:`~packaging.markers.Marker`) into a normalised boolean
-op-tree over typed atoms, with the packaging-faithful
-``(variable, operator, literal)`` dispatch, A1 lowering of ``python_version``
-onto the ``python_full_version`` axis, set-valued extras, and ``contains``
-atoms, which join a string variable's value axis and stay opaque on a
-version-dispatch one. The denotation of a value atom is delegated to packaging's
-own ``_eval_op`` so it matches packaging exactly. Decisions run an on-demand
-cell decomposition: every procedure re-partitions the referenced variables'
-domains into cells on which each atom is constant, enumerates the cell product
-under the ``max_cells`` guard, and evaluates the op-tree once per cell.
+A marker parses into a normalised op-tree over typed atoms. A value atom's
+denotation is packaging's own ``_eval_op``, so a marker means here what it means
+there, and A1 lowers ``python_version`` onto the ``python_full_version`` axis.
+
+A decision partitions each axis the tree names into cells on which every atom is
+constant, then evaluates the tree over the cells of their product.
 """
 
 from __future__ import annotations
@@ -43,40 +38,38 @@ if TYPE_CHECKING:
 class IntractableMarkerSet(ValueError):
     """The set is too complex to decide within the budget.
 
-    Raised rather than hanging, overflowing the stack, or failing obscurely: an
-    oversized cell product past ``max_cells``, a marker nested past the
-    interpreter stack, or a version literal whose numeric component exceeds the
-    digit parse limit. Subclasses :class:`ValueError` to match packaging's
-    marker exceptions.
+    Raised rather than hanging or failing obscurely, for any budget the algebra
+    runs under: a cell cap, the work meter, the interpreter's stack, and the
+    digit parse limit.
+
+    Subclasses :class:`ValueError`, as packaging's marker exceptions do.
     """
 
 
 class UnserializableMarkerSet(ValueError):
     """The set has no marker-string spelling.
 
-    Raised, rather than emitting a wrong or masquerading string, for the empty
-    set and for complements whose structure the marker grammar cannot express.
-    Subclasses :class:`ValueError` to match packaging's marker exceptions.
+    Raised for the empty set and for complements the grammar cannot express,
+    rather than emitting a string for some other set. Subclasses
+    :class:`ValueError` to match packaging's marker exceptions.
     """
 
 
-# Axis kinds. Atoms on the same axis share one cell partition and are each
-# constant on every one of its cells.
+# Axis kinds. Atoms on one axis share a partition and are constant on each cell.
 AXIS_VALUE = "value"
 AXIS_SET = "set"
 AXIS_CONTAINS = "contains"
 
-# Domain kinds a variable is typed through.
 DOMAIN_VERSION = "version"
 DOMAIN_STRING = "string"
 DOMAIN_TWIN = "version_or_string"
 DOMAIN_SET = "set"
 
-# Every variable in packaging's marker grammar, typed to a domain. The twins
-# ``implementation_version`` and ``platform_release`` dispatch as versions yet may
-# hold an arbitrary string, so both carry a string fall-through. ``python_version``
-# and ``python_full_version`` always receive a PEP 440 value, so they stay
-# version-only; ``platform_version`` is a plain string.
+# Every variable in packaging's marker grammar, typed to a domain. The twins,
+# ``implementation_version`` and ``platform_release``, dispatch as versions yet
+# may hold an arbitrary string, so they also carry the string fall-through.
+# ``python_version`` and ``python_full_version`` always receive a PEP 440 value,
+# so they stay version-only.
 DOMAIN_REGISTRY: dict[str, str] = {
     "implementation_name": DOMAIN_STRING,
     "implementation_version": DOMAIN_TWIN,
@@ -99,13 +92,13 @@ _ORDERED_UNDEFINED = frozenset({"~=", "==="})
 
 
 def _domain(variable: str) -> str:
-    """Return the effective domain of a variable under packaging typing."""
+    """Return a variable's domain, twins collapsed onto version."""
     kind = DOMAIN_REGISTRY[variable]
     return DOMAIN_VERSION if kind == DOMAIN_TWIN else kind
 
 
 def is_version_dispatch(variable: str) -> bool:
-    """Whether a variable dispatches as a version under packaging typing."""
+    """Whether a variable dispatches as a version, twins included."""
     return _domain(variable) == DOMAIN_VERSION
 
 
@@ -121,11 +114,10 @@ def _apply_memoised(lhs: str, op: str, rhs: str, key: str, _limit: int) -> bool:
 
 
 def _apply(lhs: str, op: str, rhs: str, key: str) -> bool:
-    """Evaluate ``op`` on a pair of literals under ``key``'s domain, memoised.
+    """Evaluate ``op`` on two literals under ``key``'s domain, memoised.
 
-    The int-string limit joins the four strings in the cache key: a version key
-    parses both operands, so a literal that compares under one limit raises
-    under another.
+    The int-string limit joins the cache key: a version key parses its operands,
+    so a literal that compares under one limit raises under another.
     """
     return _apply_memoised(lhs, op, rhs, key, sys.get_int_max_str_digits())
 
@@ -167,9 +159,8 @@ _DIGIT_RUN = re.compile(r"\d+")
 def _oversized_numeric(text: str) -> bool:
     """Whether a numeric run in ``text`` overflows int-from-string parsing.
 
-    A component wider than the interpreter's int-from-string limit makes
-    packaging's ``Version`` raise a bare ``ValueError`` on parse. A zero limit
-    disables the check, so nothing overflows.
+    Such a run makes packaging's ``Version`` raise a bare ``ValueError``. A zero
+    limit disables the check, so nothing overflows.
     """
     limit = sys.get_int_max_str_digits()
     if not limit:
@@ -180,10 +171,10 @@ def _oversized_numeric(text: str) -> bool:
 # ---------------------------------------------------------------------------- atoms
 
 
-# A strong table would keep an entry for every distinct atom the process ever
-# built, so values are weak and an entry lives only while its atom does. The lock
-# stops two threads minting rival atoms for one key, which the algebra would then
-# treat as two leaves rather than one.
+# A strong table would hold every distinct atom the process ever built, so the
+# values are weak and an entry lives only while its atom does. The lock stops
+# two threads minting rival atoms for one key, which the algebra would read as
+# two leaves.
 _INTERNED: weakref.WeakValueDictionary[
     tuple[str, str, str, str, str, bool, bool, bool], Atom
 ] = weakref.WeakValueDictionary()
@@ -194,12 +185,14 @@ class Atom:
     """A normalised leaf whose ``holds`` gives its denotation on one point.
 
     Interned on its fields, so two equal atoms are one object and equality is
-    identity. The only mutation after construction is the version pool it mints
-    lazily, a pure function of those same fields, so sharing it is sound.
+    identity.
 
-    A decision re-reads the same atom on the same point across partitions of one
-    axis; that memo belongs to the operation, not here, so ``holds`` recomputes.
-    The comparison it runs is memoised in :func:`_apply`.
+    Its version pool is minted lazily and is the only mutation. That pool is a
+    pure function of the same fields, so sharing it is sound.
+
+    Truth is memoised on :class:`Memo` and never here: an atom outlives any one
+    operation, and its truth depends on the int-string limit, which
+    :func:`_apply` keys on and an interned object could not.
     """
 
     __slots__ = (
@@ -217,7 +210,7 @@ class Atom:
 
     kind: str
     variable: str  # axis variable (python_version lowers to python_full_version)
-    origin: str  # the variable as written, for env lookup and serialisation
+    origin: str  # the parser's spelling, for env lookup and serialisation
     op: str
     literal: str
     swapped: bool
@@ -276,10 +269,11 @@ class Atom:
         """Return the axis this atom partitions and is constant on.
 
         A substring test on a string variable joins that variable's value axis,
-        so both readings of the variable are decided on one point. On a
-        version-dispatch variable it keeps a boolean axis of its own, one per
-        literal, because the values that embed a literal are not enumerable
-        from the literals alone.
+        so the substring test and the value comparison decide on one point.
+
+        On a version-dispatch variable that test keeps a boolean axis of its own
+        per literal, because the values embedding a literal are not enumerable
+        from it.
         """
         if self.kind == AXIS_VALUE:
             return (AXIS_VALUE, self.variable)
@@ -305,11 +299,7 @@ class Atom:
         return present if self.positive else not present
 
     def pool_entries(self) -> tuple[tuple[Version, str], ...]:
-        """The parsed version-pool points this atom seeds, minted lazily once.
-
-        A pure property of the literal: its version neighbours, plus the
-        neighbours of its version-parseable substrings for a membership atom.
-        """
+        """Return the version-pool points this atom's literal seeds, minted once."""
         entries = self._pool_entries
         if entries is None:
             texts = list(_version_neighbors(self.literal))
@@ -336,9 +326,8 @@ def _holds_value(atom: Atom, text: str) -> bool:
 
 # --------------------------------------------------------------------- the op-tree
 
-# Every node carries a structural ``key()``: two trees with the same key have the same
-# shape and the same atoms, so a decision recorded under one tree's key can be served
-# for the other. A node mints its key on first use and keeps it.
+# Two trees with the same ``key()`` have the same shape and atoms, so a decision
+# recorded under one key serves the other. A node mints its key once and keeps it.
 
 
 class BoolConst:
@@ -428,7 +417,7 @@ FALSE = BoolConst(value=False)
 
 
 def make_and(children: Iterable[Formula]) -> Formula:
-    """Build a conjunction, folding identities and the FALSE annihilator."""
+    """Build a conjunction, folding identities and FALSE."""
     flat: list[Formula] = []
     for child in children:
         if isinstance(child, BoolConst):
@@ -447,7 +436,7 @@ def make_and(children: Iterable[Formula]) -> Formula:
 
 
 def make_or(children: Iterable[Formula]) -> Formula:
-    """Build a disjunction, folding identities and the TRUE absorber."""
+    """Build a disjunction, folding identities and TRUE."""
     flat: list[Formula] = []
     for child in children:
         if isinstance(child, BoolConst):
@@ -495,17 +484,15 @@ def _parse_ast(source: str | Marker) -> list | None:
 
 
 def parse(source: str | Marker) -> Formula:
-    """Parse a marker string or :class:`Marker` into the normalised op-tree."""
+    """Parse a marker into the normalised op-tree."""
     parsed = _parse_ast(source)
     return TRUE if parsed is None else _convert(parsed)
 
 
 def variable_names(source: str | Marker) -> frozenset[str]:
-    """Return every marker variable ``source`` names, as written.
+    """Return every marker variable ``source`` names, in the parser's spelling.
 
-    Walks the parsed marker collecting the variables its operands name, without
-    building atoms, so a marker the algebra rejects at construction still yields
-    its names. The result over-approximates semantic support.
+    Builds no atoms, so a marker the algebra rejects still yields its names.
     """
     parsed = _parse_ast(source)
     if parsed is None:
@@ -558,11 +545,9 @@ def _convert_atom(item: tuple) -> Formula:
     if isinstance(rhs, Variable):
         return _make_atom(rhs.value, op, lhs.value, swapped=True)
 
-    # Neither side is a Variable node. packaging reads the right operand as an
-    # environment key, so a quoted literal naming a known variable routes like a
-    # swapped variable atom. A right operand naming no known variable folds via
-    # the string operator table (packaging raises UndefinedEnvironmentName at
-    # evaluate; the algebra evaluates, a documented divergence).
+    # packaging reads the right operand as an environment key, so a quoted
+    # literal naming a known variable routes like a swapped atom. One naming
+    # none folds through the string table where packaging raises instead.
     if rhs.value in DOMAIN_REGISTRY:
         return _make_atom(rhs.value, op, lhs.value, swapped=True)
     return BoolConst(value=_apply(lhs.value, op, rhs.value, key=""))
@@ -576,8 +561,8 @@ def _make_atom(variable: str, op: str, literal: str, *, swapped: bool) -> Formul
     if op in _MEMBERSHIP:
         return _make_membership_atom(variable, op, literal, swapped=swapped)
 
-    # These axes seed single-segment pool points, so a single-segment probe drives
-    # the swapped-operator validity check.
+    # A single-segment probe stands in for the environment value: ``~=`` builds
+    # no specifier from one, so a swapped ``~=`` surfaces as undefined here.
     _reject_undefined_operator(variable, op, literal, swapped=swapped, probe="0")
     if op == "===":
         msg = f"{op!r} is undefined on {variable!r} with literal {literal!r}"
@@ -589,9 +574,8 @@ def _make_python_version_atom(op: str, literal: str, *, swapped: bool) -> Formul
     if op in _MEMBERSHIP and swapped:
         return _make_membership_atom("python_version", op, literal, swapped=swapped)
     if op == "~=" and swapped:
-        # A swapped ~= makes the environment value the specifier bound, so the
-        # true region is the same-major lower-minor band the version pool never
-        # seeds; reject it, as the other version-dispatch axes do.
+        # A swapped ~= makes the environment value the specifier bound, so its
+        # true region is a same-major band with no pool point at its floor.
         msg = f"{op!r} is undefined on 'python_version' with literal {literal!r}"
         raise UndefinedComparison(msg)
 
@@ -643,11 +627,10 @@ def _make_set_atom(variable: str, op: str, literal: str, *, swapped: bool) -> Fo
 
 
 def reject_oversized_version_literals(variable: str, literals: Sequence[str]) -> None:
-    """Raise before a numeric component past the parse limit reaches packaging.
+    """Raise before an oversized numeric component reaches packaging.
 
-    A numeric component over sys.get_int_max_str_digits() digits makes
-    packaging's Version raise a bare ValueError; convert it to the bounded
-    IntractableMarkerSet here.
+    A component past ``sys.get_int_max_str_digits()`` digits makes ``Version``
+    raise a bare ValueError; convert it to a bounded failure here.
     """
     if is_version_dispatch(variable) and any(
         _oversized_numeric(literal) for literal in literals
@@ -662,9 +645,9 @@ def reject_oversized_version_literals(variable: str, literals: Sequence[str]) ->
 def _reject_mint_overflow(literals: Sequence[str]) -> None:
     """Reserve one digit so neighbour minting cannot overflow the parse limit.
 
-    Cell decomposition mints version neighbours by incrementing one numeric
-    component, so a run at the limit width rolls to one digit past it and
-    makes packaging's Version raise a bare ValueError. Reject one digit early.
+    Minting increments a numeric component, so a run at the limit width rolls
+    one digit past it: this rejects at the limit, where
+    :func:`reject_oversized_version_literals` rejects past it.
     """
     limit = sys.get_int_max_str_digits()
     if limit and any(
@@ -699,7 +682,7 @@ def _reject_undefined_operator(
 
 
 class Cell(NamedTuple):
-    """One piece of an axis's domain: a representative point and its truth vector."""
+    """A representative point of an axis's domain and its truth vector."""
 
     point: object
     vector: tuple[bool, ...]
@@ -715,12 +698,9 @@ class _Decision(NamedTuple):
 class Memo:
     """The verdicts, partitions, atom truths and version parses a decision re-reads.
 
-    A run over related trees decides the same tree shape more than once. Within one
-    decision, one axis is re-partitioned for overlapping atom sets, one atom re-read
-    on one point across those partitions, and the literals those partitions share
-    parsed as versions once per partition. All four are memoised here. One decision
-    makes its own unless the caller passes one to share; see
-    :class:`~packaging.markersets.DecisionStore` for the sharing contract.
+    A run over related trees re-decides the same tree shapes and re-partitions
+    the same axes, so all four are memoised here. A decision makes its own
+    unless the caller shares one.
     """
 
     __slots__ = ("decisions", "partitions", "truths", "versions")
@@ -733,7 +713,11 @@ class Memo:
 
 
 def _truth(atom: Atom, point: object, memo: Memo) -> bool:
-    """Return an atom's truth on one point, memoised for the operation's span."""
+    """Return an atom's truth on one point.
+
+    A value-axis atom's is memoised for the operation's span; the others
+    short-circuit to :meth:`Atom.holds`.
+    """
     if atom.kind != AXIS_VALUE:
         return atom.holds(point)
     key = (atom, str(point))
@@ -744,15 +728,12 @@ def _truth(atom: Atom, point: object, memo: Memo) -> bool:
 
 
 def _pooled_version(text: str, memo: Memo) -> Version | None:
-    """Return ``text`` parsed as a version, or None, memoised for the operation's span.
-
-    Distinct atom subsets of one axis re-derive their candidate pools from
-    overlapping literals, so the parse is shared rather than repeated per subset.
+    """Return ``text`` parsed as a version, or None, memoised.
 
     Keyed on text alone where :func:`_apply` also keys on the int-string limit.
-    Every text pooled here is an axis literal, a substring of one, or a neighbour
-    minted from one, and the parse-limit guards bound each of those ahead of its
-    read, so a hit is never a parse the current limit forbids.
+
+    Every text pooled here is an axis literal, a substring of one, or a point
+    minted from one, and a parse-limit guard bounds each before its read.
     """
     versions = memo.versions
     if text not in versions:
@@ -792,17 +773,16 @@ def _version_neighbors(text: str) -> list[str]:
     pre_part = f"{version.pre[0]}{version.pre[1]}" if version.pre is not None else ""
     out = [base, *_equal_twins(version)]
 
-    # Bumps stay in the literal's own epoch: the release bump of 1!3.9 is 1!3.10,
-    # which outranks it, not 3.10, which sorts below and leaves the band above the
-    # literal (1!4.0, 2!0) with no representative.
+    # Bumps stay in the literal's epoch: 1!3.9 bumps to 1!3.10, not 3.10, which
+    # sorts below and leaves the band above it unrepresented.
     prefix = f"{epoch}!" if epoch else ""
     bumps = [prefix + ".".join(str(x) for x in (*release[:-1], release[-1] + 1))]
     if len(release) > 1:
         bumps.append(f"{prefix}{major}.{release[1] + 1}")
     bumps.append(f"{prefix}{major + 1}")
     if epoch:
-        # The band above a non-zero-epoch literal continues into the next epoch
-        # (2!0 outranks every 1!* release), beyond any same-epoch bump.
+        # The band above a non-zero-epoch literal runs into the next epoch,
+        # beyond any same-epoch bump.
         bumps.append(f"{epoch + 1}!0")
 
     for bump in bumps:
@@ -821,9 +801,9 @@ def _version_neighbors(text: str) -> list[str]:
 def _suffix_neighbors(version: Version, release_str: str, pre_part: str) -> list[str]:
     """Mint the points adjacent to a pre/post/dev literal.
 
-    An exclusive comparison against a suffixed literal excludes the literal's own
-    lower-precedence variants, so the adjacent point is the next or previous
-    suffix of the same release, which no release bump reaches.
+    An exclusive comparison excludes the literal's own lower-precedence
+    variants, so the adjacent point is the next or previous suffix of the same
+    release, which no release bump reaches.
     """
     out: list[str] = []
     epoch = version.epoch
@@ -846,13 +826,14 @@ def _suffix_neighbors(version: Version, release_str: str, pre_part: str) -> list
 
 
 def _equal_twins(version: Version) -> list[str]:
-    """Mint the points equal to the literal as a version but not as a string.
+    """Mint the points that separate the literal's version reading from its string reading.
 
     ``in``/``not in`` and an invalid specifier fall through to a raw string
-    test, so separating that reading from PEP 440 matching needs a point the
-    version test accepts and the string test rejects: the release, zero-padded.
-    A local-tagged literal also needs the local-stripped release, since a
-    specifier built from a public point ignores a candidate's local label.
+    test. Separating that reading from PEP 440 matching needs the release
+    zero-padded.
+
+    A local-tagged literal needs the local-stripped release too, since a
+    specifier built from a public point ignores a local label.
     """
     padded = version.__replace__(release=(*version.release, 0))
     if version.local is None:
@@ -863,14 +844,14 @@ def _equal_twins(version: Version) -> list[str]:
 def _release_between(vlow: Version, vhigh: Version) -> str:
     """Return a plain release ranking above every variant of ``vlow``.
 
-    Release ordering runs ahead of pre, post, dev and local, so ``vlow``'s
-    release extended by one outranks ``vlow`` whatever suffix it carries. There
-    is no lowest such release: another zero can always be padded in. Within one
-    epoch the padding runs to the wider of the two releases, which is the
-    deepest place ``vhigh`` can differ, so the result stays under it whenever
-    the two releases differ at all. Across an epoch boundary ``vhigh``'s release
-    does not bound the candidate, so ``vlow``'s own width is enough. The caller
-    checks the ordering either way.
+    Release ordering runs ahead of pre, post, dev and local, so extending
+    ``vlow``'s release by one outranks it whatever suffix it carries.
+
+    Padding to the wider release keeps the result under ``vhigh`` whenever the
+    two releases differ, that being the deepest place ``vhigh`` can differ.
+
+    Where the ends share a release, or across an epoch boundary, ``vhigh`` does
+    not bound it and the caller's ordering check rejects the candidate.
     """
     low = vlow.release
     width = len(low) if vlow.epoch != vhigh.epoch else max(len(low), len(vhigh.release))
@@ -882,11 +863,12 @@ def _release_between(vlow: Version, vhigh: Version) -> str:
 def _between(vlow: Version, low: str, vhigh: Version, memo: Memo) -> str | None:
     """Return a point strictly between two adjacent pool points, or None.
 
-    The plain release comes first because an exclusive ordered comparison
-    excludes its own bound's post, local, pre and dev variants, so a band whose
-    two ends share a release is the only one the suffixed candidates can fill.
-    Where the ends differ, only a version whose release differs from both is
-    admitted, and no suffix of ``vlow`` is.
+    An exclusive comparison excludes its own bound's post, local, pre and dev
+    variants. Where the two points' releases differ, only a candidate whose own
+    release differs from both lands between them, so the plain release is tried
+    first.
+
+    The suffixed candidates fill a band whose ends share a release.
     """
     for candidate in (
         _release_between(vlow, vhigh),
@@ -941,10 +923,9 @@ def _version_pool(
 def _elevate_epochs(
     base: list[str], parsed: Sequence[tuple[Version, str]], max_cells: int
 ) -> list[str]:
-    # A1 lowers python_version onto this axis, so major.minor and full ordering
-    # diverge across an epoch boundary: Version("1!3.9") truncates to "3.9" yet
-    # outranks "3.14". Each point needs an epoch-bearing twin for every band up to
-    # one epoch above the top literal, covering gap epochs no literal names.
+    # A1 lowers python_version here, so major.minor and full order diverge across
+    # an epoch boundary: 1!3.9 truncates to 3.9 yet outranks 3.14. Each point
+    # needs a twin in every epoch the pool reaches.
     epochs = {version.epoch for version, _ in parsed}
     targets = range(1, max(epochs) + 2)
 
@@ -961,8 +942,7 @@ def _elevate_epochs(
 def _membership_candidates(atom: Atom, memo: Memo) -> list[str]:
     subs = _substrings(atom.literal)
     if atom.derive_mm:
-        # A1 membership tests the major.minor of a full version, so realisable
-        # points are the substrings of the literal that are themselves versions.
+        # A1 tests the major.minor, so a realisable point is a version substring.
         return [
             s for s in subs if _pooled_version(s.removesuffix(".*"), memo) is not None
         ]
@@ -985,8 +965,7 @@ def _dedupe_candidates(
         if candidate in seen:
             continue
         # A pure Version axis holds only PEP 440 versions, so a non-version
-        # candidate is unrealisable there. The twins keep every non-version
-        # candidate, including the OTHER-cell representative.
+        # candidate is unrealisable there; the twins keep every one.
         if pure_version and _pooled_version(candidate, memo) is None:
             continue
         seen.add(candidate)
@@ -998,12 +977,7 @@ def _dedupe_candidates(
 
 
 def _other_representative(literals: Sequence[str]) -> str:
-    """Return a string equal to no literal on the axis and parsing as no version.
-
-    One character longer than the longest literal, so no literal can equal it,
-    and built from a filler that never forms a PEP 440 version so the point
-    lands in the arbitrary-string region rather than a version cell.
-    """
+    """Return a string equal to no literal on the axis and parsing as no version."""
     width = max((len(literal) for literal in literals), default=0) + 1
     return "z" * width
 
@@ -1012,8 +986,7 @@ def _unused_character(literals: Iterable[str]) -> str:
     """Return a character none of ``literals`` uses, counting up from ``!``.
 
     A marker literal can hold any character its quote style admits, so the walk
-    can run past printable ASCII; the point only has to be a string no atom on
-    the axis matches by accident, and any unused character serves.
+    can run past printable ASCII. Any unused character serves.
     """
     used = {char for literal in literals for char in literal}
     code = ord("!")
@@ -1027,12 +1000,12 @@ def _contains_candidates(
 ) -> list[str]:
     """Mint a point for each substring pattern the axis's contains atoms allow.
 
-    A separator none of ``literals`` uses joins one subset of the substring
-    literals, so every occurrence inside the point falls in one piece: it
-    embeds that subset and whatever the subset embeds, equals no literal, and
-    is a substring of none. Any string embeds what one subset does, so with the
-    literals and their substrings the axis reaches every combination its atoms
-    can realise together.
+    A separator none of ``literals`` uses joins one subset, so every occurrence
+    in the point falls in one piece.
+
+    The point then embeds that subset and what the subset embeds, equals no
+    literal, and is a substring of none. Every combination the atoms realise
+    together is some subset, so the axis reaches all of them.
     """
     names: list[str] = []
     seen: set[str] = set()
@@ -1060,10 +1033,9 @@ def _reduce_work_exceeds(
 ) -> bool:
     """Whether the axis's guaranteed reduce work already exceeds ``max_cells``.
 
-    Every distinct literal is one point, so its count times the atom count is a
-    lower bound on the ``_reduce_cells`` work. A pure-version axis keeps only
-    version-parseable literals; the twins and string fields keep every distinct
-    literal.
+    Every distinct literal is one point, so its count times the atom count
+    lower-bounds the ``_reduce_cells`` work. A pure-version axis counts only the
+    version-parseable literals.
     """
     pure = is_pure_version(variable)
     seen: set[str] = set()
@@ -1090,14 +1062,12 @@ def _value_candidates(
     candidates: list[str] = []
     raw_kind = DOMAIN_REGISTRY[variable]
 
-    # The OTHER cell (equal to no literal and not a version) exists only where the
-    # domain admits arbitrary strings: string fields and the twins.
+    # The OTHER cell exists only where the domain admits arbitrary strings.
     if raw_kind in (DOMAIN_STRING, DOMAIN_TWIN):
         candidates.append(_other_representative(literals))
     candidates.extend(literals)
 
-    # Cap the substring enumeration across the whole axis, not each literal alone,
-    # so a set of long distinct literals fails loudly first.
+    # Cap the enumeration across the axis, not per literal.
     spent = 0
     for atom in atoms:
         if atom.kind == AXIS_VALUE and atom.op in _MEMBERSHIP:
@@ -1135,8 +1105,7 @@ def _reduce_cells(
 ) -> list[Cell]:
     points = list(points)
 
-    # The truth vector costs one holds() per atom per point; guard that product so
-    # an axis carrying many atoms fails loudly.
+    # The truth vector costs one holds() per atom per point.
     if len(points) * len(atoms) > max_cells:
         msg = (
             f"axis work {len(points)}x{len(atoms)} atoms exceeds max_cells={max_cells}"
@@ -1205,10 +1174,9 @@ def _partition_axis(
     return partition_boolean_axis(atoms, max_cells, memo)
 
 
-# ``max_cells`` bounds one decision, and the greedy fixpoint issues one per
-# clause and per atom per universe row, so the meter is what bounds the run:
-# every cell enumeration charges the work it is about to do. Thread-local, and
-# unset outside a simplify so every other decision stays unmetered.
+# ``max_cells`` bounds one decision, the meter a whole simplify: every
+# enumeration charges what it is about to do. Thread-local, and unset outside a
+# simplify, so every other decision stays unmetered.
 _work_meter = threading.local()
 
 
@@ -1229,11 +1197,7 @@ def partition_axis(
 ) -> list[Cell]:
     """Partition one axis's domain into cells on which every atom is constant.
 
-    ``store`` memoises the partition for the span of one operation; its owner decides
-    that span, and this keeps no state of its own.
-
-    The atoms are keyed in order, not as a set: :class:`Cell` vectors are aligned
-    positionally with the list a partition was built for.
+    Atoms are keyed in order: a :class:`Cell` vector lines up positionally with them.
     """
     key = (axis, tuple(atoms), max_cells)
     cached = store.partitions.get(key)
@@ -1275,12 +1239,9 @@ def _require(env: Mapping[str, object], key: str) -> object:
 def evaluate_atom(atom: Atom, env: Mapping[str, object]) -> bool:
     """Evaluate one atom against a full environment (extras are sets).
 
-    A referenced variable absent from ``env`` raises
-    :class:`UndefinedEnvironmentName` on every axis, matching packaging and
-    keeping the missing-key behaviour uniform across scalars and sets. A
-    ``python_version`` atom reads ``python_full_version`` in preference to
-    ``python_version``, so an environment supplying both keys is read through
-    ``python_full_version``.
+    A missing variable raises :class:`UndefinedEnvironmentName` on every axis,
+    as packaging does. A ``python_version`` atom prefers the
+    ``python_full_version`` key when the environment supplies both.
     """
     if atom.kind == AXIS_VALUE:
         if atom.derive_mm and "python_full_version" not in env:
@@ -1317,10 +1278,9 @@ def collect_atoms(node: Formula) -> list[Atom]:
 
 
 def reject_oversized_literals(node: Formula, env: Mapping[str, object]) -> None:
-    """Raise the bounded guard for an oversized version literal or env value.
+    """Raise the bounded guard for an oversized literal or env value.
 
-    Runs before either could reach packaging's Version and raise a bare
-    ValueError.
+    Only atoms whose variable ``env`` supplies are checked.
     """
     for atom in collect_atoms(node):
         value = _atom_env_value(atom, env)
@@ -1374,7 +1334,7 @@ def _eval_cell(node: Formula, truth: Mapping[Atom, bool]) -> bool:
 
 
 class _CellSpace(NamedTuple):
-    """The axes a tree is decided over, their atoms and cells, and the work charged."""
+    """One decision's axes, their atoms and cells, and the work charged."""
 
     axes: list[tuple[str, ...]]
     atomlists: list[list[Atom]]
@@ -1383,11 +1343,7 @@ class _CellSpace(NamedTuple):
 
 
 def _cell_space(node: Formula, max_cells: int, store: Memo) -> _CellSpace:
-    """Partition each axis a tree mentions and charge the enumeration it implies.
-
-    The charged units come back with the cells, so a repeat of the same decision can
-    charge them again without enumerating.
-    """
+    """Partition each axis a tree mentions and charge the enumeration it implies."""
     atoms = collect_atoms(node)
     grouped = _atoms_by_axis(atoms)
     axes = list(grouped)
@@ -1400,9 +1356,8 @@ def _cell_space(node: Formula, max_cells: int, store: Memo) -> _CellSpace:
     if not axes:
         return _CellSpace(axes, atomlists, partitions, 0)
 
-    # The enumeration walks the whole op-tree once per cell, so guard the cell
-    # product times the leaf-occurrence count: a marker that repeats atoms inflates
-    # the walk without inflating the distinct-atom count or the cell product.
+    # Repeated atoms inflate the per-cell walk without inflating the cell
+    # product, so the guard multiplies in the leaf count.
     units = guarded_product_size(
         (*(len(part) for part in partitions), len(atoms)), max_cells
     )
@@ -1413,7 +1368,7 @@ def _cell_space(node: Formula, max_cells: int, store: Memo) -> _CellSpace:
 def _enumerate_cells(
     node: Formula, space: _CellSpace
 ) -> Iterator[dict[tuple[str, ...], Cell]]:
-    """Yield the cells of a partitioned space on which the tree holds."""
+    """Yield the cells of ``space`` on which the tree holds."""
     for combo in product(*space.partitions):
         truth: dict[Atom, bool] = {
             atom: value
@@ -1435,12 +1390,8 @@ def _decide_empty(node: Formula, max_cells: int, store: Memo) -> _Decision:
 def is_empty(node: Formula, max_cells: int, store: Memo | None = None) -> bool:
     """Whether a tree denotes the empty set.
 
-    ``store`` is the caller's memo when this decision is one of a run over related
-    trees, and a verdict it already holds for this tree shape is reused. A lone
-    decision has no repeat to serve and partitions each axis once either way.
-
-    A reused verdict is still charged the work its enumeration cost, so a shared
-    store saves time and not budget.
+    A verdict ``store`` holds is reused and charged again, so the work budget
+    does not depend on the memo.
     """
     if store is None:
         return _decide_empty(node, max_cells, Memo()).empty
@@ -1458,15 +1409,11 @@ def is_empty(node: Formula, max_cells: int, store: Memo | None = None) -> bool:
 def witness(
     node: Formula, max_cells: int, store: Memo | None = None
 ) -> dict[str, str | frozenset[str]] | None:
-    """Return a concrete environment satisfying a tree, or ``None`` if none is found.
+    """Return an environment satisfying a tree, or ``None`` when none is found.
 
-    The returned environment is verified against the tree before it is returned.
-    ``None`` is returned for the empty set. The search over ``contains`` atoms
-    is incomplete, so ``None`` may also be returned for a non-empty set when the
-    concrete-string constraints on one variable (a value atom, one or more
-    ``contains`` atoms, or a mix) have no jointly realisable cell representative.
-    ``python_version`` and ``python_full_version`` share one axis, so those
-    constraints can sit on different variables.
+    Each candidate is evaluated against the tree before it is returned, so a
+    result is never wrong; ``None`` is weaker than empty, because the search
+    reads the same cells the decisions do.
     """
     memo = Memo() if store is None else store
     for cell in _enumerate_cells(node, _cell_space(node, max_cells, memo)):
@@ -1536,7 +1483,7 @@ def _restrict_atom(leaf: AtomLeaf, env: Mapping[str, object]) -> Formula:
 
 
 def restrict_tree(node: Formula, env: Mapping[str, object]) -> Formula:
-    """Substitute the provided variables, leaving the rest as a residual."""
+    """Substitute the variables ``env`` provides, leaving the rest."""
     if isinstance(node, BoolConst):
         return node
     if isinstance(node, AtomLeaf):
@@ -1576,9 +1523,9 @@ def _builds_specifier(op: str, literal: str) -> bool:
 
 
 def _complement_version(atom: Atom, op: str, var: str) -> Formula:
-    # Excluded middle holds only for ==/!= on a pure-version axis; ordered
-    # comparisons have the prerelease hole, and the twins can hold a non-version,
-    # so neither complements to a single atom.
+    # Excluded middle holds for an unswapped ==/!= on a pure-version axis alone.
+    # An ordered comparison has the prerelease hole and a twin may hold a
+    # non-version, so neither complements to a single atom.
     if op in ("==", "!=") and is_pure_version(var) and not atom.swapped:
         return AtomLeaf(atom.replaced(op="!=" if op == "==" else "=="))
     msg = f"cannot complement version atom on {var!r}"
@@ -1588,10 +1535,9 @@ def _complement_version(atom: Atom, op: str, var: str) -> Formula:
 def _flip_string_op(atom: Atom, flipped: str) -> Formula:
     """Return ``atom`` under ``flipped``, refusing if that leaves the string table.
 
-    The atom reaches the string table only while its literal builds no specifier
-    under its own operator, and an equality specifier accepts a wildcard and a
-    local version where an ordered one does not, so the flipped atom can
-    dispatch as a version and denote something else.
+    An equality specifier accepts a wildcard and a local version where an
+    ordered one does not, so a flip can make the atom dispatch as a version and
+    denote something else.
     """
     if is_version_dispatch(atom.variable) and _builds_specifier(flipped, atom.literal):
         msg = f"no marker string spells the complement of {_render_atom(atom)}"
@@ -1602,13 +1548,15 @@ def _flip_string_op(atom: Atom, flipped: str) -> Formula:
 def _complement_string(atom: Atom, op: str) -> Formula:
     """Complement an atom packaging reads through the string operator table.
 
-    That table folds ``<`` and ``>`` to false and ``<=`` and ``>=`` to equality,
-    so no ordered comparison complements to another ordered comparison.
+    A swapped atom on a version-dispatch variable is not the table's to
+    complement, because packaging builds its specifier from the environment
+    value.
 
-    A swapped atom on a version-dispatch variable does not reach the table at
-    all: packaging builds its specifier from the environment value, so the atom
-    compares as a version wherever that value parses as one, and the table's
-    reading holds only on the rest.
+    Such an atom compares as a version wherever that value parses as one, and
+    through the table only on the rest.
+
+    The table folds ``<`` and ``>`` to false and ``<=`` and ``>=`` to equality,
+    so no ordered comparison complements to another.
     """
     if atom.swapped and is_version_dispatch(atom.variable):
         msg = f"no marker string spells the complement of {_render_atom(atom)}"
@@ -1637,9 +1585,9 @@ def _complement_leaf(atom: Atom) -> Formula:
 def to_nnf(node: Formula) -> Formula:
     """Push complements down to the leaves (negation normal form).
 
-    A leaf and a constant are already in normal form. A tree can also normalise
-    to a constant, because complementing an atom the string operator table
-    folds to false yields one.
+    A leaf and a constant are already in normal form. A tree can normalise to a
+    constant too: the string operator table folds ``<`` and ``>`` to false, so
+    complementing such an atom yields ``TRUE``.
     """
     if isinstance(node, AndNode):
         return make_and(to_nnf(child) for child in node.children)
@@ -1664,18 +1612,12 @@ def _negate(node: Formula) -> Formula:
 
 
 def _quote(literal: str) -> str:
-    """Spell a literal as a marker string, picking the quote the grammar allows.
-
-    A PEP 508 literal is delimited by one quote style and cannot contain that
-    style, so a literal carrying a double-quote is spelled with single quotes.
-    """
+    """Quote a literal, which the grammar forbids holding its own delimiter."""
     if '"' not in literal:
         return f'"{literal}"'
     if "'" not in literal:
         return f"'{literal}'"
-    # A literal carrying both quote styles has no marker spelling. Marker
-    # literals only ever arrive through the exclusive-quote grammar, so a value
-    # holding both is unreachable from any parsed input.
+    # Unreachable: a parsed literal arrives through the exclusive-quote grammar.
     msg = f"literal {literal!r} has no marker-string quoting"  # pragma: no cover
     raise UnserializableMarkerSet(msg)  # pragma: no cover
 
@@ -1711,10 +1653,11 @@ def serialize(node: Formula) -> str:
 
 
 def describe(node: Formula) -> str:
-    """A short human summary of a set, for :func:`repr`, without the op-tree.
+    """Summarise a set for :func:`repr`, without exposing the op-tree.
 
-    Total: a constant, a set no marker string spells, and a tree nested past the
-    stack each get a word, so every set can be printed.
+    Total over what the walks raise: a constant, a set no marker string spells,
+    and a tree nested past the stack each render as a word, so every set can be
+    printed.
     """
     try:
         nnf = to_nnf(node)
@@ -1724,8 +1667,7 @@ def describe(node: Formula) -> str:
     except UnserializableMarkerSet:
         return "unrepresentable"
     except RecursionError:
-        # The two walks are the only recursion under repr, which owes its
-        # caller a string rather than the depth of the tree it was handed.
+        # repr owes its caller a string, not the depth of the tree handed to it.
         return "too deeply nested"
 
 
@@ -1785,21 +1727,6 @@ def _disjunction(clauses: Iterable[frozenset[Atom]]) -> Formula:
     return make_or(_clause_formula(clause) for clause in clauses)
 
 
-def _equivalent_within(
-    left: Formula, right: Formula, universe: Formula, max_cells: int
-) -> bool:
-    """Whether two trees denote the same set on every point of ``universe``.
-
-    The whole-matrix reference oracle: it complements ``universe`` in one shot,
-    so it overruns ``max_cells`` on a wide multi-platform universe.
-    :func:`equivalent_within_rows` decides the same verdict per row instead.
-    """
-    store: Memo = Memo()
-    return is_empty(
-        make_and((left, universe, make_not(right))), max_cells, store
-    ) and is_empty(make_and((right, universe, make_not(left))), max_cells, store)
-
-
 class _Row(NamedTuple):
     """One universe row: its entailed pins and residual bound."""
 
@@ -1808,14 +1735,12 @@ class _Row(NamedTuple):
 
 
 def _row_pins(disjunct: Formula) -> dict[str, str]:
-    """The exact-string equality pins a universe row entails.
+    """Return the exact-string equality pins a universe row entails.
 
-    Only a top-level ``==`` value conjunct pins; a nested or negated atom never
-    does.  Only a :data:`DOMAIN_STRING` variable pins: on a version-dispatch
-    variable ``==`` is PEP 440 equality, so ``platform_release == "5.10"`` still
-    admits ``"5.10.0"``, and substituting the literal would answer that
-    variable's string-reading atoms at the wrong point.  Those stay in the
-    residual bound.
+    Only an unswapped top-level ``==`` on a :data:`DOMAIN_STRING` variable
+    pins: version-dispatch ``==`` is PEP 440 equality, so
+    ``platform_release == "5.10"`` still admits ``"5.10.0"``. Declining to pin
+    loses nothing, because the constraint stays in the row's residual bound.
     """
     if isinstance(disjunct, AtomLeaf):
         conjuncts: tuple[Formula, ...] = (disjunct,)
@@ -1839,11 +1764,7 @@ def _row_pins(disjunct: Formula) -> dict[str, str]:
 
 
 def _decompose_rows(universe: Formula) -> list[_Row]:
-    """Split a universe into rows: the top-level disjuncts of its NNF.
-
-    Each row keeps its entailed pins and the residual bound left after
-    restricting the disjunct by them. Purely structural, no algebra.
-    """
+    """Split a universe into rows: each top-level NNF disjunct with its pins."""
     nnf = to_nnf(universe)
     disjuncts = nnf.children if isinstance(nnf, OrNode) else (nnf,)
     rows: list[_Row] = []
@@ -1860,11 +1781,11 @@ def _rows_equivalent(
     max_cells: int,
     store: Memo,
 ) -> bool:
-    """Whether ``left`` agrees with the per-row restriction of the constant right.
+    """Whether ``left`` agrees with ``right_by_row`` on every row.
 
-    Restricting each operand to a row's pins complements over that row's residual
-    rather than the whole-matrix product.  The rows of one universe differ on few
-    axes, so ``store`` carries each axis's partition across them.
+    ``right_by_row`` holds the right-hand tree already restricted to each row's
+    pins. Restricting to those pins complements over the row's residual rather
+    than the whole-matrix product.
     """
     for row, right in zip(rows, right_by_row, strict=True):
         left_r = restrict_tree(left, row.pins)
@@ -1882,11 +1803,7 @@ def _rows_equivalent(
 def universe_is_empty(
     universe: Formula, max_cells: int, store: Memo | None = None
 ) -> bool:
-    """Whether a universe admits no environment, decided per row.
-
-    A union is empty iff every top-level disjunct is, so each is tested alone,
-    staying on one row's product instead of the whole-matrix complement.
-    """
+    """Whether a universe admits no environment: every top-level disjunct is empty."""
     nnf = to_nnf(universe)
     disjuncts = nnf.children if isinstance(nnf, OrNode) else (nnf,)
     shared = Memo() if store is None else store
@@ -1900,14 +1817,7 @@ def equivalent_within_rows(
     max_cells: int,
     store: Memo | None = None,
 ) -> bool:
-    """Whether two trees agree on every point of ``universe``, decided per row.
-
-    The row-restricted dual of :func:`_equivalent_within`, deciding the same
-    verdict but staying decidable on wide multi-platform universes. A universe of
-    ``TRUE`` reduces it to plain global equivalence.
-
-    ``store`` is the caller's scratch when this decision is one of a run.
-    """
+    """Whether two trees agree on every point of ``universe``, decided per row."""
     rows = _decompose_rows(universe)
     right_by_row = [restrict_tree(right, row.pins) for row in rows]
     return _rows_equivalent(
@@ -1932,11 +1842,9 @@ def _rows_within(
     max_cells: int,
     store: Memo,
 ) -> bool:
-    """Whether ``left`` stays inside the constant right on every row.
+    """One direction of :func:`_rows_equivalent`, for a caller that only widens.
 
-    One direction of :func:`_rows_equivalent`, for a caller that only
-    widens its candidate: the other direction held before the change,
-    and widening cannot lose it.
+    The other direction held before the widening, so only this one is re-decided.
     """
     for row, right in zip(rows, right_by_row, strict=True):
         left_r = restrict_tree(left, row.pins)
@@ -1954,10 +1862,9 @@ def _rows_cover(
     max_cells: int,
     store: Memo,
 ) -> bool:
-    """Whether ``left`` still reaches everything the constant right does.
+    """The other direction, for a caller that only narrows.
 
-    The other direction, for a caller that only narrows its candidate:
-    narrowing cannot start reaching further than the original did.
+    Containment held before the narrowing, so only coverage is re-decided.
     """
     for row, right in zip(rows, right_by_row, strict=True):
         left_r = restrict_tree(left, row.pins)
@@ -1977,8 +1884,8 @@ def _drop_clauses(
 ) -> list[frozenset[Atom]]:
     """Drop every clause the rest of the disjunction already covers.
 
-    Removing one only narrows the candidate, so it cannot start reaching
-    past the original and only the cover direction can break.
+    Removing one only narrows the candidate, so only the cover direction can
+    break.
     """
     kept = list(clauses)
     for clause in sorted(clauses, key=_clause_key):
@@ -1997,10 +1904,9 @@ def _drop_atoms(
 ) -> list[frozenset[Atom]]:
     """Drop every atom its clause does not need to stay within the original.
 
-    Removing one only widens that clause, so the disjunction still covers
-    the original and only the widened clause can reach past it.  Testing
-    the clause alone rather than the whole disjunction is what keeps a
-    wide universe cheap: the others are unchanged and already within.
+    Removing one only widens that clause, so only that clause can reach past
+    the original. The others are unchanged and already within, so testing the
+    widened clause alone is enough.
     """
     working = [set(clause) for clause in clauses]
     for clause in working:
@@ -2023,19 +1929,20 @@ def simplify_within(
     max_work: int,
     store: Memo | None = None,
 ) -> Formula:
-    """Return the smallest tree equivalent to ``node`` on every point of ``universe``.
+    """Return a tree equivalent to ``node`` on every point of ``universe``.
 
-    Greedy: drop each clause, then each atom, whose removal preserves
-    within-universe equivalence, to a fixpoint, then factor the atoms common to
-    every surviving clause into a leading conjunction, verifying each removal
-    per universe row so a wide multi-platform universe stays decidable. A
-    universe of ``TRUE`` reduces it to a context-free factoring, and a total
-    atom order fixes the output.
+    Greedy: expand to clauses, drop each clause and then each atom whose removal
+    preserves within-universe equivalence, to a fixpoint, then factor out what
+    every survivor shares.
 
-    ``max_cells`` bounds one decision and ``max_work`` bounds the whole run,
-    because a wide matrix runs many cheap decisions where a large membership
-    powerset runs few expensive ones. Either overrun raises
-    :class:`IntractableMarkerSet`.
+    Deciding each removal per universe row is what keeps a wide universe
+    decidable, and a total atom order fixes which of the equally good results
+    comes back.
+
+    The result is not the smallest equivalent tree. The expansion runs first, so
+    a factored input whose clauses are all needed comes back expanded.
+
+    ``max_cells`` bounds one decision and ``max_work`` meters the greedy loop.
     """
     nnf = to_nnf(node)
     clauses = _dedupe(_to_clauses(nnf, max_cells))

--- a/nab-provider/src/nab_provider/_vendor/packaging/_markersets.py
+++ b/nab-provider/src/nab_provider/_vendor/packaging/_markersets.py
@@ -4,8 +4,9 @@ The private engine behind :class:`~packaging.markersets.MarkerSet`. Parses a
 marker string (or :class:`~packaging.markers.Marker`) into a normalised boolean
 op-tree over typed atoms, with the packaging-faithful
 ``(variable, operator, literal)`` dispatch, A1 lowering of ``python_version``
-onto the ``python_full_version`` axis, set-valued extras, and opaque
-``contains`` atoms. The denotation of a value atom is delegated to packaging's
+onto the ``python_full_version`` axis, set-valued extras, and ``contains``
+atoms, which join a string variable's value axis and stay opaque on a
+version-dispatch one. The denotation of a value atom is delegated to packaging's
 own ``_eval_op`` so it matches packaging exactly. Decisions run an on-demand
 cell decomposition: every procedure re-partitions the referenced variables'
 domains into cells on which each atom is constant, enumerates the cell product
@@ -272,22 +273,36 @@ class Atom:
         )
 
     def axis(self) -> tuple[str, ...]:
-        """Return the axis this atom partitions and is constant on."""
+        """Return the axis this atom partitions and is constant on.
+
+        A substring test on a string variable joins that variable's value axis,
+        so both readings of the variable are decided on one point. On a
+        version-dispatch variable it keeps a boolean axis of its own, one per
+        literal, because the values that embed a literal are not enumerable
+        from the literals alone.
+        """
         if self.kind == AXIS_VALUE:
             return (AXIS_VALUE, self.variable)
         if self.kind == AXIS_SET:
             return (AXIS_SET, self.variable)
+        if DOMAIN_REGISTRY[self.variable] == DOMAIN_STRING:
+            return (AXIS_VALUE, self.variable)
         # in / not in on the same (variable, literal) share one boolean axis.
         return (AXIS_CONTAINS, self.variable, self.literal)
 
     def holds(self, point: object) -> bool:
-        """Return the atom's truth on one point of its axis."""
+        """Return the atom's truth on one point of its axis.
+
+        A contains atom is handed the variable's value on a value axis and its
+        own truth on a boolean one, so it reads whichever it is given.
+        """
         if self.kind == AXIS_VALUE:
             return _holds_value(self, str(point))
         if self.kind == AXIS_SET:
             member = self.literal in point  # type: ignore[operator]
             return member if self.positive else not member
-        return bool(point) if self.positive else not bool(point)
+        present = self.literal in point if isinstance(point, str) else bool(point)
+        return present if self.positive else not present
 
     def pool_entries(self) -> tuple[tuple[Version, str], ...]:
         """The parsed version-pool points this atom seeds, minted lazily once.
@@ -845,8 +860,36 @@ def _equal_twins(version: Version) -> list[str]:
     return [version.public, str(padded)]
 
 
+def _release_between(vlow: Version, vhigh: Version) -> str:
+    """Return a plain release ranking above every variant of ``vlow``.
+
+    Release ordering runs ahead of pre, post, dev and local, so ``vlow``'s
+    release extended by one outranks ``vlow`` whatever suffix it carries. There
+    is no lowest such release: another zero can always be padded in. Within one
+    epoch the padding runs to the wider of the two releases, which is the
+    deepest place ``vhigh`` can differ, so the result stays under it whenever
+    the two releases differ at all. Across an epoch boundary ``vhigh``'s release
+    does not bound the candidate, so ``vlow``'s own width is enough. The caller
+    checks the ordering either way.
+    """
+    low = vlow.release
+    width = len(low) if vlow.epoch != vhigh.epoch else max(len(low), len(vhigh.release))
+    parts = (*low, *(0,) * (width - len(low)), 1)
+    prefix = f"{vlow.epoch}!" if vlow.epoch else ""
+    return prefix + ".".join(str(part) for part in parts)
+
+
 def _between(vlow: Version, low: str, vhigh: Version, memo: Memo) -> str | None:
+    """Return a point strictly between two adjacent pool points, or None.
+
+    The plain release comes first because an exclusive ordered comparison
+    excludes its own bound's post, local, pre and dev variants, so a band whose
+    two ends share a release is the only one the suffixed candidates can fill.
+    Where the ends differ, only a version whose release differs from both is
+    admitted, and no suffix of ``vlow`` is.
+    """
     for candidate in (
+        _release_between(vlow, vhigh),
         f"{low}.post0",
         f"{low}+m",
         f"{low}.dev1",
@@ -965,6 +1008,53 @@ def _other_representative(literals: Sequence[str]) -> str:
     return "z" * width
 
 
+def _unused_character(literals: Iterable[str]) -> str:
+    """Return a character none of ``literals`` uses, counting up from ``!``.
+
+    A marker literal can hold any character its quote style admits, so the walk
+    can run past printable ASCII; the point only has to be a string no atom on
+    the axis matches by accident, and any unused character serves.
+    """
+    used = {char for literal in literals for char in literal}
+    code = ord("!")
+    while chr(code) in used:
+        code += 1
+    return chr(code)
+
+
+def _contains_candidates(
+    atoms: Sequence[Atom], literals: Sequence[str], max_cells: int
+) -> list[str]:
+    """Mint a point for each substring pattern the axis's contains atoms allow.
+
+    A separator none of ``literals`` uses joins one subset of the substring
+    literals, so every occurrence inside the point falls in one piece: it
+    embeds that subset and whatever the subset embeds, equals no literal, and
+    is a substring of none. Any string embeds what one subset does, so with the
+    literals and their substrings the axis reaches every combination its atoms
+    can realise together.
+    """
+    names: list[str] = []
+    seen: set[str] = set()
+    for atom in atoms:
+        if atom.kind == AXIS_CONTAINS and atom.literal not in seen:
+            seen.add(atom.literal)
+            names.append(atom.literal)
+    if not names:
+        return []
+
+    count = len(names)
+    if (1 << count) > max_cells:
+        msg = f"substring subsets over {count} literals exceeds max_cells={max_cells}"
+        raise IntractableMarkerSet(msg)
+
+    separator = _unused_character(literals)
+    return [
+        separator + separator.join(names[i] for i in range(count) if mask & (1 << i))
+        for mask in range(1 << count)
+    ]
+
+
 def _reduce_work_exceeds(
     variable: str, literals: Sequence[str], atom_count: int, max_cells: int, memo: Memo
 ) -> bool:
@@ -1010,12 +1100,14 @@ def _value_candidates(
     # so a set of long distinct literals fails loudly first.
     spent = 0
     for atom in atoms:
-        if atom.op in _MEMBERSHIP:
+        if atom.kind == AXIS_VALUE and atom.op in _MEMBERSHIP:
             spent += _substring_cost(atom.literal)
             if spent > max_cells:
                 msg = f"substring enumeration exceeds max_cells={max_cells}"
                 raise IntractableMarkerSet(msg)
             candidates.extend(_membership_candidates(atom, memo))
+
+    candidates.extend(_contains_candidates(atoms, literals, max_cells))
 
     if is_version_dispatch(variable):
         _reject_mint_overflow(literals)
@@ -1493,16 +1585,43 @@ def _complement_version(atom: Atom, op: str, var: str) -> Formula:
     raise UnserializableMarkerSet(msg)
 
 
+def _flip_string_op(atom: Atom, flipped: str) -> Formula:
+    """Return ``atom`` under ``flipped``, refusing if that leaves the string table.
+
+    The atom reaches the string table only while its literal builds no specifier
+    under its own operator, and an equality specifier accepts a wildcard and a
+    local version where an ordered one does not, so the flipped atom can
+    dispatch as a version and denote something else.
+    """
+    if is_version_dispatch(atom.variable) and _builds_specifier(flipped, atom.literal):
+        msg = f"no marker string spells the complement of {_render_atom(atom)}"
+        raise UnserializableMarkerSet(msg)
+    return AtomLeaf(atom.replaced(op=flipped))
+
+
 def _complement_string(atom: Atom, op: str) -> Formula:
+    """Complement an atom packaging reads through the string operator table.
+
+    That table folds ``<`` and ``>`` to false and ``<=`` and ``>=`` to equality,
+    so no ordered comparison complements to another ordered comparison.
+
+    A swapped atom on a version-dispatch variable does not reach the table at
+    all: packaging builds its specifier from the environment value, so the atom
+    compares as a version wherever that value parses as one, and the table's
+    reading holds only on the rest.
+    """
+    if atom.swapped and is_version_dispatch(atom.variable):
+        msg = f"no marker string spells the complement of {_render_atom(atom)}"
+        raise UnserializableMarkerSet(msg)
     if op in ("==", ">=", "<="):
-        return AtomLeaf(atom.replaced(op="!="))
+        return _flip_string_op(atom, "!=")
     if op == "!=":
-        return AtomLeaf(atom.replaced(op="=="))
+        return _flip_string_op(atom, "==")
     if op == "in":
-        return AtomLeaf(atom.replaced(op="not in"))
+        return _flip_string_op(atom, "not in")
     if op == "not in":
-        return AtomLeaf(atom.replaced(op="in"))
-    # < and > are constant-false on a string variable, so the complement is all.
+        return _flip_string_op(atom, "in")
+    # Only < and > are left, and the table reads both as false.
     return TRUE
 
 
@@ -1516,17 +1635,19 @@ def _complement_leaf(atom: Atom) -> Formula:
 
 
 def to_nnf(node: Formula) -> Formula:
-    """Push complements down to the leaves (negation normal form)."""
-    if isinstance(node, AtomLeaf):
-        return node
+    """Push complements down to the leaves (negation normal form).
+
+    A leaf and a constant are already in normal form. A tree can also normalise
+    to a constant, because complementing an atom the string operator table
+    folds to false yields one.
+    """
     if isinstance(node, AndNode):
         return make_and(to_nnf(child) for child in node.children)
     if isinstance(node, OrNode):
         return make_or(to_nnf(child) for child in node.children)
     if isinstance(node, NotNode):
         return _negate(node.child)
-    msg = "a bare constant cannot reach to_nnf"  # pragma: no cover
-    raise RuntimeError(msg)  # pragma: no cover
+    return node
 
 
 def _negate(node: Formula) -> Formula:
@@ -1590,19 +1711,22 @@ def serialize(node: Formula) -> str:
 
 
 def describe(node: Formula) -> str:
-    """A short human summary of a set, for :func:`repr`. Total and never raises.
+    """A short human summary of a set, for :func:`repr`, without the op-tree.
 
-    Renders the constant sets as words and any other set as its marker string,
-    falling back to a placeholder for a complement the grammar cannot spell. It
-    never exposes the private op-tree and never raises, so a ``MarkerSet`` is
-    always safe to print, including inside a traceback.
+    Total: a constant, a set no marker string spells, and a tree nested past the
+    stack each get a word, so every set can be printed.
     """
-    if isinstance(node, BoolConst):
-        return "universe" if node.value else "empty"
     try:
-        return serialize(to_nnf(node))
+        nnf = to_nnf(node)
+        if isinstance(nnf, BoolConst):
+            return "universe" if nnf.value else "empty"
+        return serialize(nnf)
     except UnserializableMarkerSet:
         return "unrepresentable"
+    except RecursionError:
+        # The two walks are the only recursion under repr, which owes its
+        # caller a string rather than the depth of the tree it was handed.
+        return "too deeply nested"
 
 
 # ------------------------------------------------------------------- simplify
@@ -1720,7 +1844,7 @@ def _decompose_rows(universe: Formula) -> list[_Row]:
     Each row keeps its entailed pins and the residual bound left after
     restricting the disjunct by them. Purely structural, no algebra.
     """
-    nnf = universe if isinstance(universe, BoolConst) else to_nnf(universe)
+    nnf = to_nnf(universe)
     disjuncts = nnf.children if isinstance(nnf, OrNode) else (nnf,)
     rows: list[_Row] = []
     for disjunct in disjuncts:
@@ -1763,7 +1887,7 @@ def universe_is_empty(
     A union is empty iff every top-level disjunct is, so each is tested alone,
     staying on one row's product instead of the whole-matrix complement.
     """
-    nnf = universe if isinstance(universe, BoolConst) else to_nnf(universe)
+    nnf = to_nnf(universe)
     disjuncts = nnf.children if isinstance(nnf, OrNode) else (nnf,)
     shared = Memo() if store is None else store
     return all(is_empty(disjunct, max_cells, shared) for disjunct in disjuncts)
@@ -1913,7 +2037,7 @@ def simplify_within(
     powerset runs few expensive ones. Either overrun raises
     :class:`IntractableMarkerSet`.
     """
-    nnf = node if isinstance(node, BoolConst) else to_nnf(node)
+    nnf = to_nnf(node)
     clauses = _dedupe(_to_clauses(nnf, max_cells))
     original = _disjunction(clauses)
     rows = _decompose_rows(universe)

--- a/nab-provider/src/nab_provider/_vendor/packaging/markersets.py
+++ b/nab-provider/src/nab_provider/_vendor/packaging/markersets.py
@@ -1,19 +1,12 @@
-"""The public :class:`MarkerSet`: a marker's denotation as a set of environments.
+"""A PEP 508 marker as the set of environments it selects.
 
-A :class:`MarkerSet` is the denotation of a PEP 508 marker as a set of
-environments, the marker-side counterpart of
+:class:`MarkerSet` is the marker-side counterpart of
 :class:`~packaging.ranges.VersionRange`. It holds the states a marker string
 cannot: the full set of an absent marker, the empty set of a contradiction, and
-complements the grammar cannot spell. It reconciles with the grammar at exactly
-one boundary, :meth:`~MarkerSet.to_marker_string`, which may return ``None`` or
-raise :class:`UnserializableMarkerSet`.
+complements the grammar cannot spell.
 
-Build one with :meth:`MarkerSet.from_marker`, :meth:`MarkerSet.full`, or
-:meth:`MarkerSet.empty`;
-combine with :meth:`intersection`, :meth:`union`, and :meth:`complement` (or
-``&`` / ``|`` / ``~``); and query with the decision procedures. Equality is
-identity; :meth:`equivalent` tests whether two sets denote the same
-environments, since there is no cheap canonical form to key ``==`` on.
+:meth:`~MarkerSet.to_marker_string` converts back, returning ``None`` for the
+full set and raising for the sets above that have no spelling.
 """
 
 from __future__ import annotations
@@ -36,15 +29,10 @@ if TYPE_CHECKING:
     from ._markersets import Formula
     from .markers import Marker
 
-# The cell budget every decision runs under: a resource cap, not a semantic
-# parameter, so it is private and never reaches the public surface. No result
-# depends on its value; a set too complex to decide within it raises
-# IntractableMarkerSet.
+# Resource caps, not semantic parameters: no answer depends on their value, so
+# neither reaches the public surface. `_MAX_CELLS` bounds one decision and
+# `_MAX_WORK` the greedy loop `simplify` runs over many of them.
 _MAX_CELLS = 100_000
-
-# The total cell work one `simplify` may spend. `_MAX_CELLS` bounds a single
-# decision, this bounds the greedy loop that issues them. A runaway guard rather
-# than a tuning knob: the widest marker in nab's own CI locks spends 4.1 million.
 _MAX_WORK = 100_000_000
 
 __all__ = [
@@ -65,12 +53,10 @@ _R = TypeVar("_R")
 
 
 def _bounded(method: Callable[_P, _R]) -> Callable[_P, _R]:
-    """Report stack exhaustion on a deeply nested tree as the resource guard.
+    """Report a tree walk's :class:`RecursionError` as :class:`IntractableMarkerSet`.
 
-    A tree walk recurses as deep as the marker nests, so a marker nested past the
-    interpreter's stack raises :class:`RecursionError`. The public methods it
-    decorates report it as :class:`IntractableMarkerSet`, the one bounded failure
-    the algebra promises on pathological input.
+    A walk recurses as deep as the marker nests, so a deeply nested marker
+    exhausts the stack rather than the cell budget.
     """
 
     @wraps(method)
@@ -85,33 +71,30 @@ def _bounded(method: Callable[_P, _R]) -> Callable[_P, _R]:
 
 
 DecisionStore = _markersets.Memo
-"""Scratch that several decisions can share.
+"""Scratch several decisions can share, for one piece of work.
 
-Each decision partitions the axes its atoms sit on and reads those atoms on
-the points of the resulting cells. A run over related sets also asks the same
-question of the same tree shape more than once. Two decisions over the same
-universe mostly repeat all of that, so passing one store to both keeps the
-work; passing none is correct and starts each cold.
-
-Answers do not depend on it: the emptiness verdicts, partitions and truths it
-holds are functions of their keys alone. It grows with the atoms it has read
-and the tree shapes it has decided, and holds both, so give one to the
-decisions of a single piece of work and drop it after. Not safe to share
-across threads.
+A run over related sets re-decides the same tree shapes and re-partitions the
+same axes. Passing one store to those decisions keeps that work, and passing
+none is always correct: answers never depend on it. It grows with what it has read, so drop it
+when the work is done, and do not share one across threads.
 """
 
 
 class MarkerSet:
     """A set of environments: the denotation of a PEP 508 marker. Immutable.
 
-    Instances are created only through the factories (:meth:`from_marker`,
-    :meth:`full`, or :meth:`empty`);
-    calling ``MarkerSet(...)`` raises :class:`TypeError`.
+    A caller builds one only through the factories (:meth:`from_marker`,
+    :meth:`full`, :meth:`empty`); calling ``MarkerSet(...)`` raises
+    :class:`TypeError`.
 
-    The algebra is closed under :meth:`intersection`, :meth:`union`, and
-    :meth:`complement`. It is total on the set, so those always return a
-    ``MarkerSet``; only :meth:`to_marker_string` is partial, at the marker-grammar
-    boundary. ``==`` is identity; :meth:`equivalent` is semantic equality.
+    :meth:`intersection`, :meth:`union` and :meth:`complement` always return a
+    ``MarkerSet``. :meth:`to_marker_string` can refuse at the marker-grammar
+    boundary, and :meth:`simplify` there or on an empty ``within``. ``==`` is
+    identity; :meth:`equivalent` is semantic.
+
+    :meth:`is_empty`, :meth:`is_full`, :meth:`equivalent_within`,
+    :meth:`witness`, :meth:`simplify` and :meth:`to_marker_string` take an
+    optional ``store``, which shares scratch across a run of related decisions.
     """
 
     __slots__ = ("_tree",)
@@ -137,10 +120,10 @@ class MarkerSet:
     def from_marker(cls, marker: str | Marker) -> MarkerSet:
         """Return the set of environments a marker denotes.
 
-        :raises packaging.markers.InvalidMarker: if ``marker`` is a string that is
-            not a valid PEP 508 marker.
-        :raises IntractableMarkerSet: if a version literal overruns the
-            interpreter's integer-string limit, or the marker nests past the
+        :raises packaging.markers.InvalidMarker: for a string that is not a
+            valid PEP 508 marker.
+        :raises IntractableMarkerSet: if a ``~=`` or ``===`` version literal
+            overruns the integer-string limit, or the marker nests past the
             stack.
         """
         return cls._wrap(_markersets.parse(marker))
@@ -191,27 +174,23 @@ class MarkerSet:
     def is_empty(self, *, store: DecisionStore | None = None) -> bool:
         """Whether no environment satisfies this set (the marker is a contradiction).
 
-        Not exact on one construction: a substring test on a version-dispatch
-        variable (``python_version``, ``python_full_version``,
-        ``platform_release``, ``implementation_version``) is decided as its own
-        free boolean, independent of that variable's value, because the values
-        embedding a literal are not enumerable from it. So the set reads larger
-        than it is, ``True`` here is safe and ``False`` is the weak answer, and
-        every other decision procedure reduces to this one and inherits it.
-        :meth:`witness` and :meth:`evaluate` do not.
+        Not exact on one construction. A substring test on a version-dispatch
+        variable is decided as its own free boolean, because the values
+        embedding a literal are not enumerable from it.
 
-        ``store`` shares scratch with other decisions (:class:`DecisionStore`).
+        The set then reads larger than it is, so ``True`` is safe and ``False``
+        is the weak answer. Every predicate but :meth:`witness` and
+        :meth:`evaluate` reduces to this one and inherits that gap.
 
         :raises IntractableMarkerSet: if deciding the set exceeds the internal
-            cell budget, or the marker nests past the stack.
+            cell budget, if a version literal overruns the integer-string limit,
+            or if the marker nests past the stack.
         """
         return _markersets.is_empty(self._tree, _MAX_CELLS, store)
 
     @_bounded
     def is_full(self, *, store: DecisionStore | None = None) -> bool:
-        """Whether every environment satisfies this set (the marker is a tautology).
-
-        ``store`` shares scratch with other decisions (:class:`DecisionStore`).
+        """Whether every environment satisfies this set: ``(~self).is_empty()``.
 
         :raises IntractableMarkerSet: see :meth:`is_empty`.
         """
@@ -221,7 +200,7 @@ class MarkerSet:
     def is_disjoint(self, other: MarkerSet) -> bool:
         """Whether this set and ``other`` share no environment.
 
-        Equivalent to ``(self & other).is_empty()``.
+        ``(self & other).is_empty()``.
         """
         return _markersets.is_empty(
             _markersets.make_and((self._tree, other._tree)), _MAX_CELLS
@@ -231,7 +210,7 @@ class MarkerSet:
     def is_subset(self, other: MarkerSet) -> bool:
         """Whether every environment in this set is in ``other``.
 
-        The set-algebra reading of ``self`` implies ``other``.
+        ``(self & ~other).is_empty()``, the set reading of implication.
         """
         return _markersets.is_empty(
             _markersets.make_and((self._tree, _markersets.make_not(other._tree))),
@@ -246,9 +225,10 @@ class MarkerSet:
     def equivalent(self, other: MarkerSet) -> bool:
         """Whether the two sets denote the same environments.
 
-        The semantic equality ``==`` cannot cheaply provide, so it is a method.
+        Containment both ways. ``==`` stays identity because there is no cheap
+        canonical form to key it on.
 
-        Both containments read the same two trees, so they share one partition memo.
+        The two decisions read the same trees, so they share one memo.
         """
         store = _markersets.Memo()
         return _markersets.is_empty(
@@ -265,14 +245,11 @@ class MarkerSet:
     def equivalent_within(
         self, other: MarkerSet, within: MarkerSet, *, store: DecisionStore | None = None
     ) -> bool:
-        """Whether the two sets denote the same environments on every point of ``within``.
+        """Whether the sets denote the same environments on every point of ``within``.
 
-        The row-restricted counterpart of :meth:`equivalent`, deciding each of
-        ``within``'s rows under its pins so it stays decidable on wide
-        multi-platform universes. A universe of :meth:`full` reduces it to plain
-        :meth:`equivalent`.
-
-        ``store`` shares scratch with other decisions (:class:`DecisionStore`).
+        Deciding each row of ``within`` under its own pins keeps a wide
+        multi-platform universe decidable, whereas complementing ``within`` as a
+        whole does not. Use :meth:`equivalent` when the universe is full.
         """
         return _markersets.equivalent_within_rows(
             self._tree, other._tree, within._tree, _MAX_CELLS, store
@@ -289,14 +266,14 @@ class MarkerSet:
     ) -> MarkerSet:
         """Substitute the provided variables, returning a residual set.
 
-        With ``on_unknown_variable="error"`` a referenced variable absent from
-        ``env`` raises :class:`ValueError`; with ``"residual"`` (the default) it
-        is left in the residual set.
+        A variable ``env`` omits stays in the result, unless
+        ``on_unknown_variable="error"`` asks for a :class:`ValueError` instead.
 
-        :raises ValueError: for an unknown ``on_unknown_variable``, or for a
-            referenced-but-unprovided variable under ``"error"``.
-        :raises IntractableMarkerSet: if a version literal or value overruns the
-            integer-string limit, or the marker nests past the stack.
+        :raises ValueError: for an unknown ``on_unknown_variable``, or for an
+            unprovided variable under ``"error"``.
+        :raises IntractableMarkerSet: if a version literal or value overruns
+            the integer-string limit on a variable ``env`` supplies, or the
+            marker nests past the stack.
         """
         if on_unknown_variable not in ("residual", "error"):
             msg = (
@@ -321,10 +298,13 @@ class MarkerSet:
 
     @_bounded
     def evaluate(self, env: Mapping[str, str | AbstractSet[str]]) -> bool:
-        """Whether a full environment is in the set (membership variables are sets).
+        """Whether a full environment is in the set (set variables take sets).
 
-        :raises packaging.markers.UndefinedEnvironmentName: if the marker
-            references a variable ``env`` does not supply.
+        Exact: no cell decomposition runs, so the gap :meth:`is_empty` carries
+        does not apply.
+
+        :raises packaging.markers.UndefinedEnvironmentName: for a variable
+            ``env`` does not supply.
         :raises IntractableMarkerSet: if a version literal or value overruns the
             integer-string limit.
         """
@@ -335,16 +315,14 @@ class MarkerSet:
     def witness(
         self, *, store: DecisionStore | None = None
     ) -> dict[str, str | frozenset[str]] | None:
-        """Return a satisfying environment, or ``None`` when none is found.
+        """Return an environment in this set, or ``None`` when none is found.
 
-        ``None`` is returned for the empty set. The search over ``contains``
-        atoms is incomplete, so ``None`` may also be returned for a non-empty set
-        when the concrete-string constraints on one variable (a value atom, one
-        or more ``contains`` atoms, or a mix) have no jointly realisable cell
-        representative. ``python_version`` and ``python_full_version`` share one
-        axis, so those constraints can sit on different variables.
+        Never wrong: the environment is checked against the set before it is
+        returned, so it does not inherit the gap :meth:`is_empty` carries.
 
-        ``store`` shares scratch with other decisions (:class:`DecisionStore`).
+        ``None`` does not prove the set empty. The search enumerates the cells
+        :meth:`is_empty` decides on, so a set whose only environments lie
+        outside them is inhabited and still yields ``None``.
         """
         return _markersets.witness(self._tree, _MAX_CELLS, store)
 
@@ -354,19 +332,21 @@ class MarkerSet:
     def simplify(
         self, *, within: MarkerSet, store: DecisionStore | None = None
     ) -> MarkerSet:
-        """Return the smallest set equivalent to this one on every point of ``within``.
+        """Return a set that agrees with this one on every point of ``within``.
 
-        ``within`` is the universe the result must agree with this set over: pass
-        the union of a lock's declared environments for universe-aware
-        simplification, or :meth:`full` for a context-free factoring.
+        Pass the union of a lock's declared environments as ``within``, or
+        :meth:`full` for a context-free factoring.
 
-        ``store`` shares scratch with other decisions (:class:`DecisionStore`).
+        Clauses and then atoms are dropped greedily, so the result is not the
+        smallest equivalent set, and a factored input whose clauses are all
+        needed comes back expanded.
 
         :raises ValueError: if ``within`` is the empty set, which makes every set
             vacuously equivalent.
-        :raises IntractableMarkerSet: if deciding a removal exceeds the internal
-            cell budget, if the whole run exceeds the internal work budget, or
-            if the marker nests past the stack.
+        :raises UnserializableMarkerSet: for a complement the grammar cannot
+            negate, such as ``~(python_version >= "3.9")``.
+        :raises IntractableMarkerSet: see :meth:`is_empty`, plus the work budget
+            the greedy loop runs under.
         """
         if _markersets.universe_is_empty(within._tree, _MAX_CELLS, store):
             msg = "within must not be the empty set"
@@ -381,16 +361,14 @@ class MarkerSet:
 
     @_bounded
     def to_marker_string(self, *, store: DecisionStore | None = None) -> str | None:
-        """Return a marker string that re-parses to an equivalent set, or ``None``.
+        """Return a marker string denoting this set, or ``None`` for the full set.
 
-        ``None`` means the full set (no marker needed). The empty set, and any set
-        whose complement structure the marker grammar cannot express, raise
-        :class:`UnserializableMarkerSet` rather than emit a wrong string. The
-        produced string is verified equivalent to this set before it is returned.
+        Two kinds raise rather than getting a string for some other set: the
+        empty set, and one whose complement the grammar cannot negate.
+        ``~(python_version == "3.9")`` is spellable and
+        ``~(python_version >= "3.9")`` is not.
 
-        ``store`` shares scratch with other decisions (:class:`DecisionStore`).
-        The two emptiness decisions read the same atoms, so they share one
-        partition memo whether or not one is passed.
+        What is returned is parsed back and checked equivalent first.
         """
         if store is None:
             store = _markersets.Memo()

--- a/nab-provider/src/nab_provider/_vendor/packaging/markersets.py
+++ b/nab-provider/src/nab_provider/_vendor/packaging/markersets.py
@@ -191,6 +191,15 @@ class MarkerSet:
     def is_empty(self, *, store: DecisionStore | None = None) -> bool:
         """Whether no environment satisfies this set (the marker is a contradiction).
 
+        Not exact on one construction: a substring test on a version-dispatch
+        variable (``python_version``, ``python_full_version``,
+        ``platform_release``, ``implementation_version``) is decided as its own
+        free boolean, independent of that variable's value, because the values
+        embedding a literal are not enumerable from it. So the set reads larger
+        than it is, ``True`` here is safe and ``False`` is the weak answer, and
+        every other decision procedure reduces to this one and inherits it.
+        :meth:`witness` and :meth:`evaluate` do not.
+
         ``store`` shares scratch with other decisions (:class:`DecisionStore`).
 
         :raises IntractableMarkerSet: if deciding the set exceeds the internal

--- a/nab-provider/tests/test_marker_algebra.py
+++ b/nab-provider/tests/test_marker_algebra.py
@@ -26,6 +26,7 @@ from nab_provider._vendor.packaging.markersets import (
     UnserializableMarkerSet,
     variable_names,
 )
+from nab_provider._vendor.packaging.version import Version
 
 
 def ms(text: str) -> MarkerSet:
@@ -819,10 +820,17 @@ def test_witness_of_contains() -> None:
     assert marker.evaluate(env)
 
 
+def test_string_axis_decides_a_substring_contradiction() -> None:
+    # A string variable's value axis carries both readings, so the pair is
+    # decided rather than over-approximated.
+    assert ms('platform_machine == "arm64" and "x86" in platform_machine').is_empty()
+
+
 def test_witness_none_for_opaque_over_approximation() -> None:
-    # Opaque contains over-approximates: the set is not is_empty, yet no real
-    # environment satisfies "x86_64 and contains x86-but-not-x86".
-    marker = ms('platform_machine == "arm64" and "x86" in platform_machine')
+    # A version-dispatch variable keeps the opaque boolean, because the values
+    # embedding a literal are not enumerable from it. So the pair reads as
+    # inhabited and no cell representative satisfies it.
+    marker = ms('implementation_version == "3.9" and "zq" in implementation_version')
     assert not marker.is_empty()
     assert marker.witness() is None
 
@@ -939,9 +947,107 @@ def test_double_negation_serialises() -> None:
     assert marker.equivalent(ms(text))
 
 
+def test_open_band_between_adjacent_literals_is_sound() -> None:
+    # An exclusive comparison excludes its own bound's post, pre, dev and local
+    # variants, so a band open at both ends admits only a version whose release
+    # differs from both. The pool seeds one; before it did not and the band
+    # decided empty.
+    for text, witness in (
+        ('platform_release > "6" and platform_release < "6.1"', "6.0.1"),
+        ('python_full_version > "3" and python_full_version < "3.1"', "3.0.1"),
+        ('implementation_version > "9" and implementation_version < "9.1"', "9.0.1"),
+    ):
+        band = ms(text)
+        assert not band.is_empty(), text
+        assert band.evaluate(_env_for(text, witness)), text
+
+
+def _env_for(text: str, value: str) -> dict[str, str]:
+    """The environment pinning whichever variable ``text`` names to ``value``."""
+    name = next(iter(variable_names(text)))
+    env = {name: value}
+    if name == "python_full_version":
+        env["python_version"] = ".".join(value.split(".")[:2])
+    return env
+
+
+def test_open_band_predicates_and_simplify_stay_sound() -> None:
+    band = ms('platform_release > "6" and platform_release < "6.1"')
+
+    assert not band.is_subset(ms('sys_platform == "win32"'))
+    assert not band.is_disjoint(MarkerSet.full())
+    assert not band.equivalent(MarkerSet.empty())
+    assert not band.simplify(within=MarkerSet.full()).is_empty()
+
+
+def test_release_between_reads_both_epochs_and_widths() -> None:
+    # Two branches no marker-level case separates: the padding width is vhigh's
+    # only inside one epoch, and the prefix is vlow's epoch, not vhigh's.
+    between = _markersets._release_between
+
+    assert between(Version("1!3"), Version("1!3.1")) == "1!3.0.1"
+    assert between(Version("3"), Version("3.1.1.1")) == "3.0.0.0.1"
+    assert between(Version("3"), Version("1!3.1.1.1")) == "3.1"
+
+
+def test_string_axis_decides_a_substring_against_its_own_value() -> None:
+    # On a string variable the substring test and the value comparison share one
+    # axis, so the pair is decided rather than read as inhabited.
+    assert ms('os_name == "posix" and "posix" not in os_name').is_empty()
+    assert ms('sys_platform == "linux" and "win" in sys_platform').is_empty()
+    assert ms('os_name == "posix"').is_subset(ms('"posix" in os_name'))
+
+    # And a pair that is genuinely inhabited still reads as inhabited.
+    both = ms('"lin" in sys_platform and "ux" in sys_platform')
+    assert not both.is_empty()
+    assert both.evaluate({"sys_platform": "linux"})
+
+
+def test_substring_on_a_version_variable_stays_a_free_boolean() -> None:
+    # A version axis keeps the opaque reading rather than folding the two. No
+    # finite pool covers the values that embed an arbitrary literal, so folding
+    # would decide empty where a real value satisfies both.
+    assert not ms('python_version == "3.9" and "9" not in python_version').is_empty()
+
+    both = ms('platform_release == "6" and "zq" in platform_release')
+    assert not both.is_empty()
+    assert both.evaluate({"platform_release": "6.0+zq"})
+
+
+def test_many_substring_literals_on_one_axis_refuse_loudly() -> None:
+    # Folding mints a point per subset, so an axis carrying many substring tests
+    # refuses rather than answering. Refusing is the contract; the
+    # over-approximation it replaces was an answer.
+    text = " and ".join(f'"{chr(ord("a") + i) * 2}" in os_name' for i in range(17))
+
+    with pytest.raises(IntractableMarkerSet, match="substring subsets over 17"):
+        ms(text).is_empty()
+
+
 def test_unserializable_ordered_version_complement() -> None:
     with pytest.raises(UnserializableMarkerSet):
         ms('python_full_version >= "3.9"').complement().to_marker_string()
+
+
+def test_unserializable_swapped_version_complement() -> None:
+    # A swapped atom builds its specifier from the environment value, so it
+    # compares as a version wherever that value parses as one and through the
+    # string table on the rest. No single flipped atom is its complement, and
+    # `<` and `>` are not constant there either.
+    for text in (
+        '"pypy" == implementation_version',
+        '"pypy" != implementation_version',
+        '"3.9+local" < python_full_version',
+        '"3.9" >= platform_release',
+    ):
+        with pytest.raises(UnserializableMarkerSet):
+            ms(text).complement().to_marker_string()
+
+    # A swapped atom on a string variable still complements: that variable never
+    # dispatches as a version, so the table's reading is the whole story.
+    assert ms('"linux" == sys_platform').complement().to_marker_string() == (
+        '"linux" != sys_platform'
+    )
 
 
 def test_unserializable_twin_equality_complement() -> None:
@@ -949,10 +1055,25 @@ def test_unserializable_twin_equality_complement() -> None:
         ms('platform_release == "6.6"').complement().to_marker_string()
 
 
+def test_repr_is_total_on_a_constant_normal_form() -> None:
+    # Complementing an atom the string table folds to false yields a constant,
+    # which serialize has no atom spelling for. repr answers with a word.
+    assert repr(~ms('python_full_version < "3.*"')) == "<MarkerSet 'universe'>"
+
+
+def test_repr_past_the_stack_is_total() -> None:
+    deep = ms('sys_platform == "linux"')
+    other = ms('os_name == "posix"')
+    for i in range(3000):
+        deep = (deep | other) if i % 2 else (deep & other)
+
+    assert repr(deep) == "<MarkerSet 'too deeply nested'>"
+
+
 def test_repr_summarises_without_leaking_the_tree() -> None:
-    # repr renders a marker-string summary, never the private op-tree, and never
-    # raises: the constant sets read as words, a plain set as its marker string,
-    # and a grammar-inexpressible complement as a placeholder.
+    # repr renders a marker-string summary, never the private op-tree: the
+    # constant sets read as words, a plain set as its marker string, and a
+    # grammar-inexpressible complement as a placeholder.
     assert (
         repr(ms('sys_platform == "linux"')) == "<MarkerSet 'sys_platform == \"linux\"'>"
     )

--- a/nab-provider/tests/test_marker_algebra_differential.py
+++ b/nab-provider/tests/test_marker_algebra_differential.py
@@ -8,7 +8,9 @@ Two ground-truth cross-checks against the vendored packaging:
   equivalent is checked against an exact packaging grid, and any disagreement
   where the algebra is more permissive than the grid is a failure.
 
-Both use a deterministic, CI-fast generator (a few hundred cases).
+Both use a deterministic, CI-fast generator (a few hundred cases). The census at
+the end of the file is exhaustive instead, over every two-atom marker its
+alphabet spells.
 """
 
 from __future__ import annotations
@@ -45,6 +47,8 @@ PFV_GRID = [
     "1!4.0",
     "2!0",
     "3.9.7+local",
+    "3.9.0.1",
+    "1!3.0.1",
 ]
 SYS_GRID = ["linux", "win32", "darwin"]
 MACHINE_GRID = ["x86_64", "aarch64", "arm64"]
@@ -77,6 +81,8 @@ def _grid() -> list[dict[str, str]]:
                 "platform_version": "#1 SMP",
             }
         )
+    for release in ("6", "6.0.1", "6.1", "6.1.0.4", "7", "generic"):
+        envs.append({**envs[0], "platform_release": release})
     return envs
 
 
@@ -109,6 +115,10 @@ VERSION_ATOMS = [
     'python_version > "3.14.0rc1"',
     'python_full_version > "1!3.9"',
     'python_full_version ~= "1!3.9"',
+    'python_full_version > "3.9"',
+    'python_full_version < "3.9.1"',
+    'python_full_version > "1!3"',
+    'python_full_version < "1!3.1"',
 ]
 STRING_ATOMS = [
     'sys_platform == "linux"',
@@ -116,11 +126,20 @@ STRING_ATOMS = [
     'platform_machine == "x86_64"',
     'platform_machine != "arm64"',
     'os_name == "posix"',
+    'sys_platform in "linuxwin32"',
+    '"win" in sys_platform',
+    '"posix" not in os_name',
+    '"arm" in platform_machine',
+    'os_name >= "posix"',
 ]
 TWIN_ATOMS = [
     'implementation_version == "pypy"',
     'implementation_version != "foo"',
     'implementation_version >= "3.9"',
+    'platform_release > "6"',
+    'platform_release < "6.1"',
+    'platform_release > "6.1"',
+    'platform_release <= "6.1.0.4"',
 ]
 ALPHABET = VERSION_ATOMS + STRING_ATOMS + TWIN_ATOMS
 
@@ -186,6 +205,112 @@ def test_is_empty_and_tautology_never_unsound() -> None:
             assert not any(marker.evaluate(e) for e in GRID), ("empty", text)
         if algebra.is_full():
             assert all(marker.evaluate(e) for e in GRID), ("tautology", text)
+
+
+# ------------------------------------------------------------------- census
+
+# Every two-atom marker over these, against every environment the values below
+# spell. The alphabet holds both directions of each shape the decision reads
+# through a pool: a value comparison, a substring test and an ordered band, on a
+# string variable, on both pure-version variables and on a twin.
+CENSUS_ATOMS = [
+    'os_name == "posix"',
+    'os_name != "posix"',
+    'os_name >= "posix"',
+    '"posix" in os_name',
+    '"posix" not in os_name',
+    'python_version == "3.9"',
+    'python_version >= "3.10"',
+    '"9" in python_version',
+    '"9" not in python_version',
+    'python_full_version < "3.14"',
+    'python_full_version > "3.9.7"',
+    'platform_release == "6"',
+    'platform_release > "6"',
+    'platform_release < "6.1"',
+    '"zq" in platform_release',
+    '"zq" not in platform_release',
+]
+
+# Wide enough to realise every truth vector the atoms admit together, which is
+# what makes an unsatisfied marker evidence rather than a gap in the values.
+# platform_release carries the awkward ones: 6.0.1 sits inside the open band,
+# and 6.0+zq embeds a literal while still comparing as a version.
+CENSUS_VALUES = {
+    "os_name": ["posix", "nt", "posixx", "xposix", "java"],
+    "python_version": ["3.9", "3.10", "3.11", "9.0", "3.19"],
+    "python_full_version": [
+        "3.9.0",
+        "3.9.7",
+        "3.9.8",
+        "3.10.0",
+        "3.13.9",
+        "3.14.0",
+        "9.0.0",
+    ],
+    "platform_release": [
+        "6",
+        "6.0",
+        "6.0.1",
+        "6.1",
+        "6.0+zq",
+        "6zq",
+        "zq",
+        "6.0.1+zq",
+        "7",
+        "generic",
+    ],
+}
+
+# A substring test on a version-dispatch variable is decided as its own free
+# boolean, so a marker pairing one with a value comparison reads as inhabited
+# when it is not. The gap is deliberate: no pool built from these literals mints
+# 6.0+zq, which is what makes platform_release == "6" and "zq" in
+# platform_release right.
+CENSUS_OVER_APPROXIMATE = {
+    'python_version == "3.9" and "9" not in python_version',
+    '"9" not in python_version and python_version == "3.9"',
+}
+
+
+def _census_environments() -> list[dict[str, str]]:
+    """Every combination of CENSUS_VALUES, over a fixed base for the rest."""
+    names = sorted(CENSUS_VALUES)
+    columns = [CENSUS_VALUES[name] for name in names]
+    return [
+        {**GRID[0], **dict(zip(names, values, strict=True))}
+        for values in itertools.product(*columns)
+    ]
+
+
+def test_two_atom_census_pins_soundness_and_its_one_gap() -> None:
+    """No marker decides empty while inhabited, and the gap is exactly two.
+
+    Both halves discriminate. Deciding an inhabited marker empty is the failure
+    that reaches a caller as a dropped requirement, and a widened gap costs
+    precision without announcing itself.
+    """
+    environments = _census_environments()
+    joined = [
+        f"{left}{joiner}{right}"
+        for left in CENSUS_ATOMS
+        for right in CENSUS_ATOMS
+        for joiner in (" and ", " or ")
+    ]
+
+    unsound, over_approximate = [], set()
+    for text in joined:
+        inhabited = any(Marker(text).evaluate(env) for env in environments)
+        if MarkerSet.from_marker(text).is_empty():
+            if inhabited:
+                unsound.append(text)
+        elif not inhabited:
+            over_approximate.add(text)
+
+    assert len(joined) == 512
+    assert len(environments) == 1750
+    assert unsound == []
+    assert over_approximate == CENSUS_OVER_APPROXIMATE
 
 
 # --------------------------------------------------------------------- laws

--- a/nab-provider/tests/test_markersets.py
+++ b/nab-provider/tests/test_markersets.py
@@ -327,7 +327,23 @@ def test_row_oracle_matches_whole_matrix(
     lf = engine.parse(left)
     rf = engine.parse(right)
     assert engine.equivalent_within_rows(lf, rf, universe, _MAX_CELLS) == (
-        engine._equivalent_within(lf, rf, universe, _MAX_CELLS)
+        whole_matrix_equivalent_within(lf, rf, universe)
+    )
+
+
+def whole_matrix_equivalent_within(
+    left: engine.Formula, right: engine.Formula, universe: engine.Formula
+) -> bool:
+    """Reference oracle for equivalent_within_rows, over the whole matrix at once.
+
+    Complements the universe in one shot rather than per row, so it agrees with
+    the shipped decision on a narrow universe and raises on a wide one.
+    """
+    store = engine.Memo()
+    return engine.is_empty(
+        engine.make_and((left, universe, engine.make_not(right))), _MAX_CELLS, store
+    ) and engine.is_empty(
+        engine.make_and((right, universe, engine.make_not(left))), _MAX_CELLS, store
     )
 
 
@@ -350,11 +366,10 @@ def _narrow_linux_span() -> str:
 def test_wide_full_span_raises_on_whole_matrix_today() -> None:
     marker = corpus.wide_curated()[0]["marker"]
     with pytest.raises(IntractableMarkerSet):
-        engine._equivalent_within(
+        whole_matrix_equivalent_within(
             engine.parse(marker),
             engine.parse(marker),
             _wide_universe()._tree,
-            _MAX_CELLS,
         )
 
 

--- a/tasks/vendoring/packaging.patch
+++ b/tasks/vendoring/packaging.patch
@@ -1,22 +1,17 @@
 diff --git a/nab-provider/src/nab_provider/_vendor/packaging/_markersets.py b/nab-provider/src/nab_provider/_vendor/packaging/_markersets.py
 new file mode 100644
-index 0000000..080f09f
+index 0000000..0b9b90e
 --- /dev/null
 +++ b/nab-provider/src/nab_provider/_vendor/packaging/_markersets.py
-@@ -0,0 +1,2069 @@
-+"""Marker algebra engine: reason about PEP 508 markers as sets of environments.
+@@ -0,0 +1,1976 @@
++"""Marker algebra engine behind :class:`~packaging.markersets.MarkerSet`.
 +
-+The private engine behind :class:`~packaging.markersets.MarkerSet`. Parses a
-+marker string (or :class:`~packaging.markers.Marker`) into a normalised boolean
-+op-tree over typed atoms, with the packaging-faithful
-+``(variable, operator, literal)`` dispatch, A1 lowering of ``python_version``
-+onto the ``python_full_version`` axis, set-valued extras, and ``contains``
-+atoms, which join a string variable's value axis and stay opaque on a
-+version-dispatch one. The denotation of a value atom is delegated to packaging's
-+own ``_eval_op`` so it matches packaging exactly. Decisions run an on-demand
-+cell decomposition: every procedure re-partitions the referenced variables'
-+domains into cells on which each atom is constant, enumerates the cell product
-+under the ``max_cells`` guard, and evaluates the op-tree once per cell.
++A marker parses into a normalised op-tree over typed atoms. A value atom's
++denotation is packaging's own ``_eval_op``, so a marker means here what it means
++there, and A1 lowers ``python_version`` onto the ``python_full_version`` axis.
++
++A decision partitions each axis the tree names into cells on which every atom is
++constant, then evaluates the tree over the cells of their product.
 +"""
 +
 +from __future__ import annotations
@@ -49,40 +44,38 @@ index 0000000..080f09f
 +class IntractableMarkerSet(ValueError):
 +    """The set is too complex to decide within the budget.
 +
-+    Raised rather than hanging, overflowing the stack, or failing obscurely: an
-+    oversized cell product past ``max_cells``, a marker nested past the
-+    interpreter stack, or a version literal whose numeric component exceeds the
-+    digit parse limit. Subclasses :class:`ValueError` to match packaging's
-+    marker exceptions.
++    Raised rather than hanging or failing obscurely, for any budget the algebra
++    runs under: a cell cap, the work meter, the interpreter's stack, and the
++    digit parse limit.
++
++    Subclasses :class:`ValueError`, as packaging's marker exceptions do.
 +    """
 +
 +
 +class UnserializableMarkerSet(ValueError):
 +    """The set has no marker-string spelling.
 +
-+    Raised, rather than emitting a wrong or masquerading string, for the empty
-+    set and for complements whose structure the marker grammar cannot express.
-+    Subclasses :class:`ValueError` to match packaging's marker exceptions.
++    Raised for the empty set and for complements the grammar cannot express,
++    rather than emitting a string for some other set. Subclasses
++    :class:`ValueError` to match packaging's marker exceptions.
 +    """
 +
 +
-+# Axis kinds. Atoms on the same axis share one cell partition and are each
-+# constant on every one of its cells.
++# Axis kinds. Atoms on one axis share a partition and are constant on each cell.
 +AXIS_VALUE = "value"
 +AXIS_SET = "set"
 +AXIS_CONTAINS = "contains"
 +
-+# Domain kinds a variable is typed through.
 +DOMAIN_VERSION = "version"
 +DOMAIN_STRING = "string"
 +DOMAIN_TWIN = "version_or_string"
 +DOMAIN_SET = "set"
 +
-+# Every variable in packaging's marker grammar, typed to a domain. The twins
-+# ``implementation_version`` and ``platform_release`` dispatch as versions yet may
-+# hold an arbitrary string, so both carry a string fall-through. ``python_version``
-+# and ``python_full_version`` always receive a PEP 440 value, so they stay
-+# version-only; ``platform_version`` is a plain string.
++# Every variable in packaging's marker grammar, typed to a domain. The twins,
++# ``implementation_version`` and ``platform_release``, dispatch as versions yet
++# may hold an arbitrary string, so they also carry the string fall-through.
++# ``python_version`` and ``python_full_version`` always receive a PEP 440 value,
++# so they stay version-only.
 +DOMAIN_REGISTRY: dict[str, str] = {
 +    "implementation_name": DOMAIN_STRING,
 +    "implementation_version": DOMAIN_TWIN,
@@ -105,13 +98,13 @@ index 0000000..080f09f
 +
 +
 +def _domain(variable: str) -> str:
-+    """Return the effective domain of a variable under packaging typing."""
++    """Return a variable's domain, twins collapsed onto version."""
 +    kind = DOMAIN_REGISTRY[variable]
 +    return DOMAIN_VERSION if kind == DOMAIN_TWIN else kind
 +
 +
 +def is_version_dispatch(variable: str) -> bool:
-+    """Whether a variable dispatches as a version under packaging typing."""
++    """Whether a variable dispatches as a version, twins included."""
 +    return _domain(variable) == DOMAIN_VERSION
 +
 +
@@ -127,11 +120,10 @@ index 0000000..080f09f
 +
 +
 +def _apply(lhs: str, op: str, rhs: str, key: str) -> bool:
-+    """Evaluate ``op`` on a pair of literals under ``key``'s domain, memoised.
++    """Evaluate ``op`` on two literals under ``key``'s domain, memoised.
 +
-+    The int-string limit joins the four strings in the cache key: a version key
-+    parses both operands, so a literal that compares under one limit raises
-+    under another.
++    The int-string limit joins the cache key: a version key parses its operands,
++    so a literal that compares under one limit raises under another.
 +    """
 +    return _apply_memoised(lhs, op, rhs, key, sys.get_int_max_str_digits())
 +
@@ -173,9 +165,8 @@ index 0000000..080f09f
 +def _oversized_numeric(text: str) -> bool:
 +    """Whether a numeric run in ``text`` overflows int-from-string parsing.
 +
-+    A component wider than the interpreter's int-from-string limit makes
-+    packaging's ``Version`` raise a bare ``ValueError`` on parse. A zero limit
-+    disables the check, so nothing overflows.
++    Such a run makes packaging's ``Version`` raise a bare ``ValueError``. A zero
++    limit disables the check, so nothing overflows.
 +    """
 +    limit = sys.get_int_max_str_digits()
 +    if not limit:
@@ -186,10 +177,10 @@ index 0000000..080f09f
 +# ---------------------------------------------------------------------------- atoms
 +
 +
-+# A strong table would keep an entry for every distinct atom the process ever
-+# built, so values are weak and an entry lives only while its atom does. The lock
-+# stops two threads minting rival atoms for one key, which the algebra would then
-+# treat as two leaves rather than one.
++# A strong table would hold every distinct atom the process ever built, so the
++# values are weak and an entry lives only while its atom does. The lock stops
++# two threads minting rival atoms for one key, which the algebra would read as
++# two leaves.
 +_INTERNED: weakref.WeakValueDictionary[
 +    tuple[str, str, str, str, str, bool, bool, bool], Atom
 +] = weakref.WeakValueDictionary()
@@ -200,12 +191,14 @@ index 0000000..080f09f
 +    """A normalised leaf whose ``holds`` gives its denotation on one point.
 +
 +    Interned on its fields, so two equal atoms are one object and equality is
-+    identity. The only mutation after construction is the version pool it mints
-+    lazily, a pure function of those same fields, so sharing it is sound.
++    identity.
 +
-+    A decision re-reads the same atom on the same point across partitions of one
-+    axis; that memo belongs to the operation, not here, so ``holds`` recomputes.
-+    The comparison it runs is memoised in :func:`_apply`.
++    Its version pool is minted lazily and is the only mutation. That pool is a
++    pure function of the same fields, so sharing it is sound.
++
++    Truth is memoised on :class:`Memo` and never here: an atom outlives any one
++    operation, and its truth depends on the int-string limit, which
++    :func:`_apply` keys on and an interned object could not.
 +    """
 +
 +    __slots__ = (
@@ -223,7 +216,7 @@ index 0000000..080f09f
 +
 +    kind: str
 +    variable: str  # axis variable (python_version lowers to python_full_version)
-+    origin: str  # the variable as written, for env lookup and serialisation
++    origin: str  # the parser's spelling, for env lookup and serialisation
 +    op: str
 +    literal: str
 +    swapped: bool
@@ -282,10 +275,11 @@ index 0000000..080f09f
 +        """Return the axis this atom partitions and is constant on.
 +
 +        A substring test on a string variable joins that variable's value axis,
-+        so both readings of the variable are decided on one point. On a
-+        version-dispatch variable it keeps a boolean axis of its own, one per
-+        literal, because the values that embed a literal are not enumerable
-+        from the literals alone.
++        so the substring test and the value comparison decide on one point.
++
++        On a version-dispatch variable that test keeps a boolean axis of its own
++        per literal, because the values embedding a literal are not enumerable
++        from it.
 +        """
 +        if self.kind == AXIS_VALUE:
 +            return (AXIS_VALUE, self.variable)
@@ -311,11 +305,7 @@ index 0000000..080f09f
 +        return present if self.positive else not present
 +
 +    def pool_entries(self) -> tuple[tuple[Version, str], ...]:
-+        """The parsed version-pool points this atom seeds, minted lazily once.
-+
-+        A pure property of the literal: its version neighbours, plus the
-+        neighbours of its version-parseable substrings for a membership atom.
-+        """
++        """Return the version-pool points this atom's literal seeds, minted once."""
 +        entries = self._pool_entries
 +        if entries is None:
 +            texts = list(_version_neighbors(self.literal))
@@ -342,9 +332,8 @@ index 0000000..080f09f
 +
 +# --------------------------------------------------------------------- the op-tree
 +
-+# Every node carries a structural ``key()``: two trees with the same key have the same
-+# shape and the same atoms, so a decision recorded under one tree's key can be served
-+# for the other. A node mints its key on first use and keeps it.
++# Two trees with the same ``key()`` have the same shape and atoms, so a decision
++# recorded under one key serves the other. A node mints its key once and keeps it.
 +
 +
 +class BoolConst:
@@ -434,7 +423,7 @@ index 0000000..080f09f
 +
 +
 +def make_and(children: Iterable[Formula]) -> Formula:
-+    """Build a conjunction, folding identities and the FALSE annihilator."""
++    """Build a conjunction, folding identities and FALSE."""
 +    flat: list[Formula] = []
 +    for child in children:
 +        if isinstance(child, BoolConst):
@@ -453,7 +442,7 @@ index 0000000..080f09f
 +
 +
 +def make_or(children: Iterable[Formula]) -> Formula:
-+    """Build a disjunction, folding identities and the TRUE absorber."""
++    """Build a disjunction, folding identities and TRUE."""
 +    flat: list[Formula] = []
 +    for child in children:
 +        if isinstance(child, BoolConst):
@@ -501,17 +490,15 @@ index 0000000..080f09f
 +
 +
 +def parse(source: str | Marker) -> Formula:
-+    """Parse a marker string or :class:`Marker` into the normalised op-tree."""
++    """Parse a marker into the normalised op-tree."""
 +    parsed = _parse_ast(source)
 +    return TRUE if parsed is None else _convert(parsed)
 +
 +
 +def variable_names(source: str | Marker) -> frozenset[str]:
-+    """Return every marker variable ``source`` names, as written.
++    """Return every marker variable ``source`` names, in the parser's spelling.
 +
-+    Walks the parsed marker collecting the variables its operands name, without
-+    building atoms, so a marker the algebra rejects at construction still yields
-+    its names. The result over-approximates semantic support.
++    Builds no atoms, so a marker the algebra rejects still yields its names.
 +    """
 +    parsed = _parse_ast(source)
 +    if parsed is None:
@@ -564,11 +551,9 @@ index 0000000..080f09f
 +    if isinstance(rhs, Variable):
 +        return _make_atom(rhs.value, op, lhs.value, swapped=True)
 +
-+    # Neither side is a Variable node. packaging reads the right operand as an
-+    # environment key, so a quoted literal naming a known variable routes like a
-+    # swapped variable atom. A right operand naming no known variable folds via
-+    # the string operator table (packaging raises UndefinedEnvironmentName at
-+    # evaluate; the algebra evaluates, a documented divergence).
++    # packaging reads the right operand as an environment key, so a quoted
++    # literal naming a known variable routes like a swapped atom. One naming
++    # none folds through the string table where packaging raises instead.
 +    if rhs.value in DOMAIN_REGISTRY:
 +        return _make_atom(rhs.value, op, lhs.value, swapped=True)
 +    return BoolConst(value=_apply(lhs.value, op, rhs.value, key=""))
@@ -582,8 +567,8 @@ index 0000000..080f09f
 +    if op in _MEMBERSHIP:
 +        return _make_membership_atom(variable, op, literal, swapped=swapped)
 +
-+    # These axes seed single-segment pool points, so a single-segment probe drives
-+    # the swapped-operator validity check.
++    # A single-segment probe stands in for the environment value: ``~=`` builds
++    # no specifier from one, so a swapped ``~=`` surfaces as undefined here.
 +    _reject_undefined_operator(variable, op, literal, swapped=swapped, probe="0")
 +    if op == "===":
 +        msg = f"{op!r} is undefined on {variable!r} with literal {literal!r}"
@@ -595,9 +580,8 @@ index 0000000..080f09f
 +    if op in _MEMBERSHIP and swapped:
 +        return _make_membership_atom("python_version", op, literal, swapped=swapped)
 +    if op == "~=" and swapped:
-+        # A swapped ~= makes the environment value the specifier bound, so the
-+        # true region is the same-major lower-minor band the version pool never
-+        # seeds; reject it, as the other version-dispatch axes do.
++        # A swapped ~= makes the environment value the specifier bound, so its
++        # true region is a same-major band with no pool point at its floor.
 +        msg = f"{op!r} is undefined on 'python_version' with literal {literal!r}"
 +        raise UndefinedComparison(msg)
 +
@@ -649,11 +633,10 @@ index 0000000..080f09f
 +
 +
 +def reject_oversized_version_literals(variable: str, literals: Sequence[str]) -> None:
-+    """Raise before a numeric component past the parse limit reaches packaging.
++    """Raise before an oversized numeric component reaches packaging.
 +
-+    A numeric component over sys.get_int_max_str_digits() digits makes
-+    packaging's Version raise a bare ValueError; convert it to the bounded
-+    IntractableMarkerSet here.
++    A component past ``sys.get_int_max_str_digits()`` digits makes ``Version``
++    raise a bare ValueError; convert it to a bounded failure here.
 +    """
 +    if is_version_dispatch(variable) and any(
 +        _oversized_numeric(literal) for literal in literals
@@ -668,9 +651,9 @@ index 0000000..080f09f
 +def _reject_mint_overflow(literals: Sequence[str]) -> None:
 +    """Reserve one digit so neighbour minting cannot overflow the parse limit.
 +
-+    Cell decomposition mints version neighbours by incrementing one numeric
-+    component, so a run at the limit width rolls to one digit past it and
-+    makes packaging's Version raise a bare ValueError. Reject one digit early.
++    Minting increments a numeric component, so a run at the limit width rolls
++    one digit past it: this rejects at the limit, where
++    :func:`reject_oversized_version_literals` rejects past it.
 +    """
 +    limit = sys.get_int_max_str_digits()
 +    if limit and any(
@@ -705,7 +688,7 @@ index 0000000..080f09f
 +
 +
 +class Cell(NamedTuple):
-+    """One piece of an axis's domain: a representative point and its truth vector."""
++    """A representative point of an axis's domain and its truth vector."""
 +
 +    point: object
 +    vector: tuple[bool, ...]
@@ -721,12 +704,9 @@ index 0000000..080f09f
 +class Memo:
 +    """The verdicts, partitions, atom truths and version parses a decision re-reads.
 +
-+    A run over related trees decides the same tree shape more than once. Within one
-+    decision, one axis is re-partitioned for overlapping atom sets, one atom re-read
-+    on one point across those partitions, and the literals those partitions share
-+    parsed as versions once per partition. All four are memoised here. One decision
-+    makes its own unless the caller passes one to share; see
-+    :class:`~packaging.markersets.DecisionStore` for the sharing contract.
++    A run over related trees re-decides the same tree shapes and re-partitions
++    the same axes, so all four are memoised here. A decision makes its own
++    unless the caller shares one.
 +    """
 +
 +    __slots__ = ("decisions", "partitions", "truths", "versions")
@@ -739,7 +719,11 @@ index 0000000..080f09f
 +
 +
 +def _truth(atom: Atom, point: object, memo: Memo) -> bool:
-+    """Return an atom's truth on one point, memoised for the operation's span."""
++    """Return an atom's truth on one point.
++
++    A value-axis atom's is memoised for the operation's span; the others
++    short-circuit to :meth:`Atom.holds`.
++    """
 +    if atom.kind != AXIS_VALUE:
 +        return atom.holds(point)
 +    key = (atom, str(point))
@@ -750,15 +734,12 @@ index 0000000..080f09f
 +
 +
 +def _pooled_version(text: str, memo: Memo) -> Version | None:
-+    """Return ``text`` parsed as a version, or None, memoised for the operation's span.
-+
-+    Distinct atom subsets of one axis re-derive their candidate pools from
-+    overlapping literals, so the parse is shared rather than repeated per subset.
++    """Return ``text`` parsed as a version, or None, memoised.
 +
 +    Keyed on text alone where :func:`_apply` also keys on the int-string limit.
-+    Every text pooled here is an axis literal, a substring of one, or a neighbour
-+    minted from one, and the parse-limit guards bound each of those ahead of its
-+    read, so a hit is never a parse the current limit forbids.
++
++    Every text pooled here is an axis literal, a substring of one, or a point
++    minted from one, and a parse-limit guard bounds each before its read.
 +    """
 +    versions = memo.versions
 +    if text not in versions:
@@ -798,17 +779,16 @@ index 0000000..080f09f
 +    pre_part = f"{version.pre[0]}{version.pre[1]}" if version.pre is not None else ""
 +    out = [base, *_equal_twins(version)]
 +
-+    # Bumps stay in the literal's own epoch: the release bump of 1!3.9 is 1!3.10,
-+    # which outranks it, not 3.10, which sorts below and leaves the band above the
-+    # literal (1!4.0, 2!0) with no representative.
++    # Bumps stay in the literal's epoch: 1!3.9 bumps to 1!3.10, not 3.10, which
++    # sorts below and leaves the band above it unrepresented.
 +    prefix = f"{epoch}!" if epoch else ""
 +    bumps = [prefix + ".".join(str(x) for x in (*release[:-1], release[-1] + 1))]
 +    if len(release) > 1:
 +        bumps.append(f"{prefix}{major}.{release[1] + 1}")
 +    bumps.append(f"{prefix}{major + 1}")
 +    if epoch:
-+        # The band above a non-zero-epoch literal continues into the next epoch
-+        # (2!0 outranks every 1!* release), beyond any same-epoch bump.
++        # The band above a non-zero-epoch literal runs into the next epoch,
++        # beyond any same-epoch bump.
 +        bumps.append(f"{epoch + 1}!0")
 +
 +    for bump in bumps:
@@ -827,9 +807,9 @@ index 0000000..080f09f
 +def _suffix_neighbors(version: Version, release_str: str, pre_part: str) -> list[str]:
 +    """Mint the points adjacent to a pre/post/dev literal.
 +
-+    An exclusive comparison against a suffixed literal excludes the literal's own
-+    lower-precedence variants, so the adjacent point is the next or previous
-+    suffix of the same release, which no release bump reaches.
++    An exclusive comparison excludes the literal's own lower-precedence
++    variants, so the adjacent point is the next or previous suffix of the same
++    release, which no release bump reaches.
 +    """
 +    out: list[str] = []
 +    epoch = version.epoch
@@ -852,13 +832,14 @@ index 0000000..080f09f
 +
 +
 +def _equal_twins(version: Version) -> list[str]:
-+    """Mint the points equal to the literal as a version but not as a string.
++    """Mint the points that separate the literal's version reading from its string reading.
 +
 +    ``in``/``not in`` and an invalid specifier fall through to a raw string
-+    test, so separating that reading from PEP 440 matching needs a point the
-+    version test accepts and the string test rejects: the release, zero-padded.
-+    A local-tagged literal also needs the local-stripped release, since a
-+    specifier built from a public point ignores a candidate's local label.
++    test. Separating that reading from PEP 440 matching needs the release
++    zero-padded.
++
++    A local-tagged literal needs the local-stripped release too, since a
++    specifier built from a public point ignores a local label.
 +    """
 +    padded = version.__replace__(release=(*version.release, 0))
 +    if version.local is None:
@@ -869,14 +850,14 @@ index 0000000..080f09f
 +def _release_between(vlow: Version, vhigh: Version) -> str:
 +    """Return a plain release ranking above every variant of ``vlow``.
 +
-+    Release ordering runs ahead of pre, post, dev and local, so ``vlow``'s
-+    release extended by one outranks ``vlow`` whatever suffix it carries. There
-+    is no lowest such release: another zero can always be padded in. Within one
-+    epoch the padding runs to the wider of the two releases, which is the
-+    deepest place ``vhigh`` can differ, so the result stays under it whenever
-+    the two releases differ at all. Across an epoch boundary ``vhigh``'s release
-+    does not bound the candidate, so ``vlow``'s own width is enough. The caller
-+    checks the ordering either way.
++    Release ordering runs ahead of pre, post, dev and local, so extending
++    ``vlow``'s release by one outranks it whatever suffix it carries.
++
++    Padding to the wider release keeps the result under ``vhigh`` whenever the
++    two releases differ, that being the deepest place ``vhigh`` can differ.
++
++    Where the ends share a release, or across an epoch boundary, ``vhigh`` does
++    not bound it and the caller's ordering check rejects the candidate.
 +    """
 +    low = vlow.release
 +    width = len(low) if vlow.epoch != vhigh.epoch else max(len(low), len(vhigh.release))
@@ -888,11 +869,12 @@ index 0000000..080f09f
 +def _between(vlow: Version, low: str, vhigh: Version, memo: Memo) -> str | None:
 +    """Return a point strictly between two adjacent pool points, or None.
 +
-+    The plain release comes first because an exclusive ordered comparison
-+    excludes its own bound's post, local, pre and dev variants, so a band whose
-+    two ends share a release is the only one the suffixed candidates can fill.
-+    Where the ends differ, only a version whose release differs from both is
-+    admitted, and no suffix of ``vlow`` is.
++    An exclusive comparison excludes its own bound's post, local, pre and dev
++    variants. Where the two points' releases differ, only a candidate whose own
++    release differs from both lands between them, so the plain release is tried
++    first.
++
++    The suffixed candidates fill a band whose ends share a release.
 +    """
 +    for candidate in (
 +        _release_between(vlow, vhigh),
@@ -947,10 +929,9 @@ index 0000000..080f09f
 +def _elevate_epochs(
 +    base: list[str], parsed: Sequence[tuple[Version, str]], max_cells: int
 +) -> list[str]:
-+    # A1 lowers python_version onto this axis, so major.minor and full ordering
-+    # diverge across an epoch boundary: Version("1!3.9") truncates to "3.9" yet
-+    # outranks "3.14". Each point needs an epoch-bearing twin for every band up to
-+    # one epoch above the top literal, covering gap epochs no literal names.
++    # A1 lowers python_version here, so major.minor and full order diverge across
++    # an epoch boundary: 1!3.9 truncates to 3.9 yet outranks 3.14. Each point
++    # needs a twin in every epoch the pool reaches.
 +    epochs = {version.epoch for version, _ in parsed}
 +    targets = range(1, max(epochs) + 2)
 +
@@ -967,8 +948,7 @@ index 0000000..080f09f
 +def _membership_candidates(atom: Atom, memo: Memo) -> list[str]:
 +    subs = _substrings(atom.literal)
 +    if atom.derive_mm:
-+        # A1 membership tests the major.minor of a full version, so realisable
-+        # points are the substrings of the literal that are themselves versions.
++        # A1 tests the major.minor, so a realisable point is a version substring.
 +        return [
 +            s for s in subs if _pooled_version(s.removesuffix(".*"), memo) is not None
 +        ]
@@ -991,8 +971,7 @@ index 0000000..080f09f
 +        if candidate in seen:
 +            continue
 +        # A pure Version axis holds only PEP 440 versions, so a non-version
-+        # candidate is unrealisable there. The twins keep every non-version
-+        # candidate, including the OTHER-cell representative.
++        # candidate is unrealisable there; the twins keep every one.
 +        if pure_version and _pooled_version(candidate, memo) is None:
 +            continue
 +        seen.add(candidate)
@@ -1004,12 +983,7 @@ index 0000000..080f09f
 +
 +
 +def _other_representative(literals: Sequence[str]) -> str:
-+    """Return a string equal to no literal on the axis and parsing as no version.
-+
-+    One character longer than the longest literal, so no literal can equal it,
-+    and built from a filler that never forms a PEP 440 version so the point
-+    lands in the arbitrary-string region rather than a version cell.
-+    """
++    """Return a string equal to no literal on the axis and parsing as no version."""
 +    width = max((len(literal) for literal in literals), default=0) + 1
 +    return "z" * width
 +
@@ -1018,8 +992,7 @@ index 0000000..080f09f
 +    """Return a character none of ``literals`` uses, counting up from ``!``.
 +
 +    A marker literal can hold any character its quote style admits, so the walk
-+    can run past printable ASCII; the point only has to be a string no atom on
-+    the axis matches by accident, and any unused character serves.
++    can run past printable ASCII. Any unused character serves.
 +    """
 +    used = {char for literal in literals for char in literal}
 +    code = ord("!")
@@ -1033,12 +1006,12 @@ index 0000000..080f09f
 +) -> list[str]:
 +    """Mint a point for each substring pattern the axis's contains atoms allow.
 +
-+    A separator none of ``literals`` uses joins one subset of the substring
-+    literals, so every occurrence inside the point falls in one piece: it
-+    embeds that subset and whatever the subset embeds, equals no literal, and
-+    is a substring of none. Any string embeds what one subset does, so with the
-+    literals and their substrings the axis reaches every combination its atoms
-+    can realise together.
++    A separator none of ``literals`` uses joins one subset, so every occurrence
++    in the point falls in one piece.
++
++    The point then embeds that subset and what the subset embeds, equals no
++    literal, and is a substring of none. Every combination the atoms realise
++    together is some subset, so the axis reaches all of them.
 +    """
 +    names: list[str] = []
 +    seen: set[str] = set()
@@ -1066,10 +1039,9 @@ index 0000000..080f09f
 +) -> bool:
 +    """Whether the axis's guaranteed reduce work already exceeds ``max_cells``.
 +
-+    Every distinct literal is one point, so its count times the atom count is a
-+    lower bound on the ``_reduce_cells`` work. A pure-version axis keeps only
-+    version-parseable literals; the twins and string fields keep every distinct
-+    literal.
++    Every distinct literal is one point, so its count times the atom count
++    lower-bounds the ``_reduce_cells`` work. A pure-version axis counts only the
++    version-parseable literals.
 +    """
 +    pure = is_pure_version(variable)
 +    seen: set[str] = set()
@@ -1096,14 +1068,12 @@ index 0000000..080f09f
 +    candidates: list[str] = []
 +    raw_kind = DOMAIN_REGISTRY[variable]
 +
-+    # The OTHER cell (equal to no literal and not a version) exists only where the
-+    # domain admits arbitrary strings: string fields and the twins.
++    # The OTHER cell exists only where the domain admits arbitrary strings.
 +    if raw_kind in (DOMAIN_STRING, DOMAIN_TWIN):
 +        candidates.append(_other_representative(literals))
 +    candidates.extend(literals)
 +
-+    # Cap the substring enumeration across the whole axis, not each literal alone,
-+    # so a set of long distinct literals fails loudly first.
++    # Cap the enumeration across the axis, not per literal.
 +    spent = 0
 +    for atom in atoms:
 +        if atom.kind == AXIS_VALUE and atom.op in _MEMBERSHIP:
@@ -1141,8 +1111,7 @@ index 0000000..080f09f
 +) -> list[Cell]:
 +    points = list(points)
 +
-+    # The truth vector costs one holds() per atom per point; guard that product so
-+    # an axis carrying many atoms fails loudly.
++    # The truth vector costs one holds() per atom per point.
 +    if len(points) * len(atoms) > max_cells:
 +        msg = (
 +            f"axis work {len(points)}x{len(atoms)} atoms exceeds max_cells={max_cells}"
@@ -1211,10 +1180,9 @@ index 0000000..080f09f
 +    return partition_boolean_axis(atoms, max_cells, memo)
 +
 +
-+# ``max_cells`` bounds one decision, and the greedy fixpoint issues one per
-+# clause and per atom per universe row, so the meter is what bounds the run:
-+# every cell enumeration charges the work it is about to do. Thread-local, and
-+# unset outside a simplify so every other decision stays unmetered.
++# ``max_cells`` bounds one decision, the meter a whole simplify: every
++# enumeration charges what it is about to do. Thread-local, and unset outside a
++# simplify, so every other decision stays unmetered.
 +_work_meter = threading.local()
 +
 +
@@ -1235,11 +1203,7 @@ index 0000000..080f09f
 +) -> list[Cell]:
 +    """Partition one axis's domain into cells on which every atom is constant.
 +
-+    ``store`` memoises the partition for the span of one operation; its owner decides
-+    that span, and this keeps no state of its own.
-+
-+    The atoms are keyed in order, not as a set: :class:`Cell` vectors are aligned
-+    positionally with the list a partition was built for.
++    Atoms are keyed in order: a :class:`Cell` vector lines up positionally with them.
 +    """
 +    key = (axis, tuple(atoms), max_cells)
 +    cached = store.partitions.get(key)
@@ -1281,12 +1245,9 @@ index 0000000..080f09f
 +def evaluate_atom(atom: Atom, env: Mapping[str, object]) -> bool:
 +    """Evaluate one atom against a full environment (extras are sets).
 +
-+    A referenced variable absent from ``env`` raises
-+    :class:`UndefinedEnvironmentName` on every axis, matching packaging and
-+    keeping the missing-key behaviour uniform across scalars and sets. A
-+    ``python_version`` atom reads ``python_full_version`` in preference to
-+    ``python_version``, so an environment supplying both keys is read through
-+    ``python_full_version``.
++    A missing variable raises :class:`UndefinedEnvironmentName` on every axis,
++    as packaging does. A ``python_version`` atom prefers the
++    ``python_full_version`` key when the environment supplies both.
 +    """
 +    if atom.kind == AXIS_VALUE:
 +        if atom.derive_mm and "python_full_version" not in env:
@@ -1323,10 +1284,9 @@ index 0000000..080f09f
 +
 +
 +def reject_oversized_literals(node: Formula, env: Mapping[str, object]) -> None:
-+    """Raise the bounded guard for an oversized version literal or env value.
++    """Raise the bounded guard for an oversized literal or env value.
 +
-+    Runs before either could reach packaging's Version and raise a bare
-+    ValueError.
++    Only atoms whose variable ``env`` supplies are checked.
 +    """
 +    for atom in collect_atoms(node):
 +        value = _atom_env_value(atom, env)
@@ -1380,7 +1340,7 @@ index 0000000..080f09f
 +
 +
 +class _CellSpace(NamedTuple):
-+    """The axes a tree is decided over, their atoms and cells, and the work charged."""
++    """One decision's axes, their atoms and cells, and the work charged."""
 +
 +    axes: list[tuple[str, ...]]
 +    atomlists: list[list[Atom]]
@@ -1389,11 +1349,7 @@ index 0000000..080f09f
 +
 +
 +def _cell_space(node: Formula, max_cells: int, store: Memo) -> _CellSpace:
-+    """Partition each axis a tree mentions and charge the enumeration it implies.
-+
-+    The charged units come back with the cells, so a repeat of the same decision can
-+    charge them again without enumerating.
-+    """
++    """Partition each axis a tree mentions and charge the enumeration it implies."""
 +    atoms = collect_atoms(node)
 +    grouped = _atoms_by_axis(atoms)
 +    axes = list(grouped)
@@ -1406,9 +1362,8 @@ index 0000000..080f09f
 +    if not axes:
 +        return _CellSpace(axes, atomlists, partitions, 0)
 +
-+    # The enumeration walks the whole op-tree once per cell, so guard the cell
-+    # product times the leaf-occurrence count: a marker that repeats atoms inflates
-+    # the walk without inflating the distinct-atom count or the cell product.
++    # Repeated atoms inflate the per-cell walk without inflating the cell
++    # product, so the guard multiplies in the leaf count.
 +    units = guarded_product_size(
 +        (*(len(part) for part in partitions), len(atoms)), max_cells
 +    )
@@ -1419,7 +1374,7 @@ index 0000000..080f09f
 +def _enumerate_cells(
 +    node: Formula, space: _CellSpace
 +) -> Iterator[dict[tuple[str, ...], Cell]]:
-+    """Yield the cells of a partitioned space on which the tree holds."""
++    """Yield the cells of ``space`` on which the tree holds."""
 +    for combo in product(*space.partitions):
 +        truth: dict[Atom, bool] = {
 +            atom: value
@@ -1441,12 +1396,8 @@ index 0000000..080f09f
 +def is_empty(node: Formula, max_cells: int, store: Memo | None = None) -> bool:
 +    """Whether a tree denotes the empty set.
 +
-+    ``store`` is the caller's memo when this decision is one of a run over related
-+    trees, and a verdict it already holds for this tree shape is reused. A lone
-+    decision has no repeat to serve and partitions each axis once either way.
-+
-+    A reused verdict is still charged the work its enumeration cost, so a shared
-+    store saves time and not budget.
++    A verdict ``store`` holds is reused and charged again, so the work budget
++    does not depend on the memo.
 +    """
 +    if store is None:
 +        return _decide_empty(node, max_cells, Memo()).empty
@@ -1464,15 +1415,11 @@ index 0000000..080f09f
 +def witness(
 +    node: Formula, max_cells: int, store: Memo | None = None
 +) -> dict[str, str | frozenset[str]] | None:
-+    """Return a concrete environment satisfying a tree, or ``None`` if none is found.
++    """Return an environment satisfying a tree, or ``None`` when none is found.
 +
-+    The returned environment is verified against the tree before it is returned.
-+    ``None`` is returned for the empty set. The search over ``contains`` atoms
-+    is incomplete, so ``None`` may also be returned for a non-empty set when the
-+    concrete-string constraints on one variable (a value atom, one or more
-+    ``contains`` atoms, or a mix) have no jointly realisable cell representative.
-+    ``python_version`` and ``python_full_version`` share one axis, so those
-+    constraints can sit on different variables.
++    Each candidate is evaluated against the tree before it is returned, so a
++    result is never wrong; ``None`` is weaker than empty, because the search
++    reads the same cells the decisions do.
 +    """
 +    memo = Memo() if store is None else store
 +    for cell in _enumerate_cells(node, _cell_space(node, max_cells, memo)):
@@ -1542,7 +1489,7 @@ index 0000000..080f09f
 +
 +
 +def restrict_tree(node: Formula, env: Mapping[str, object]) -> Formula:
-+    """Substitute the provided variables, leaving the rest as a residual."""
++    """Substitute the variables ``env`` provides, leaving the rest."""
 +    if isinstance(node, BoolConst):
 +        return node
 +    if isinstance(node, AtomLeaf):
@@ -1582,9 +1529,9 @@ index 0000000..080f09f
 +
 +
 +def _complement_version(atom: Atom, op: str, var: str) -> Formula:
-+    # Excluded middle holds only for ==/!= on a pure-version axis; ordered
-+    # comparisons have the prerelease hole, and the twins can hold a non-version,
-+    # so neither complements to a single atom.
++    # Excluded middle holds for an unswapped ==/!= on a pure-version axis alone.
++    # An ordered comparison has the prerelease hole and a twin may hold a
++    # non-version, so neither complements to a single atom.
 +    if op in ("==", "!=") and is_pure_version(var) and not atom.swapped:
 +        return AtomLeaf(atom.replaced(op="!=" if op == "==" else "=="))
 +    msg = f"cannot complement version atom on {var!r}"
@@ -1594,10 +1541,9 @@ index 0000000..080f09f
 +def _flip_string_op(atom: Atom, flipped: str) -> Formula:
 +    """Return ``atom`` under ``flipped``, refusing if that leaves the string table.
 +
-+    The atom reaches the string table only while its literal builds no specifier
-+    under its own operator, and an equality specifier accepts a wildcard and a
-+    local version where an ordered one does not, so the flipped atom can
-+    dispatch as a version and denote something else.
++    An equality specifier accepts a wildcard and a local version where an
++    ordered one does not, so a flip can make the atom dispatch as a version and
++    denote something else.
 +    """
 +    if is_version_dispatch(atom.variable) and _builds_specifier(flipped, atom.literal):
 +        msg = f"no marker string spells the complement of {_render_atom(atom)}"
@@ -1608,13 +1554,15 @@ index 0000000..080f09f
 +def _complement_string(atom: Atom, op: str) -> Formula:
 +    """Complement an atom packaging reads through the string operator table.
 +
-+    That table folds ``<`` and ``>`` to false and ``<=`` and ``>=`` to equality,
-+    so no ordered comparison complements to another ordered comparison.
++    A swapped atom on a version-dispatch variable is not the table's to
++    complement, because packaging builds its specifier from the environment
++    value.
 +
-+    A swapped atom on a version-dispatch variable does not reach the table at
-+    all: packaging builds its specifier from the environment value, so the atom
-+    compares as a version wherever that value parses as one, and the table's
-+    reading holds only on the rest.
++    Such an atom compares as a version wherever that value parses as one, and
++    through the table only on the rest.
++
++    The table folds ``<`` and ``>`` to false and ``<=`` and ``>=`` to equality,
++    so no ordered comparison complements to another.
 +    """
 +    if atom.swapped and is_version_dispatch(atom.variable):
 +        msg = f"no marker string spells the complement of {_render_atom(atom)}"
@@ -1643,9 +1591,9 @@ index 0000000..080f09f
 +def to_nnf(node: Formula) -> Formula:
 +    """Push complements down to the leaves (negation normal form).
 +
-+    A leaf and a constant are already in normal form. A tree can also normalise
-+    to a constant, because complementing an atom the string operator table
-+    folds to false yields one.
++    A leaf and a constant are already in normal form. A tree can normalise to a
++    constant too: the string operator table folds ``<`` and ``>`` to false, so
++    complementing such an atom yields ``TRUE``.
 +    """
 +    if isinstance(node, AndNode):
 +        return make_and(to_nnf(child) for child in node.children)
@@ -1670,18 +1618,12 @@ index 0000000..080f09f
 +
 +
 +def _quote(literal: str) -> str:
-+    """Spell a literal as a marker string, picking the quote the grammar allows.
-+
-+    A PEP 508 literal is delimited by one quote style and cannot contain that
-+    style, so a literal carrying a double-quote is spelled with single quotes.
-+    """
++    """Quote a literal, which the grammar forbids holding its own delimiter."""
 +    if '"' not in literal:
 +        return f'"{literal}"'
 +    if "'" not in literal:
 +        return f"'{literal}'"
-+    # A literal carrying both quote styles has no marker spelling. Marker
-+    # literals only ever arrive through the exclusive-quote grammar, so a value
-+    # holding both is unreachable from any parsed input.
++    # Unreachable: a parsed literal arrives through the exclusive-quote grammar.
 +    msg = f"literal {literal!r} has no marker-string quoting"  # pragma: no cover
 +    raise UnserializableMarkerSet(msg)  # pragma: no cover
 +
@@ -1717,10 +1659,11 @@ index 0000000..080f09f
 +
 +
 +def describe(node: Formula) -> str:
-+    """A short human summary of a set, for :func:`repr`, without the op-tree.
++    """Summarise a set for :func:`repr`, without exposing the op-tree.
 +
-+    Total: a constant, a set no marker string spells, and a tree nested past the
-+    stack each get a word, so every set can be printed.
++    Total over what the walks raise: a constant, a set no marker string spells,
++    and a tree nested past the stack each render as a word, so every set can be
++    printed.
 +    """
 +    try:
 +        nnf = to_nnf(node)
@@ -1730,8 +1673,7 @@ index 0000000..080f09f
 +    except UnserializableMarkerSet:
 +        return "unrepresentable"
 +    except RecursionError:
-+        # The two walks are the only recursion under repr, which owes its
-+        # caller a string rather than the depth of the tree it was handed.
++        # repr owes its caller a string, not the depth of the tree handed to it.
 +        return "too deeply nested"
 +
 +
@@ -1791,21 +1733,6 @@ index 0000000..080f09f
 +    return make_or(_clause_formula(clause) for clause in clauses)
 +
 +
-+def _equivalent_within(
-+    left: Formula, right: Formula, universe: Formula, max_cells: int
-+) -> bool:
-+    """Whether two trees denote the same set on every point of ``universe``.
-+
-+    The whole-matrix reference oracle: it complements ``universe`` in one shot,
-+    so it overruns ``max_cells`` on a wide multi-platform universe.
-+    :func:`equivalent_within_rows` decides the same verdict per row instead.
-+    """
-+    store: Memo = Memo()
-+    return is_empty(
-+        make_and((left, universe, make_not(right))), max_cells, store
-+    ) and is_empty(make_and((right, universe, make_not(left))), max_cells, store)
-+
-+
 +class _Row(NamedTuple):
 +    """One universe row: its entailed pins and residual bound."""
 +
@@ -1814,14 +1741,12 @@ index 0000000..080f09f
 +
 +
 +def _row_pins(disjunct: Formula) -> dict[str, str]:
-+    """The exact-string equality pins a universe row entails.
++    """Return the exact-string equality pins a universe row entails.
 +
-+    Only a top-level ``==`` value conjunct pins; a nested or negated atom never
-+    does.  Only a :data:`DOMAIN_STRING` variable pins: on a version-dispatch
-+    variable ``==`` is PEP 440 equality, so ``platform_release == "5.10"`` still
-+    admits ``"5.10.0"``, and substituting the literal would answer that
-+    variable's string-reading atoms at the wrong point.  Those stay in the
-+    residual bound.
++    Only an unswapped top-level ``==`` on a :data:`DOMAIN_STRING` variable
++    pins: version-dispatch ``==`` is PEP 440 equality, so
++    ``platform_release == "5.10"`` still admits ``"5.10.0"``. Declining to pin
++    loses nothing, because the constraint stays in the row's residual bound.
 +    """
 +    if isinstance(disjunct, AtomLeaf):
 +        conjuncts: tuple[Formula, ...] = (disjunct,)
@@ -1845,11 +1770,7 @@ index 0000000..080f09f
 +
 +
 +def _decompose_rows(universe: Formula) -> list[_Row]:
-+    """Split a universe into rows: the top-level disjuncts of its NNF.
-+
-+    Each row keeps its entailed pins and the residual bound left after
-+    restricting the disjunct by them. Purely structural, no algebra.
-+    """
++    """Split a universe into rows: each top-level NNF disjunct with its pins."""
 +    nnf = to_nnf(universe)
 +    disjuncts = nnf.children if isinstance(nnf, OrNode) else (nnf,)
 +    rows: list[_Row] = []
@@ -1866,11 +1787,11 @@ index 0000000..080f09f
 +    max_cells: int,
 +    store: Memo,
 +) -> bool:
-+    """Whether ``left`` agrees with the per-row restriction of the constant right.
++    """Whether ``left`` agrees with ``right_by_row`` on every row.
 +
-+    Restricting each operand to a row's pins complements over that row's residual
-+    rather than the whole-matrix product.  The rows of one universe differ on few
-+    axes, so ``store`` carries each axis's partition across them.
++    ``right_by_row`` holds the right-hand tree already restricted to each row's
++    pins. Restricting to those pins complements over the row's residual rather
++    than the whole-matrix product.
 +    """
 +    for row, right in zip(rows, right_by_row, strict=True):
 +        left_r = restrict_tree(left, row.pins)
@@ -1888,11 +1809,7 @@ index 0000000..080f09f
 +def universe_is_empty(
 +    universe: Formula, max_cells: int, store: Memo | None = None
 +) -> bool:
-+    """Whether a universe admits no environment, decided per row.
-+
-+    A union is empty iff every top-level disjunct is, so each is tested alone,
-+    staying on one row's product instead of the whole-matrix complement.
-+    """
++    """Whether a universe admits no environment: every top-level disjunct is empty."""
 +    nnf = to_nnf(universe)
 +    disjuncts = nnf.children if isinstance(nnf, OrNode) else (nnf,)
 +    shared = Memo() if store is None else store
@@ -1906,14 +1823,7 @@ index 0000000..080f09f
 +    max_cells: int,
 +    store: Memo | None = None,
 +) -> bool:
-+    """Whether two trees agree on every point of ``universe``, decided per row.
-+
-+    The row-restricted dual of :func:`_equivalent_within`, deciding the same
-+    verdict but staying decidable on wide multi-platform universes. A universe of
-+    ``TRUE`` reduces it to plain global equivalence.
-+
-+    ``store`` is the caller's scratch when this decision is one of a run.
-+    """
++    """Whether two trees agree on every point of ``universe``, decided per row."""
 +    rows = _decompose_rows(universe)
 +    right_by_row = [restrict_tree(right, row.pins) for row in rows]
 +    return _rows_equivalent(
@@ -1938,11 +1848,9 @@ index 0000000..080f09f
 +    max_cells: int,
 +    store: Memo,
 +) -> bool:
-+    """Whether ``left`` stays inside the constant right on every row.
++    """One direction of :func:`_rows_equivalent`, for a caller that only widens.
 +
-+    One direction of :func:`_rows_equivalent`, for a caller that only
-+    widens its candidate: the other direction held before the change,
-+    and widening cannot lose it.
++    The other direction held before the widening, so only this one is re-decided.
 +    """
 +    for row, right in zip(rows, right_by_row, strict=True):
 +        left_r = restrict_tree(left, row.pins)
@@ -1960,10 +1868,9 @@ index 0000000..080f09f
 +    max_cells: int,
 +    store: Memo,
 +) -> bool:
-+    """Whether ``left`` still reaches everything the constant right does.
++    """The other direction, for a caller that only narrows.
 +
-+    The other direction, for a caller that only narrows its candidate:
-+    narrowing cannot start reaching further than the original did.
++    Containment held before the narrowing, so only coverage is re-decided.
 +    """
 +    for row, right in zip(rows, right_by_row, strict=True):
 +        left_r = restrict_tree(left, row.pins)
@@ -1983,8 +1890,8 @@ index 0000000..080f09f
 +) -> list[frozenset[Atom]]:
 +    """Drop every clause the rest of the disjunction already covers.
 +
-+    Removing one only narrows the candidate, so it cannot start reaching
-+    past the original and only the cover direction can break.
++    Removing one only narrows the candidate, so only the cover direction can
++    break.
 +    """
 +    kept = list(clauses)
 +    for clause in sorted(clauses, key=_clause_key):
@@ -2003,10 +1910,9 @@ index 0000000..080f09f
 +) -> list[frozenset[Atom]]:
 +    """Drop every atom its clause does not need to stay within the original.
 +
-+    Removing one only widens that clause, so the disjunction still covers
-+    the original and only the widened clause can reach past it.  Testing
-+    the clause alone rather than the whole disjunction is what keeps a
-+    wide universe cheap: the others are unchanged and already within.
++    Removing one only widens that clause, so only that clause can reach past
++    the original. The others are unchanged and already within, so testing the
++    widened clause alone is enough.
 +    """
 +    working = [set(clause) for clause in clauses]
 +    for clause in working:
@@ -2029,19 +1935,20 @@ index 0000000..080f09f
 +    max_work: int,
 +    store: Memo | None = None,
 +) -> Formula:
-+    """Return the smallest tree equivalent to ``node`` on every point of ``universe``.
++    """Return a tree equivalent to ``node`` on every point of ``universe``.
 +
-+    Greedy: drop each clause, then each atom, whose removal preserves
-+    within-universe equivalence, to a fixpoint, then factor the atoms common to
-+    every surviving clause into a leading conjunction, verifying each removal
-+    per universe row so a wide multi-platform universe stays decidable. A
-+    universe of ``TRUE`` reduces it to a context-free factoring, and a total
-+    atom order fixes the output.
++    Greedy: expand to clauses, drop each clause and then each atom whose removal
++    preserves within-universe equivalence, to a fixpoint, then factor out what
++    every survivor shares.
 +
-+    ``max_cells`` bounds one decision and ``max_work`` bounds the whole run,
-+    because a wide matrix runs many cheap decisions where a large membership
-+    powerset runs few expensive ones. Either overrun raises
-+    :class:`IntractableMarkerSet`.
++    Deciding each removal per universe row is what keeps a wide universe
++    decidable, and a total atom order fixes which of the equally good results
++    comes back.
++
++    The result is not the smallest equivalent tree. The expansion runs first, so
++    a factored input whose clauses are all needed comes back expanded.
++
++    ``max_cells`` bounds one decision and ``max_work`` meters the greedy loop.
 +    """
 +    nnf = to_nnf(node)
 +    clauses = _dedupe(_to_clauses(nnf, max_cells))
@@ -2416,26 +2323,19 @@ index 609099c..07c7d81 100644
  def _pep440_python_full_version(python_full_version: str) -> str:
 diff --git a/nab-provider/src/nab_provider/_vendor/packaging/markersets.py b/nab-provider/src/nab_provider/_vendor/packaging/markersets.py
 new file mode 100644
-index 0000000..d7a3fb6
+index 0000000..c804e5e
 --- /dev/null
 +++ b/nab-provider/src/nab_provider/_vendor/packaging/markersets.py
-@@ -0,0 +1,413 @@
-+"""The public :class:`MarkerSet`: a marker's denotation as a set of environments.
+@@ -0,0 +1,391 @@
++"""A PEP 508 marker as the set of environments it selects.
 +
-+A :class:`MarkerSet` is the denotation of a PEP 508 marker as a set of
-+environments, the marker-side counterpart of
++:class:`MarkerSet` is the marker-side counterpart of
 +:class:`~packaging.ranges.VersionRange`. It holds the states a marker string
 +cannot: the full set of an absent marker, the empty set of a contradiction, and
-+complements the grammar cannot spell. It reconciles with the grammar at exactly
-+one boundary, :meth:`~MarkerSet.to_marker_string`, which may return ``None`` or
-+raise :class:`UnserializableMarkerSet`.
++complements the grammar cannot spell.
 +
-+Build one with :meth:`MarkerSet.from_marker`, :meth:`MarkerSet.full`, or
-+:meth:`MarkerSet.empty`;
-+combine with :meth:`intersection`, :meth:`union`, and :meth:`complement` (or
-+``&`` / ``|`` / ``~``); and query with the decision procedures. Equality is
-+identity; :meth:`equivalent` tests whether two sets denote the same
-+environments, since there is no cheap canonical form to key ``==`` on.
++:meth:`~MarkerSet.to_marker_string` converts back, returning ``None`` for the
++full set and raising for the sets above that have no spelling.
 +"""
 +
 +from __future__ import annotations
@@ -2458,15 +2358,10 @@ index 0000000..d7a3fb6
 +    from ._markersets import Formula
 +    from .markers import Marker
 +
-+# The cell budget every decision runs under: a resource cap, not a semantic
-+# parameter, so it is private and never reaches the public surface. No result
-+# depends on its value; a set too complex to decide within it raises
-+# IntractableMarkerSet.
++# Resource caps, not semantic parameters: no answer depends on their value, so
++# neither reaches the public surface. `_MAX_CELLS` bounds one decision and
++# `_MAX_WORK` the greedy loop `simplify` runs over many of them.
 +_MAX_CELLS = 100_000
-+
-+# The total cell work one `simplify` may spend. `_MAX_CELLS` bounds a single
-+# decision, this bounds the greedy loop that issues them. A runaway guard rather
-+# than a tuning knob: the widest marker in nab's own CI locks spends 4.1 million.
 +_MAX_WORK = 100_000_000
 +
 +__all__ = [
@@ -2487,12 +2382,10 @@ index 0000000..d7a3fb6
 +
 +
 +def _bounded(method: Callable[_P, _R]) -> Callable[_P, _R]:
-+    """Report stack exhaustion on a deeply nested tree as the resource guard.
++    """Report a tree walk's :class:`RecursionError` as :class:`IntractableMarkerSet`.
 +
-+    A tree walk recurses as deep as the marker nests, so a marker nested past the
-+    interpreter's stack raises :class:`RecursionError`. The public methods it
-+    decorates report it as :class:`IntractableMarkerSet`, the one bounded failure
-+    the algebra promises on pathological input.
++    A walk recurses as deep as the marker nests, so a deeply nested marker
++    exhausts the stack rather than the cell budget.
 +    """
 +
 +    @wraps(method)
@@ -2507,33 +2400,30 @@ index 0000000..d7a3fb6
 +
 +
 +DecisionStore = _markersets.Memo
-+"""Scratch that several decisions can share.
++"""Scratch several decisions can share, for one piece of work.
 +
-+Each decision partitions the axes its atoms sit on and reads those atoms on
-+the points of the resulting cells. A run over related sets also asks the same
-+question of the same tree shape more than once. Two decisions over the same
-+universe mostly repeat all of that, so passing one store to both keeps the
-+work; passing none is correct and starts each cold.
-+
-+Answers do not depend on it: the emptiness verdicts, partitions and truths it
-+holds are functions of their keys alone. It grows with the atoms it has read
-+and the tree shapes it has decided, and holds both, so give one to the
-+decisions of a single piece of work and drop it after. Not safe to share
-+across threads.
++A run over related sets re-decides the same tree shapes and re-partitions the
++same axes. Passing one store to those decisions keeps that work, and passing
++none is always correct: answers never depend on it. It grows with what it has read, so drop it
++when the work is done, and do not share one across threads.
 +"""
 +
 +
 +class MarkerSet:
 +    """A set of environments: the denotation of a PEP 508 marker. Immutable.
 +
-+    Instances are created only through the factories (:meth:`from_marker`,
-+    :meth:`full`, or :meth:`empty`);
-+    calling ``MarkerSet(...)`` raises :class:`TypeError`.
++    A caller builds one only through the factories (:meth:`from_marker`,
++    :meth:`full`, :meth:`empty`); calling ``MarkerSet(...)`` raises
++    :class:`TypeError`.
 +
-+    The algebra is closed under :meth:`intersection`, :meth:`union`, and
-+    :meth:`complement`. It is total on the set, so those always return a
-+    ``MarkerSet``; only :meth:`to_marker_string` is partial, at the marker-grammar
-+    boundary. ``==`` is identity; :meth:`equivalent` is semantic equality.
++    :meth:`intersection`, :meth:`union` and :meth:`complement` always return a
++    ``MarkerSet``. :meth:`to_marker_string` can refuse at the marker-grammar
++    boundary, and :meth:`simplify` there or on an empty ``within``. ``==`` is
++    identity; :meth:`equivalent` is semantic.
++
++    :meth:`is_empty`, :meth:`is_full`, :meth:`equivalent_within`,
++    :meth:`witness`, :meth:`simplify` and :meth:`to_marker_string` take an
++    optional ``store``, which shares scratch across a run of related decisions.
 +    """
 +
 +    __slots__ = ("_tree",)
@@ -2559,10 +2449,10 @@ index 0000000..d7a3fb6
 +    def from_marker(cls, marker: str | Marker) -> MarkerSet:
 +        """Return the set of environments a marker denotes.
 +
-+        :raises packaging.markers.InvalidMarker: if ``marker`` is a string that is
-+            not a valid PEP 508 marker.
-+        :raises IntractableMarkerSet: if a version literal overruns the
-+            interpreter's integer-string limit, or the marker nests past the
++        :raises packaging.markers.InvalidMarker: for a string that is not a
++            valid PEP 508 marker.
++        :raises IntractableMarkerSet: if a ``~=`` or ``===`` version literal
++            overruns the integer-string limit, or the marker nests past the
 +            stack.
 +        """
 +        return cls._wrap(_markersets.parse(marker))
@@ -2613,27 +2503,23 @@ index 0000000..d7a3fb6
 +    def is_empty(self, *, store: DecisionStore | None = None) -> bool:
 +        """Whether no environment satisfies this set (the marker is a contradiction).
 +
-+        Not exact on one construction: a substring test on a version-dispatch
-+        variable (``python_version``, ``python_full_version``,
-+        ``platform_release``, ``implementation_version``) is decided as its own
-+        free boolean, independent of that variable's value, because the values
-+        embedding a literal are not enumerable from it. So the set reads larger
-+        than it is, ``True`` here is safe and ``False`` is the weak answer, and
-+        every other decision procedure reduces to this one and inherits it.
-+        :meth:`witness` and :meth:`evaluate` do not.
++        Not exact on one construction. A substring test on a version-dispatch
++        variable is decided as its own free boolean, because the values
++        embedding a literal are not enumerable from it.
 +
-+        ``store`` shares scratch with other decisions (:class:`DecisionStore`).
++        The set then reads larger than it is, so ``True`` is safe and ``False``
++        is the weak answer. Every predicate but :meth:`witness` and
++        :meth:`evaluate` reduces to this one and inherits that gap.
 +
 +        :raises IntractableMarkerSet: if deciding the set exceeds the internal
-+            cell budget, or the marker nests past the stack.
++            cell budget, if a version literal overruns the integer-string limit,
++            or if the marker nests past the stack.
 +        """
 +        return _markersets.is_empty(self._tree, _MAX_CELLS, store)
 +
 +    @_bounded
 +    def is_full(self, *, store: DecisionStore | None = None) -> bool:
-+        """Whether every environment satisfies this set (the marker is a tautology).
-+
-+        ``store`` shares scratch with other decisions (:class:`DecisionStore`).
++        """Whether every environment satisfies this set: ``(~self).is_empty()``.
 +
 +        :raises IntractableMarkerSet: see :meth:`is_empty`.
 +        """
@@ -2643,7 +2529,7 @@ index 0000000..d7a3fb6
 +    def is_disjoint(self, other: MarkerSet) -> bool:
 +        """Whether this set and ``other`` share no environment.
 +
-+        Equivalent to ``(self & other).is_empty()``.
++        ``(self & other).is_empty()``.
 +        """
 +        return _markersets.is_empty(
 +            _markersets.make_and((self._tree, other._tree)), _MAX_CELLS
@@ -2653,7 +2539,7 @@ index 0000000..d7a3fb6
 +    def is_subset(self, other: MarkerSet) -> bool:
 +        """Whether every environment in this set is in ``other``.
 +
-+        The set-algebra reading of ``self`` implies ``other``.
++        ``(self & ~other).is_empty()``, the set reading of implication.
 +        """
 +        return _markersets.is_empty(
 +            _markersets.make_and((self._tree, _markersets.make_not(other._tree))),
@@ -2668,9 +2554,10 @@ index 0000000..d7a3fb6
 +    def equivalent(self, other: MarkerSet) -> bool:
 +        """Whether the two sets denote the same environments.
 +
-+        The semantic equality ``==`` cannot cheaply provide, so it is a method.
++        Containment both ways. ``==`` stays identity because there is no cheap
++        canonical form to key it on.
 +
-+        Both containments read the same two trees, so they share one partition memo.
++        The two decisions read the same trees, so they share one memo.
 +        """
 +        store = _markersets.Memo()
 +        return _markersets.is_empty(
@@ -2687,14 +2574,11 @@ index 0000000..d7a3fb6
 +    def equivalent_within(
 +        self, other: MarkerSet, within: MarkerSet, *, store: DecisionStore | None = None
 +    ) -> bool:
-+        """Whether the two sets denote the same environments on every point of ``within``.
++        """Whether the sets denote the same environments on every point of ``within``.
 +
-+        The row-restricted counterpart of :meth:`equivalent`, deciding each of
-+        ``within``'s rows under its pins so it stays decidable on wide
-+        multi-platform universes. A universe of :meth:`full` reduces it to plain
-+        :meth:`equivalent`.
-+
-+        ``store`` shares scratch with other decisions (:class:`DecisionStore`).
++        Deciding each row of ``within`` under its own pins keeps a wide
++        multi-platform universe decidable, whereas complementing ``within`` as a
++        whole does not. Use :meth:`equivalent` when the universe is full.
 +        """
 +        return _markersets.equivalent_within_rows(
 +            self._tree, other._tree, within._tree, _MAX_CELLS, store
@@ -2711,14 +2595,14 @@ index 0000000..d7a3fb6
 +    ) -> MarkerSet:
 +        """Substitute the provided variables, returning a residual set.
 +
-+        With ``on_unknown_variable="error"`` a referenced variable absent from
-+        ``env`` raises :class:`ValueError`; with ``"residual"`` (the default) it
-+        is left in the residual set.
++        A variable ``env`` omits stays in the result, unless
++        ``on_unknown_variable="error"`` asks for a :class:`ValueError` instead.
 +
-+        :raises ValueError: for an unknown ``on_unknown_variable``, or for a
-+            referenced-but-unprovided variable under ``"error"``.
-+        :raises IntractableMarkerSet: if a version literal or value overruns the
-+            integer-string limit, or the marker nests past the stack.
++        :raises ValueError: for an unknown ``on_unknown_variable``, or for an
++            unprovided variable under ``"error"``.
++        :raises IntractableMarkerSet: if a version literal or value overruns
++            the integer-string limit on a variable ``env`` supplies, or the
++            marker nests past the stack.
 +        """
 +        if on_unknown_variable not in ("residual", "error"):
 +            msg = (
@@ -2743,10 +2627,13 @@ index 0000000..d7a3fb6
 +
 +    @_bounded
 +    def evaluate(self, env: Mapping[str, str | AbstractSet[str]]) -> bool:
-+        """Whether a full environment is in the set (membership variables are sets).
++        """Whether a full environment is in the set (set variables take sets).
 +
-+        :raises packaging.markers.UndefinedEnvironmentName: if the marker
-+            references a variable ``env`` does not supply.
++        Exact: no cell decomposition runs, so the gap :meth:`is_empty` carries
++        does not apply.
++
++        :raises packaging.markers.UndefinedEnvironmentName: for a variable
++            ``env`` does not supply.
 +        :raises IntractableMarkerSet: if a version literal or value overruns the
 +            integer-string limit.
 +        """
@@ -2757,16 +2644,14 @@ index 0000000..d7a3fb6
 +    def witness(
 +        self, *, store: DecisionStore | None = None
 +    ) -> dict[str, str | frozenset[str]] | None:
-+        """Return a satisfying environment, or ``None`` when none is found.
++        """Return an environment in this set, or ``None`` when none is found.
 +
-+        ``None`` is returned for the empty set. The search over ``contains``
-+        atoms is incomplete, so ``None`` may also be returned for a non-empty set
-+        when the concrete-string constraints on one variable (a value atom, one
-+        or more ``contains`` atoms, or a mix) have no jointly realisable cell
-+        representative. ``python_version`` and ``python_full_version`` share one
-+        axis, so those constraints can sit on different variables.
++        Never wrong: the environment is checked against the set before it is
++        returned, so it does not inherit the gap :meth:`is_empty` carries.
 +
-+        ``store`` shares scratch with other decisions (:class:`DecisionStore`).
++        ``None`` does not prove the set empty. The search enumerates the cells
++        :meth:`is_empty` decides on, so a set whose only environments lie
++        outside them is inhabited and still yields ``None``.
 +        """
 +        return _markersets.witness(self._tree, _MAX_CELLS, store)
 +
@@ -2776,19 +2661,21 @@ index 0000000..d7a3fb6
 +    def simplify(
 +        self, *, within: MarkerSet, store: DecisionStore | None = None
 +    ) -> MarkerSet:
-+        """Return the smallest set equivalent to this one on every point of ``within``.
++        """Return a set that agrees with this one on every point of ``within``.
 +
-+        ``within`` is the universe the result must agree with this set over: pass
-+        the union of a lock's declared environments for universe-aware
-+        simplification, or :meth:`full` for a context-free factoring.
++        Pass the union of a lock's declared environments as ``within``, or
++        :meth:`full` for a context-free factoring.
 +
-+        ``store`` shares scratch with other decisions (:class:`DecisionStore`).
++        Clauses and then atoms are dropped greedily, so the result is not the
++        smallest equivalent set, and a factored input whose clauses are all
++        needed comes back expanded.
 +
 +        :raises ValueError: if ``within`` is the empty set, which makes every set
 +            vacuously equivalent.
-+        :raises IntractableMarkerSet: if deciding a removal exceeds the internal
-+            cell budget, if the whole run exceeds the internal work budget, or
-+            if the marker nests past the stack.
++        :raises UnserializableMarkerSet: for a complement the grammar cannot
++            negate, such as ``~(python_version >= "3.9")``.
++        :raises IntractableMarkerSet: see :meth:`is_empty`, plus the work budget
++            the greedy loop runs under.
 +        """
 +        if _markersets.universe_is_empty(within._tree, _MAX_CELLS, store):
 +            msg = "within must not be the empty set"
@@ -2803,16 +2690,14 @@ index 0000000..d7a3fb6
 +
 +    @_bounded
 +    def to_marker_string(self, *, store: DecisionStore | None = None) -> str | None:
-+        """Return a marker string that re-parses to an equivalent set, or ``None``.
++        """Return a marker string denoting this set, or ``None`` for the full set.
 +
-+        ``None`` means the full set (no marker needed). The empty set, and any set
-+        whose complement structure the marker grammar cannot express, raise
-+        :class:`UnserializableMarkerSet` rather than emit a wrong string. The
-+        produced string is verified equivalent to this set before it is returned.
++        Two kinds raise rather than getting a string for some other set: the
++        empty set, and one whose complement the grammar cannot negate.
++        ``~(python_version == "3.9")`` is spellable and
++        ``~(python_version >= "3.9")`` is not.
 +
-+        ``store`` shares scratch with other decisions (:class:`DecisionStore`).
-+        The two emptiness decisions read the same atoms, so they share one
-+        partition memo whether or not one is passed.
++        What is returned is parsed back and checked equivalent first.
 +        """
 +        if store is None:
 +            store = _markersets.Memo()

--- a/tasks/vendoring/packaging.patch
+++ b/tasks/vendoring/packaging.patch
@@ -1,17 +1,18 @@
 diff --git a/nab-provider/src/nab_provider/_vendor/packaging/_markersets.py b/nab-provider/src/nab_provider/_vendor/packaging/_markersets.py
 new file mode 100644
-index 0000000..9e908b1
+index 0000000..080f09f
 --- /dev/null
 +++ b/nab-provider/src/nab_provider/_vendor/packaging/_markersets.py
-@@ -0,0 +1,1945 @@
+@@ -0,0 +1,2069 @@
 +"""Marker algebra engine: reason about PEP 508 markers as sets of environments.
 +
 +The private engine behind :class:`~packaging.markersets.MarkerSet`. Parses a
 +marker string (or :class:`~packaging.markers.Marker`) into a normalised boolean
 +op-tree over typed atoms, with the packaging-faithful
 +``(variable, operator, literal)`` dispatch, A1 lowering of ``python_version``
-+onto the ``python_full_version`` axis, set-valued extras, and opaque
-+``contains`` atoms. The denotation of a value atom is delegated to packaging's
++onto the ``python_full_version`` axis, set-valued extras, and ``contains``
++atoms, which join a string variable's value axis and stay opaque on a
++version-dispatch one. The denotation of a value atom is delegated to packaging's
 +own ``_eval_op`` so it matches packaging exactly. Decisions run an on-demand
 +cell decomposition: every procedure re-partitions the referenced variables'
 +domains into cells on which each atom is constant, enumerates the cell product
@@ -278,22 +279,36 @@ index 0000000..9e908b1
 +        )
 +
 +    def axis(self) -> tuple[str, ...]:
-+        """Return the axis this atom partitions and is constant on."""
++        """Return the axis this atom partitions and is constant on.
++
++        A substring test on a string variable joins that variable's value axis,
++        so both readings of the variable are decided on one point. On a
++        version-dispatch variable it keeps a boolean axis of its own, one per
++        literal, because the values that embed a literal are not enumerable
++        from the literals alone.
++        """
 +        if self.kind == AXIS_VALUE:
 +            return (AXIS_VALUE, self.variable)
 +        if self.kind == AXIS_SET:
 +            return (AXIS_SET, self.variable)
++        if DOMAIN_REGISTRY[self.variable] == DOMAIN_STRING:
++            return (AXIS_VALUE, self.variable)
 +        # in / not in on the same (variable, literal) share one boolean axis.
 +        return (AXIS_CONTAINS, self.variable, self.literal)
 +
 +    def holds(self, point: object) -> bool:
-+        """Return the atom's truth on one point of its axis."""
++        """Return the atom's truth on one point of its axis.
++
++        A contains atom is handed the variable's value on a value axis and its
++        own truth on a boolean one, so it reads whichever it is given.
++        """
 +        if self.kind == AXIS_VALUE:
 +            return _holds_value(self, str(point))
 +        if self.kind == AXIS_SET:
 +            member = self.literal in point  # type: ignore[operator]
 +            return member if self.positive else not member
-+        return bool(point) if self.positive else not bool(point)
++        present = self.literal in point if isinstance(point, str) else bool(point)
++        return present if self.positive else not present
 +
 +    def pool_entries(self) -> tuple[tuple[Version, str], ...]:
 +        """The parsed version-pool points this atom seeds, minted lazily once.
@@ -851,8 +866,36 @@ index 0000000..9e908b1
 +    return [version.public, str(padded)]
 +
 +
++def _release_between(vlow: Version, vhigh: Version) -> str:
++    """Return a plain release ranking above every variant of ``vlow``.
++
++    Release ordering runs ahead of pre, post, dev and local, so ``vlow``'s
++    release extended by one outranks ``vlow`` whatever suffix it carries. There
++    is no lowest such release: another zero can always be padded in. Within one
++    epoch the padding runs to the wider of the two releases, which is the
++    deepest place ``vhigh`` can differ, so the result stays under it whenever
++    the two releases differ at all. Across an epoch boundary ``vhigh``'s release
++    does not bound the candidate, so ``vlow``'s own width is enough. The caller
++    checks the ordering either way.
++    """
++    low = vlow.release
++    width = len(low) if vlow.epoch != vhigh.epoch else max(len(low), len(vhigh.release))
++    parts = (*low, *(0,) * (width - len(low)), 1)
++    prefix = f"{vlow.epoch}!" if vlow.epoch else ""
++    return prefix + ".".join(str(part) for part in parts)
++
++
 +def _between(vlow: Version, low: str, vhigh: Version, memo: Memo) -> str | None:
++    """Return a point strictly between two adjacent pool points, or None.
++
++    The plain release comes first because an exclusive ordered comparison
++    excludes its own bound's post, local, pre and dev variants, so a band whose
++    two ends share a release is the only one the suffixed candidates can fill.
++    Where the ends differ, only a version whose release differs from both is
++    admitted, and no suffix of ``vlow`` is.
++    """
 +    for candidate in (
++        _release_between(vlow, vhigh),
 +        f"{low}.post0",
 +        f"{low}+m",
 +        f"{low}.dev1",
@@ -971,6 +1014,53 @@ index 0000000..9e908b1
 +    return "z" * width
 +
 +
++def _unused_character(literals: Iterable[str]) -> str:
++    """Return a character none of ``literals`` uses, counting up from ``!``.
++
++    A marker literal can hold any character its quote style admits, so the walk
++    can run past printable ASCII; the point only has to be a string no atom on
++    the axis matches by accident, and any unused character serves.
++    """
++    used = {char for literal in literals for char in literal}
++    code = ord("!")
++    while chr(code) in used:
++        code += 1
++    return chr(code)
++
++
++def _contains_candidates(
++    atoms: Sequence[Atom], literals: Sequence[str], max_cells: int
++) -> list[str]:
++    """Mint a point for each substring pattern the axis's contains atoms allow.
++
++    A separator none of ``literals`` uses joins one subset of the substring
++    literals, so every occurrence inside the point falls in one piece: it
++    embeds that subset and whatever the subset embeds, equals no literal, and
++    is a substring of none. Any string embeds what one subset does, so with the
++    literals and their substrings the axis reaches every combination its atoms
++    can realise together.
++    """
++    names: list[str] = []
++    seen: set[str] = set()
++    for atom in atoms:
++        if atom.kind == AXIS_CONTAINS and atom.literal not in seen:
++            seen.add(atom.literal)
++            names.append(atom.literal)
++    if not names:
++        return []
++
++    count = len(names)
++    if (1 << count) > max_cells:
++        msg = f"substring subsets over {count} literals exceeds max_cells={max_cells}"
++        raise IntractableMarkerSet(msg)
++
++    separator = _unused_character(literals)
++    return [
++        separator + separator.join(names[i] for i in range(count) if mask & (1 << i))
++        for mask in range(1 << count)
++    ]
++
++
 +def _reduce_work_exceeds(
 +    variable: str, literals: Sequence[str], atom_count: int, max_cells: int, memo: Memo
 +) -> bool:
@@ -1016,12 +1106,14 @@ index 0000000..9e908b1
 +    # so a set of long distinct literals fails loudly first.
 +    spent = 0
 +    for atom in atoms:
-+        if atom.op in _MEMBERSHIP:
++        if atom.kind == AXIS_VALUE and atom.op in _MEMBERSHIP:
 +            spent += _substring_cost(atom.literal)
 +            if spent > max_cells:
 +                msg = f"substring enumeration exceeds max_cells={max_cells}"
 +                raise IntractableMarkerSet(msg)
 +            candidates.extend(_membership_candidates(atom, memo))
++
++    candidates.extend(_contains_candidates(atoms, literals, max_cells))
 +
 +    if is_version_dispatch(variable):
 +        _reject_mint_overflow(literals)
@@ -1499,16 +1591,43 @@ index 0000000..9e908b1
 +    raise UnserializableMarkerSet(msg)
 +
 +
++def _flip_string_op(atom: Atom, flipped: str) -> Formula:
++    """Return ``atom`` under ``flipped``, refusing if that leaves the string table.
++
++    The atom reaches the string table only while its literal builds no specifier
++    under its own operator, and an equality specifier accepts a wildcard and a
++    local version where an ordered one does not, so the flipped atom can
++    dispatch as a version and denote something else.
++    """
++    if is_version_dispatch(atom.variable) and _builds_specifier(flipped, atom.literal):
++        msg = f"no marker string spells the complement of {_render_atom(atom)}"
++        raise UnserializableMarkerSet(msg)
++    return AtomLeaf(atom.replaced(op=flipped))
++
++
 +def _complement_string(atom: Atom, op: str) -> Formula:
++    """Complement an atom packaging reads through the string operator table.
++
++    That table folds ``<`` and ``>`` to false and ``<=`` and ``>=`` to equality,
++    so no ordered comparison complements to another ordered comparison.
++
++    A swapped atom on a version-dispatch variable does not reach the table at
++    all: packaging builds its specifier from the environment value, so the atom
++    compares as a version wherever that value parses as one, and the table's
++    reading holds only on the rest.
++    """
++    if atom.swapped and is_version_dispatch(atom.variable):
++        msg = f"no marker string spells the complement of {_render_atom(atom)}"
++        raise UnserializableMarkerSet(msg)
 +    if op in ("==", ">=", "<="):
-+        return AtomLeaf(atom.replaced(op="!="))
++        return _flip_string_op(atom, "!=")
 +    if op == "!=":
-+        return AtomLeaf(atom.replaced(op="=="))
++        return _flip_string_op(atom, "==")
 +    if op == "in":
-+        return AtomLeaf(atom.replaced(op="not in"))
++        return _flip_string_op(atom, "not in")
 +    if op == "not in":
-+        return AtomLeaf(atom.replaced(op="in"))
-+    # < and > are constant-false on a string variable, so the complement is all.
++        return _flip_string_op(atom, "in")
++    # Only < and > are left, and the table reads both as false.
 +    return TRUE
 +
 +
@@ -1522,17 +1641,19 @@ index 0000000..9e908b1
 +
 +
 +def to_nnf(node: Formula) -> Formula:
-+    """Push complements down to the leaves (negation normal form)."""
-+    if isinstance(node, AtomLeaf):
-+        return node
++    """Push complements down to the leaves (negation normal form).
++
++    A leaf and a constant are already in normal form. A tree can also normalise
++    to a constant, because complementing an atom the string operator table
++    folds to false yields one.
++    """
 +    if isinstance(node, AndNode):
 +        return make_and(to_nnf(child) for child in node.children)
 +    if isinstance(node, OrNode):
 +        return make_or(to_nnf(child) for child in node.children)
 +    if isinstance(node, NotNode):
 +        return _negate(node.child)
-+    msg = "a bare constant cannot reach to_nnf"  # pragma: no cover
-+    raise RuntimeError(msg)  # pragma: no cover
++    return node
 +
 +
 +def _negate(node: Formula) -> Formula:
@@ -1596,19 +1717,22 @@ index 0000000..9e908b1
 +
 +
 +def describe(node: Formula) -> str:
-+    """A short human summary of a set, for :func:`repr`. Total and never raises.
++    """A short human summary of a set, for :func:`repr`, without the op-tree.
 +
-+    Renders the constant sets as words and any other set as its marker string,
-+    falling back to a placeholder for a complement the grammar cannot spell. It
-+    never exposes the private op-tree and never raises, so a ``MarkerSet`` is
-+    always safe to print, including inside a traceback.
++    Total: a constant, a set no marker string spells, and a tree nested past the
++    stack each get a word, so every set can be printed.
 +    """
-+    if isinstance(node, BoolConst):
-+        return "universe" if node.value else "empty"
 +    try:
-+        return serialize(to_nnf(node))
++        nnf = to_nnf(node)
++        if isinstance(nnf, BoolConst):
++            return "universe" if nnf.value else "empty"
++        return serialize(nnf)
 +    except UnserializableMarkerSet:
 +        return "unrepresentable"
++    except RecursionError:
++        # The two walks are the only recursion under repr, which owes its
++        # caller a string rather than the depth of the tree it was handed.
++        return "too deeply nested"
 +
 +
 +# ------------------------------------------------------------------- simplify
@@ -1726,7 +1850,7 @@ index 0000000..9e908b1
 +    Each row keeps its entailed pins and the residual bound left after
 +    restricting the disjunct by them. Purely structural, no algebra.
 +    """
-+    nnf = universe if isinstance(universe, BoolConst) else to_nnf(universe)
++    nnf = to_nnf(universe)
 +    disjuncts = nnf.children if isinstance(nnf, OrNode) else (nnf,)
 +    rows: list[_Row] = []
 +    for disjunct in disjuncts:
@@ -1769,7 +1893,7 @@ index 0000000..9e908b1
 +    A union is empty iff every top-level disjunct is, so each is tested alone,
 +    staying on one row's product instead of the whole-matrix complement.
 +    """
-+    nnf = universe if isinstance(universe, BoolConst) else to_nnf(universe)
++    nnf = to_nnf(universe)
 +    disjuncts = nnf.children if isinstance(nnf, OrNode) else (nnf,)
 +    shared = Memo() if store is None else store
 +    return all(is_empty(disjunct, max_cells, shared) for disjunct in disjuncts)
@@ -1919,7 +2043,7 @@ index 0000000..9e908b1
 +    powerset runs few expensive ones. Either overrun raises
 +    :class:`IntractableMarkerSet`.
 +    """
-+    nnf = node if isinstance(node, BoolConst) else to_nnf(node)
++    nnf = to_nnf(node)
 +    clauses = _dedupe(_to_clauses(nnf, max_cells))
 +    original = _disjunction(clauses)
 +    rows = _decompose_rows(universe)
@@ -2292,10 +2416,10 @@ index 609099c..07c7d81 100644
  def _pep440_python_full_version(python_full_version: str) -> str:
 diff --git a/nab-provider/src/nab_provider/_vendor/packaging/markersets.py b/nab-provider/src/nab_provider/_vendor/packaging/markersets.py
 new file mode 100644
-index 0000000..a5e2740
+index 0000000..d7a3fb6
 --- /dev/null
 +++ b/nab-provider/src/nab_provider/_vendor/packaging/markersets.py
-@@ -0,0 +1,404 @@
+@@ -0,0 +1,413 @@
 +"""The public :class:`MarkerSet`: a marker's denotation as a set of environments.
 +
 +A :class:`MarkerSet` is the denotation of a PEP 508 marker as a set of
@@ -2488,6 +2612,15 @@ index 0000000..a5e2740
 +    @_bounded
 +    def is_empty(self, *, store: DecisionStore | None = None) -> bool:
 +        """Whether no environment satisfies this set (the marker is a contradiction).
++
++        Not exact on one construction: a substring test on a version-dispatch
++        variable (``python_version``, ``python_full_version``,
++        ``platform_release``, ``implementation_version``) is decided as its own
++        free boolean, independent of that variable's value, because the values
++        embedding a literal are not enumerable from it. So the set reads larger
++        than it is, ``True`` here is safe and ``False`` is the weak answer, and
++        every other decision procedure reduces to this one and inherits it.
++        :meth:`witness` and :meth:`evaluate` do not.
 +
 +        ``store`` shares scratch with other decisions (:class:`DecisionStore`).
 +


### PR DESCRIPTION
Three shapes the marker algebra's cell decomposition read wrong, fixed in the vendored tree so the correctness does not wait on the `nab-markersets` extraction.

| | was | is |
|---|---|---|
| `platform_release > "6" and platform_release < "6.1"` | `is_empty()` True, though 6.0.1 satisfies it | `False`. The pool now seeds `vlow`'s release extended by one, which outranks every variant an exclusive comparison refuses |
| `os_name == "posix" and "posix" not in os_name` | `is_empty()` False on a contradiction | `True`. On a string variable the substring test and the value comparison share one axis |
| `repr(~MarkerSet.from_marker('python_full_version < "3.*"'))` | `RuntimeError`, from a line marked unreachable | `<MarkerSet 'universe'>` |

The first is the one that matters: every predicate inherits it in the unsafe direction, and `simplify` acts on the verdict.

`to_marker_string` reached that same line, so complementing a swapped ordered comparison on a version-dispatch variable now raises `UnserializableMarkerSet` rather than a bare `RuntimeError`.

One inexactness remains and it errs safe. A substring test on a version-dispatch variable keeps its own free boolean, so `python_version == "3.9" and "9" not in python_version` reads as inhabited. Keeping it is what makes `platform_release == "6" and "zq" in platform_release` right, since `6.0+zq` satisfies that and no pool built from those literals mints it.

`test_two_atom_census_pins_soundness_and_its_one_gap` pins both halves against packaging's own `evaluate`: over 512 two-atom markers and 1,750 environments, nothing decides empty while inhabited, and the markers that read too large are exactly that one shape in both operand orders.

No committed lockfile moves. Reverting any one of the fixes turns the suite red.

The second commit also drops two docstring claims that were false: `simplify` said it returned the smallest equivalent set, and `_equivalent_within` was shipped code no caller reached.
