### PR TITLE
Pin the colour precedence and correct the TERM row it contradicts

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -264,7 +264,7 @@ at every verbosity.
 | ---- | ------ |
 | `-v`, `-vv`, `--verbose` | Raise verbosity. `-v` adds the engine's `INFO` records and deepens the `Diagnostics:` section of a resolution failure, `-vv` adds `DEBUG`. `--verbose` counts as one `-v`; repeats add, and `-vvv` saturates at `-vv`. |
 | `-q`, `-qq`, `--quiet` | Lower verbosity. `-q` drops the run summary and notes, keeping warnings and errors; `-qq` keeps only errors. `--quiet` counts as one `-q`. |
-| `--color` | When to colour nab's output: `auto` (default), `always`, or `never`. `auto` asks each stream on its own, so a help page piped to a file is plain while a refusal on the terminal beside it is not, and it honours `NO_COLOR`, `FORCE_COLOR`, and `TERM=dumb`; `always` and `never` win outright. Colour marks a message's leading token, a heading, and a spelling you can type, so every page reads the same stripped. |
+| `--color` | When to colour nab's output: `auto` (default), `always`, or `never`. `auto` decides per stream and honours the colour variables below, so a redirected page is plain while an error on the terminal is not. `always` and `never` win outright. |
 | `--no-color` | Shorthand for `--color never`. |
 | `--no-progress` | Suppress the live progress line (also `NAB_NO_PROGRESS`). |
 
@@ -291,9 +291,12 @@ It shows only at normal verbosity on an stderr terminal; `--no-progress`
 | `XDG_CONFIG_HOME` | If set, the user `nab.toml` is read from `$XDG_CONFIG_HOME/nab/nab.toml` instead of `~/.config/nab/nab.toml`. |
 | `NAB_VERBOSITY` | Default verbosity when no `-v` / `-q` flag is given: one of `silent`, `quiet`, `normal`, `verbose`, `debug`. A `-v` / `-q` flag overrides it. An unrecognised value is rejected by any command that reads it; `--version` and `--help` do not read it, so they neither honour nor refuse it. |
 | `NAB_NO_PROGRESS` | If set to a non-empty value, suppress the live progress line, like `--no-progress`. |
-| `NO_COLOR` | If set to a non-empty value, disable colour under `--color auto`. |
-| `FORCE_COLOR` | If set to a non-empty value, force colour under `--color auto`. |
+| `NO_COLOR` | Any non-empty value disables colour under `--color auto`. |
+| `FORCE_COLOR` | Any non-empty value, `0` included, forces colour under `--color auto`. |
 | `TERM` | `dumb` disables colour under `--color auto`. |
+
+Under `--color auto` those three are read in that order, and the first that
+applies decides.
 
 ## Exit codes
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -668,3 +668,23 @@ def test_progress_repaints_after_diagnostic() -> None:
     printer.warning("careful")
     reporter.on_pin(1)
     assert err.getvalue().endswith("\r\033[K⠙ Resolving... 1 fetched, 1 pinned")
+
+
+class TestColourPrecedence:
+    """The order the three variables are read in, as the CLI page states it."""
+
+    _PLAIN = _TTY(tty=False)
+
+    def test_no_color_beats_force_color(self) -> None:
+        env = {"NO_COLOR": "1", "FORCE_COLOR": "1"}
+        assert should_color(ColorChoice.AUTO, self._PLAIN, env) is False
+
+    def test_force_color_beats_a_dumb_terminal(self) -> None:
+        env = {"FORCE_COLOR": "1", "TERM": "dumb"}
+        assert should_color(ColorChoice.AUTO, self._PLAIN, env) is True
+
+    def test_force_color_zero_still_forces(self) -> None:
+        assert should_color(ColorChoice.AUTO, self._PLAIN, {"FORCE_COLOR": "0"}) is True
+
+    def test_a_dumb_terminal_disables_on_its_own(self) -> None:
+        assert should_color(ColorChoice.AUTO, self._PLAIN, {"TERM": "dumb"}) is False


### PR DESCRIPTION
`docs/reference/cli.md` said `TERM=dumb` disables colour under `--color auto`. It does not when `FORCE_COLOR` is set:

    $ env -u NO_COLOR FORCE_COLOR=1 TERM=dumb nab lock /nope/missing.toml 2>&1 >/dev/null | cat -v
    ^[[31merror:^[[0m /nope/missing.toml not found

`nab.env.color_enabled` reads `NO_COLOR`, then `FORCE_COLOR`, then `TERM`, and the first that applies decides. The three rows say that once between them instead of each hedging about the others, and `FORCE_COLOR` names the surprise: `0` is non-empty, so it forces colour on.

The `--color` row drops a sentence that told the reader nothing they could act on, and goes from 71 words to 44.

Four cases in `tests/test_output.py` pin the order. No source changes.
