### PR TITLE
Ignore a relative XDG_CACHE_HOME and XDG_CONFIG_HOME

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -287,8 +287,8 @@ It shows only at normal verbosity on an stderr terminal; `--no-progress`
 
 | Variable | Effect |
 | -------- | ------ |
-| `XDG_CACHE_HOME` | If set, `nab`'s default cache root is `$XDG_CACHE_HOME/nab` instead of `~/.cache/nab`. |
-| `XDG_CONFIG_HOME` | If set, the user `nab.toml` is read from `$XDG_CONFIG_HOME/nab/nab.toml` instead of `~/.config/nab/nab.toml`. |
+| `XDG_CACHE_HOME` | If set, `nab`'s default cache root is `$XDG_CACHE_HOME/nab` instead of `~/.cache/nab`. A relative value is ignored. |
+| `XDG_CONFIG_HOME` | If set, the user `nab.toml` is read from `$XDG_CONFIG_HOME/nab/nab.toml` instead of `~/.config/nab/nab.toml`. A relative value is ignored. |
 | `NAB_VERBOSITY` | Default verbosity when no `-v` / `-q` flag is given: one of `silent`, `quiet`, `normal`, `verbose`, `debug`. A `-v` / `-q` flag overrides it. An unrecognised value is rejected by any command that reads it; `--version` and `--help` do not read it, so they neither honour nor refuse it. |
 | `NAB_NO_PROGRESS` | If set to a non-empty value, suppress the live progress line, like `--no-progress`. |
 | `NO_COLOR` | Any non-empty value disables colour under `--color auto`. |

--- a/src/nab/env.py
+++ b/src/nab/env.py
@@ -84,15 +84,25 @@ def progress_suppressed(environ: Mapping[str, str] | None = None) -> bool:
     return bool(current(environ).get(NAB_NO_PROGRESS))
 
 
-def cache_root(environ: Mapping[str, str] | None = None) -> str | None:
-    """Return ``XDG_CACHE_HOME`` as written, or ``None`` when it is unset.
+def _absolute_root(environ: Mapping[str, str] | None, name: str) -> str | None:
+    """Return ``name`` as written, or ``None`` when unset or relative.
 
-    The raw string, so this module needs no ``pathlib``; the caller builds
-    the path and picks the fallback.
+    The XDG base directory specification calls a relative value invalid.
     """
-    return current(environ).get(XDG_CACHE_HOME)
+    value = current(environ).get(name)
+
+    # Path.is_absolute would pull pathlib, 17 modules and about 5 ms, onto a
+    # startup that loads 52 and imports it nowhere else.
+    if value is None or not os.path.isabs(value):  # noqa: PTH117
+        return None
+    return value
+
+
+def cache_root(environ: Mapping[str, str] | None = None) -> str | None:
+    """Return ``XDG_CACHE_HOME`` when it names an absolute path."""
+    return _absolute_root(environ, XDG_CACHE_HOME)
 
 
 def config_root(environ: Mapping[str, str] | None = None) -> str | None:
-    """Return ``XDG_CONFIG_HOME`` as written, or ``None`` when it is unset."""
-    return current(environ).get(XDG_CONFIG_HOME)
+    """Return ``XDG_CONFIG_HOME`` when it names an absolute path."""
+    return _absolute_root(environ, XDG_CONFIG_HOME)

--- a/tests/test_env_layer.py
+++ b/tests/test_env_layer.py
@@ -236,12 +236,26 @@ def test_progress_suppressed_reads_nab_no_progress() -> None:
     assert env.progress_suppressed({}) is False
 
 
-def test_cache_and_config_roots_are_the_raw_values() -> None:
-    environ = {env.XDG_CACHE_HOME: "cache", env.XDG_CONFIG_HOME: "config"}
-    assert env.cache_root(environ) == "cache"
-    assert env.config_root(environ) == "config"
+def test_cache_and_config_roots_are_the_raw_values(tmp_path: Path) -> None:
+    cache, config = str(tmp_path / "cache"), str(tmp_path / "config")
+    environ = {env.XDG_CACHE_HOME: cache, env.XDG_CONFIG_HOME: config}
+
+    assert env.cache_root(environ) == cache
+    assert env.config_root(environ) == config
     assert env.cache_root({}) is None
     assert env.config_root({}) is None
+
+
+def test_a_relative_root_is_ignored() -> None:
+    relative = {env.XDG_CACHE_HOME: "cache", env.XDG_CONFIG_HOME: "../config"}
+
+    assert env.cache_root(relative) is None
+    assert env.config_root(relative) is None
+
+
+def test_an_empty_root_is_ignored() -> None:
+    assert env.cache_root({env.XDG_CACHE_HOME: ""}) is None
+    assert env.config_root({env.XDG_CONFIG_HOME: ""}) is None
 
 
 def test_output_owned_names_the_two_output_variables() -> None:


### PR DESCRIPTION
`XDG_CACHE_HOME=rel/here nab cache dir` printed `rel/here/nab`, a path relative to wherever the command ran. The XDG base directory specification calls a relative value invalid, so nab now falls back to `~/.cache/nab`. Same for `XDG_CONFIG_HOME` and the user `nab.toml`.

**This is a silent behaviour change** for anyone who set either to a relative path and relied on it resolving against the working directory.

`nab.env.cache_root` and `config_root` share one `_absolute_root` helper. It uses `os.path.isabs`, not `Path.is_absolute`, because `pathlib` is 17 modules and about 5 ms on a startup that loads 52 and imports it nowhere else.

Three cases in `tests/test_env_layer.py` cover absolute, relative and empty. The absolute one builds its path from `tmp_path`: a literal `/cache` is absolute on POSIX but not on Windows since Python 3.13 changed `ntpath.isabs`.
