### PR TITLE
Open the resolve's fetches at max-concurrency, not a fixed 50

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1038,7 +1038,7 @@ written, like `git config` reporting configured rather than derived state.
 | `NAB_OFFLINE` | `offline` | `1`/`0`/`true`/`false`. |
 | `NAB_CACHE_DIR` | `cache-dir` | Cache root path. |
 | `NAB_HTTP_BACKEND` | `http-backend` | `urllib3` or `httpx`. |
-| `NAB_MAX_CONCURRENCY` | `max-concurrency` | Parallel HTTP fetches for `nab download` (at least `1`). |
+| `NAB_MAX_CONCURRENCY` | `max-concurrency` | Parallel HTTP fetches, for the resolve as well as the downloads (at least `1`). |
 
 A `NAB_*` name that is not one of these (a typo, or `NAB_RESOLUTION`
 for a project-scope option) is ignored with a warning naming the

--- a/nab-project/src/nab_project/fetch.py
+++ b/nab-project/src/nab_project/fetch.py
@@ -72,6 +72,9 @@ __all__ = [
 
 # Maximum time the main thread waits for the fetcher thread to drain
 # its queue and exit on :meth:`FetchCoordinator.shutdown`.
+# How many fetches a resolve opens at once when its caller names no bound.
+DEFAULT_MAX_CONCURRENCY = 50
+
 _COORDINATOR_JOIN_TIMEOUT_SECONDS = 10
 
 # A warm listing whose parsed blob is smaller than this is declined to the
@@ -233,7 +236,7 @@ class FetchCoordinator:
         transport: AsyncHttpTransport,
         *,
         indexes: list[IndexConfig] | None = None,
-        max_concurrency: int = 50,
+        max_concurrency: int = DEFAULT_MAX_CONCURRENCY,
         cache_dir: Path | None = None,
         cache_backend: CacheBackend | None = None,
         offline: bool = False,

--- a/nab-project/src/nab_project/resolve.py
+++ b/nab-project/src/nab_project/resolve.py
@@ -78,7 +78,12 @@ from .conflicts import (
     validate_conflict_exclusions,
     validate_conflict_minimums,
 )
-from .fetch import FetchCoordinator, index_cache_floors, index_routes
+from .fetch import (
+    DEFAULT_MAX_CONCURRENCY,
+    FetchCoordinator,
+    index_cache_floors,
+    index_routes,
+)
 from .inputs import ResolveInputs
 from .lockfile import LockInput, TargetLock
 
@@ -135,6 +140,7 @@ def resolve_for_targets(  # noqa: PLR0913 - the knobs of a project resolve
     build_requirements: bool = False,
     resolution_strategy: ResolutionStrategy | None = None,
     progress: ProgressSink | None = None,
+    max_concurrency: int = DEFAULT_MAX_CONCURRENCY,
 ) -> ResolveResult:
     """Resolve the project at ``path`` for each of ``targets``.
 
@@ -191,6 +197,7 @@ def resolve_for_targets(  # noqa: PLR0913 - the knobs of a project resolve
         index_cache_floors=index_cache_floors(inputs),
         on_fetch=progress.on_fetch if progress is not None else None,
         build_config=inputs,
+        max_concurrency=max_concurrency,
     ) as coordinator:
         return resolve_with_coordinator(
             coordinator,

--- a/nab-project/tests/test_resolve.py
+++ b/nab-project/tests/test_resolve.py
@@ -31,6 +31,7 @@ from nab_project.conflicts import (
     ConflictSelectionError,
     ConflictSet,
 )
+from nab_project.fetch import DEFAULT_MAX_CONCURRENCY
 from nab_project.inputs import ResolveInputs
 from nab_project.lockfile import LockInput, PinShape, build_pylock
 from nab_project.pyproject_files import (
@@ -7378,3 +7379,39 @@ class TestPyprojectParsedOnce:
             ).raise_for_failure()
 
         assert parsed.count(body) == 1
+
+
+class TestFetchWidth:
+    """The width the resolve opens its fetches at is the caller's to set."""
+
+    @staticmethod
+    def _project(tmp_path: Path) -> Path:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\nversion = "0"\ndependencies = []\n'
+        )
+        return pyproject
+
+    @staticmethod
+    def _width(path: Path, **kwargs: object) -> int:
+        """The ``max_concurrency`` the resolve hands its coordinator."""
+        with patch("nab_project.resolve.FetchCoordinator") as mock_coord_cls:
+            mock_coord_cls.return_value.__enter__ = MagicMock(
+                side_effect=RuntimeError("stop after construction")
+            )
+            try:
+                _resolved(path, **kwargs)
+            except RuntimeError:
+                pass
+
+        return mock_coord_cls.call_args.kwargs["max_concurrency"]
+
+    def test_an_unset_width_is_the_named_default(self, tmp_path: Path) -> None:
+        path = self._project(tmp_path)
+
+        assert self._width(path) == DEFAULT_MAX_CONCURRENCY
+
+    def test_the_callers_width_reaches_the_coordinator(self, tmp_path: Path) -> None:
+        path = self._project(tmp_path)
+
+        assert self._width(path, max_concurrency=3) == 3

