### PR TITLE
Read the config ladder once per lock so an unknown NAB_* warns once

### DIFF
--- a/src/nab/_download.py
+++ b/src/nab/_download.py
@@ -118,8 +118,9 @@ def download(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config 
         discover_workspace=workspace_discovery,
         cli_overrides=project_overrides,
     )
+    ladder = _cli.read_config_ladder(path, overrides)
     settings = _cli._layered_run_settings_or_exit(  # noqa: SLF001
-        path, overrides, produces_lock=False
+        ladder, produces_lock=False
     )
     effective_cache_dir = _cli._resolve_effective_cache_dir(  # noqa: SLF001
         settings.cache_dir, cache=cache

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -99,6 +99,8 @@ if TYPE_CHECKING:
 
     from nab_provider.target import ResolveTarget
 
+    from .cli import ConfigLadder
+
 
 _DEFAULT_PROJECT_PATH = Path("pyproject.toml")
 
@@ -245,13 +247,13 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
     )
     project_overrides = _cli.project_config_overrides(overrides)
     _cli._project_cli_overrides_or_exit(project_overrides)  # noqa: SLF001
+    ladder = _cli.read_config_ladder(path, overrides)
     anchor = _determine_lock_anchor(
-        path,
+        ladder,
         output=output,
         format=format,
         build_requirements=build_requirements,
         upgrade=upgrade,
-        cli_overrides=project_overrides,
     )
     config = _cli._load_config(  # noqa: SLF001
         path,
@@ -265,7 +267,7 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
         _cli.printer().error("--locked is not supported in universal mode.")
         sys.exit(1)
     _cli._reject_python_override_in_universal(config, python)  # noqa: SLF001
-    settings = _cli._layered_run_settings_or_exit(path, overrides)  # noqa: SLF001
+    settings = _cli._layered_run_settings_or_exit(ladder)  # noqa: SLF001
     effective_cache_dir = _cli._resolve_effective_cache_dir(  # noqa: SLF001
         settings.cache_dir, cache=cache
     )
@@ -1208,26 +1210,23 @@ def _build_provenance(
 
 
 def _reused_lock_anchor(
-    path: Path,
+    ladder: ConfigLadder,
     *,
     output: Path | None,
     format: str,  # noqa: A002 - shadows builtin by convention
     build_requirements: bool = False,
-    cli_overrides: Mapping[str, object] | None = None,
 ) -> tuple[datetime | None, datetime | None]:
     """Return ``(absolute_cutoff, prior_lock_anchor)`` for the re-lock anchor.
 
     An absolute ``uploaded-prior-to`` fixes the resolve window, so it is the
     anchor regardless of ``--upgrade``, and two locks from identical inputs
-    produce identical bytes.  ``cli_overrides`` carries a
-    ``--project-uploaded-prior-to`` override so the anchor it produces matches
-    the resolve window.  When there is no absolute cutoff, a ``pylock`` written
-    to a file reuses the ``created-at`` from the existing lock so re-locks
-    reproduce the same cutoff; that recorded timestamp is the only anchor
-    ``--upgrade`` actually drops.  Stdout, the requirements formats, and a
-    first lock have nothing to reuse.
+    produce identical bytes.  When there is no absolute cutoff, a ``pylock``
+    written to a file reuses the ``created-at`` from the existing lock so
+    re-locks reproduce the same cutoff; that recorded timestamp is the only
+    anchor ``--upgrade`` actually drops.  Stdout, the requirements formats,
+    and a first lock have nothing to reuse.
     """
-    absolute = _cli.lock_anchor(path, cli_overrides)
+    absolute = _cli.lock_anchor(ladder)
     if absolute is not None:
         return absolute, None
     if _cli.is_stdout(output) or format != "pylock":
@@ -1237,30 +1236,27 @@ def _reused_lock_anchor(
 
 
 def _determine_lock_anchor(
-    path: Path,
+    ladder: ConfigLadder,
     *,
     output: Path | None,
     format: str,  # noqa: A002 - shadows builtin by convention
     build_requirements: bool = False,
     upgrade: bool,
-    cli_overrides: Mapping[str, object] | None = None,
 ) -> datetime:
     """Pick the ``P<n>D`` anchor for ``nab lock``.
 
     Without ``--upgrade`` the anchor is the cutoff a re-lock reuses: an
     absolute ``uploaded-prior-to`` cutoff, or the ``created-at`` from an
-    existing pylock, falling back to ``datetime.now(UTC)``.  ``cli_overrides``
-    is forwarded so a ``--project-uploaded-prior-to`` flag pins the anchor.
-    ``--upgrade`` re-anchors to now.  It changes the resolve only when it drops
-    a reused lockfile ``created-at`` (an absolute cutoff still governs the
-    resolve either way), so the notice fires only in that case.
+    existing pylock, falling back to ``datetime.now(UTC)``.  ``--upgrade``
+    re-anchors to now.  It changes the resolve only when it drops a reused
+    lockfile ``created-at`` (an absolute cutoff still governs the resolve
+    either way), so the notice fires only in that case.
     """
     absolute, prior = _reused_lock_anchor(
-        path,
+        ladder,
         output=output,
         format=format,
         build_requirements=build_requirements,
-        cli_overrides=cli_overrides,
     )
     if upgrade:
         fresh = datetime.now(timezone.utc)

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -328,29 +328,37 @@ def effective_config(
         return resolve_config(layers, env_layer, cli_layer, rejected=rejected)
 
 
-def lock_anchor(
-    path: Path, cli_overrides: Mapping[str, object] | None = None
-) -> datetime | None:
-    """Return the absolute ``uploaded-prior-to`` cutoff for ``nab lock``.
+ConfigLadder = dict[str, EffectiveValue] | SourceConfigError
+"""One read of the layered config: the effective map, or the error it raised."""
 
-    Sources the cutoff through the same registry ladder the resolve uses
-    (so a value set in the project-dir ``nab.toml`` is honoured exactly
-    like one in pyproject ``[tool.nab]``).  ``cli_overrides`` lets a
-    ``--project-uploaded-prior-to`` flag set the cutoff too, so the lock
-    anchor matches the resolve window the override produces.  An absolute
-    datetime is the lock anchor: the resolve window is already fixed, so
-    anchoring there makes ``created-at`` deterministic and two locks from
-    identical inputs produce identical bytes.  A relative ``P<n>D``
-    duration anchors to run time, so it is not reproducible and returns
-    ``None``; an unset value returns ``None`` too.  Config errors are
-    swallowed here (the full resolve parse reports them) so this
-    best-effort read never crashes.
+
+def read_config_ladder(path: Path, cli_overrides: Mapping[str, object]) -> ConfigLadder:
+    """Read the layered config once for a run and hold what came back.
+
+    A command builds one of these and threads it, so the environment is
+    read, and an unknown ``NAB_*`` var warned about, once per
+    invocation.  A category error is held rather than raised because the
+    lock anchor tolerates one and the run-settings fold exits on it.
     """
     try:
-        effective = effective_config(path, cli_overrides=cli_overrides)
-    except SourceConfigError:
+        return effective_config(path, cli_overrides=cli_overrides)
+    except SourceConfigError as exc:
+        return exc
+
+
+def lock_anchor(ladder: ConfigLadder) -> datetime | None:
+    """Return the absolute ``uploaded-prior-to`` cutoff for ``nab lock``.
+
+    An absolute datetime is the lock anchor: it already fixes the resolve
+    window, so anchoring there makes ``created-at`` deterministic and two
+    locks from identical inputs produce identical bytes.  A relative
+    ``P<n>D`` duration anchors to run time, so it is not reproducible and
+    returns ``None``; an unset value, and a ladder that failed to
+    resolve, return ``None`` too.
+    """
+    if isinstance(ladder, SourceConfigError):
         return None
-    value = effective["uploaded-prior-to"].value
+    value = ladder["uploaded-prior-to"].value
     return value if isinstance(value, datetime) else None
 
 
@@ -458,21 +466,16 @@ def project_override_arguments(cli_overrides: Mapping[str, object]) -> list[str]
     return arguments
 
 
-def _layered_run_settings(
-    path: Path, cli_overrides: Mapping[str, object]
-) -> tuple[RunSettings, Mapping[str, EffectiveValue]]:
-    """Fold the layered registry values into a subcommand's run knobs.
+def _layered_run_settings(effective: Mapping[str, EffectiveValue]) -> RunSettings:
+    """Fold the effective registry values into a subcommand's run knobs.
 
-    Returns the :class:`RunSettings` reflecting the full ladder, plus the
-    effective map so the caller can emit the reproducibility notice for a
-    CLI PROJECT override.  ``resolution`` stays ``None`` (config wins
-    downstream) when no source above the default set it, preserving the
-    contract that the resolver falls back to ``config.resolution``.
+    ``resolution`` stays ``None`` (config wins downstream) when no source
+    above the default set it, preserving the contract that the resolver
+    falls back to ``config.resolution``.
     """
-    effective = effective_config(path, cli_overrides=cli_overrides)
     res_ev = effective["resolution"]
     resolution = res_ev.value if res_ev.origin.kind is not SourceKind.DEFAULT else None
-    settings = RunSettings(
+    return RunSettings(
         resolution=resolution,
         offline=effective["offline"].value,
         cache_dir=effective["cache-dir"].value,
@@ -480,31 +483,25 @@ def _layered_run_settings(
         max_concurrency=effective["max-concurrency"].value,
         cli_project_overrides=project_cli_override_records(effective),
     )
-    return settings, effective
 
 
 def _layered_run_settings_or_exit(
-    path: Path,
-    cli_overrides: Mapping[str, object],
-    *,
-    produces_lock: bool = True,
+    ladder: ConfigLadder, *, produces_lock: bool = True
 ) -> RunSettings:
-    """Fold the layered run settings, exiting on a category error.
+    """Fold the ladder's run knobs, exiting on a category error it holds.
 
-    Wraps :func:`_layered_run_settings` with the single
-    ``SourceConfigError`` -> ``error: config error: ...`` -> ``exit(1)`` mapping
-    shared by ``nab lock`` and ``nab download``.  On success it also emits
-    the reproducibility notice when a PROJECT option was set on the CLI,
-    so a result-shaping override is never silent.  ``produces_lock`` picks
-    the wording: ``nab lock`` warns about the lock it produces while ``nab
-    download`` (which writes no lock) warns only that the resolved set
-    reflects the override.
+    The single ``SourceConfigError`` -> ``error: config error: ...`` ->
+    ``exit(1)`` mapping shared by ``nab lock`` and ``nab download`` lives
+    here.  On success it also emits the reproducibility notice when a
+    PROJECT option was set on the CLI, so a result-shaping override is
+    never silent.  ``produces_lock`` picks the wording: ``nab lock`` warns
+    about the lock it produces while ``nab download`` (which writes no
+    lock) warns only that the resolved set reflects the override.
     """
-    try:
-        settings, effective = _layered_run_settings(path, cli_overrides)
-    except SourceConfigError as exc:
-        _fail_config(exc)
-    notice = project_cli_override_notice(effective, produces_lock=produces_lock)
+    if isinstance(ladder, SourceConfigError):
+        _fail_config(ladder)
+    settings = _layered_run_settings(ladder)
+    notice = project_cli_override_notice(ladder, produces_lock=produces_lock)
     if notice is not None:
         sys.stderr.write(notice)
     return settings

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,6 +46,7 @@ from nab._lock import (
 )
 from nab.cli import (
     _DEFAULT_OUTPUT,
+    ConfigLadder,
     _default_cache_dir,
     _make_resolve_transport,
     _make_transport,
@@ -55,6 +56,7 @@ from nab.cli import (
     app,
     console_entry,
     main,
+    read_config_ladder,
 )
 from nab.output import Printer, ProgressReporter, Verbosity
 from nab_index.atomic import atomic_write_text
@@ -4109,6 +4111,11 @@ class TestCliDocstringCommandModules:
         )
 
 
+def _ladder(pyproject: Path) -> ConfigLadder:
+    """Read the config ladder as ``nab lock`` does when no flag overrides a key."""
+    return read_config_ladder(pyproject, {})
+
+
 class TestDetermineLockAnchor:
     """``_determine_lock_anchor`` chooses between fresh and reused anchors."""
 
@@ -4127,7 +4134,7 @@ class TestDetermineLockAnchor:
         self._write_prior(target)
         pyproject = _make_pyproject(tmp_path)
         anchor = _determine_lock_anchor(
-            pyproject, output=target, format="pylock", upgrade=True
+            _ladder(pyproject), output=target, format="pylock", upgrade=True
         )
         assert anchor != self._RECORDED
         assert (datetime.now(timezone.utc) - anchor).total_seconds() < 60
@@ -4141,7 +4148,7 @@ class TestDetermineLockAnchor:
         err = io.StringIO()
         with contextlib.redirect_stderr(err):
             _determine_lock_anchor(
-                pyproject, output=target, format="pylock", upgrade=True
+                _ladder(pyproject), output=target, format="pylock", upgrade=True
             )
         notice = err.getvalue()
         assert "--upgrade re-anchored" in notice
@@ -4156,7 +4163,7 @@ class TestDetermineLockAnchor:
         err = io.StringIO()
         with contextlib.redirect_stderr(err):
             _determine_lock_anchor(
-                pyproject, output=None, format="pylock", upgrade=True
+                _ladder(pyproject), output=None, format="pylock", upgrade=True
             )
         assert err.getvalue() == ""
 
@@ -4173,7 +4180,7 @@ class TestDetermineLockAnchor:
         err = io.StringIO()
         with contextlib.redirect_stderr(err):
             anchor = _determine_lock_anchor(
-                pyproject, output=target, format="pylock", upgrade=True
+                _ladder(pyproject), output=target, format="pylock", upgrade=True
             )
         assert err.getvalue() == ""
         assert (datetime.now(timezone.utc) - anchor).total_seconds() < 60
@@ -4181,7 +4188,7 @@ class TestDetermineLockAnchor:
     def test_stdout_returns_fresh(self, tmp_path: Path) -> None:
         pyproject = _make_pyproject(tmp_path)
         anchor = _determine_lock_anchor(
-            pyproject, output=Path("-"), format="pylock", upgrade=False
+            _ladder(pyproject), output=Path("-"), format="pylock", upgrade=False
         )
         assert (datetime.now(timezone.utc) - anchor).total_seconds() < 60
 
@@ -4189,7 +4196,7 @@ class TestDetermineLockAnchor:
         # requirements format has no [tool.nab] block to read from.
         pyproject = _make_pyproject(tmp_path)
         anchor = _determine_lock_anchor(
-            pyproject,
+            _ladder(pyproject),
             output=tmp_path / "requirements.txt",
             format="requirements",
             upgrade=False,
@@ -4202,7 +4209,7 @@ class TestDetermineLockAnchor:
         monkeypatch.chdir(tmp_path)
         pyproject = _make_pyproject(tmp_path)
         anchor = _determine_lock_anchor(
-            pyproject, output=None, format="pylock", upgrade=False
+            _ladder(pyproject), output=None, format="pylock", upgrade=False
         )
         assert (datetime.now(timezone.utc) - anchor).total_seconds() < 60
 
@@ -4211,7 +4218,7 @@ class TestDetermineLockAnchor:
         self._write_prior(target)
         pyproject = _make_pyproject(tmp_path)
         anchor = _determine_lock_anchor(
-            pyproject, output=target, format="pylock", upgrade=False
+            _ladder(pyproject), output=target, format="pylock", upgrade=False
         )
         assert anchor == self._RECORDED
 
@@ -4223,7 +4230,7 @@ class TestDetermineLockAnchor:
         self._write_prior(tmp_path / "pylock.toml")
         pyproject = _make_pyproject(tmp_path)
         anchor = _determine_lock_anchor(
-            pyproject, output=None, format="pylock", upgrade=False
+            _ladder(pyproject), output=None, format="pylock", upgrade=False
         )
         assert anchor == self._RECORDED
 
@@ -4237,7 +4244,7 @@ class TestDetermineLockAnchor:
             f'[tool.nab]\nuploaded-prior-to = "{self._ABSOLUTE.isoformat()}"\n',
         )
         anchor = _determine_lock_anchor(
-            pyproject, output=target, format="pylock", upgrade=False
+            _ladder(pyproject), output=target, format="pylock", upgrade=False
         )
         assert anchor == self._ABSOLUTE
 
@@ -4253,7 +4260,7 @@ class TestDetermineLockAnchor:
             f'uploaded-prior-to = "{self._ABSOLUTE.isoformat()}"\n'
         )
         anchor = _determine_lock_anchor(
-            pyproject, output=target, format="pylock", upgrade=False
+            _ladder(pyproject), output=target, format="pylock", upgrade=False
         )
         assert anchor == self._ABSOLUTE
 
@@ -4261,9 +4268,7 @@ class TestDetermineLockAnchor:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         # A category-gated value (uploaded-prior-to in a USER source) makes
-        # the best-effort anchor read raise SourceConfigError; it is
-        # swallowed so the full resolve parse reports it, and the anchor
-        # falls through to the prior lock.
+        # the ladder read fail, so the anchor falls through to the prior lock.
         target = tmp_path / "pylock.toml"
         self._write_prior(target)
         pyproject = _make_pyproject(tmp_path)
@@ -4280,7 +4285,7 @@ class TestDetermineLockAnchor:
 
         monkeypatch.setattr("nab.cli._config_search_roots", fake_roots)
         anchor = _determine_lock_anchor(
-            pyproject, output=target, format="pylock", upgrade=False
+            _ladder(pyproject), output=target, format="pylock", upgrade=False
         )
         assert anchor == self._RECORDED
 
@@ -4291,7 +4296,7 @@ class TestDetermineLockAnchor:
             f'[tool.nab]\nuploaded-prior-to = "{self._ABSOLUTE.isoformat()}"\n',
         )
         anchor = _determine_lock_anchor(
-            pyproject, output=None, format="pylock", upgrade=True
+            _ladder(pyproject), output=None, format="pylock", upgrade=True
         )
         assert anchor != self._ABSOLUTE
         assert (datetime.now(timezone.utc) - anchor).total_seconds() < 60
@@ -4304,7 +4309,7 @@ class TestDetermineLockAnchor:
             '[project]\ndependencies = ["foo"]\n[tool.nab]\nuploaded-prior-to = "P4D"\n',
         )
         anchor = _determine_lock_anchor(
-            pyproject, output=target, format="pylock", upgrade=False
+            _ladder(pyproject), output=target, format="pylock", upgrade=False
         )
         assert anchor == self._RECORDED
 

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -39,7 +39,13 @@ from nab._download import download
 from nab._lock import lock
 from nab.cli import app, effective_config
 from nab_project.config import NabProjectConfig
-from nab_project.config_sources import OPTIONS, OptionSpec, Scope, SourceRoots
+from nab_project.config_sources import (
+    OPTIONS,
+    OptionSpec,
+    Scope,
+    SourceConfigError,
+    SourceRoots,
+)
 from nab_project.download import DownloadResult
 from nab_project.lockfile import (
     IndexPin,
@@ -823,6 +829,31 @@ class TestCliFlagValues:
         assert covered == set(_CLI_FLAGS)
 
 
+def _fold_run_settings(
+    path: Path,
+    *,
+    cli_offline: bool | None = None,
+    cli_cache_dir: Path | None = None,
+    cli_http_backend: str | None = None,
+    cli_max_concurrency: int | None = None,
+) -> nab_cli.RunSettings:
+    """The run knobs a subcommand folds from ``path`` under these CLI flags.
+
+    The assert reports a ladder holding a config error as itself, rather
+    than as a subscript failure inside the fold.
+    """
+    overrides = nab_cli._cli_overrides(
+        cli_resolution=None,
+        cli_offline=cli_offline,
+        cli_cache_dir=cli_cache_dir,
+        cli_http_backend=cli_http_backend,
+        cli_max_concurrency=cli_max_concurrency,
+    )
+    ladder = nab_cli.read_config_ladder(path, overrides)
+    assert not isinstance(ladder, SourceConfigError), ladder
+    return nab_cli._layered_run_settings(ladder)
+
+
 class TestEffectiveConfigBridge:
     def test_effective_config_default_roots_callable(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -840,12 +871,7 @@ class TestEffectiveConfigBridge:
 
     def test_layered_run_settings_defaults_noop(self, tmp_path: Path) -> None:
         proj = _project(tmp_path)
-        settings, _effective = nab_cli._layered_run_settings(
-            proj,
-            nab_cli._cli_overrides(
-                cli_resolution=None, cli_offline=None, cli_cache_dir=None
-            ),
-        )
+        settings = _fold_run_settings(proj)
         assert settings.resolution is None
         assert settings.offline is False
         assert settings.cache_dir is None
@@ -856,21 +882,13 @@ class TestEffectiveConfigBridge:
         self, hermetic_roots: Path
     ) -> None:
         _project(hermetic_roots, 'resolution = "lowest"\n')
-        settings, _effective = nab_cli._layered_run_settings(
-            hermetic_roots / "pyproject.toml",
-            nab_cli._cli_overrides(
-                cli_resolution=None, cli_offline=None, cli_cache_dir=None
-            ),
-        )
+        settings = _fold_run_settings(hermetic_roots / "pyproject.toml")
         assert settings.resolution is ResolutionStrategy.LOWEST
 
     def test_layered_run_settings_cli_offline_set(self, hermetic_roots: Path) -> None:
         _project(hermetic_roots)
-        settings, _effective = nab_cli._layered_run_settings(
-            hermetic_roots / "pyproject.toml",
-            nab_cli._cli_overrides(
-                cli_resolution=None, cli_offline=True, cli_cache_dir=None
-            ),
+        settings = _fold_run_settings(
+            hermetic_roots / "pyproject.toml", cli_offline=True
         )
         assert settings.offline is True
 
@@ -881,32 +899,23 @@ class TestEffectiveConfigBridge:
         # a lower NAB_OFFLINE=1 env value.
         _project(hermetic_roots)
         monkeypatch.setenv("NAB_OFFLINE", "1")
-        settings, _effective = nab_cli._layered_run_settings(
-            hermetic_roots / "pyproject.toml",
-            nab_cli._cli_overrides(
-                cli_resolution=None, cli_offline=False, cli_cache_dir=None
-            ),
+        settings = _fold_run_settings(
+            hermetic_roots / "pyproject.toml", cli_offline=False
         )
         assert settings.offline is False
 
     def test_cli_no_offline_beats_project_toml(self, hermetic_roots: Path) -> None:
         _project(hermetic_roots)
         _write(hermetic_roots / "nab.toml", "offline = true\n")
-        settings, _effective = nab_cli._layered_run_settings(
-            hermetic_roots / "pyproject.toml",
-            nab_cli._cli_overrides(
-                cli_resolution=None, cli_offline=False, cli_cache_dir=None
-            ),
+        settings = _fold_run_settings(
+            hermetic_roots / "pyproject.toml", cli_offline=False
         )
         assert settings.offline is False
 
     def test_layered_run_settings_cli_cache_dir(self, hermetic_roots: Path) -> None:
         _project(hermetic_roots)
-        settings, _effective = nab_cli._layered_run_settings(
-            hermetic_roots / "pyproject.toml",
-            nab_cli._cli_overrides(
-                cli_resolution=None, cli_offline=None, cli_cache_dir=Path("/c/cli")
-            ),
+        settings = _fold_run_settings(
+            hermetic_roots / "pyproject.toml", cli_cache_dir=Path("/c/cli")
         )
         assert settings.cache_dir == Path("/c/cli")
 
@@ -917,23 +926,14 @@ class TestEffectiveConfigBridge:
         _project(hermetic_roots)
         monkeypatch.setenv("NAB_HTTP_BACKEND", "httpx")
         monkeypatch.setenv("NAB_MAX_CONCURRENCY", "3")
-        settings, _effective = nab_cli._layered_run_settings(
-            hermetic_roots / "pyproject.toml",
-            nab_cli._cli_overrides(
-                cli_resolution=None, cli_offline=None, cli_cache_dir=None
-            ),
-        )
+        settings = _fold_run_settings(hermetic_roots / "pyproject.toml")
         assert settings.http_backend == "httpx"
         assert settings.max_concurrency == 3
-        cli_settings, _ = nab_cli._layered_run_settings(
+
+        cli_settings = _fold_run_settings(
             hermetic_roots / "pyproject.toml",
-            nab_cli._cli_overrides(
-                cli_resolution=None,
-                cli_offline=None,
-                cli_cache_dir=None,
-                cli_http_backend="urllib3",
-                cli_max_concurrency=16,
-            ),
+            cli_http_backend="urllib3",
+            cli_max_concurrency=16,
         )
         assert cli_settings.http_backend == "urllib3"
         assert cli_settings.max_concurrency == 16
@@ -1247,9 +1247,10 @@ class TestProjectCliOverrides:
         self, hermetic_roots: Path
     ) -> None:
         proj = _project(hermetic_roots)
-        anchor = nab_cli.lock_anchor(
+        ladder = nab_cli.read_config_ladder(
             proj, {"uploaded-prior-to": "2024-06-01T00:00:00Z"}
         )
+        anchor = nab_cli.lock_anchor(ladder)
         assert anchor == datetime(2024, 6, 1, tzinfo=timezone.utc)
 
     def test_relative_uploaded_prior_to_override_pins_no_anchor(
@@ -1258,17 +1259,19 @@ class TestProjectCliOverrides:
         # A P<n>D override sets the resolve window relative to the run but is
         # not a reusable absolute cutoff, so it pins no lock anchor.
         proj = _project(hermetic_roots)
-        assert nab_cli.lock_anchor(proj, {"uploaded-prior-to": "P7D"}) is None
+        ladder = nab_cli.read_config_ladder(proj, {"uploaded-prior-to": "P7D"})
+        assert nab_cli.lock_anchor(ladder) is None
 
-    def test_lock_anchor_swallows_digit_run_past_int_limit(
+    def test_lock_anchor_none_for_digit_run_past_int_limit(
         self, hermetic_roots: Path
     ) -> None:
         # A digit run past CPython's int limit raises a bare ValueError;
-        # the best-effort anchor read swallows it like any config error.
+        # the ladder read holds it like any config error, so the anchor
+        # read stays quiet.
         proj = _project(
             hermetic_roots, 'environment = { python = "3.' + "9" * 5000 + '" }\n'
         )
-        assert nab_cli.lock_anchor(proj) is None
+        assert nab_cli.lock_anchor(nab_cli.read_config_ladder(proj, {})) is None
 
 
 class TestDownloadLadder:

--- a/tests/test_env_layer.py
+++ b/tests/test_env_layer.py
@@ -1,0 +1,73 @@
+"""Tests for the ``NAB_*`` environment layer the config ladder reads."""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+
+from nab.cli import main
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_PROJECT = '[project]\nname = "probe"\nversion = "0.1"\ndependencies = []\n'
+
+_TYPO_WARNING = "NAB_OFLINE is not a recognized nab setting"
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        pytest.param(
+            (
+                "lock",
+                "{project}/pyproject.toml",
+                "--output",
+                "{project}/pylock.toml",
+                "--cache-dir",
+                "{project}/cache",
+            ),
+            id="lock",
+        ),
+        pytest.param(
+            (
+                "download",
+                "{project}/pyproject.toml",
+                "--output",
+                "{project}/wheels",
+                "--cache-dir",
+                "{project}/cache",
+            ),
+            id="download",
+        ),
+        pytest.param(
+            ("config", "list", "--path", "{project}/pyproject.toml"),
+            id="config-list",
+        ),
+        pytest.param(("cache", "dir"), id="cache-dir"),
+    ],
+)
+def test_unknown_env_warning_fires_once(
+    argv: tuple[str, ...],
+    hermetic_roots: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Every command reads the env layer once, so a typo warns once.
+
+    The count is the assertion: zero would mean the guard stopped
+    running, and two that the command built the layer twice.
+    """
+    (hermetic_roots / "pyproject.toml").write_text(_PROJECT)
+    monkeypatch.setenv("NAB_OFLINE", "1")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["nab", *(part.format(project=hermetic_roots) for part in argv)],
+    )
+
+    main()
+
+    assert capsys.readouterr().err.count(_TYPO_WARNING) == 1


### PR DESCRIPTION
An unrecognized `NAB_*` variable makes `nab lock` print the same warning twice:

```
$ NAB_OFLINE=1 nab lock pyproject.toml
warning: NAB_OFLINE is not a recognized nab setting and was ignored; the known NAB_* variables are [...].
warning: NAB_OFLINE is not a recognized nab setting and was ignored; the known NAB_* variables are [...].
```

It resolves the layered config twice, in `lock_anchor` for the `uploaded-prior-to` cutoff and in `_layered_run_settings` for the run knobs, and each pass reads `NAB_*` and warns about what it does not recognize. `lock()` now calls `read_config_ladder` once and threads the result into both.

`read_config_ladder` returns the effective map or the `SourceConfigError` resolving it raised, rather than raising: the anchor read returns `None` on one, and the settings fold is still what prints `error: config error: ...` and exits 1.

The shared ladder is built from the whole CLI override map where the anchor previously saw only the PROJECT subset. `uploaded-prior-to` is in both, so `--project-uploaded-prior-to` still pins the anchor.

`nab download`, `nab config list` and `nab cache dir` warned once before this change and still do.