### PR TITLE
Share one METADATA hash pair per listing, 6% to 10% off peak memory

### DIFF
--- a/nab-index/src/nab_index/parsed_listing.py
+++ b/nab-index/src/nab_index/parsed_listing.py
@@ -262,13 +262,20 @@ def _decode_zip_sdists(value: object) -> frozenset[str]:
 
 
 def _decode_rows(rows: object) -> list[WheelFile | SdistFile]:
-    """Rehydrate every row, raising :class:`_BadRowError` on the first bad one."""
+    """Rehydrate every row, raising :class:`_BadRowError` on the first bad one.
+
+    One sidecar pool serves the whole blob, so rows publishing the same
+    METADATA digest share the pair they hold.
+    """
     if not isinstance(rows, list):
         raise _BadRowError
-    return [_decode_row(row) for row in rows]
+    sidecar_pool: dict[tuple[str, str], tuple[str, str]] = {}
+    return [_decode_row(row, sidecar_pool) for row in rows]
 
 
-def _decode_row(row: object) -> WheelFile | SdistFile:
+def _decode_row(
+    row: object, sidecar_pool: dict[tuple[str, str], tuple[str, str]]
+) -> WheelFile | SdistFile:
     """Rehydrate one row, dispatching on the tag its first element carries."""
     if not isinstance(row, list) or not row:
         raise _BadRowError
@@ -277,13 +284,15 @@ def _decode_row(row: object) -> WheelFile | SdistFile:
     if type(tag) is not int:
         raise _BadRowError
     if tag == _TAG_WHEEL:
-        return _decode_wheel(row)
+        return _decode_wheel(row, sidecar_pool)
     if tag == _TAG_SDIST:
         return _decode_sdist(row)
     raise _BadRowError
 
 
-def _decode_wheel(row: Sequence[object]) -> WheelFile:
+def _decode_wheel(
+    row: Sequence[object], sidecar_pool: dict[tuple[str, str], tuple[str, str]]
+) -> WheelFile:
     """Rehydrate a wheel row.
 
     An integrity cell holding the index's own table passes through unparsed,
@@ -327,6 +336,7 @@ def _decode_wheel(row: Sequence[object]) -> WheelFile:
         metadata_hash
         if isinstance(metadata_hash, dict)
         else _pair_or_none(metadata_hash),
+        sidecar_pool,
     )
 
 

--- a/nab-index/tests/test_parsed_listing_codec.py
+++ b/nab-index/tests/test_parsed_listing_codec.py
@@ -488,6 +488,20 @@ def test_a_rehydrated_sdist_defers_its_hashes() -> None:
     assert decoded.hashes == ((SHA256, DIGEST),)
 
 
+def test_wheels_publishing_one_metadata_share_the_pair_they_hold() -> None:
+    """One pool serves the blob, so its rows hold one pair per sidecar digest."""
+    first, second = _roundtrip(
+        [
+            _deferred_wheel({"sha256": "b" * 64}, sidecar={"sha256": DIGEST}),
+            _deferred_wheel({"sha256": "c" * 64}, sidecar={"sha256": DIGEST}),
+        ]
+    )
+    assert isinstance(first, WheelFile)
+    assert isinstance(second, WheelFile)
+
+    assert first._raw_metadata is second._raw_metadata
+
+
 def test_a_row_is_the_same_whether_or_not_the_record_was_read() -> None:
     """A read record keeps its table, so encoding does not depend on read order."""
     unread = _deferred_wheel({"sha256": DIGEST}, sidecar={"sha256": DIGEST})

--- a/nab-provider/src/nab_provider/records.py
+++ b/nab-provider/src/nab_provider/records.py
@@ -117,18 +117,28 @@ def _compact_table(table: dict[object, object]) -> object:
     return table
 
 
-def _compact_shared_table(table: dict[object, object]) -> object:
+def _compact_shared_table(
+    table: dict[object, object],
+    pool: dict[tuple[str, str], tuple[str, str]] | None = None,
+) -> object:
     """Compact ``table`` for a caller whose rows already share one name object.
 
     One cached listing's rows are decoded together and get a single object for
     a repeated name, and :func:`parse_hash_table` interns whatever a reader
     parses out of the pair, so :func:`_compact_table`'s per-row intern buys
     nothing here.
