### PR TITLE
Keep the fetch stack and asyncio off startup, ~7.8% off importing nab.cli

### DIFF
--- a/nab-project/src/nab_project/_lockfile/builder.py
+++ b/nab-project/src/nab_project/_lockfile/builder.py
@@ -25,7 +25,7 @@ from nab_provider.extra_keys import split_extra
 from nab_provider.iso8601 import parse_iso_datetime
 from nab_provider.metadata import validate_specifier_versions
 from nab_provider.policy import DistPolicy
-from nab_provider.records import SdistFile, WheelFile
+from nab_provider.records import DEFAULT_INDEX_URL, SdistFile, WheelFile
 
 from .. import toml_io
 from .._toml import tool_nab_section
@@ -520,7 +520,6 @@ def _index_pin_from_listing(
     otherwise reject a widened pin whose lock still carried the narrow
     artefact value.
     """
-    from ..fetch import DEFAULT_INDEX_URL
     from ..lockfile import IndexPin, SdistArtifact, WheelArtifact
 
     files = list(provider.dist_files_for(canonical, version))

--- a/nab-project/src/nab_project/_routes.py
+++ b/nab-project/src/nab_project/_routes.py
@@ -1,0 +1,27 @@
+"""The per-package index routing rule.
+
+Kept out of :mod:`nab_project.fetch` so the config layer can name a route
+without importing the coordinator and its async stack.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = ["IndexRoute"]
+
+
+@dataclass(frozen=True, slots=True)
+class IndexRoute:
+    """Per-package index routing rule (a strict pin to one index).
+
+    ``name`` is the package name (canonicalised internally).  ``index``
+    is the *name* of an :class:`~nab_provider.records.IndexConfig`
+    declared in the coordinator's ordered list.  Routing decides where to
+    fetch a package's listing before any version is known, so a route
+    carries no version scope and no marker; the override layer guarantees
+    at most one route per package.
+    """
+
+    name: str
+    index: str

--- a/nab-project/src/nab_project/config.py
+++ b/nab-project/src/nab_project/config.py
@@ -43,7 +43,7 @@ from nab_provider.policy import (
     ResolveMode,
     VcsSource,
 )
-from nab_provider.records import IndexConfig
+from nab_provider.records import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL, IndexConfig
 from nab_provider.serialization import SimpleSerialization
 from nab_provider.subdir import subdirectory_escapes
 from nab_provider.tags import (
@@ -65,6 +65,7 @@ from nab_provider.target import (
 from nab_provider.vcs_admission import VcsConfig, VcsPolicy, known_vcs_schemes
 
 from . import toml_io
+from ._routes import IndexRoute
 from ._toml import tool_nab_section
 from ._value import ValueType
 from .config_sources import (
@@ -80,7 +81,6 @@ from .config_sources import (
     resolve_anchor,
     resolve_config,
 )
-from .fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL, IndexRoute
 from .paths import realpath, resolve_path
 from .workspace import (
     WorkspaceConfig,

--- a/nab-project/src/nab_project/config_sources.py
+++ b/nab-project/src/nab_project/config_sources.py
@@ -51,14 +51,13 @@ from nab_provider.policy import (
     ResolveMode,
     VcsSource,
 )
-from nab_provider.records import IndexConfig
+from nab_provider.records import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL, IndexConfig
 from nab_provider.serialization import SimpleSerialization
 from nab_provider.vcs_admission import VcsConfig
 
 from . import toml_io
 from ._toml import tool_nab_section
 from ._value import ValueType
-from .fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL
 from .paths import PathState, is_usable_path_name, path_state
 
 if TYPE_CHECKING:

--- a/nab-project/src/nab_project/download.py
+++ b/nab-project/src/nab_project/download.py
@@ -14,7 +14,6 @@ programmatically after :func:`~nab_project.resolve.build_lock_input`.
 
 from __future__ import annotations
 
-import asyncio
 import hashlib
 import logging
 import posixpath
@@ -203,6 +202,8 @@ def download_lock(
     already-present files and local ``file://`` artefacts are still
     served.
     """
+    import asyncio  # noqa: PLC0415 (keeps asyncio off the CLI import path)
+
     output_dir.mkdir(parents=True, exist_ok=True)
     artefacts = _coalesce_download_targets(list(iter_artifacts(lock_input)))
     return asyncio.run(
@@ -220,6 +221,8 @@ async def _run_downloads(
     *,
     offline: bool,
 ) -> DownloadResult:
+    import asyncio  # noqa: PLC0415 (keeps asyncio off the CLI import path)
+
     sem = asyncio.Semaphore(max_concurrency)
     client = AsyncSimpleClient(transport)
     written: list[Path] = []

--- a/nab-project/src/nab_project/fetch.py
+++ b/nab-project/src/nab_project/fetch.py
@@ -46,6 +46,7 @@ from nab_provider.serialization import SimpleSerialization
 from nab_provider.store import InMemoryIndex, metadata_pending_key, range_pending_key
 
 from ._build_remote import build_remote_sdist
+from ._routes import IndexRoute
 from ._sources import materialize_source
 from ._toml import parse_pyproject_table
 
@@ -106,22 +107,6 @@ class FetchKind(enum.Enum):
     SDIST = "sdist"
     SDIST_ARCHIVE = "sdist-archive"
     DIRECT_ARCHIVE = "direct-archive"
-
-
-@dataclass(frozen=True, slots=True)
-class IndexRoute:
-    """Per-package index routing rule (a strict pin to one index).
-
-    ``name`` is the package name (canonicalised internally).  ``index``
-    is the *name* of an :class:`IndexConfig` declared in the
-    coordinator's ordered list.  Routing decides where to fetch a
-    package's listing before any version is known, so a route carries no
-    version scope and no marker; the override layer guarantees at most one
-    route per package.
-    """
-
-    name: str
-    index: str
 
 
 def _resolve_routes(routes: list[IndexRoute]) -> dict[str, str]:

--- a/nab-project/src/nab_project/resolve.py
+++ b/nab-project/src/nab_project/resolve.py
@@ -85,7 +85,6 @@ from .config import (
     validate_conflict_minimums,
     with_python_override,
 )
-from .fetch import FetchCoordinator
 from .lockfile import LockInput, TargetLock
 from .pyproject_files import (
     read_pyproject_build_requires,
@@ -104,6 +103,8 @@ if TYPE_CHECKING:
     from nab_provider.provider import ResolutionStrategy
     from nab_provider.resolver_inputs import MarkerHolds
 
+    from .fetch import FetchCoordinator
+
 
 __all__ = [
     "InstallContexts",
@@ -117,6 +118,30 @@ __all__ = [
     "resolve_for_targets",
     "resolve_with_coordinator",
 ]
+
+
+def _fetch_coordinator() -> type[FetchCoordinator]:
+    """Return the coordinator class, importing the fetch stack on first use.
+
+    Reads the module global first, so a test that patches
+    ``nab_project.resolve.FetchCoordinator`` still decides what a resolve builds.
+    """
+    bound: type[FetchCoordinator] | None = globals().get("FetchCoordinator")
+    if bound is not None:
+        return bound
+
+    from .fetch import FetchCoordinator  # noqa: PLC0415 (startup deferral)
+
+    globals()["FetchCoordinator"] = FetchCoordinator
+    return FetchCoordinator
+
+
+def __getattr__(name: str) -> object:
+    """Serve ``FetchCoordinator`` on first attribute access (PEP 562)."""
+    if name != "FetchCoordinator":
+        msg = f"module {__name__!r} has no attribute {name!r}"
+        raise AttributeError(msg)
+    return _fetch_coordinator()
 
 
 _logger = logging.getLogger(__name__)
@@ -212,7 +237,8 @@ def resolve_for_targets(  # noqa: PLR0913 - the knobs of a project resolve
         groups=effective_groups,
     )
 
-    with FetchCoordinator(
+    coordinator_class = _fetch_coordinator()
+    with coordinator_class(
         transport,
         indexes=list(config.indexes),
         cache_dir=cache_dir,

--- a/nab-project/tests/test_resolve.py
+++ b/nab-project/tests/test_resolve.py
@@ -13,6 +13,8 @@ import httpx
 import pytest
 import respx
 
+import nab_project.fetch
+import nab_project.resolve
 from nab_index.client import SdistFile, WheelFile
 from nab_index.httpx_async_transport import HttpxAsyncTransport
 from nab_index.transport import AsyncHttpTransport, HttpError
@@ -190,6 +192,26 @@ def _malformed_group_pyproject(tmp_path: Path) -> Path:
         'conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]\n'
     )
     return pyproject
+
+
+class TestLazyFetchCoordinator:
+    """``nab_project.resolve`` serves ``FetchCoordinator`` through PEP 562."""
+
+    def test_binds_the_real_coordinator_class(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Reading the name imports ``nab_project.fetch`` and yields its class."""
+        # An earlier resolve in this process may already have bound the name.
+        monkeypatch.delattr(nab_project.resolve, "FetchCoordinator", raising=False)
+
+        assert (
+            nab_project.resolve.FetchCoordinator is nab_project.fetch.FetchCoordinator
+        )
+
+    def test_unknown_name_still_raises_attribute_error(self) -> None:
+        """The module ``__getattr__`` answers only for the one deferred name."""
+        with pytest.raises(AttributeError, match="no attribute 'no_such_name'"):
+            _ = nab_project.resolve.no_such_name
 
 
 class TestSpecificModeConflictValidation:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6500,6 +6500,26 @@ assert not leaked, f"importing nab.cli loaded {leaked}"
 """
 
 
+_FETCH_STACK_PROBE = """
+import sys
+
+import nab.cli
+
+leaked = sorted(
+    {
+        "asyncio",
+        "nab_index.cached_client",
+        "nab_index.lazy_wheel",
+        "nab_index.multi_index",
+        "nab_project.fetch",
+        "nab_provider.store",
+    }
+    & sys.modules.keys()
+)
+assert not leaked, f"importing nab.cli loaded {leaked}"
+"""
+
+
 class TestCliImportPath:
     """What importing :mod:`nab.cli` is allowed to pull in."""
 
@@ -6517,6 +6537,12 @@ class TestCliImportPath:
         """
         subprocess.run(  # noqa: S603 - the probe is this file's own source
             [sys.executable, "-c", _STDLIB_MODULE_PROBE], check=True
+        )
+
+    def test_fetch_stack_stays_unimported(self) -> None:
+        """asyncio and the coordinator belong to a resolve, not to startup."""
+        subprocess.run(  # noqa: S603 - the probe is this file's own source
+            [sys.executable, "-c", _FETCH_STACK_PROBE], check=True
         )
 
 


### PR DESCRIPTION
Importing `nab.cli` retires 7.8% fewer instructions, and the installed `nab --version` 7.5%. A command that resolves pays about half a percent more.

| workload | main | branch | change |
| --- | ---: | ---: | ---: |
| `import nab.cli` | 837,464,472 | 771,916,726 | -65,547,746 |
| `nab --version` | 802,192,990 | 741,864,375 | -60,328,615 |
| `nab lock`, one dependency, offline | 1,006,696,684 | 1,011,812,321 | +5,115,637 |

The lock row is `gc.freeze()`: `nab._entry` freezes the heap right after importing the CLI, the deferred subtree is no longer in it, so the freeze covers 8,534 fewer objects and the collector walks them during the resolve. The same lock under `python -m nab`, which never freezes, is +125,539 of 1,118,103,295.

`IndexRoute` moves to `nab_project._routes`, so `config.py` and `config_sources.py` stop importing `fetch.py`; `resolve.py` binds `FetchCoordinator` on first use through a module `__getattr__`; `download.py` imports asyncio inside the two functions that need it.

43 modules leave the import path, 35 of them the asyncio subtree; a probe in `tests/test_cli.py` pins asyncio and five of the rest by name. Live traced bytes at import fall about 16%, roughly 2.5 MB of 15.7 MB.

The asyncio half needs typing_extensions 4.16 or newer; before that, the `@deprecated` decorators in tyro import `asyncio.coroutines` on Python 3.12 whatever nab does.

Timing `nab cache dir` locally only rules out a regression: nothing above about 6% wall or about 1.8% peak RSS.
