### PR TITLE
Route python -m nab through nab._entry, ~11% off its --version

### DIFF
--- a/src/nab/__main__.py
+++ b/src/nab/__main__.py
@@ -1,6 +1,6 @@
 """Allow ``python -m nab ...`` to drive the CLI."""
 
-from .cli import main
+from ._entry import console_entry
 
 if __name__ == "__main__":
-    main()
+    console_entry()

--- a/src/nab/_entry.py
+++ b/src/nab/_entry.py
@@ -1,25 +1,20 @@
-"""Process entry for the installed ``nab`` command."""
+"""Process entry for the ``nab`` command and for ``python -m nab``."""
 
 from __future__ import annotations
 
 import gc
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from typing import NoReturn
 
 
-def console_entry() -> NoReturn:
+def console_entry() -> None:
     """Import the CLI with the cyclic collector off, then hand the process to it.
 
-    The console script names this module rather than :mod:`nab.cli` so that no
+    Both entry paths name this module rather than :mod:`nab.cli` so that no
     part of the CLI's import graph is built while the collector is on: the
     import allocates a graph the process keeps, and every pass over it frees
     almost none of it. Freezing empties the generations the import filled, so
     re-enabling does not trigger a pass over the whole graph.
 
-    Only the installed command takes this path, so importing :mod:`nab.cli`
-    leaves the collector as it found it.
+    Importing :mod:`nab.cli` leaves the collector as it found it.
     """
     gc.disable()
     try:

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -640,17 +640,16 @@ def _python_override_or_exit(
 def _collector_paused() -> Iterator[None]:
     """Disable the cyclic collector for the duration of the resolve.
 
-    Only the CLI sets a collector policy, since it owns its process; the
-    library entry points leave it alone. Exit enables the collector rather
-    than restoring the state it found.
+    Exit enables the collector and unfreezes rather than restoring what it
+    found, so every caller of :func:`_resolve` is left in that state and not
+    the one it came in with.
 
     Everything the resolve allocated is in generation 0 by then, so the
     collections that follow the enable walk the whole resolve graph. Freezing
     empties every generation into the permanent one and unfreezing returns the
     permanent generation to generation 2, which takes the graph out of
-    generation 0 and leaves those collections less to walk. Unfreezing also
-    returns anything frozen before the resolve; the CLI owns its process.
-    PyPy has no ``gc.freeze``.
+    generation 0 and leaves those collections less to walk. PyPy has no
+    ``gc.freeze``.
     """
     gc.disable()
     try:
@@ -988,10 +987,10 @@ def _flush_std_streams() -> bool:
 def console_entry() -> NoReturn:
     """Run the CLI, then end the process without freeing the resolve graph.
 
-    Only the installed ``nab`` command takes this path, because it owns its
-    process; :func:`main` returns normally for every other caller. No
-    ``atexit`` hook and no finalizer runs after this, so a command has to
-    finish any work it cannot lose before :func:`main` returns.
+    Both ``nab`` and ``python -m nab`` end here; :func:`main` returns
+    normally for every other caller. No ``atexit`` hook and no finalizer runs
+    after this, so a command has to finish any work it cannot lose before
+    :func:`main` returns.
     """
     status = 0
     try:

--- a/tasks/check_dists.py
+++ b/tasks/check_dists.py
@@ -159,8 +159,8 @@ def _check_version(command: list[str], version: str) -> None:
 def install_wheels(dist_root: Path, scratch: Path) -> None:
     """Install every wheel together, then import each package and run the CLI.
 
-    ``python -m nab`` and the console script enter through different
-    functions, so both are run.
+    ``[project.scripts]`` and ``src/nab/__main__.py`` name the entry
+    independently of each other, so both are run.
     """
     wheels = [str(_wheel(dist_root, package)) for package in PACKAGES]
     version = _wheel_version(_wheel(dist_root, "nab"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,10 +50,11 @@ def _reset_nab_output(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
 
 @pytest.fixture
 def restored_gc_state() -> Iterator[None]:
-    """Put the cyclic collector back the way the test found it.
+    """Restore ``gc.isenabled()`` after the test.
 
     A test that lets the CLI switch the collector off leaks that state into
-    the rest of the session when the CLI's own restore is what broke.
+    the rest of the session when the CLI's own restore is what broke. The
+    permanent generation is not part of this; see :func:`stubbed_gc_freeze`.
     """
     enabled = gc.isenabled()
     try:
@@ -63,6 +64,17 @@ def restored_gc_state() -> Iterator[None]:
             gc.enable()
         else:
             gc.disable()
+
+
+@pytest.fixture
+def stubbed_gc_freeze(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace ``gc.freeze`` with a no-op for a test that runs the real entry.
+
+    :func:`nab._entry.console_entry` freezes the import graph, and there is no
+    partial unfreeze to undo it, so a real call would leave everything the
+    session holds in the permanent generation.
+    """
+    monkeypatch.setattr(gc, "freeze", lambda: None)
 
 
 @pytest.fixture

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5604,11 +5604,37 @@ class TestPackageVersion:
         """The literal tracks the version the distribution declares."""
         assert nab_version.__version__ == importlib.metadata.version("nab")
 
-    def test_python_dash_m_runs_main(self) -> None:
-        """``python -m nab`` invokes the CLI's main() entry point."""
-        with patch("nab.cli.main") as mock_main:
+    @pytest.mark.usefixtures("restored_gc_state", "stubbed_gc_freeze")
+    def test_python_dash_m_runs_console_entry(self) -> None:
+        """``python -m nab`` ends in ``os._exit``, not by returning from main().
+
+        ``os._exit`` is patched because the real call would end the test
+        session from inside runpy.
+        """
+        with (
+            patch("nab.cli.main") as mock_main,
+            patch("nab.cli.os._exit") as mock_exit,
+        ):
             runpy.run_module("nab", run_name="__main__")
+
         mock_main.assert_called_once()
+        mock_exit.assert_called_once_with(0)
+
+    def test_python_dash_m_takes_the_collector_off_entry(self) -> None:
+        """``python -m nab`` calls :mod:`nab._entry`'s entry, not the CLI's.
+
+        Both end in the same CLI call, so the swap is invisible to any test
+        that only checks what the command did. Only :mod:`nab._entry` builds
+        the CLI's import graph with the collector off.
+        """
+        with (
+            patch("nab._entry.console_entry") as mock_entry,
+            patch("nab.cli.console_entry") as mock_cli_entry,
+        ):
+            runpy.run_module("nab", run_name="__main__")
+
+        mock_entry.assert_called_once_with()
+        assert mock_cli_entry.call_count == 0
 
 
 class TestMain:
@@ -5800,7 +5826,7 @@ class TestMain:
 
 
 class TestConsoleEntry:
-    """Tests for the installed ``nab`` command's entry point.
+    """Tests for ``console_entry``, which both entry paths reach.
 
     ``os._exit`` ends the process outright, so every test here patches it.
     """
@@ -5864,7 +5890,7 @@ class TestClosedStandardStreams:
 
     CPython leaves the matching ``sys`` attribute as ``None`` when the
     descriptor is closed before the process starts. ``os._exit`` ends the
-    process outright, so the tests that go through ``console_entry`` patch it.
+    process outright, so every test here patches it.
     """
 
     def test_closed_stdout_exits_120(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -5924,32 +5950,35 @@ class TestClosedStandardStreams:
             console_entry()
         mock_exit.assert_called_once_with(120)
 
+    @pytest.mark.usefixtures("restored_gc_state", "stubbed_gc_freeze")
     def test_python_dash_m_exits_120(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """``python -m nab`` exits 120 rather than returning normally."""
         monkeypatch.setattr(sys, "argv", ["nab", "--version"])
         monkeypatch.setattr(sys, "stdout", None)
-        with pytest.raises(SystemExit) as excinfo:
+        with patch("nab.cli.os._exit") as mock_exit:
             runpy.run_module("nab", run_name="__main__")
-        assert excinfo.value.code == 120
+        mock_exit.assert_called_once_with(120)
 
+    @pytest.mark.usefixtures("restored_gc_state", "stubbed_gc_freeze")
     def test_python_dash_m_reports_a_loss_over_the_command_status(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A failing command whose error had nowhere to go exits 120, not 2."""
         monkeypatch.setattr(sys, "argv", ["nab", "--color", "rainbow", "lock"])
         monkeypatch.setattr(sys, "stderr", None)
-        with pytest.raises(SystemExit) as excinfo:
+        with patch("nab.cli.os._exit") as mock_exit:
             runpy.run_module("nab", run_name="__main__")
-        assert excinfo.value.code == 120
+        mock_exit.assert_called_once_with(120)
 
+    @pytest.mark.usefixtures("restored_gc_state", "stubbed_gc_freeze")
     def test_python_dash_m_with_open_streams_keeps_its_status(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A run that loses no output keeps its own exit status."""
         monkeypatch.setattr(sys, "argv", ["nab", "--color", "rainbow", "lock"])
-        with pytest.raises(SystemExit) as excinfo:
+        with patch("nab.cli.os._exit") as mock_exit:
             runpy.run_module("nab", run_name="__main__")
-        assert excinfo.value.code == 2
+        mock_exit.assert_called_once_with(2)
 
 
 class TestSystemExitStatus:

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -1,10 +1,13 @@
-"""Tests for the installed ``nab`` command's process entry."""
+"""Tests for the process entry both the ``nab`` command and ``python -m nab`` use."""
 
 from __future__ import annotations
 
 import builtins
 import gc
 import importlib
+import os
+import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -15,8 +18,16 @@ from nab._entry import console_entry
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
+_TYPING_PROBE = """
+import sys
 
-@pytest.mark.usefixtures("restored_gc_state")
+import nab._entry
+
+assert "typing" not in sys.modules, "importing nab._entry loaded typing"
+"""
+
+
+@pytest.mark.usefixtures("restored_gc_state", "stubbed_gc_freeze")
 def test_imports_the_cli_while_the_collector_is_off(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -33,9 +44,6 @@ def test_imports_the_cli_while_the_collector_is_off(
         if name == "nab.cli":
             enabled_at_import.append(gc.isenabled())
         return real_import(name, *args, **kwargs)
-
-    # A real freeze would make every object the test session holds permanent.
-    monkeypatch.setattr(gc, "freeze", lambda: None)
 
     monkeypatch.setattr("nab.cli.console_entry", lambda: None)
     monkeypatch.setattr(builtins, "__import__", record_import)
@@ -80,10 +88,28 @@ def test_without_gc_freeze_still_reenables_the_collector(
 def test_console_script_runs_the_collector_off_entry() -> None:
     """``[project.scripts]`` points the ``nab`` command at this module.
 
-    The console script is the only thing that reaches it, so a target left on
-    ``nab.cli`` would pass every other test.
+    Nothing else reads that declaration, so a target left on ``nab.cli`` would
+    pass every other test in this file.
     """
     pyproject = tomli.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
     module_name, _, attribute = pyproject["project"]["scripts"]["nab"].partition(":")
 
     assert getattr(importlib.import_module(module_name), attribute) is console_entry
+
+
+def test_the_entry_module_loads_no_typing() -> None:
+    """Importing this module pulls in no ``typing``.
+
+    A ``TYPE_CHECKING`` import is still an ``import typing`` at runtime, and
+    this module is imported before :func:`console_entry` switches the
+    collector off. Only a fresh interpreter can see it: the test session has
+    ``typing`` loaded before collection starts.
+    """
+    # coverage's .pth imports coverage, and so typing, in any child it starts.
+    env = dict(os.environ)
+    env.pop("COVERAGE_PROCESS_START", None)
+    env.pop("COVERAGE_PROCESS_CONFIG", None)
+
+    subprocess.run(  # noqa: S603 - the probe is this file's own source
+        [sys.executable, "-c", _TYPING_PROBE], check=True, env=env
+    )


### PR DESCRIPTION
`python -m nab --version` loses 97,350,960 instructions, 11.1% of the base process's 878,263,477, and runs about 15% faster locally. The counts reproduce anywhere; timings do not.

| | instructions | share |
| --- | ---: | ---: |
| teardown skipped | 63,077,895 | 7.18% |
| CLI imported with the collector off | 34,208,659 | 3.90% |
| `typing` shed via `nab.cli` | 64,406 | 0.01% |

`__main__.py` called `main()` and returned, so the process paid interpreter teardown. It now calls `console_entry`, which flushes the streams and leaves through `os._exit`, and importing through `nab._entry` builds the CLI's graph with the collector off.

The installed `nab` command never imports `__main__.py`; it gains 1,161,001 of 781,932,298, 0.15%, from `_entry.py` shedding `from typing import TYPE_CHECKING`.

A host importing `nab.cli` gets no collector policy.