+
+    ``pool``, when given, maps a pair to itself, so a caller decoding many rows
+    holds one pair per distinct digest. Only a string digest is pooled: a list
+    cannot key the pool, and ``True`` would share ``1``'s cell.
     """
     if len(table) == 1:
         ((algo, digest),) = table.items()
         if type(algo) is str:
-            return (algo, digest)
+            cell = (algo, digest)
+            if pool is not None and type(digest) is str:
+                return pool.setdefault(cell, cell)
+            return cell
     return table
 
 
@@ -342,7 +352,7 @@ _set_wheel_raw_hashes = _slot_writer(_WheelIntegrity, "_raw_hashes")
 _set_wheel_raw_metadata = _slot_writer(_WheelIntegrity, "_raw_metadata")
 
 
-def rehydrated_wheel(  # noqa: PLR0913, PLR0917 - the record's fields, in its own order
+def rehydrated_wheel(  # noqa: PLR0913, PLR0917 - the record's fields in order, then the pool
     filename: str,
     url: str,
     version: str,
@@ -352,6 +362,7 @@ def rehydrated_wheel(  # noqa: PLR0913, PLR0917 - the record's fields, in its ow
     hashes: tuple[tuple[str, str], ...] | dict[Any, Any],
     size: int | None,
     metadata_hash: tuple[str, str] | dict[Any, Any] | None,
+    sidecar_pool: dict[tuple[str, str], tuple[str, str]] | None = None,
 ) -> WheelFile:
     """Return a wheel rebuilt from a cached listing row.
 
