### PR TITLE
Move the selection helpers to nab/_run.py so nab._lock imports alone

### DIFF
--- a/src/nab/_config_cmd.py
+++ b/src/nab/_config_cmd.py
@@ -26,6 +26,7 @@ from nab_project.config_sources import (
     render_list,
 )
 
+from . import _run
 from .cli import (
     BuildPolicyFlag,
     DecisionOrderFlag,
@@ -39,7 +40,6 @@ from .cli import (
     app,
     effective_config,
     printer,
-    require_pyproject_file,
 )
 
 ActionArg = Annotated[str, tyro.conf.Positional]
@@ -101,7 +101,7 @@ def config_command(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag
     # Validate the pyproject path the same way the run commands do: a
     # --path that is missing, a directory, or not a regular file is a hard
     # error, not a silently-skipped source that prints all-built-in defaults.
-    require_pyproject_file(path)
+    _run.require_pyproject_file(path)
 
     cli_overrides = _cli_overrides(
         cli_resolution=project_resolution,

--- a/src/nab/_download.py
+++ b/src/nab/_download.py
@@ -5,8 +5,9 @@ archive into a local directory: the union of every target's
 artefacts, deduplicated by URL, which for a declared matrix
 pre-populates a directory for offline deployment across platforms.
 
-The helpers this shares with :mod:`nab._lock` (config loading, the
-printer, transport selection, the resolve step) live in :mod:`nab.cli`;
+The helpers this shares with :mod:`nab._lock` live in :mod:`nab.cli`
+(config loading, the printer, transport selection, the resolve step) and
+:mod:`nab._run` (the project-path guard, the group and extra selection);
 everything else is imported from the module that defines it.
 """
 
@@ -21,8 +22,8 @@ import tyro
 from nab_project.download import DownloadError, download_lock
 from nab_project.resolve import build_lock_input
 
+from . import _run
 from . import cli as _cli
-from ._lock import resolve_extra_selection, resolve_group_selection
 from .cli import (
     BuildPolicyFlag,
     DecisionOrderFlag,
@@ -86,10 +87,10 @@ def download(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config 
     system/user/project ``nab.toml`` is read for ``nab download`` as for
     ``nab lock``.
     """
-    selected_groups = resolve_group_selection(
+    selected_groups = _run.resolve_group_selection(
         path, groups=groups, all_groups=all_groups
     )
-    selected_extras = resolve_extra_selection(
+    selected_extras = _run.resolve_extra_selection(
         path, extras=extras, all_extras=all_extras
     )
 

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -4,8 +4,9 @@ Wires :func:`resolve_for_targets` to the writers in
 :mod:`nab_project.lockfile`, plus the per-target emission shapes a matrix
 needs (a templated file per tuple, multi-block stdout).
 
-The helpers this shares with :mod:`nab._download` (config loading, the
-printer, transport selection, the resolve step) live in :mod:`nab.cli`;
+The helpers this shares with :mod:`nab._download` live in :mod:`nab.cli`
+(config loading, the printer, transport selection, the resolve step) and
+:mod:`nab._run` (the project-path guard, the group and extra selection);
 everything else is imported from the module that defines it.
 """
 
@@ -24,7 +25,6 @@ from pathlib import Path
 from string import Formatter
 from typing import TYPE_CHECKING, Annotated, Any, NamedTuple, NoReturn
 
-import tomli
 import tyro
 
 from nab._version import __version__
@@ -79,6 +79,7 @@ from nab_provider.requirements_file import (
 )
 from nab_provider.target import IntractableMarkerError, UnevaluableMarkerError
 
+from . import _run
 from . import cli as _cli
 from .cli import (
     BuildPolicyFlag,
@@ -277,10 +278,10 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
         anchor=anchor,
         cli_project_overrides=settings.cli_project_overrides,
     )
-    selected_groups = resolve_group_selection(
+    selected_groups = _run.resolve_group_selection(
         path, groups=groups, all_groups=all_groups
     )
-    selected_extras = resolve_extra_selection(
+    selected_extras = _run.resolve_extra_selection(
         path, extras=extras, all_extras=all_extras
     )
 
@@ -1098,73 +1099,6 @@ def _render_requirements_or_exit(
         _cli.printer().error(f"cannot lock: {e}")
         sys.exit(1)
     return text, sum(len(lock.pins) for lock in lock_input.targets.values())
-
-
-def _read_selection_table_or_exit(
-    path: Path,
-    reader: Callable[[Path], Mapping[str, object]],
-) -> Mapping[str, object]:
-    """Read the table a selection flag expands over, exiting 1 on a bad file.
-
-    ``nab download`` selects groups and extras before it loads the config, so
-    this read can be the first to touch the pyproject and runs the path guards
-    itself rather than relying on the config load having run.
-    """
-    _cli.require_pyproject_file(path)
-
-    try:
-        return reader(path)
-    except OSError as e:
-        _cli.printer().error(f"cannot read {path}: {e}")
-        sys.exit(1)
-    except (UnicodeDecodeError, tomli.TOMLDecodeError) as e:
-        _cli.printer().error(f"{path} is not valid TOML: {e}")
-        sys.exit(1)
-    except TypeError as e:
-        _cli.printer().error(f"in {path}: {e}")
-        sys.exit(1)
-
-
-def resolve_group_selection(
-    path: Path,
-    *,
-    groups: tuple[str, ...],
-    all_groups: bool,
-) -> tuple[str, ...]:
-    """Return the canonical, deduplicated group selection for this run.
-
-    ``groups`` is the user-supplied list (already split by tyro on
-    commas).  ``all_groups`` overrides it: when set, every group
-    defined in the project's ``[dependency-groups]`` table is
-    selected.  An ``--all-groups`` paired with a non-empty
-    ``--groups`` list raises a clean error rather than silently
-    preferring one over the other.
-    """
-    if all_groups and groups:
-        _cli.printer().error("--all-groups and --groups are mutually exclusive")
-        sys.exit(1)
-    if not (all_groups or groups):
-        return ()
-
-    defined = _read_selection_table_or_exit(path, read_pyproject_groups)
-    return tuple(defined.keys()) if all_groups else tuple(dict.fromkeys(groups))
-
-
-def resolve_extra_selection(
-    path: Path,
-    *,
-    extras: tuple[str, ...],
-    all_extras: bool,
-) -> tuple[str, ...]:
-    """Return the canonical, deduplicated extras selection for this run."""
-    if all_extras and extras:
-        _cli.printer().error("--all-extras and --extras are mutually exclusive")
-        sys.exit(1)
-    if not (all_extras or extras):
-        return ()
-
-    defined = _read_selection_table_or_exit(path, read_pyproject_optional_dependencies)
-    return tuple(defined.keys()) if all_extras else tuple(dict.fromkeys(extras))
 
 
 def _build_provenance(

--- a/src/nab/_run.py
+++ b/src/nab/_run.py
@@ -1,0 +1,129 @@
+"""Helpers the command modules and :mod:`nab.cli` share.
+
+``require_pyproject_file`` guards the project path for every command that
+takes one, and the selection helpers turn ``nab lock``'s and ``nab
+download``'s group and extra flags into canonical tuples.  A helper
+belongs here once a second command module needs it, so that neither has
+to import the other.
+
+This module and ``cli`` import each other, so each binds the other module
+rather than a name off it: a name import on either side of that cycle
+fails in a fresh interpreter.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import tomli
+
+from nab_project.paths import PathState, path_state
+from nab_project.pyproject_files import (
+    read_pyproject_groups,
+    read_pyproject_optional_dependencies,
+)
+
+from . import cli as _cli
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+    from pathlib import Path
+
+
+def require_pyproject_file(path: Path) -> None:
+    """Exit 1 if ``path`` is not a readable pyproject file.
+
+    Shared by every command that takes a project path, so the rejection
+    wording lives in one place.  A ``--path`` that is missing, a
+    directory, or not a regular file is a hard error, not a
+    silently-skipped source.  A path whose stat fails passes: the config
+    read reports it, naming the errno.
+    """
+    state = path_state(path)
+
+    if state is PathState.DIRECTORY:
+        _cli.printer().error(f"{path} is a directory")
+        sys.exit(1)
+
+    if state is PathState.OTHER:
+        _cli.printer().error(f"{path} exists but is not a regular file")
+        sys.exit(1)
+
+    if state is PathState.ABSENT:
+        _cli.printer().error(f"{path} not found")
+        sys.exit(1)
+
+    if _cli._is_pylock(path):  # noqa: SLF001
+        _cli.printer().error(
+            f"{path} is a PEP 751 lockfile, not a pyproject.  nab resolves"
+            " from project inputs, so pass the pyproject.toml instead."
+        )
+        sys.exit(1)
+
+
+def _read_selection_table_or_exit(
+    path: Path,
+    reader: Callable[[Path], Mapping[str, object]],
+) -> Mapping[str, object]:
+    """Read the table a selection flag expands over, exiting 1 on a bad file.
+
+    ``nab download`` selects groups and extras before it loads the config, so
+    this read can be the first to touch the pyproject and runs the path guards
+    itself rather than relying on the config load having run.
+    """
+    require_pyproject_file(path)
+
+    try:
+        return reader(path)
+    except OSError as e:
+        _cli.printer().error(f"cannot read {path}: {e}")
+        sys.exit(1)
+    except (UnicodeDecodeError, tomli.TOMLDecodeError) as e:
+        _cli.printer().error(f"{path} is not valid TOML: {e}")
+        sys.exit(1)
+    except TypeError as e:
+        _cli.printer().error(f"in {path}: {e}")
+        sys.exit(1)
+
+
+def resolve_group_selection(
+    path: Path,
+    *,
+    groups: tuple[str, ...],
+    all_groups: bool,
+) -> tuple[str, ...]:
+    """Return the canonical, deduplicated group selection for this run.
+
+    ``groups`` is the user-supplied list (already split by tyro on
+    commas).  ``all_groups`` overrides it: when set, every group
+    defined in the project's ``[dependency-groups]`` table is
+    selected.  An ``--all-groups`` paired with a non-empty
+    ``--groups`` list raises a clean error rather than silently
+    preferring one over the other.
+    """
+    if all_groups and groups:
+        _cli.printer().error("--all-groups and --groups are mutually exclusive")
+        sys.exit(1)
+    if not (all_groups or groups):
+        return ()
+
+    defined = _read_selection_table_or_exit(path, read_pyproject_groups)
+    return tuple(defined.keys()) if all_groups else tuple(dict.fromkeys(groups))
+
+
+def resolve_extra_selection(
+    path: Path,
+    *,
+    extras: tuple[str, ...],
+    all_extras: bool,
+) -> tuple[str, ...]:
+    """Return the canonical, deduplicated extras selection for this run."""
+    if all_extras and extras:
+        _cli.printer().error("--all-extras and --extras are mutually exclusive")
+        sys.exit(1)
+    if not (all_extras or extras):
+        return ()
+
+    defined = _read_selection_table_or_exit(path, read_pyproject_optional_dependencies)
+    return tuple(defined.keys()) if all_extras else tuple(dict.fromkeys(extras))

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -4,6 +4,8 @@ Holds the tyro :class:`SubcommandApp` registration plus the helpers the
 command modules share: config loading and cache-directory defaults,
 plus the HTTP transport selection and resolver-error-to-exit-code
 translation that only :mod:`nab._lock` and :mod:`nab._download` use.
+The project-path guard and the group and extra selection live in
+:mod:`nab._run`.
 
 The subcommands live in :mod:`nab._lock`, :mod:`nab._download`,
 :mod:`nab._config_cmd`, and :mod:`nab._cache_cmd`; this module imports
@@ -55,7 +57,7 @@ from nab_project.config_sources import (
     resolve_config,
 )
 from nab_project.lockfile import MissingHashError, MissingSdistError
-from nab_project.paths import PathState, path_state, realpath
+from nab_project.paths import realpath
 from nab_project.resolve import resolve_for_targets
 from nab_project.workspace import WorkspaceDiscoveryError
 from nab_provider.errors import (
@@ -83,6 +85,7 @@ from nab_provider.target import (
 )
 from nab_resolver.errors import ResolutionError
 
+from . import _run
 from .output import (
     OUTPUT_ENV_VARS,
     OutputOptionError,
@@ -527,37 +530,6 @@ def _is_pylock(path: Path) -> bool:
     return "lock-version" in data and "project" not in data
 
 
-def require_pyproject_file(path: Path) -> None:
-    """Exit 1 if ``path`` is not a readable pyproject file.
-
-    Shared by every command that takes a project path, so the rejection
-    wording lives in one place.  A ``--path`` that is missing, a
-    directory, or not a regular file is a hard error, not a
-    silently-skipped source.  A path whose stat fails passes: the config
-    read reports it, naming the errno.
-    """
-    state = path_state(path)
-
-    if state is PathState.DIRECTORY:
-        printer().error(f"{path} is a directory")
-        sys.exit(1)
-
-    if state is PathState.OTHER:
-        printer().error(f"{path} exists but is not a regular file")
-        sys.exit(1)
-
-    if state is PathState.ABSENT:
-        printer().error(f"{path} not found")
-        sys.exit(1)
-
-    if _is_pylock(path):
-        printer().error(
-            f"{path} is a PEP 751 lockfile, not a pyproject.  nab resolves"
-            " from project inputs, so pass the pyproject.toml instead."
-        )
-        sys.exit(1)
-
-
 def _project_cli_overrides_or_exit(project_overrides: Mapping[str, object]) -> None:
     """Exit 1 when a ``--project-*`` override has a bad value, naming the flag.
 
@@ -583,7 +555,7 @@ def _load_config(
     anchor: datetime | None = None,
     cli_overrides: Mapping[str, object] | None = None,
 ) -> NabProjectConfig:
-    require_pyproject_file(path)
+    _run.require_pyproject_file(path)
 
     try:
         return read_pyproject_config(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,9 +40,8 @@ from nab._lock import (
     _emit_or_exit,
     _emit_pylock,
     lock,
-    resolve_extra_selection,
-    resolve_group_selection,
 )
+from nab._run import resolve_extra_selection, resolve_group_selection
 from nab.cli import (
     _DEFAULT_OUTPUT,
     ConfigLadder,
@@ -4089,11 +4088,12 @@ class TestConfigErrors:
 
 
 class TestCliDocstringCommandModules:
-    """``nab.cli``'s docstring names every module that registers a subcommand."""
+    """``nab.cli``'s docstring names every ``nab._*`` module ``cli`` binds."""
 
     def test_docstring_names_every_command_module(self) -> None:
         # A command module only registers if cli.py imports it for the side
-        # effect, so cli's own module bindings are the registration set.
+        # effect, so every one of them is a binding here.  cli binds helper
+        # modules too, and the docstring has to name those as well.
         imported = {
             module.__name__
             for _, module in inspect.getmembers(cli, inspect.ismodule)
@@ -4105,8 +4105,7 @@ class TestCliDocstringCommandModules:
         named = set(re.findall(r"nab\._\w+", docstring))
 
         assert named == imported, (
-            f"docstring misses {imported - named}, "
-            f"names unregistered {named - imported}"
+            f"docstring misses {imported - named}, names unbound {named - imported}"
         )
 
 
@@ -5050,7 +5049,7 @@ class TestGroupAndExtraSelection:
         pyproject = _make_pyproject(tmp_path)
         denied = PermissionError(errno.EACCES, "Permission denied", str(pyproject))
         with (
-            patch("nab._lock.read_pyproject_groups", side_effect=denied),
+            patch("nab._run.read_pyproject_groups", side_effect=denied),
             pytest.raises(SystemExit, match="1"),
         ):
             resolve_group_selection(pyproject, groups=(), all_groups=True)
@@ -5065,7 +5064,7 @@ class TestGroupAndExtraSelection:
         pyproject = _make_pyproject(tmp_path)
         denied = PermissionError(errno.EACCES, "Permission denied", str(pyproject))
         with (
-            patch("nab._lock.read_pyproject_optional_dependencies", side_effect=denied),
+            patch("nab._run.read_pyproject_optional_dependencies", side_effect=denied),
             pytest.raises(SystemExit, match="1"),
         ):
             resolve_extra_selection(pyproject, extras=(), all_extras=True)
@@ -6504,6 +6503,36 @@ class TestCliImportPath:
         subprocess.run(  # noqa: S603 - the probe is this file's own source
             [sys.executable, "-c", _STDLIB_MODULE_PROBE], check=True
         )
+
+
+_PACKAGE_ENTRY_STATEMENTS = (
+    "import nab.cli",
+    "import nab._run",
+    "import nab._config_cmd",
+    "from nab._lock import lock",
+    "from nab._download import download",
+)
+
+
+class TestPackageEntryStatements:
+    """Each of these imports works in an interpreter holding no nab module."""
+
+    @pytest.mark.parametrize("statement", _PACKAGE_ENTRY_STATEMENTS)
+    def test_entry_statement_runs_in_a_fresh_interpreter(self, statement: str) -> None:
+        """A name import across the ``cli`` to ``_run`` cycle raises on some.
+
+        Nothing else in the suite can see that: ``conftest`` imports
+        ``nab.cli`` before any test runs, so no test enters the package by
+        another route.
+        """
+        probe = subprocess.run(  # noqa: S603 - the probe is this file's own source
+            [sys.executable, "-c", statement],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert probe.returncode == 0, probe.stderr
 
 
 class TestDownloadCommand:


### PR DESCRIPTION
`import nab._lock` fails on main:

```
ImportError: cannot import name 'resolve_extra_selection' from partially initialized module 'nab._lock' (most likely due to a circular import)
```

`_lock` imports `cli` for helpers it shares with `_download`, `cli` imports `_download` for its `@app.command` decorators, and `_download` reaches back into `_lock` before it finishes. `tests/conftest.py` imports `nab.cli` first, so no test sees it.

`require_pyproject_file`, `_read_selection_table_or_exit`, `resolve_group_selection` and `resolve_extra_selection` move to a new `nab/_run.py`, and `_download` stops importing `_lock`.

`cli` and `_run` still import each other, each binding the other module rather than a name off it, since a name import either way moves the ImportError elsewhere. A parametrized test imports each of `cli`, `_run`, `_config_cmd`, `_lock` and `_download` first, in a fresh interpreter.