--- a/src/nab/_download.py
+++ b/src/nab/_download.py
@@ -142,6 +142,7 @@ def download(  # noqa: PLR0913 - one keyword per flag is the public surface
         extras=selected_extras,
         resolution_strategy=settings.resolution,
         progress=ProgressReporter(printer()),
+        max_concurrency=settings.max_concurrency,
     )
     lock_input = build_lock_input(
         result,

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -344,6 +344,7 @@ def lock(  # noqa: PLR0913 - one keyword per flag is the public surface
         build_requirements=build_requirements,
         resolution_strategy=settings.resolution,
         progress=ProgressReporter(printer()),
+        max_concurrency=settings.max_concurrency,
     )
 
     lock_input = drop_workspace_pins(

--- a/src/nab/_resolve.py
+++ b/src/nab/_resolve.py
@@ -306,6 +306,7 @@ def _resolve(  # noqa: PLR0913, PLR0912, C901 - one wrapper per resolve_for_targ
     build_requirements: bool = False,
     resolution_strategy: ResolutionStrategy | None = None,
     progress: ProgressReporter | None = None,
+    max_concurrency: int,
 ) -> ResolveResult:
     """Run the resolver and translate every failure to an exit.
 
@@ -334,6 +335,7 @@ def _resolve(  # noqa: PLR0913, PLR0912, C901 - one wrapper per resolve_for_targ
                     build_requirements=build_requirements,
                     resolution_strategy=resolution_strategy,
                     progress=progress,
+                    max_concurrency=max_concurrency,
                 )
         finally:
             if progress is not None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,7 +59,7 @@ from nab_index.transport import HttpError
 from nab_index.urllib3_async_transport import Urllib3AsyncTransport
 from nab_project._testing.coordinator_fake import make_coordinator
 from nab_project.download import DownloadError, DownloadResult
-from nab_project.fetch import FetchCoordinator
+from nab_project.fetch import DEFAULT_MAX_CONCURRENCY, FetchCoordinator
 from nab_project.lockfile import (
     ArchivePin,
     DisjointnessError,
@@ -5861,6 +5861,7 @@ class TestMain:
                 offline=False,
                 transport=MagicMock(),
                 failure_prefix="cannot lock",
+                max_concurrency=DEFAULT_MAX_CONCURRENCY,
             )
         assert result.success
 
@@ -5883,6 +5884,7 @@ class TestMain:
                 offline=False,
                 transport=MagicMock(),
                 failure_prefix="cannot lock",
+                max_concurrency=DEFAULT_MAX_CONCURRENCY,
             )
         assert enabled_during == [False]
         assert gc.isenabled()
@@ -5917,6 +5919,7 @@ class TestMain:
                 offline=False,
                 transport=MagicMock(),
                 failure_prefix="cannot lock",
+                max_concurrency=DEFAULT_MAX_CONCURRENCY,
             )
 
         # gc.get_objects allocates, and a collection it triggers would move the
@@ -5954,6 +5957,7 @@ class TestMain:
                 offline=False,
                 transport=MagicMock(),
                 failure_prefix="cannot lock",
+                max_concurrency=DEFAULT_MAX_CONCURRENCY,
             )
         assert gc.isenabled()
 
@@ -5976,6 +5980,7 @@ class TestMain:
                 offline=False,
                 transport=MagicMock(),
                 failure_prefix="cannot lock",
+                max_concurrency=DEFAULT_MAX_CONCURRENCY,
             )
         assert gc.isenabled()
 


### PR DESCRIPTION
`nab lock` and `nab download` resolved at 50 parallel fetches whatever `max-concurrency` said; only `nab download`'s download step honoured it. `resolve_for_targets` now takes `max_concurrency` and both commands pass `settings.max_concurrency`, so the resolve opens at 8 by default instead of 50.

**This lowers the default fetch width for a resolve from 50 to 8**, which is the change worth your call rather than the plumbing.

The fixed `50` becomes `nab_project.fetch.DEFAULT_MAX_CONCURRENCY`, named once and used by both the coordinator's default and the resolve's. `nab._resolve._resolve` takes the value as a required keyword, so a command cannot forget to pass it.

`docs/reference/configuration.md` said the setting covered `nab download`; it now says the resolve too. Two cases in `nab-project/tests/test_resolve.py` assert the width the coordinator is constructed with, unset and set.