@@ -359,6 +370,10 @@ def rehydrated_wheel(  # noqa: PLR0913, PLR0917 - the record's fields, in its ow
     index's own table, and a table is held raw for the field's first read to
     parse.  Deferring a field means leaving its slot unwritten, which
     ``__init__`` cannot do, so this writes the slots directly.
+
+    ``sidecar_pool`` lets one listing's rows share the pair they hold when they
+    publish the same METADATA digest. ``hashes`` takes no pool: each file has a
+    digest of its own.
 
     ``local_path`` is ``None``: a cached listing row carries none.
     """
@@ -378,7 +393,9 @@ def rehydrated_wheel(  # noqa: PLR0913, PLR0917 - the record's fields, in its ow
         _set_wheel_hashes(wheel, hashes)
 
     if isinstance(metadata_hash, dict):
-        _set_wheel_raw_metadata(wheel, _compact_shared_table(metadata_hash))
+        _set_wheel_raw_metadata(
+            wheel, _compact_shared_table(metadata_hash, sidecar_pool)
+        )
     else:
         _set_wheel_metadata_hash(wheel, metadata_hash)
 

--- a/nab-provider/tests/test_record_deferral.py
+++ b/nab-provider/tests/test_record_deferral.py
@@ -35,8 +35,14 @@ def _deferred_wheel(hashes: object, *, sidecar: object) -> WheelFile:
     return wheel
 
 
-def _rehydrated_wheel(table: dict[object, str]) -> WheelFile:
-    """A wheel rebuilt from a cached listing row that holds ``table`` for both fields."""
+def _rehydrated_wheel(
+    table: dict[object, object],
+    pool: dict[tuple[str, str], tuple[str, str]] | None = None,
+) -> WheelFile:
+    """A wheel rebuilt from a cached listing row that holds ``table`` for both fields.
+
+    ``pool`` is the sidecar pool the rows of one decoded blob share.
+    """
     return rehydrated_wheel(
         filename="pkg-1.0-py3-none-any.whl",
         url="https://files.example/pkg-1.0-py3-none-any.whl",
@@ -47,6 +53,7 @@ def _rehydrated_wheel(table: dict[object, str]) -> WheelFile:
         hashes=table,
         size=None,
         metadata_hash=table,
+        sidecar_pool=pool,
     )
 
 
@@ -119,13 +126,48 @@ def test_a_rehydrated_one_algorithm_table_keeps_the_name_the_row_carried() -> No
     "table", [{"sha256": DIGEST, "sha512": "f" * 128}, {7: DIGEST}]
 )
 def test_a_rehydrated_table_the_pair_form_cannot_hold_is_kept_whole(
-    table: dict[object, str],
+    table: dict[object, object],
 ) -> None:
     """Several algorithms, or a name that is not a string, is held as it stands."""
     wheel = _rehydrated_wheel(table)
 
     assert wheel._raw_hashes == table
     assert wheel._raw_metadata == table
+
+
+def test_rows_publishing_the_same_digest_share_one_pooled_pair() -> None:
+    """A release's wheels publish one METADATA, so its rows repeat one digest."""
+    pool: dict[tuple[str, str], tuple[str, str]] = {}
+    same_digest = DIGEST.encode().decode()
+    assert same_digest is not DIGEST
+
+    first = _rehydrated_wheel({SHA256: DIGEST}, pool)
+    second = _rehydrated_wheel({SHA256: same_digest}, pool)
+
+    assert first._raw_metadata is second._raw_metadata
+    assert second.metadata_hash == (SHA256, DIGEST)
+
+    # The hashes cell takes no pool: each file publishes its own digest.
+    assert first._raw_hashes is not second._raw_hashes
+
+
+@pytest.mark.parametrize("digest", [[DIGEST], 1, True])
+def test_a_sidecar_digest_that_is_not_a_string_is_kept_per_row(
+    digest: object,
+) -> None:
+    """The pool keys on a string pair, so any other digest is held per row.
+
+    A list cannot key the pool at all, and ``1`` and ``True`` are equal, so
+    pooling those would collapse two rows the index served differently.
+    """
+    pool: dict[tuple[str, str], tuple[str, str]] = {}
+
+    wheel = _rehydrated_wheel({SHA256: digest}, pool)
+
+    held = wheel._raw_metadata
+    assert isinstance(held, tuple)
+    assert held[1] is digest
+    assert pool == {}
 
 
 def test_a_read_keeps_the_table_it_parsed() -> None:


### PR DESCRIPTION
Sharing one `(algo, digest)` METADATA pair across a cached listing's rows takes 6% to 10% off peak traced bytes, on pairs matched at equal decision counts:

| scenario | base | branch | off |
| --- | --- | --- | --- |
| `pip:google-bigquery-soda@lowest` | 68,201,926 | 64,064,115 | 6.1% |
| `ai-stack:vllm-transformers-floor@highest` | 119,741,048 | 108,262,996 | 9.6% |
| `airflow:airflow-3-0-2-awswrangler@lowest-direct` | 127,569,198 | 116,523,277 | 8.7% |

Peak RSS is about 6.6% lower locally over the same three scenarios.

Every wheel row decoded from a cached listing built its own pair, and they repeat: the soda resolve holds 35,577 of them over 6,088 distinct values. `_decode_rows` now threads one dict per listing through to `_compact_shared_table`, so rows publishing the same digest share a pair. That leaves 4,749,023 fewer bytes live at the end of that resolve.

It costs CPU. The soda resolve goes from 3,840,505,936 instructions to 3,886,456,015, +1.2%, the pool probe on each of the 35,577 METADATA pairs it decodes. The clock cannot see that: the timing runs only rule out a slowdown above about 4.5% wall and 2.3% CPU.

The `hashes` cell stays per row, since all 39,928 in that resolve are distinct. The wire format and `FORMAT_VERSION` do not change.
