### PR TITLE
Move the selection and shared helpers to nab/_run.py and the env reads to nab/env.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ exclude = [
     "tests/test_cli_docs.py",
     "tests/test_contributing_docs.py",
     "tests/test_embedding_docs.py",
+    "tests/test_env_layer.py",
     "tests/test_release.py",
     "tests/test_type_check_scope.py",
     "tests/test_workspace_shape.py",

--- a/src/nab/_cache_cmd.py
+++ b/src/nab/_cache_cmd.py
@@ -21,13 +21,9 @@ import tyro
 from nab_index.cache import OnDiskCache, is_recognized_bucket
 from nab_project.config_sources import SourceConfigError
 
-from .cli import (
-    _default_cache_dir,
-    _fail_config,
-    app,
-    effective_config,
-    printer,
-)
+from ._run import _default_cache_dir, _fail_config, effective_config
+from .cli import app
+from .output import printer
 
 ActionArg = Annotated[str, tyro.conf.Positional]
 

--- a/src/nab/_config_cmd.py
+++ b/src/nab/_config_cmd.py
@@ -26,6 +26,12 @@ from nab_project.config_sources import (
     render_list,
 )
 
+from ._run import (
+    _cli_overrides,
+    _fail_config,
+    effective_config,
+    require_pyproject_file,
+)
 from .cli import (
     BuildPolicyFlag,
     DecisionOrderFlag,
@@ -34,13 +40,9 @@ from .cli import (
     ModeFlag,
     OfflineFlag,
     ResolutionFlag,
-    _cli_overrides,
-    _fail_config,
     app,
-    effective_config,
-    printer,
-    require_pyproject_file,
 )
+from .output import printer
 
 ActionArg = Annotated[str, tyro.conf.Positional]
 KeyArg = Annotated[str, tyro.conf.Positional]

--- a/src/nab/_download.py
+++ b/src/nab/_download.py
@@ -5,9 +5,9 @@ archive into a local directory: the union of every target's
 artefacts, deduplicated by URL, which for a declared matrix
 pre-populates a directory for offline deployment across platforms.
 
-The helpers this shares with :mod:`nab._lock` (config loading, the
-printer, transport selection, the resolve step) live in :mod:`nab.cli`;
-everything else is imported from the module that defines it.
+The helpers this shares with :mod:`nab._lock` live in :mod:`nab._run`,
+and the run's printer in :mod:`nab.output`; everything else is imported
+from the module that defines it.
 """
 
 from __future__ import annotations
@@ -21,8 +21,20 @@ import tyro
 from nab_project.download import DownloadError, download_lock
 from nab_project.resolve import build_lock_input
 
-from . import cli as _cli
-from ._lock import resolve_extra_selection, resolve_group_selection
+from ._run import (
+    _cli_overrides,
+    _layered_run_settings_or_exit,
+    _load_config,
+    _make_transport,
+    _project_cli_overrides_or_exit,
+    _reject_python_override_in_universal,
+    _resolve,
+    _resolve_effective_cache_dir,
+    project_config_overrides,
+    read_config_ladder,
+    resolve_extra_selection,
+    resolve_group_selection,
+)
 from .cli import (
     BuildPolicyFlag,
     DecisionOrderFlag,
@@ -34,7 +46,7 @@ from .cli import (
     ResolutionFlag,
     app,
 )
-from .output import ProgressReporter
+from .output import ProgressReporter, printer
 
 
 @app.command
@@ -93,7 +105,7 @@ def download(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config 
         path, extras=extras, all_extras=all_extras
     )
 
-    overrides = _cli._cli_overrides(  # noqa: SLF001
+    overrides = _cli_overrides(
         cli_resolution=project_resolution,
         cli_offline=offline,
         cli_cache_dir=cache_dir,
@@ -111,23 +123,19 @@ def download(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config 
         cli_base_group=project_base_group,
         cli_build_group=project_build_group,
     )
-    project_overrides = _cli.project_config_overrides(overrides)
-    _cli._project_cli_overrides_or_exit(project_overrides)  # noqa: SLF001
-    config = _cli._load_config(  # noqa: SLF001
+    project_overrides = project_config_overrides(overrides)
+    _project_cli_overrides_or_exit(project_overrides)
+    config = _load_config(
         path,
         discover_workspace=workspace_discovery,
         cli_overrides=project_overrides,
     )
-    ladder = _cli.read_config_ladder(path, overrides)
-    settings = _cli._layered_run_settings_or_exit(  # noqa: SLF001
-        ladder, produces_lock=False
-    )
-    effective_cache_dir = _cli._resolve_effective_cache_dir(  # noqa: SLF001
-        settings.cache_dir, cache=cache
-    )
-    _cli._reject_python_override_in_universal(config, python)  # noqa: SLF001
-    transport = _cli._make_transport(settings.http_backend)  # noqa: SLF001
-    result = _cli._resolve(  # noqa: SLF001
+    ladder = read_config_ladder(path, overrides)
+    settings = _layered_run_settings_or_exit(ladder, produces_lock=False)
+    effective_cache_dir = _resolve_effective_cache_dir(settings.cache_dir, cache=cache)
+    _reject_python_override_in_universal(config, python)
+    transport = _make_transport(settings.http_backend)
+    result = _resolve(
         path,
         config=config,
         cache_dir=effective_cache_dir,
@@ -138,7 +146,7 @@ def download(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config 
         groups=selected_groups,
         extras=selected_extras,
         resolution_strategy=settings.resolution,
-        progress=ProgressReporter(_cli.printer()),
+        progress=ProgressReporter(printer()),
     )
     lock_input = build_lock_input(
         result,
@@ -147,7 +155,7 @@ def download(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config 
         dependency_groups=selected_groups,
     )
 
-    download_transport = _cli._make_transport(settings.http_backend)  # noqa: SLF001
+    download_transport = _make_transport(settings.http_backend)
     try:
         outcome = download_lock(
             lock_input,
@@ -157,13 +165,13 @@ def download(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config 
             offline=settings.offline,
         )
     except DownloadError as e:
-        _cli.printer().error(f"download failed: {e}")
+        printer().error(f"download failed: {e}")
         sys.exit(1)
     except OSError as e:
-        _cli.printer().error(f"cannot write to output directory {output}: {e}")
+        printer().error(f"cannot write to output directory {output}: {e}")
         sys.exit(1)
 
-    _cli.printer().done(
+    printer().done(
         f"Downloaded {len(outcome.written)} files,"
         f" {len(outcome.skipped)} already present, into {output}"
     )

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -4,9 +4,9 @@ Wires :func:`resolve_for_targets` to the writers in
 :mod:`nab_project.lockfile`, plus the per-target emission shapes a matrix
 needs (a templated file per tuple, multi-block stdout).
 
-The helpers this shares with :mod:`nab._download` (config loading, the
-printer, transport selection, the resolve step) live in :mod:`nab.cli`;
-everything else is imported from the module that defines it.
+The helpers this shares with :mod:`nab._download` live in
+:mod:`nab._run`, and the run's printer in :mod:`nab.output`; everything
+else is imported from the module that defines it.
 """
 
 from __future__ import annotations
@@ -24,7 +24,6 @@ from pathlib import Path
 from string import Formatter
 from typing import TYPE_CHECKING, Annotated, Any, NamedTuple, NoReturn
 
-import tomli
 import tyro
 
 from nab._version import __version__
@@ -79,7 +78,25 @@ from nab_provider.requirements_file import (
 )
 from nab_provider.target import IntractableMarkerError, UnevaluableMarkerError
 
-from . import cli as _cli
+from ._run import (
+    ConfigLadder,
+    _cli_overrides,
+    _layered_run_settings_or_exit,
+    _load_config,
+    _make_resolve_transport,
+    _project_cli_overrides_or_exit,
+    _python_override_or_exit,
+    _reject_python_override_in_universal,
+    _resolve,
+    _resolve_effective_cache_dir,
+    is_stdout,
+    lock_anchor,
+    project_config_overrides,
+    project_override_arguments,
+    read_config_ladder,
+    resolve_extra_selection,
+    resolve_group_selection,
+)
 from .cli import (
     BuildPolicyFlag,
     DecisionOrderFlag,
@@ -92,17 +109,17 @@ from .cli import (
     ResolutionFlag,
     app,
 )
-from .output import ProgressReporter
+from .output import ProgressReporter, printer
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Mapping, Sequence
 
     from nab_provider.target import ResolveTarget
 
-    from .cli import ConfigLadder
-
 
 _DEFAULT_PROJECT_PATH = Path("pyproject.toml")
+
+TUPLE_TEMPLATE_VARS = ("{python_version}", "{platform_id}", "{selection}")
 
 
 def _emit_or_exit(emit: Callable[[], None]) -> None:
@@ -114,7 +131,7 @@ def _emit_or_exit(emit: Callable[[], None]) -> None:
     try:
         emit()
     except (OSError, UnicodeEncodeError) as e:
-        _cli.printer().error(f"cannot write output: {e}")
+        printer().error(f"cannot write output: {e}")
         sys.exit(1)
 
 
@@ -215,8 +232,8 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
     It is for pylock output to a file, single-environment mode only.
     """
     _validate_pylock_output_name(output=output, format=format)
-    if locked and (format != "pylock" or _cli.is_stdout(output)):
-        _cli.printer().error("--locked is only supported for pylock output to a file.")
+    if locked and (format != "pylock" or is_stdout(output)):
+        printer().error("--locked is only supported for pylock output to a file.")
         sys.exit(1)
     if build_requirements:
         _refuse_group_selection_with_build_requirements(
@@ -228,7 +245,7 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
             base_group=project_base_group,
             build_group=project_build_group,
         )
-    overrides = _cli._cli_overrides(  # noqa: SLF001
+    overrides = _cli_overrides(
         cli_resolution=project_resolution,
         cli_offline=offline,
         cli_cache_dir=cache_dir,
@@ -245,9 +262,9 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
         cli_base_group=project_base_group,
         cli_build_group=project_build_group,
     )
-    project_overrides = _cli.project_config_overrides(overrides)
-    _cli._project_cli_overrides_or_exit(project_overrides)  # noqa: SLF001
-    ladder = _cli.read_config_ladder(path, overrides)
+    project_overrides = project_config_overrides(overrides)
+    _project_cli_overrides_or_exit(project_overrides)
+    ladder = read_config_ladder(path, overrides)
     anchor = _determine_lock_anchor(
         ladder,
         output=output,
@@ -255,7 +272,7 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
         build_requirements=build_requirements,
         upgrade=upgrade,
     )
-    config = _cli._load_config(  # noqa: SLF001
+    config = _load_config(
         path,
         discover_workspace=workspace_discovery,
         anchor=anchor,
@@ -264,13 +281,11 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
     if build_requirements:
         config = config_for_build_requirements(config)
     if locked and config.mode is ResolveMode.UNIVERSAL:
-        _cli.printer().error("--locked is not supported in universal mode.")
+        printer().error("--locked is not supported in universal mode.")
         sys.exit(1)
-    _cli._reject_python_override_in_universal(config, python)  # noqa: SLF001
-    settings = _cli._layered_run_settings_or_exit(ladder)  # noqa: SLF001
-    effective_cache_dir = _cli._resolve_effective_cache_dir(  # noqa: SLF001
-        settings.cache_dir, cache=cache
-    )
+    _reject_python_override_in_universal(config, python)
+    settings = _layered_run_settings_or_exit(ladder)
+    effective_cache_dir = _resolve_effective_cache_dir(settings.cache_dir, cache=cache)
     provenance = _build_provenance(
         path,
         config=config,
@@ -289,7 +304,7 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
     )
 
     if config.mode is ResolveMode.UNIVERSAL:
-        _cli.printer().warning(
+        printer().warning(
             "the multi-target ('universal') lockfile format is"
             " experimental and may change without notice"
         )
@@ -311,10 +326,8 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
     if locked:
         _fast_fail_locked(run, config=config, workspace_to_drop=workspace_to_drop)
 
-    transport = _cli._make_resolve_transport(  # noqa: SLF001
-        settings.http_backend, offline=settings.offline
-    )
-    result = _cli._resolve(  # noqa: SLF001
+    transport = _make_resolve_transport(settings.http_backend, offline=settings.offline)
+    result = _resolve(
         path,
         config=config,
         cache_dir=effective_cache_dir,
@@ -326,7 +339,7 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
         extras=selected_extras,
         build_requirements=build_requirements,
         resolution_strategy=settings.resolution,
-        progress=ProgressReporter(_cli.printer()),
+        progress=ProgressReporter(printer()),
     )
 
     lock_input = drop_workspace_pins(
@@ -384,6 +397,12 @@ def _packages_only(text: str) -> dict[str, Any]:
     return data
 
 
+_DEFAULT_OUTPUT: dict[str, str] = {
+    "pylock": "pylock.toml",
+    "requirements": "requirements.txt",
+    "requirements-without-hashes": "requirements.txt",
+}
+
 _BUILD_DEFAULT_OUTPUT: dict[str, str] = {
     "pylock": "pylock.build.toml",
     "requirements": "build-requirements.txt",
@@ -402,7 +421,7 @@ def _default_output_path(
     overwrite the project's runtime lock.  ``pylock.build.toml`` is the
     PEP 751 ``pylock.<name>.toml`` spelling.
     """
-    names = _BUILD_DEFAULT_OUTPUT if build_requirements else _cli._DEFAULT_OUTPUT  # noqa: SLF001
+    names = _BUILD_DEFAULT_OUTPUT if build_requirements else _DEFAULT_OUTPUT
     return Path(names[format])
 
 
@@ -436,7 +455,7 @@ def _refuse_group_selection_with_build_requirements(
     )
     if not any(named):
         return
-    _cli.printer().error(
+    printer().error(
         "--build-requirements locks [build-system].requires, which has no"
         " groups or extras to select."
     )
@@ -523,7 +542,7 @@ class _LockRun:
         if self.no_emit_workspace:
             arguments.append("--no-emit-workspace")
 
-        arguments += _cli.project_override_arguments(self.cli_overrides)
+        arguments += project_override_arguments(self.cli_overrides)
         if self.upgrade:
             arguments.append("--upgrade")
         return arguments
@@ -552,7 +571,7 @@ def _fast_fail_locked(
     error: reporting a stale lock instead would point at a refresh command
     carrying the same rejected value.
     """
-    retargeted = _cli._python_override_or_exit(config, run.python)  # noqa: SLF001
+    retargeted = _python_override_or_exit(config, run.python)
 
     target = _locked_target_path(run)
     refresh = run.refresh_command()
@@ -581,7 +600,7 @@ def _fast_fail_locked(
 
     # A stat that failed is not an absent lock.
     if path_state(target) is PathState.ABSENT:
-        _cli.printer().error(
+        printer().error(
             f"--locked: no lockfile at {target} to check; run `{refresh}` first."
         )
         sys.exit(1)
@@ -603,23 +622,23 @@ def _fast_fail_locked(
             exclude=workspace_to_drop,
         )
     except OSError as e:
-        _cli.printer().error(f"--locked: cannot read lockfile {target}: {e}.")
+        printer().error(f"--locked: cannot read lockfile {target}: {e}.")
         sys.exit(1)
     except LockfileSyntaxError as e:
-        _cli.printer().error(
+        printer().error(
             f"--locked: lockfile {target} is not valid TOML: {e};"
             f" re-run `{refresh}` to regenerate it."
         )
         sys.exit(1)
     except InvalidLockfileError as e:
-        _cli.printer().error(
+        printer().error(
             f"--locked: lockfile {target} is not a valid PEP 751 lockfile: {e};"
             f" re-run `{refresh}` to regenerate it."
         )
         sys.exit(1)
     if disqualification is None:
         return
-    _cli.printer().error(
+    printer().error(
         f"--locked: lockfile {target} is out of date: {disqualification.reason};"
         f" re-run `{refresh}` to update it."
     )
@@ -721,9 +740,9 @@ def _check_locked(lock_input: LockInput, *, run: _LockRun) -> None:
     new_text = _render_or_exit(lambda: render_lock(lock_input, lock_dir=target.parent))
     committed = _packages_only(target.read_text(encoding="utf-8"))
     if _packages_only(new_text) == committed:
-        _cli.printer().done(f"Lockfile {target} is up to date.")
+        printer().done(f"Lockfile {target} is up to date.")
         return
-    _cli.printer().error(
+    printer().error(
         f"--locked: lockfile {target} is out of date;"
         f" re-run `{run.refresh_command()}` to update it."
     )
@@ -734,7 +753,7 @@ def _emit_pylock(
     lock_input: LockInput, *, output: Path | None, default_output: Path
 ) -> None:
     """Write the PEP 751 lock to a file, or print it."""
-    if _cli.is_stdout(output):
+    if is_stdout(output):
         _print_lock(_write_lock_or_exit(lock_input, target=None))
         return
 
@@ -744,7 +763,7 @@ def _emit_pylock(
     # Pass the target so wheel/sdist/directory paths are written relative
     # to the lockfile's own directory, not the cwd.
     _write_lock_or_exit(lock_input, target=target)
-    _cli.printer().done(f"Wrote {target} ({summarize_lock(lock_input, prior)})")
+    printer().done(f"Wrote {target} ({summarize_lock(lock_input, prior)})")
 
 
 def _write_lock_or_exit(lock_input: LockInput, *, target: Path | None) -> str:
@@ -757,10 +776,10 @@ def _render_or_exit(render: Callable[[], str]) -> str:
     try:
         return render()
     except (MissingHashError, LockValidationError, IntractableMarkerError) as e:
-        _cli.printer().error(f"cannot lock: {e}")
+        printer().error(f"cannot lock: {e}")
         sys.exit(1)
     except (DisjointnessError, DivergentBaseDependencyError) as e:
-        _cli.printer().error(str(e))
+        printer().error(str(e))
         sys.exit(1)
 
 
@@ -805,12 +824,12 @@ def _and_list(names: Sequence[str]) -> str:
 def _check_output_template(output: Path, template: str) -> None:
     """Reject an --output template that ``str.format`` cannot render.
 
-    Only the bare :data:`~nab.cli.TUPLE_TEMPLATE_VARS` fields are
+    Only the bare :data:`TUPLE_TEMPLATE_VARS` fields are
     accepted. An unbalanced brace, an unknown field name, or a field
     carrying a format spec (``{platform_id:d}``) or conversion
     (``{python_version!r}``) is rejected here.
     """
-    allowed_vars = _cli.TUPLE_TEMPLATE_VARS
+    allowed_vars = TUPLE_TEMPLATE_VARS
     allowed = {
         name
         for v in allowed_vars
@@ -824,12 +843,12 @@ def _check_output_template(output: Path, template: str) -> None:
             if name is not None
         ]
     except ValueError as e:
-        _cli.printer().error(f"--output {output} is not a valid template: {e}")
+        printer().error(f"--output {output} is not a valid template: {e}")
         sys.exit(1)
     supported = _and_list(allowed_vars)
     unknown = sorted(f"{{{name}}}" for name, _, _ in fields if name not in allowed)
     if unknown:
-        _cli.printer().error(
+        printer().error(
             f"--output {output} has unknown template placeholder(s)"
             f" {', '.join(unknown)}; only {supported} are supported."
         )
@@ -838,7 +857,7 @@ def _check_output_template(output: Path, template: str) -> None:
         {f"{{{name}}}" for name, spec, conversion in fields if spec or conversion}
     )
     if decorated:
-        _cli.printer().error(
+        printer().error(
             f"--output {output} is not a valid template:"
             f" {', '.join(decorated)} may not carry a format spec or conversion;"
             f" only bare {supported} are supported."
@@ -864,7 +883,7 @@ def _emit_requirements(
       file to fall back to: there is no one file to write.
     * ``output`` is unset and the lock covers one target: write
       ``default_output``.
-    * ``output`` names a :data:`~nab.cli.TUPLE_TEMPLATE_VARS` variable:
+    * ``output`` names a :data:`TUPLE_TEMPLATE_VARS` variable:
       write one file per target, substituting the target's values into
       the template.  This is the constraints-per-Python-version shape
       (e.g. ``constraints-{python_version}.txt``), and
@@ -880,20 +899,20 @@ def _emit_requirements(
     """
     with_hashes = format == "requirements"
     multi_target = len(lock_input.targets) > 1
-    if _cli.is_stdout(output) or (output is None and multi_target):
+    if is_stdout(output) or (output is None and multi_target):
         text, _ = _render_requirements_or_exit(lock_input, with_hashes)
         _print_lock(text)
         return
 
     target = output if output is not None else default_output
     template = str(target)
-    if not any(var in template for var in _cli.TUPLE_TEMPLATE_VARS):
+    if not any(var in template for var in TUPLE_TEMPLATE_VARS):
         if multi_target:
             _refuse_untemplated(lock_input, target)
         _, count = _render_requirements_or_exit(
             lock_input, with_hashes, output_path=target
         )
-        _cli.printer().done(f"Wrote {target} ({count} packages)")
+        printer().done(f"Wrote {target} ({count} packages)")
         return
 
     _check_output_template(target, template)
@@ -922,7 +941,7 @@ def _refuse_untemplated(lock_input: LockInput, output: Path) -> NoReturn:
     count = len(targets)
     separating = _separating_vars(targets)
     if not separating:
-        _cli.printer().error(
+        printer().error(
             f"the resolve produced {count} tuples and no --output template"
             f" variable tells them apart, so {output} cannot hold them."
             "  Emit pylock output instead."
@@ -930,7 +949,7 @@ def _refuse_untemplated(lock_input: LockInput, output: Path) -> NoReturn:
         sys.exit(1)
     placeholders = _and_list([f"{{{name}}}" for name in separating])
     example = "constraints" + "".join(f"-{{{name}}}" for name in separating) + ".txt"
-    _cli.printer().error(
+    printer().error(
         f"the resolve produced {count} tuples but --output {output} has no"
         f" template variable to disambiguate.  Use {placeholders} in the path,"
         f" e.g.:\n  --output '{example}'"
@@ -963,13 +982,13 @@ def _refuse_collision(
         f" both map to {path!r};"
     )
     if not missing:
-        _cli.printer().error(
+        printer().error(
             f"{head} no --output template variable tells them apart."
             "  Emit pylock output instead."
         )
         sys.exit(1)
     placeholders = _and_list([f"{{{name}}}" for name in missing])
-    _cli.printer().error(
+    printer().error(
         f"{head} --output {output} is missing a template variable to"
         f" disambiguate.  Add {placeholders} to the path."
     )
@@ -1033,7 +1052,7 @@ def _write_requirements_files(rendered: list[_RenderedFile]) -> None:
 
     for tmp, item in staged:
         tmp.replace(item.path)
-        _cli.printer().done(
+        printer().done(
             f"Wrote {item.path} ({item.pin_count} packages, tuple {item.label})"
         )
 
@@ -1095,76 +1114,9 @@ def _render_requirements_or_exit(
                 lock_input, output_path=output_path
             )
     except MissingHashError as e:
-        _cli.printer().error(f"cannot lock: {e}")
+        printer().error(f"cannot lock: {e}")
         sys.exit(1)
     return text, sum(len(lock.pins) for lock in lock_input.targets.values())
-
-
-def _read_selection_table_or_exit(
-    path: Path,
-    reader: Callable[[Path], Mapping[str, object]],
-) -> Mapping[str, object]:
-    """Read the table a selection flag expands over, exiting 1 on a bad file.
-
-    ``nab download`` selects groups and extras before it loads the config, so
-    this read can be the first to touch the pyproject and runs the path guards
-    itself rather than relying on the config load having run.
-    """
-    _cli.require_pyproject_file(path)
-
-    try:
-        return reader(path)
-    except OSError as e:
-        _cli.printer().error(f"cannot read {path}: {e}")
-        sys.exit(1)
-    except (UnicodeDecodeError, tomli.TOMLDecodeError) as e:
-        _cli.printer().error(f"{path} is not valid TOML: {e}")
-        sys.exit(1)
-    except TypeError as e:
-        _cli.printer().error(f"in {path}: {e}")
-        sys.exit(1)
-
-
-def resolve_group_selection(
-    path: Path,
-    *,
-    groups: tuple[str, ...],
-    all_groups: bool,
-) -> tuple[str, ...]:
-    """Return the canonical, deduplicated group selection for this run.
-
-    ``groups`` is the user-supplied list (already split by tyro on
-    commas).  ``all_groups`` overrides it: when set, every group
-    defined in the project's ``[dependency-groups]`` table is
-    selected.  An ``--all-groups`` paired with a non-empty
-    ``--groups`` list raises a clean error rather than silently
-    preferring one over the other.
-    """
-    if all_groups and groups:
-        _cli.printer().error("--all-groups and --groups are mutually exclusive")
-        sys.exit(1)
-    if not (all_groups or groups):
-        return ()
-
-    defined = _read_selection_table_or_exit(path, read_pyproject_groups)
-    return tuple(defined.keys()) if all_groups else tuple(dict.fromkeys(groups))
-
-
-def resolve_extra_selection(
-    path: Path,
-    *,
-    extras: tuple[str, ...],
-    all_extras: bool,
-) -> tuple[str, ...]:
-    """Return the canonical, deduplicated extras selection for this run."""
-    if all_extras and extras:
-        _cli.printer().error("--all-extras and --extras are mutually exclusive")
-        sys.exit(1)
-    if not (all_extras or extras):
-        return ()
-
-    defined = _read_selection_table_or_exit(path, read_pyproject_optional_dependencies)
-    return tuple(defined.keys()) if all_extras else tuple(dict.fromkeys(extras))
 
 
 def _build_provenance(
@@ -1226,10 +1178,10 @@ def _reused_lock_anchor(
     anchor ``--upgrade`` actually drops.  Stdout, the requirements formats,
     and a first lock have nothing to reuse.
     """
-    absolute = _cli.lock_anchor(ladder)
+    absolute = lock_anchor(ladder)
     if absolute is not None:
         return absolute, None
-    if _cli.is_stdout(output) or format != "pylock":
+    if is_stdout(output) or format != "pylock":
         return None, None
     target = _default_output_path(format, build_requirements=build_requirements)
     return None, read_lockfile_anchor(output if output is not None else target)
@@ -1261,7 +1213,7 @@ def _determine_lock_anchor(
     if upgrade:
         fresh = datetime.now(timezone.utc)
         if prior is not None:
-            _cli.printer().note(
+            printer().note(
                 "--upgrade re-anchored the resolve window to"
                 f" {fresh.isoformat()}, dropping the cutoff {prior.isoformat()}"
                 " recorded in the existing lockfile."
@@ -1284,12 +1236,12 @@ def _validate_pylock_output_name(
     name) and a bad name both exit 1, the latter with a suggested
     correction.
     """
-    if format != "pylock" or output is None or _cli.is_stdout(output):
+    if format != "pylock" or output is None or is_stdout(output):
         return
     if is_valid_pylock_path(output):
         return
     if not output.name:
-        _cli.printer().error(
+        printer().error(
             f"--output {str(output)!r} names a directory, not a file; the"
             " pylock output must be a file named 'pylock.toml' or"
             " 'pylock.<name>.toml'."
@@ -1299,7 +1251,7 @@ def _validate_pylock_output_name(
     # dotted form can produce, such as '.' from a bare '-'.
     dotted = output.name.replace("-", ".")
     suggestion = dotted if is_valid_pylock_path(Path(dotted)) else "pylock.toml"
-    _cli.printer().error(
+    printer().error(
         f"output file name {output.name!r} must match 'pylock.toml'"
         " or 'pylock.<name>.toml' per PEP 751 (note the dot separator,"
         f" not a hyphen).  Try {suggestion!r}."

--- a/src/nab/_run.py
+++ b/src/nab/_run.py
@@ -1,0 +1,810 @@
+"""Helpers the command modules call.
+
+The project-path guard, the group and extra selection, the layered
+config read and the run knobs folded out of it, the cache-directory
+default, HTTP transport selection, and the resolve step with its
+failure-to-exit-code translation.
+
+Nothing here imports :mod:`nab.cli`: that module imports the command
+modules and they import these helpers, so a helper reaching back would
+close a cycle that breaks entering the package through a command module.
+"""
+
+from __future__ import annotations
+
+import gc
+import sys
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, NoReturn
+
+import tomli
+
+from nab_project import toml_io
+from nab_project.config import (
+    ConfigError,
+    NabProjectConfig,
+    ResolveMode,
+    read_pyproject_config,
+    with_python_override,
+)
+from nab_project.config_sources import (
+    OPTIONS,
+    EffectiveValue,
+    RejectedLayer,
+    Scope,
+    SourceConfigError,
+    SourceKind,
+    SourceRoots,
+    build_cli_layer,
+    build_cli_overrides,
+    discover_layers,
+    inspector_anchor,
+    project_cli_override_notice,
+    project_cli_override_records,
+    read_env_layer,
+    resolve_config,
+)
+from nab_project.lockfile import MissingHashError, MissingSdistError
+from nab_project.paths import PathState, path_state, realpath
+from nab_project.pyproject_files import (
+    read_pyproject_groups,
+    read_pyproject_optional_dependencies,
+)
+from nab_project.resolve import resolve_for_targets
+from nab_project.workspace import WorkspaceDiscoveryError
+from nab_provider.errors import (
+    IndexAccessError,
+    MetadataHashMismatchError,
+    SdistHashMismatchError,
+    WheelHashMismatchError,
+)
+from nab_provider.provider import (
+    InvalidUploadTimeError,
+    MetadataError,
+    MissingExtraError,
+    SiblingMetadataDivergenceError,
+    SourceNameMismatchError,
+    UnsupportedVcsError,
+)
+from nab_provider.requirements_file import (
+    InvalidProjectRequirementError,
+    InvalidProjectTableError,
+)
+from nab_provider.target import (
+    IntractableMarkerError,
+    NonIntervalMarkerError,
+    UnevaluableMarkerError,
+)
+from nab_resolver.errors import ResolutionError
+
+from . import env
+from .output import OUTPUT_ENV_VARS, ProgressReporter, Verbosity, printer
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator, Mapping
+
+    from nab_index.transport import AsyncHttpTransport, HttpResponse
+    from nab_project.resolve import ResolveResult
+    from nab_provider.provider import ResolutionStrategy
+
+
+def require_pyproject_file(path: Path) -> None:
+    """Exit 1 if ``path`` is not a readable pyproject file.
+
+    Shared by every command that takes a project path, so the rejection
+    wording lives in one place.  A ``--path`` that is missing, a
+    directory, or not a regular file is a hard error, not a
+    silently-skipped source.  A path whose stat fails passes: the config
+    read reports it, naming the errno.
+    """
+    state = path_state(path)
+
+    if state is PathState.DIRECTORY:
+        printer().error(f"{path} is a directory")
+        sys.exit(1)
+
+    if state is PathState.OTHER:
+        printer().error(f"{path} exists but is not a regular file")
+        sys.exit(1)
+
+    if state is PathState.ABSENT:
+        printer().error(f"{path} not found")
+        sys.exit(1)
+
+    if _is_pylock(path):
+        printer().error(
+            f"{path} is a PEP 751 lockfile, not a pyproject.  nab resolves"
+            " from project inputs, so pass the pyproject.toml instead."
+        )
+        sys.exit(1)
+
+
+def _read_selection_table_or_exit(
+    path: Path,
+    reader: Callable[[Path], Mapping[str, object]],
+) -> Mapping[str, object]:
+    """Read the table a selection flag expands over, exiting 1 on a bad file.
+
+    ``nab download`` selects groups and extras before it loads the config, so
+    this read can be the first to touch the pyproject and runs the path guards
+    itself rather than relying on the config load having run.
+    """
+    require_pyproject_file(path)
+
+    try:
+        return reader(path)
+    except OSError as e:
+        printer().error(f"cannot read {path}: {e}")
+        sys.exit(1)
+    except (UnicodeDecodeError, tomli.TOMLDecodeError) as e:
+        printer().error(f"{path} is not valid TOML: {e}")
+        sys.exit(1)
+    except TypeError as e:
+        printer().error(f"in {path}: {e}")
+        sys.exit(1)
+
+
+def resolve_group_selection(
+    path: Path,
+    *,
+    groups: tuple[str, ...],
+    all_groups: bool,
+) -> tuple[str, ...]:
+    """Return the canonical, deduplicated group selection for this run.
+
+    ``groups`` is the user-supplied list (already split by tyro on
+    commas).  ``all_groups`` overrides it: when set, every group
+    defined in the project's ``[dependency-groups]`` table is
+    selected.  An ``--all-groups`` paired with a non-empty
+    ``--groups`` list raises a clean error rather than silently
+    preferring one over the other.
+    """
+    if all_groups and groups:
+        printer().error("--all-groups and --groups are mutually exclusive")
+        sys.exit(1)
+    if not (all_groups or groups):
+        return ()
+
+    defined = _read_selection_table_or_exit(path, read_pyproject_groups)
+    return tuple(defined.keys()) if all_groups else tuple(dict.fromkeys(groups))
+
+
+def resolve_extra_selection(
+    path: Path,
+    *,
+    extras: tuple[str, ...],
+    all_extras: bool,
+) -> tuple[str, ...]:
+    """Return the canonical, deduplicated extras selection for this run."""
+    if all_extras and extras:
+        printer().error("--all-extras and --extras are mutually exclusive")
+        sys.exit(1)
+    if not (all_extras or extras):
+        return ()
+
+    defined = _read_selection_table_or_exit(path, read_pyproject_optional_dependencies)
+    return tuple(defined.keys()) if all_extras else tuple(dict.fromkeys(extras))
+
+
+def _make_urllib3_transport() -> AsyncHttpTransport:
+    """Return a urllib3 transport, importing urllib3 and truststore to build it."""
+    from nab_index.urllib3_async_transport import (  # noqa: PLC0415
+        Urllib3AsyncTransport,
+    )
+
+    return Urllib3AsyncTransport()
+
+
+def _make_transport(backend: str) -> AsyncHttpTransport:
+    """Return the transport for ``backend``.
+
+    Importing either transport module loads its HTTP library and truststore,
+    so both imports stay local: the CLI itself needs neither, and httpx is an
+    optional extra a urllib3-only install will not have.
+    """
+    if backend == "httpx":
+        try:
+            from nab_index.httpx_async_transport import (  # noqa: PLC0415
+                HttpxAsyncTransport,
+            )
+        except ImportError:
+            printer().error("httpx is not installed; run `pip install nab[httpx]`")
+            sys.exit(1)
+
+        # httpx raises ImportError from its client constructor when h2 is missing.
+        try:
+            return HttpxAsyncTransport()
+        except ImportError:
+            printer().error(
+                "httpx is installed without HTTP/2 support; "
+                "run `pip install nab[httpx]`"
+            )
+            sys.exit(1)
+
+    return _make_urllib3_transport()
+
+
+class _DeferredUrllib3Transport:
+    """Transport that builds a urllib3 transport on the first request.
+
+    Building one imports urllib3 and truststore, which a resolve answered
+    entirely from the cache never needs.
+    """
+
+    def __init__(self) -> None:
+        self._transport: AsyncHttpTransport | None = None
+
+    async def get(
+        self, url: str, *, headers: dict[str, str] | None = None
+    ) -> HttpResponse:
+        if self._transport is None:
+            self._transport = _make_urllib3_transport()
+        return await self._transport.get(url, headers=headers)
+
+    async def aclose(self) -> None:
+        if self._transport is not None:
+            await self._transport.aclose()
+
+
+def _make_resolve_transport(backend: str, *, offline: bool) -> AsyncHttpTransport:
+    """Return the transport for a resolve on ``backend``.
+
+    An offline resolve is served from the cache and asks for no URL, so the
+    urllib3 transport is built only if something does. httpx is built up front
+    either way: a missing httpx exits the CLI, which has to happen on the main
+    thread before the resolve starts.
+    """
+    if offline and backend == "urllib3":
+        return _DeferredUrllib3Transport()
+    return _make_transport(backend)
+
+
+def _default_cache_dir() -> Path:
+    """Return the default per-user cache root.
+
+    Mirrors ``platformdirs.user_cache_path("nab")`` without the
+    dependency: ``$XDG_CACHE_HOME/nab`` or ``~/.cache/nab``.
+    """
+    base = env.cache_root()
+    if base:
+        return Path(base) / "nab"
+    return Path.home() / ".cache" / "nab"
+
+
+def _resolve_effective_cache_dir(cache_dir: Path | None, *, cache: bool) -> Path | None:
+    if not cache:
+        return None
+    if cache_dir is not None:
+        return cache_dir
+    return _default_cache_dir()
+
+
+def _config_search_roots(pyproject: Path) -> SourceRoots:
+    """Locate the system/user/project config roots for ``pyproject``.
+
+    Uses the same XDG roots as cache-dir: the user ``nab.toml`` lives at
+    ``$XDG_CONFIG_HOME/nab/nab.toml`` or ``~/.config/nab/nab.toml``; the
+    system file at ``/etc/nab/nab.toml``.  Tests inject roots by
+    monkeypatching this function, so the real ``~/.config`` is never
+    touched in the suite.  Discovery is project-dir only.  There is no
+    walk-up.
+
+    ``pyproject`` is the project file the user pointed at, threaded
+    through so the registry's pyproject layer reads that exact file even
+    when its name is not ``pyproject.toml``; the project-dir ``nab.toml``
+    is looked up beside it.  The pyproject root keeps the file's own
+    directory (resolved) rather than resolving the file itself, so a
+    relative ``local-sources`` path resolves against the symlink's
+    directory, matching the resolve path; ``open`` still follows the
+    symlink to read it.
+    """
+    base = env.config_root()
+    user_dir = Path(base) if base else Path.home() / ".config"
+    project_dir = realpath(pyproject.parent)
+    return SourceRoots(
+        system_toml=Path("/etc/nab/nab.toml"),
+        user_toml=user_dir / "nab" / "nab.toml",
+        project_dir=project_dir,
+        pyproject=project_dir / pyproject.name,
+    )
+
+
+def effective_config(
+    path: Path,
+    *,
+    cli_overrides: Mapping[str, object] | None = None,
+    collect_rejected: bool = False,
+    rejected_out: list[RejectedLayer] | None = None,
+    read_pyproject: bool = True,
+) -> dict[str, EffectiveValue]:
+    """Resolve the full layered config for the pyproject at ``path``.
+
+    Discovers the system/user/project TOML layers (roots from
+    :func:`_config_search_roots`), reads the ``NAB_*`` env layer, builds
+    the CLI layer from ``cli_overrides`` (only keys the user set), and
+    merges them through the registry.  Returns the effective map; when
+    ``collect_rejected`` is set the category-rejections are attached per
+    key (``EffectiveValue.rejected``) for ``explain --include-rejected``.
+    ``rejected_out``, when supplied, is filled with the full rejection
+    list so the caller can also surface the orphan rejections (an unknown
+    key or ``NAB_*`` var that names no registry option, and so attaches to
+    no key) that ``nab config list`` reports.  ``read_pyproject=False``
+    skips the pyproject layer, for a caller reading a USER-scope key that
+    pyproject may not set.
+    """
+    roots = _config_search_roots(path)
+    rejected: list[RejectedLayer] = []
+    sink = rejected if collect_rejected else None
+    # Pin one ``now`` for the pass so identical relative ``P<n>D`` override
+    # durations across the two project files are not read as conflicting
+    # values (the resolve path uses its lockfile anchor instead).
+    with inspector_anchor():
+        layers = discover_layers(roots, rejections=sink, read_pyproject=read_pyproject)
+        env_layer = read_env_layer(
+            env.current(), reserved_env=OUTPUT_ENV_VARS, rejections=sink
+        )
+        cli_layer = build_cli_layer(cli_overrides or {})
+        if rejected_out is not None:
+            rejected_out.extend(rejected)
+        return resolve_config(layers, env_layer, cli_layer, rejected=rejected)
+
+
+ConfigLadder = dict[str, EffectiveValue] | SourceConfigError
+"""One read of the layered config: the effective map, or the error it raised."""
+
+
+def read_config_ladder(path: Path, cli_overrides: Mapping[str, object]) -> ConfigLadder:
+    """Read the layered config once for a run and hold what came back.
+
+    A command builds one of these and threads it, so the environment is
+    read, and an unknown ``NAB_*`` var warned about, once per
+    invocation.  A category error is held rather than raised because the
+    lock anchor tolerates one and the run-settings fold exits on it.
+    """
+    try:
+        return effective_config(path, cli_overrides=cli_overrides)
+    except SourceConfigError as exc:
+        return exc
+
+
+def lock_anchor(ladder: ConfigLadder) -> datetime | None:
+    """Return the absolute ``uploaded-prior-to`` cutoff for ``nab lock``.
+
+    An absolute datetime is the lock anchor: it already fixes the resolve
+    window, so anchoring there makes ``created-at`` deterministic and two
+    locks from identical inputs produce identical bytes.  A relative
+    ``P<n>D`` duration anchors to run time, so it is not reproducible and
+    returns ``None``; an unset value, and a ladder that failed to
+    resolve, return ``None`` too.
+    """
+    if isinstance(ladder, SourceConfigError):
+        return None
+    value = ladder["uploaded-prior-to"].value
+    return value if isinstance(value, datetime) else None
+
+
+@dataclass(frozen=True, slots=True)
+class RunSettings:
+    """The run knobs a subcommand reads from the layered config for one run."""
+
+    resolution: ResolutionStrategy | None
+    offline: bool
+    cache_dir: Path | None
+    http_backend: str
+    max_concurrency: int
+    # The (flag, rendered value) pairs for any --project-* override set on
+    # the CLI, recorded into the lockfile provenance so the lock is auditable.
+    cli_project_overrides: tuple[tuple[str, str], ...]
+
+
+def _cli_overrides(  # noqa: PLR0913 - one keyword per CLI flag it maps to a registry key
+    *,
+    cli_resolution: str | None,
+    cli_offline: bool | None,
+    cli_cache_dir: Path | None,
+    cli_http_backend: str | None = None,
+    cli_max_concurrency: int | None = None,
+    cli_mode: str | None = None,
+    cli_requires_python: str | None = None,
+    cli_uploaded_prior_to: str | None = None,
+    cli_dist_policy: str | None = None,
+    cli_build_policy: str | None = None,
+    cli_build_requires_depth: int | None = None,
+    cli_decision_order: str | None = None,
+    cli_constraint: tuple[str, ...] = (),
+    cli_default_group: tuple[str, ...] = (),
+    cli_base_group: str | None = None,
+    cli_build_group: str | None = None,
+) -> dict[str, object]:
+    """Build the registry-keyed CLI override dict from the named flags.
+
+    The one place the ``cli_param`` -> value mapping is written: the run
+    subcommands and ``nab config`` route their flag values through here so
+    the literal lives once.  ``build_cli_overrides`` then keeps only the
+    keys the user actually set.  USER options and the ``--project-*``
+    overrides for the scalar and array PROJECT options pass through; the
+    structured PROJECT tables stay file-only.
+    """
+    return build_cli_overrides(
+        {
+            "project_resolution": cli_resolution,
+            "offline": cli_offline,
+            "cache_dir": cli_cache_dir,
+            "http_backend": cli_http_backend,
+            "max_concurrency": cli_max_concurrency,
+            "project_mode": cli_mode,
+            "project_requires_python": cli_requires_python,
+            "project_uploaded_prior_to": cli_uploaded_prior_to,
+            "project_dist_policy": cli_dist_policy,
+            "project_build_policy": cli_build_policy,
+            "project_build_requires_depth": cli_build_requires_depth,
+            "project_decision_order": cli_decision_order,
+            "project_constraint": cli_constraint,
+            "project_default_group": cli_default_group,
+            "project_base_group": cli_base_group,
+            "project_build_group": cli_build_group,
+        }
+    )
+
+
+def project_config_overrides(
+    cli_overrides: Mapping[str, object],
+) -> dict[str, object]:
+    """Return the PROJECT-scope CLI overrides that belong in the config.
+
+    ``resolution`` is excluded: it keeps its own ``resolution_strategy``
+    path into the resolver, so it must not also enter the merged config.
+    USER options are excluded too (they configure the run, not the project).
+    The rest are the ``--project-*`` overrides the resolve folds in through
+    :func:`read_pyproject_config`.
+    """
+    project_keys = {
+        spec.key
+        for spec in OPTIONS
+        if spec.scope is Scope.PROJECT and spec.key != "resolution"
+    }
+    return {key: value for key, value in cli_overrides.items() if key in project_keys}
+
+
+def project_override_arguments(cli_overrides: Mapping[str, object]) -> list[str]:
+    """Return the CLI tokens that re-apply this run's ``--project-*`` overrides.
+
+    Takes the raw map :func:`_cli_overrides` built, not the config subset, so
+    ``resolution`` is carried too: it shapes the resolve without entering the
+    merged config.  A repeatable flag is emitted once per element.
+    """
+    arguments: list[str] = []
+    for spec in OPTIONS:
+        flag = spec.cli_flag
+        if spec.scope is not Scope.PROJECT or flag is None:
+            continue
+        value = cli_overrides.get(spec.key)
+        if value is None:
+            continue
+        items = value if isinstance(value, tuple) else (value,)
+        for item in items:
+            arguments += [flag, str(item)]
+    return arguments
+
+
+def _layered_run_settings(effective: Mapping[str, EffectiveValue]) -> RunSettings:
+    """Fold the effective registry values into a subcommand's run knobs.
+
+    ``resolution`` stays ``None`` (config wins downstream) when no source
+    above the default set it, preserving the contract that the resolver
+    falls back to ``config.resolution``.
+    """
+    res_ev = effective["resolution"]
+    resolution = res_ev.value if res_ev.origin.kind is not SourceKind.DEFAULT else None
+    return RunSettings(
+        resolution=resolution,
+        offline=effective["offline"].value,
+        cache_dir=effective["cache-dir"].value,
+        http_backend=effective["http-backend"].value,
+        max_concurrency=effective["max-concurrency"].value,
+        cli_project_overrides=project_cli_override_records(effective),
+    )
+
+
+def _layered_run_settings_or_exit(
+    ladder: ConfigLadder, *, produces_lock: bool = True
+) -> RunSettings:
+    """Fold the ladder's run knobs, exiting on a category error it holds.
+
+    The single ``SourceConfigError`` -> ``error: config error: ...`` ->
+    ``exit(1)`` mapping shared by ``nab lock`` and ``nab download`` lives
+    here.  On success it also emits the reproducibility notice when a
+    PROJECT option was set on the CLI, so a result-shaping override is
+    never silent.  ``produces_lock`` picks the wording: ``nab lock`` warns
+    about the lock it produces while ``nab download`` (which writes no
+    lock) warns only that the resolved set reflects the override.
+    """
+    if isinstance(ladder, SourceConfigError):
+        _fail_config(ladder)
+    settings = _layered_run_settings(ladder)
+    notice = project_cli_override_notice(ladder, produces_lock=produces_lock)
+    if notice is not None:
+        sys.stderr.write(notice)
+    return settings
+
+
+def _fail_config(exc: SourceConfigError) -> NoReturn:
+    """Map a layered config error to the shared ``error: config error:`` exit."""
+    printer().error(f"config error: {exc}")
+    sys.exit(1)
+
+
+def _is_pylock(path: Path) -> bool:
+    """Whether ``path`` holds a PEP 751 lock rather than a pyproject.
+
+    ``lock-version`` is the one required key PEP 751 gives a lock and a
+    pyproject never carries.  An unreadable or malformed file is left for
+    the pyproject parser to report.
+    """
+    try:
+        data = toml_io.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, tomli.TOMLDecodeError):
+        return False
+    return "lock-version" in data and "project" not in data
+
+
+def _project_cli_overrides_or_exit(project_overrides: Mapping[str, object]) -> None:
+    """Exit 1 when a ``--project-*`` override has a bad value, naming the flag.
+
+    These overrides otherwise reach validation only through the
+    ``[tool.nab]`` parse in :func:`_load_config`, which stamps every error
+    ``in [tool.nab]:`` and points at a table the project may not have.
+    Parsing them here surfaces the error against the flag instead.
+    """
+    for spec in OPTIONS:
+        if spec.key not in project_overrides:
+            continue
+        try:
+            build_cli_layer({spec.key: project_overrides[spec.key]})
+        except SourceConfigError as exc:
+            printer().error(f"{spec.cli_flag}: {exc}")
+            sys.exit(1)
+
+
+def _load_config(
+    path: Path,
+    *,
+    discover_workspace: bool = True,
+    anchor: datetime | None = None,
+    cli_overrides: Mapping[str, object] | None = None,
+) -> NabProjectConfig:
+    require_pyproject_file(path)
+
+    try:
+        return read_pyproject_config(
+            path,
+            discover_workspace=discover_workspace,
+            anchor=anchor,
+            cli_overrides=cli_overrides,
+        )
+    except ConfigError as exc:
+        printer().error(f"in [tool.nab]: {exc}")
+        sys.exit(1)
+    except WorkspaceDiscoveryError as exc:
+        printer().error(f"workspace discovery error: {exc}")
+        sys.exit(1)
+
+
+def is_stdout(output: Path | None) -> bool:
+    return output is not None and str(output) == "-"
+
+
+def _reject_python_override_in_universal(
+    config: NabProjectConfig, python: str | None
+) -> None:
+    """Exit 1 when ``--python`` is passed to a matrix-declaring project.
+
+    The matrix declares the python axis itself, so a single Python for the
+    run has nowhere to land; silently ignoring the flag would lock a set
+    the user did not ask for.
+    """
+    if python is not None and config.mode is ResolveMode.UNIVERSAL:
+        printer().error(
+            "--python is not supported in universal mode;"
+            " [tool.nab.matrix].python declares the Python axis."
+        )
+        sys.exit(1)
+
+
+def _python_override_or_exit(
+    config: NabProjectConfig, python: str | None
+) -> NabProjectConfig:
+    """Retarget ``config`` onto the ``--python`` value, exiting 1 on a bad one.
+
+    Applied here rather than forwarded to the resolve, so the error reads
+    as a flag error, not a ``[tool.nab]`` one.
+    """
+    try:
+        return with_python_override(config, python)
+    except ConfigError as e:
+        printer().error(str(e))
+        sys.exit(1)
+
+
+@contextmanager
+def _collector_paused() -> Iterator[None]:
+    """Disable the cyclic collector for the duration of the resolve.
+
+    Exit enables the collector and unfreezes rather than restoring what it
+    found, so every caller of :func:`_resolve` is left in that state and not
+    the one it came in with.
+
+    Everything the resolve allocated is in generation 0 by then, so the
+    collections that follow the enable walk the whole resolve graph. Freezing
+    empties every generation into the permanent one and unfreezing returns the
+    permanent generation to generation 2, which takes the graph out of
+    generation 0 and leaves those collections less to walk. PyPy has no
+    ``gc.freeze``.
+    """
+    gc.disable()
+    try:
+        yield
+    finally:
+        if hasattr(gc, "freeze"):
+            gc.freeze()
+            gc.unfreeze()
+        gc.enable()
+
+
+def _resolve(  # noqa: PLR0913, PLR0912, C901 - one wrapper per resolve_for_targets kwarg / exit-mapped error
+    path: Path,
+    *,
+    config: NabProjectConfig,
+    cache_dir: Path | None,
+    offline: bool,
+    transport: AsyncHttpTransport,
+    failure_prefix: str,
+    python: str | None = None,
+    groups: tuple[str, ...] = (),
+    extras: tuple[str, ...] = (),
+    build_requirements: bool = False,
+    resolution_strategy: ResolutionStrategy | None = None,
+    progress: ProgressReporter | None = None,
+) -> ResolveResult:
+    """Run the resolver and translate every failure to an exit.
+
+    A returned result is always fully successful: a target that did not
+    resolve is reported (one line for a single environment, a per-tuple
+    block for a matrix) and the process exits 1.
+
+    ``progress`` renders the live resolve line while ``resolve_for_targets``
+    runs; it is cleared before any summary or error is written, so the two
+    never collide.
+    """
+    config = _python_override_or_exit(config, python)
+    try:
+        try:
+            with _collector_paused():
+                result = resolve_for_targets(
+                    path,
+                    transport,
+                    config=config,
+                    cache_dir=cache_dir,
+                    offline=offline,
+                    groups=groups,
+                    extras=extras,
+                    build_requirements=build_requirements,
+                    resolution_strategy=resolution_strategy,
+                    progress=progress,
+                )
+        finally:
+            if progress is not None:
+                progress.clear()
+    except ResolutionError as e:
+        printer().error(f"resolution failed: {_error_text(e)}")
+        sys.exit(1)
+    except (
+        UnsupportedVcsError,
+        MissingExtraError,
+        SiblingMetadataDivergenceError,
+        SourceNameMismatchError,
+        NonIntervalMarkerError,
+        UnevaluableMarkerError,
+        IntractableMarkerError,
+    ) as e:
+        printer().error(f"{failure_prefix}: {e}")
+        sys.exit(1)
+    except InvalidUploadTimeError as e:
+        printer().error(str(e))
+        sys.exit(1)
+    except KeyError:
+        printer().error(f"{path} has no [project].dependencies")
+        sys.exit(1)
+    except InvalidProjectTableError as e:
+        printer().error(f"in {path}: {e}")
+        sys.exit(1)
+    except InvalidProjectRequirementError as e:
+        printer().error(str(e))
+        sys.exit(1)
+    except LookupError as e:
+        printer().error(str(e))
+        sys.exit(1)
+    except (
+        MissingHashError,
+        MissingSdistError,
+        MetadataError,
+        MetadataHashMismatchError,
+        SdistHashMismatchError,
+        WheelHashMismatchError,
+    ) as e:
+        printer().error(f"{failure_prefix}: {e}")
+        sys.exit(1)
+    except NotImplementedError as e:
+        printer().error(f"{failure_prefix}: {e}")
+        sys.exit(1)
+    except ConfigError as e:
+        printer().error(f"in [tool.nab]: {e}")
+        sys.exit(1)
+    except IndexAccessError as e:
+        printer().error(f"{failure_prefix}: {e}")
+        sys.exit(1)
+
+    if not result.success:
+        _report_failures(result)
+        sys.exit(1)
+    return result
+
+
+def _report_failures(result: ResolveResult) -> None:
+    """Report the targets that did not resolve.
+
+    A resolve with one target has one error, and it is the run's error.
+    A resolve with several (a matrix's tuples, or a conflict fork's
+    members, which fork in specific mode too) has one error per target,
+    and the pins that did resolve are as informative as the failures, so
+    each target gets a labelled block.  The check keys on the target
+    count, matching the lock-emission paths.  Both go to stderr: the
+    report is a diagnostic, not the requested lock, so stdout stays clean
+    for a caller that piped it.
+    """
+    if len(result.target_results) <= 1:
+        first = next(tr.error for tr in result.every_result if tr.error is not None)
+        printer().error(f"resolution failed: {_error_text(first)}")
+        return
+
+    blocks: list[str] = []
+    for tr in result.target_results:
+        label = tr.target.label
+        if not tr.success:
+            blocks.append(f"# {label}: FAILED")
+            blocks.extend(_error_lines(tr.error))
+            continue
+        blocks.append(f"# {label}")
+        blocks.extend(f"{name}=={tr.pins[name]}" for name in sorted(tr.pins))
+
+    # Surface base-pass failures so a successful tuple set does not
+    # mask a missing base attribution.
+    for br in result.base_results:
+        if br.success:
+            continue
+        blocks.append(f"# base/{br.target.label}: FAILED")
+        blocks.extend(_error_lines(br.error))
+
+    sys.stderr.write("\n".join(blocks) + "\n")
+
+
+def _error_lines(error: ResolutionError | None) -> list[str]:
+    """Render a failed target's error as commented block lines."""
+    text = f"{type(error).__name__}: {_error_text(error)}" if error is not None else ""
+    return [f"#   {line}" for line in text.splitlines()]
+
+
+def _error_text(error: ResolutionError) -> str:
+    """Return the error at the depth the run's verbosity asks for.
+
+    A resolution failure carries two renderings of its ``Diagnostics:``
+    section: one line per package by default, and each package's clauses
+    and ``note:`` at ``-v``.  An error nothing augmented carries only the
+    one.
+    """
+    if printer().verbosity >= Verbosity.VERBOSE and error.verbose_message is not None:
+        return error.verbose_message
+    return str(error)

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -1,9 +1,9 @@
 """Entry point for the nab command.
 
-Holds the tyro :class:`SubcommandApp` registration plus the helpers the
-command modules share: config loading and cache-directory defaults,
-plus the HTTP transport selection and resolver-error-to-exit-code
-translation that only :mod:`nab._lock` and :mod:`nab._download` use.
+Holds the tyro :class:`SubcommandApp` registration, the flag types the
+command signatures annotate with, and the global flags :func:`main`
+handles before any subcommand runs: the version line, the output flags,
+and the standard streams.
 
 The subcommands live in :mod:`nab._lock`, :mod:`nab._download`,
 :mod:`nab._config_cmd`, and :mod:`nab._cache_cmd`; this module imports
@@ -13,97 +13,26 @@ the CLI.
 
 from __future__ import annotations
 
-import gc
 import io
 import os
 import sys
-from contextlib import contextmanager
-from dataclasses import dataclass
-from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Literal, NoReturn
 
-import tomli
 import tyro
 from typing_extensions import override
 from tyro.extras import SubcommandApp
 
 from nab._version import __version__
-from nab_project import toml_io
-from nab_project.config import (
-    ConfigError,
-    NabProjectConfig,
-    ResolveMode,
-    read_pyproject_config,
-    with_python_override,
-)
-from nab_project.config_sources import (
-    OPTIONS,
-    EffectiveValue,
-    RejectedLayer,
-    Scope,
-    SourceConfigError,
-    SourceKind,
-    SourceRoots,
-    build_cli_layer,
-    build_cli_overrides,
-    discover_layers,
-    inspector_anchor,
-    project_cli_override_notice,
-    project_cli_override_records,
-    read_env_layer,
-    resolve_config,
-)
-from nab_project.lockfile import MissingHashError, MissingSdistError
-from nab_project.paths import PathState, path_state, realpath
-from nab_project.resolve import resolve_for_targets
-from nab_project.workspace import WorkspaceDiscoveryError
-from nab_provider.errors import (
-    IndexAccessError,
-    MetadataHashMismatchError,
-    SdistHashMismatchError,
-    WheelHashMismatchError,
-)
-from nab_provider.provider import (
-    InvalidUploadTimeError,
-    MetadataError,
-    MissingExtraError,
-    SiblingMetadataDivergenceError,
-    SourceNameMismatchError,
-    UnsupportedVcsError,
-)
-from nab_provider.requirements_file import (
-    InvalidProjectRequirementError,
-    InvalidProjectTableError,
-)
-from nab_provider.target import (
-    IntractableMarkerError,
-    NonIntervalMarkerError,
-    UnevaluableMarkerError,
-)
-from nab_resolver.errors import ResolutionError
 
-from .output import (
-    OUTPUT_ENV_VARS,
-    OutputOptionError,
-    Printer,
-    ProgressReporter,
-    Verbosity,
-    install_log_handler,
-    parse_output_options,
-)
+from . import env
+from .output import OutputOptionError, begin, parse_output_options
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator, Mapping
     from typing import TextIO
-
-    from nab_index.transport import AsyncHttpTransport, HttpResponse
-    from nab_project.resolve import ResolveResult
-    from nab_provider.provider import ResolutionStrategy
 
 __all__ = [
     "main",
-    "printer",
 ]
 
 
@@ -134,14 +63,6 @@ OfflineFlag = Annotated[
     ),
 ]
 
-_DEFAULT_OUTPUT: dict[str, str] = {
-    "pylock": "pylock.toml",
-    "requirements": "requirements.txt",
-    "requirements-without-hashes": "requirements.txt",
-}
-
-TUPLE_TEMPLATE_VARS = ("{python_version}", "{platform_id}", "{selection}")
-
 # Conventional KeyboardInterrupt exit code: 128 + SIGINT(2).
 _SIGINT_EXIT_CODE = 130
 
@@ -149,673 +70,6 @@ _SIGINT_EXIT_CODE = 130
 _FLUSH_FAILED_EXIT_CODE = 120
 
 app = SubcommandApp()
-
-_printer: Printer | None = None
-
-
-def printer() -> Printer:
-    """Return the run's :class:`~nab.output.Printer`.
-
-    :func:`main` installs the printer resolved from the global output flags.
-    A subcommand called directly (bypassing ``main``, as many tests do) gets a
-    fresh default printer that reads the current process streams.
-    """
-    return _printer if _printer is not None else Printer()
-
-
-def _make_urllib3_transport() -> AsyncHttpTransport:
-    """Return a urllib3 transport, importing urllib3 and truststore to build it."""
-    from nab_index.urllib3_async_transport import (  # noqa: PLC0415
-        Urllib3AsyncTransport,
-    )
-
-    return Urllib3AsyncTransport()
-
-
-def _make_transport(backend: HttpBackend) -> AsyncHttpTransport:
-    """Return the transport for ``backend``.
-
-    Importing either transport module loads its HTTP library and truststore,
-    so both imports stay local: the CLI itself needs neither, and httpx is an
-    optional extra a urllib3-only install will not have.
-    """
-    if backend == "httpx":
-        try:
-            from nab_index.httpx_async_transport import (  # noqa: PLC0415
-                HttpxAsyncTransport,
-            )
-        except ImportError:
-            printer().error("httpx is not installed; run `pip install nab[httpx]`")
-            sys.exit(1)
-
-        # httpx raises ImportError from its client constructor when h2 is missing.
-        try:
-            return HttpxAsyncTransport()
-        except ImportError:
-            printer().error(
-                "httpx is installed without HTTP/2 support; "
-                "run `pip install nab[httpx]`"
-            )
-            sys.exit(1)
-
-    return _make_urllib3_transport()
-
-
-class _DeferredUrllib3Transport:
-    """Transport that builds a urllib3 transport on the first request.
-
-    Building one imports urllib3 and truststore, which a resolve answered
-    entirely from the cache never needs.
-    """
-
-    def __init__(self) -> None:
-        self._transport: AsyncHttpTransport | None = None
-
-    async def get(
-        self, url: str, *, headers: dict[str, str] | None = None
-    ) -> HttpResponse:
-        if self._transport is None:
-            self._transport = _make_urllib3_transport()
-        return await self._transport.get(url, headers=headers)
-
-    async def aclose(self) -> None:
-        if self._transport is not None:
-            await self._transport.aclose()
-
-
-def _make_resolve_transport(
-    backend: HttpBackend, *, offline: bool
-) -> AsyncHttpTransport:
-    """Return the transport for a resolve on ``backend``.
-
-    An offline resolve is served from the cache and asks for no URL, so the
-    urllib3 transport is built only if something does. httpx is built up front
-    either way: a missing httpx exits the CLI, which has to happen on the main
-    thread before the resolve starts.
-    """
-    if offline and backend == "urllib3":
-        return _DeferredUrllib3Transport()
-    return _make_transport(backend)
-
-
-def _default_cache_dir() -> Path:
-    """Return the default per-user cache root.
-
-    Mirrors ``platformdirs.user_cache_path("nab")`` without the
-    dependency: ``$XDG_CACHE_HOME/nab`` or ``~/.cache/nab``.
-    """
-    base = os.environ.get("XDG_CACHE_HOME")
-    if base:
-        return Path(base) / "nab"
-    return Path.home() / ".cache" / "nab"
-
-
-def _resolve_effective_cache_dir(cache_dir: Path | None, *, cache: bool) -> Path | None:
-    if not cache:
-        return None
-    if cache_dir is not None:
-        return cache_dir
-    return _default_cache_dir()
-
-
-def _config_search_roots(pyproject: Path) -> SourceRoots:
-    """Locate the system/user/project config roots for ``pyproject``.
-
-    Uses the same XDG roots as cache-dir: the user ``nab.toml`` lives at
-    ``$XDG_CONFIG_HOME/nab/nab.toml`` or ``~/.config/nab/nab.toml``; the
-    system file at ``/etc/nab/nab.toml``.  Tests inject roots by
-    monkeypatching this function, so the real ``~/.config`` is never
-    touched in the suite.  Discovery is project-dir only.  There is no
-    walk-up.
-
-    ``pyproject`` is the project file the user pointed at, threaded
-    through so the registry's pyproject layer reads that exact file even
-    when its name is not ``pyproject.toml``; the project-dir ``nab.toml``
-    is looked up beside it.  The pyproject root keeps the file's own
-    directory (resolved) rather than resolving the file itself, so a
-    relative ``local-sources`` path resolves against the symlink's
-    directory, matching the resolve path; ``open`` still follows the
-    symlink to read it.
-    """
-    base = os.environ.get("XDG_CONFIG_HOME")
-    user_dir = Path(base) if base else Path.home() / ".config"
-    project_dir = realpath(pyproject.parent)
-    return SourceRoots(
-        system_toml=Path("/etc/nab/nab.toml"),
-        user_toml=user_dir / "nab" / "nab.toml",
-        project_dir=project_dir,
-        pyproject=project_dir / pyproject.name,
-    )
-
-
-def effective_config(
-    path: Path,
-    *,
-    cli_overrides: Mapping[str, object] | None = None,
-    collect_rejected: bool = False,
-    rejected_out: list[RejectedLayer] | None = None,
-    read_pyproject: bool = True,
-) -> dict[str, EffectiveValue]:
-    """Resolve the full layered config for the pyproject at ``path``.
-
-    Discovers the system/user/project TOML layers (roots from
-    :func:`_config_search_roots`), reads the ``NAB_*`` env layer, builds
-    the CLI layer from ``cli_overrides`` (only keys the user set), and
-    merges them through the registry.  Returns the effective map; when
-    ``collect_rejected`` is set the category-rejections are attached per
-    key (``EffectiveValue.rejected``) for ``explain --include-rejected``.
-    ``rejected_out``, when supplied, is filled with the full rejection
-    list so the caller can also surface the orphan rejections (an unknown
-    key or ``NAB_*`` var that names no registry option, and so attaches to
-    no key) that ``nab config list`` reports.  ``read_pyproject=False``
-    skips the pyproject layer, for a caller reading a USER-scope key that
-    pyproject may not set.
-    """
-    roots = _config_search_roots(path)
-    rejected: list[RejectedLayer] = []
-    sink = rejected if collect_rejected else None
-    # Pin one ``now`` for the pass so identical relative ``P<n>D`` override
-    # durations across the two project files are not read as conflicting
-    # values (the resolve path uses its lockfile anchor instead).
-    with inspector_anchor():
-        layers = discover_layers(roots, rejections=sink, read_pyproject=read_pyproject)
-        env_layer = read_env_layer(
-            os.environ, reserved_env=OUTPUT_ENV_VARS, rejections=sink
-        )
-        cli_layer = build_cli_layer(cli_overrides or {})
-        if rejected_out is not None:
-            rejected_out.extend(rejected)
-        return resolve_config(layers, env_layer, cli_layer, rejected=rejected)
-
-
-ConfigLadder = dict[str, EffectiveValue] | SourceConfigError
-"""One read of the layered config: the effective map, or the error it raised."""
-
-
-def read_config_ladder(path: Path, cli_overrides: Mapping[str, object]) -> ConfigLadder:
-    """Read the layered config once for a run and hold what came back.
-
-    A command builds one of these and threads it, so the environment is
-    read, and an unknown ``NAB_*`` var warned about, once per
-    invocation.  A category error is held rather than raised because the
-    lock anchor tolerates one and the run-settings fold exits on it.
-    """
-    try:
-        return effective_config(path, cli_overrides=cli_overrides)
-    except SourceConfigError as exc:
-        return exc
-
-
-def lock_anchor(ladder: ConfigLadder) -> datetime | None:
-    """Return the absolute ``uploaded-prior-to`` cutoff for ``nab lock``.
-
-    An absolute datetime is the lock anchor: it already fixes the resolve
-    window, so anchoring there makes ``created-at`` deterministic and two
-    locks from identical inputs produce identical bytes.  A relative
-    ``P<n>D`` duration anchors to run time, so it is not reproducible and
-    returns ``None``; an unset value, and a ladder that failed to
-    resolve, return ``None`` too.
-    """
-    if isinstance(ladder, SourceConfigError):
-        return None
-    value = ladder["uploaded-prior-to"].value
-    return value if isinstance(value, datetime) else None
-
-
-@dataclass(frozen=True, slots=True)
-class RunSettings:
-    """The run knobs a subcommand reads from the layered config for one run."""
-
-    resolution: ResolutionStrategy | None
-    offline: bool
-    cache_dir: Path | None
-    http_backend: HttpBackend
-    max_concurrency: int
-    # The (flag, rendered value) pairs for any --project-* override set on
-    # the CLI, recorded into the lockfile provenance so the lock is auditable.
-    cli_project_overrides: tuple[tuple[str, str], ...]
-
-
-def _cli_overrides(  # noqa: PLR0913 - one keyword per CLI flag it maps to a registry key
-    *,
-    cli_resolution: str | None,
-    cli_offline: bool | None,
-    cli_cache_dir: Path | None,
-    cli_http_backend: str | None = None,
-    cli_max_concurrency: int | None = None,
-    cli_mode: str | None = None,
-    cli_requires_python: str | None = None,
-    cli_uploaded_prior_to: str | None = None,
-    cli_dist_policy: str | None = None,
-    cli_build_policy: str | None = None,
-    cli_build_requires_depth: int | None = None,
-    cli_decision_order: str | None = None,
-    cli_constraint: tuple[str, ...] = (),
-    cli_default_group: tuple[str, ...] = (),
-    cli_base_group: str | None = None,
-    cli_build_group: str | None = None,
-) -> dict[str, object]:
-    """Build the registry-keyed CLI override dict from the named flags.
-
-    The one place the ``cli_param`` -> value mapping is written: the run
-    subcommands and ``nab config`` route their flag values through here so
-    the literal lives once.  ``build_cli_overrides`` then keeps only the
-    keys the user actually set.  USER options and the ``--project-*``
-    overrides for the scalar and array PROJECT options pass through; the
-    structured PROJECT tables stay file-only.
-    """
-    return build_cli_overrides(
-        {
-            "project_resolution": cli_resolution,
-            "offline": cli_offline,
-            "cache_dir": cli_cache_dir,
-            "http_backend": cli_http_backend,
-            "max_concurrency": cli_max_concurrency,
-            "project_mode": cli_mode,
-            "project_requires_python": cli_requires_python,
-            "project_uploaded_prior_to": cli_uploaded_prior_to,
-            "project_dist_policy": cli_dist_policy,
-            "project_build_policy": cli_build_policy,
-            "project_build_requires_depth": cli_build_requires_depth,
-            "project_decision_order": cli_decision_order,
-            "project_constraint": cli_constraint,
-            "project_default_group": cli_default_group,
-            "project_base_group": cli_base_group,
-            "project_build_group": cli_build_group,
-        }
-    )
-
-
-def project_config_overrides(
-    cli_overrides: Mapping[str, object],
-) -> dict[str, object]:
-    """Return the PROJECT-scope CLI overrides that belong in the config.
-
-    ``resolution`` is excluded: it keeps its own ``resolution_strategy``
-    path into the resolver, so it must not also enter the merged config.
-    USER options are excluded too (they configure the run, not the project).
-    The rest are the ``--project-*`` overrides the resolve folds in through
-    :func:`config.read_pyproject_config`.
-    """
-    project_keys = {
-        spec.key
-        for spec in OPTIONS
-        if spec.scope is Scope.PROJECT and spec.key != "resolution"
-    }
-    return {key: value for key, value in cli_overrides.items() if key in project_keys}
-
-
-def project_override_arguments(cli_overrides: Mapping[str, object]) -> list[str]:
-    """Return the CLI tokens that re-apply this run's ``--project-*`` overrides.
-
-    Takes the raw map :func:`_cli_overrides` built, not the config subset, so
-    ``resolution`` is carried too: it shapes the resolve without entering the
-    merged config.  A repeatable flag is emitted once per element.
-    """
-    arguments: list[str] = []
-    for spec in OPTIONS:
-        flag = spec.cli_flag
-        if spec.scope is not Scope.PROJECT or flag is None:
-            continue
-        value = cli_overrides.get(spec.key)
-        if value is None:
-            continue
-        items = value if isinstance(value, tuple) else (value,)
-        for item in items:
-            arguments += [flag, str(item)]
-    return arguments
-
-
-def _layered_run_settings(effective: Mapping[str, EffectiveValue]) -> RunSettings:
-    """Fold the effective registry values into a subcommand's run knobs.
-
-    ``resolution`` stays ``None`` (config wins downstream) when no source
-    above the default set it, preserving the contract that the resolver
-    falls back to ``config.resolution``.
-    """
-    res_ev = effective["resolution"]
-    resolution = res_ev.value if res_ev.origin.kind is not SourceKind.DEFAULT else None
-    return RunSettings(
-        resolution=resolution,
-        offline=effective["offline"].value,
-        cache_dir=effective["cache-dir"].value,
-        http_backend=effective["http-backend"].value,
-        max_concurrency=effective["max-concurrency"].value,
-        cli_project_overrides=project_cli_override_records(effective),
-    )
-
-
-def _layered_run_settings_or_exit(
-    ladder: ConfigLadder, *, produces_lock: bool = True
-) -> RunSettings:
-    """Fold the ladder's run knobs, exiting on a category error it holds.
-
-    The single ``SourceConfigError`` -> ``error: config error: ...`` ->
-    ``exit(1)`` mapping shared by ``nab lock`` and ``nab download`` lives
-    here.  On success it also emits the reproducibility notice when a
-    PROJECT option was set on the CLI, so a result-shaping override is
-    never silent.  ``produces_lock`` picks the wording: ``nab lock`` warns
-    about the lock it produces while ``nab download`` (which writes no
-    lock) warns only that the resolved set reflects the override.
-    """
-    if isinstance(ladder, SourceConfigError):
-        _fail_config(ladder)
-    settings = _layered_run_settings(ladder)
-    notice = project_cli_override_notice(ladder, produces_lock=produces_lock)
-    if notice is not None:
-        sys.stderr.write(notice)
-    return settings
-
-
-def _fail_config(exc: SourceConfigError) -> NoReturn:
-    """Map a layered config error to the shared ``error: config error:`` exit."""
-    printer().error(f"config error: {exc}")
-    sys.exit(1)
-
-
-def _is_pylock(path: Path) -> bool:
-    """Whether ``path`` holds a PEP 751 lock rather than a pyproject.
-
-    ``lock-version`` is the one required key PEP 751 gives a lock and a
-    pyproject never carries.  An unreadable or malformed file is left for
-    the pyproject parser to report.
-    """
-    try:
-        data = toml_io.loads(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError, tomli.TOMLDecodeError):
-        return False
-    return "lock-version" in data and "project" not in data
-
-
-def require_pyproject_file(path: Path) -> None:
-    """Exit 1 if ``path`` is not a readable pyproject file.
-
-    Shared by every command that takes a project path, so the rejection
-    wording lives in one place.  A ``--path`` that is missing, a
-    directory, or not a regular file is a hard error, not a
-    silently-skipped source.  A path whose stat fails passes: the config
-    read reports it, naming the errno.
-    """
-    state = path_state(path)
-
-    if state is PathState.DIRECTORY:
-        printer().error(f"{path} is a directory")
-        sys.exit(1)
-
-    if state is PathState.OTHER:
-        printer().error(f"{path} exists but is not a regular file")
-        sys.exit(1)
-
-    if state is PathState.ABSENT:
-        printer().error(f"{path} not found")
-        sys.exit(1)
-
-    if _is_pylock(path):
-        printer().error(
-            f"{path} is a PEP 751 lockfile, not a pyproject.  nab resolves"
-            " from project inputs, so pass the pyproject.toml instead."
-        )
-        sys.exit(1)
-
-
-def _project_cli_overrides_or_exit(project_overrides: Mapping[str, object]) -> None:
-    """Exit 1 when a ``--project-*`` override has a bad value, naming the flag.
-
-    These overrides otherwise reach validation only through the
-    ``[tool.nab]`` parse in :func:`_load_config`, which stamps every error
-    ``in [tool.nab]:`` and points at a table the project may not have.
-    Parsing them here surfaces the error against the flag instead.
-    """
-    for spec in OPTIONS:
-        if spec.key not in project_overrides:
-            continue
-        try:
-            build_cli_layer({spec.key: project_overrides[spec.key]})
-        except SourceConfigError as exc:
-            printer().error(f"{spec.cli_flag}: {exc}")
-            sys.exit(1)
-
-
-def _load_config(
-    path: Path,
-    *,
-    discover_workspace: bool = True,
-    anchor: datetime | None = None,
-    cli_overrides: Mapping[str, object] | None = None,
-) -> NabProjectConfig:
-    require_pyproject_file(path)
-
-    try:
-        return read_pyproject_config(
-            path,
-            discover_workspace=discover_workspace,
-            anchor=anchor,
-            cli_overrides=cli_overrides,
-        )
-    except ConfigError as exc:
-        printer().error(f"in [tool.nab]: {exc}")
-        sys.exit(1)
-    except WorkspaceDiscoveryError as exc:
-        printer().error(f"workspace discovery error: {exc}")
-        sys.exit(1)
-
-
-def is_stdout(output: Path | None) -> bool:
-    return output is not None and str(output) == "-"
-
-
-def _reject_python_override_in_universal(
-    config: NabProjectConfig, python: str | None
-) -> None:
-    """Exit 1 when ``--python`` is passed to a matrix-declaring project.
-
-    The matrix declares the python axis itself, so a single Python for the
-    run has nowhere to land; silently ignoring the flag would lock a set
-    the user did not ask for.
-    """
-    if python is not None and config.mode is ResolveMode.UNIVERSAL:
-        printer().error(
-            "--python is not supported in universal mode;"
-            " [tool.nab.matrix].python declares the Python axis."
-        )
-        sys.exit(1)
-
-
-def _python_override_or_exit(
-    config: NabProjectConfig, python: str | None
-) -> NabProjectConfig:
-    """Retarget ``config`` onto the ``--python`` value, exiting 1 on a bad one.
-
-    Applied here rather than forwarded to the resolve, so the error reads
-    as a flag error, not a ``[tool.nab]`` one.
-    """
-    try:
-        return with_python_override(config, python)
-    except ConfigError as e:
-        printer().error(str(e))
-        sys.exit(1)
-
-
-@contextmanager
-def _collector_paused() -> Iterator[None]:
-    """Disable the cyclic collector for the duration of the resolve.
-
-    Exit enables the collector and unfreezes rather than restoring what it
-    found, so every caller of :func:`_resolve` is left in that state and not
-    the one it came in with.
-
-    Everything the resolve allocated is in generation 0 by then, so the
-    collections that follow the enable walk the whole resolve graph. Freezing
-    empties every generation into the permanent one and unfreezing returns the
-    permanent generation to generation 2, which takes the graph out of
-    generation 0 and leaves those collections less to walk. PyPy has no
-    ``gc.freeze``.
-    """
-    gc.disable()
-    try:
-        yield
-    finally:
-        if hasattr(gc, "freeze"):
-            gc.freeze()
-            gc.unfreeze()
-        gc.enable()
-
-
-def _resolve(  # noqa: PLR0913, PLR0912, C901 - one wrapper per resolve_for_targets kwarg / exit-mapped error
-    path: Path,
-    *,
-    config: NabProjectConfig,
-    cache_dir: Path | None,
-    offline: bool,
-    transport: AsyncHttpTransport,
-    failure_prefix: str,
-    python: str | None = None,
-    groups: tuple[str, ...] = (),
-    extras: tuple[str, ...] = (),
-    build_requirements: bool = False,
-    resolution_strategy: ResolutionStrategy | None = None,
-    progress: ProgressReporter | None = None,
-) -> ResolveResult:
-    """Run the resolver and translate every failure to an exit.
-
-    A returned result is always fully successful: a target that did not
-    resolve is reported (one line for a single environment, a per-tuple
-    block for a matrix) and the process exits 1.
-
-    ``progress`` renders the live resolve line while ``resolve_for_targets``
-    runs; it is cleared before any summary or error is written, so the two
-    never collide.
-    """
-    config = _python_override_or_exit(config, python)
-    try:
-        try:
-            with _collector_paused():
-                result = resolve_for_targets(
-                    path,
-                    transport,
-                    config=config,
-                    cache_dir=cache_dir,
-                    offline=offline,
-                    groups=groups,
-                    extras=extras,
-                    build_requirements=build_requirements,
-                    resolution_strategy=resolution_strategy,
-                    progress=progress,
-                )
-        finally:
-            if progress is not None:
-                progress.clear()
-    except ResolutionError as e:
-        printer().error(f"resolution failed: {_error_text(e)}")
-        sys.exit(1)
-    except (
-        UnsupportedVcsError,
-        MissingExtraError,
-        SiblingMetadataDivergenceError,
-        SourceNameMismatchError,
-        NonIntervalMarkerError,
-        UnevaluableMarkerError,
-        IntractableMarkerError,
-    ) as e:
-        printer().error(f"{failure_prefix}: {e}")
-        sys.exit(1)
-    except InvalidUploadTimeError as e:
-        printer().error(str(e))
-        sys.exit(1)
-    except KeyError:
-        printer().error(f"{path} has no [project].dependencies")
-        sys.exit(1)
-    except InvalidProjectTableError as e:
-        printer().error(f"in {path}: {e}")
-        sys.exit(1)
-    except InvalidProjectRequirementError as e:
-        printer().error(str(e))
-        sys.exit(1)
-    except LookupError as e:
-        printer().error(str(e))
-        sys.exit(1)
-    except (
-        MissingHashError,
-        MissingSdistError,
-        MetadataError,
-        MetadataHashMismatchError,
-        SdistHashMismatchError,
-        WheelHashMismatchError,
-    ) as e:
-        printer().error(f"{failure_prefix}: {e}")
-        sys.exit(1)
-    except NotImplementedError as e:
-        printer().error(f"{failure_prefix}: {e}")
-        sys.exit(1)
-    except ConfigError as e:
-        printer().error(f"in [tool.nab]: {e}")
-        sys.exit(1)
-    except IndexAccessError as e:
-        printer().error(f"{failure_prefix}: {e}")
-        sys.exit(1)
-
-    if not result.success:
-        _report_failures(result)
-        sys.exit(1)
-    return result
-
-
-def _report_failures(result: ResolveResult) -> None:
-    """Report the targets that did not resolve.
-
-    A resolve with one target has one error, and it is the run's error.
-    A resolve with several (a matrix's tuples, or a conflict fork's
-    members, which fork in specific mode too) has one error per target,
-    and the pins that did resolve are as informative as the failures, so
-    each target gets a labelled block.  The check keys on the target
-    count, matching the lock-emission paths.  Both go to stderr: the
-    report is a diagnostic, not the requested lock, so stdout stays clean
-    for a caller that piped it.
-    """
-    if len(result.target_results) <= 1:
-        first = next(tr.error for tr in result.every_result if tr.error is not None)
-        printer().error(f"resolution failed: {_error_text(first)}")
-        return
-
-    blocks: list[str] = []
-    for tr in result.target_results:
-        label = tr.target.label
-        if not tr.success:
-            blocks.append(f"# {label}: FAILED")
-            blocks.extend(_error_lines(tr.error))
-            continue
-        blocks.append(f"# {label}")
-        blocks.extend(f"{name}=={tr.pins[name]}" for name in sorted(tr.pins))
-
-    # Surface base-pass failures so a successful tuple set does not
-    # mask a missing base attribution.
-    for br in result.base_results:
-        if br.success:
-            continue
-        blocks.append(f"# base/{br.target.label}: FAILED")
-        blocks.extend(_error_lines(br.error))
-
-    sys.stderr.write("\n".join(blocks) + "\n")
-
-
-def _error_lines(error: ResolutionError | None) -> list[str]:
-    """Render a failed target's error as commented block lines."""
-    text = f"{type(error).__name__}: {_error_text(error)}" if error is not None else ""
-    return [f"#   {line}" for line in text.splitlines()]
-
-
-def _error_text(error: ResolutionError) -> str:
-    """Return the error at the depth the run's verbosity asks for.
-
-    A resolution failure carries two renderings of its ``Diagnostics:``
-    section: one line per package by default, and each package's clauses
-    and ``note:`` at ``-v``.  An error nothing augmented carries only the
-    one.
-    """
-    if printer().verbosity >= Verbosity.VERBOSE and error.verbose_message is not None:
-        return error.verbose_message
-    return str(error)
-
 
 # Layered boolean flags (currently just --offline) are tri-state, which tyro
 # renders as a value-taking --flag {True,False} rather than a --flag / --no-flag
@@ -864,8 +118,9 @@ def _normalize_layered_bool_flags(argv: list[str]) -> list[str]:
 
 
 # Side-effect imports: each module's @app.command decorators register the
-# subcommand.  Placed at the bottom so the helpers above bind before the
-# command modules import them back.
+# subcommand.  Placed at the bottom so ``app`` and the flag types above bind
+# before the command modules import them back, and bound as modules because a
+# name import here would raise when the package is entered through one of them.
 from . import _cache_cmd as _cache_module  # noqa: E402, F401 - side-effect
 from . import _config_cmd as _config_module  # noqa: E402, F401 - side-effect
 from . import _download as _download_module  # noqa: E402, F401 - side-effect
@@ -889,8 +144,6 @@ def main() -> None:
 
 def _run_cli() -> None:
     """Parse the global flags and run the requested subcommand."""
-    global _printer  # noqa: PLW0603 - the run's printer is a module singleton, set here
-
     # Tyro's SubcommandApp does not surface global flags, so ``--version`` and
     # the output flags (-v/-q, --color, --no-progress) are parsed before
     # ``app.cli()`` sees the sub-command.
@@ -900,20 +153,17 @@ def _run_cli() -> None:
         return
 
     try:
-        options, rest = parse_output_options(argv, os.environ)
+        options, rest = parse_output_options(argv, env.current())
     except OutputOptionError as exc:
         sys.stderr.write(f"error: {exc}\n")
         sys.exit(2)
 
-    _printer = Printer(
-        verbosity=options.verbosity, color=options.color, progress=options.progress
-    )
-    install_log_handler(_printer)
+    run_printer = begin(options)
 
     try:
         app.cli(prog="nab", args=_normalize_layered_bool_flags(rest))
     except KeyboardInterrupt:
-        _printer.error("interrupted")
+        run_printer.error("interrupted")
         sys.exit(_SIGINT_EXIT_CODE)
 
 

--- a/src/nab/env.py
+++ b/src/nab/env.py
@@ -1,0 +1,97 @@
+"""The process environment nab reads to decide what it does.
+
+A read is either :func:`current` here or a reader the census in
+``tests/test_env_layer.py`` names, so the variables that change nab's
+behaviour are enumerable rather than found by grep.  A variable a
+subprocess is handed is not one of these: the package that spawns the
+process owns that environment.
+
+``HOME`` belongs to the list but is not named in the code: the cache and
+config fallbacks reach it through ``Path.home()``, which reads it on
+POSIX and ``USERPROFILE`` on Windows.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+NO_COLOR = "NO_COLOR"
+FORCE_COLOR = "FORCE_COLOR"
+TERM = "TERM"
+NAB_VERBOSITY = "NAB_VERBOSITY"
+NAB_NO_PROGRESS = "NAB_NO_PROGRESS"
+XDG_CACHE_HOME = "XDG_CACHE_HOME"
+XDG_CONFIG_HOME = "XDG_CONFIG_HOME"
+
+OUTPUT_OWNED = frozenset({NAB_VERBOSITY, NAB_NO_PROGRESS})
+"""The ``NAB_*`` names the output layer owns, and the config ladder skips."""
+
+
+def current(environ: Mapping[str, str] | None = None) -> Mapping[str, str]:
+    """Return ``environ``, or the process environment when it is ``None``.
+
+    The one door onto ``os.environ`` in this package.  A caller with a
+    mapping of its own (a test, or a layer handed one) passes it through
+    unchanged.
+    """
+    return os.environ if environ is None else environ
+
+
+def verbosity_name(environ: Mapping[str, str] | None = None) -> str | None:
+    """Return the raw ``NAB_VERBOSITY`` value, unvalidated, or ``None``.
+
+    Mapping a name to a level is :mod:`nab.output`'s, which raises on one
+    it does not recognize; this module holds no level type.
+    """
+    return current(environ).get(NAB_VERBOSITY)
+
+
+def color_enabled(
+    choice: str,
+    *,
+    isatty: bool,
+    environ: Mapping[str, str] | None = None,
+) -> bool:
+    """Decide whether to colour output, the one place that rule lives.
+
+    ``choice`` is the ``--color`` value: ``always`` and ``never`` win
+    outright.  Otherwise ``NO_COLOR`` (non-empty) disables, ``FORCE_COLOR``
+    (non-empty) forces, ``TERM=dumb`` disables, and the fallback is
+    ``isatty``, whether the stream being written to is a terminal.
+    """
+    if choice == "always":
+        return True
+    if choice == "never":
+        return False
+
+    env = current(environ)
+    if env.get(NO_COLOR):
+        return False
+    if env.get(FORCE_COLOR):
+        return True
+    if env.get(TERM) == "dumb":
+        return False
+    return isatty
+
+
+def progress_suppressed(environ: Mapping[str, str] | None = None) -> bool:
+    """Whether ``NAB_NO_PROGRESS`` switches the live progress line off."""
+    return bool(current(environ).get(NAB_NO_PROGRESS))
+
+
+def cache_root(environ: Mapping[str, str] | None = None) -> str | None:
+    """Return ``XDG_CACHE_HOME`` as written, or ``None`` when it is unset.
+
+    The raw string, so this module needs no ``pathlib``; the caller builds
+    the path and picks the fallback.
+    """
+    return current(environ).get(XDG_CACHE_HOME)
+
+
+def config_root(environ: Mapping[str, str] | None = None) -> str | None:
+    """Return ``XDG_CONFIG_HOME`` as written, or ``None`` when it is unset."""
+    return current(environ).get(XDG_CONFIG_HOME)

--- a/src/nab/output.py
+++ b/src/nab/output.py
@@ -3,8 +3,8 @@
 stdout carries only the requested, machine-readable output (a lockfile, a
 requirements list, a config dump).  stderr carries everything a human reads:
 the run summary, notes, warnings, errors, progress, and logs.  The verbosity
-level and the colour decision are resolved once in :func:`nab.cli.main` and
-shared through a single :class:`Printer`, so no command re-invents the policy.
+level and the colour decision are resolved once by :func:`begin` and shared
+through a single :class:`Printer`, so no command re-invents the policy.
 
 The design follows uv: a small printer with a level, a data channel that
 survives ``--quiet``, and colour applied only to a message's leading token so
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import enum
 import logging
-import os
 import sys
 import threading
 import time
@@ -23,6 +22,14 @@ from dataclasses import dataclass
 from typing import IO, TYPE_CHECKING
 
 from typing_extensions import override
+
+from .env import (
+    NAB_VERBOSITY,
+    OUTPUT_OWNED,
+    color_enabled,
+    progress_suppressed,
+    verbosity_name,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
@@ -35,18 +42,20 @@ __all__ = [
     "Printer",
     "ProgressReporter",
     "Verbosity",
+    "begin",
     "install_log_handler",
     "logging_level_for",
+    "options_from_flags",
     "parse_output_options",
+    "printer",
     "reset_log_handlers",
+    "reset_run",
     "should_color",
     "verbosity_from_counts",
 ]
 
-NAB_VERBOSITY_ENV = "NAB_VERBOSITY"
-NAB_NO_PROGRESS_ENV = "NAB_NO_PROGRESS"
-OUTPUT_ENV_VARS: frozenset[str] = frozenset({NAB_VERBOSITY_ENV, NAB_NO_PROGRESS_ENV})
-"""The ``NAB_*`` environment variables the output layer owns."""
+OUTPUT_ENV_VARS: frozenset[str] = OUTPUT_OWNED
+"""The names the config ladder is told to skip, because this layer owns them."""
 
 
 class Verbosity(enum.IntEnum):
@@ -87,26 +96,21 @@ def _isatty(stream: IO[str]) -> bool:
     return bool(isatty()) if isatty is not None else False
 
 
-def should_color(choice: ColorChoice, stream: IO[str], env: Mapping[str, str]) -> bool:
+def should_color(
+    choice: ColorChoice, stream: IO[str], env: Mapping[str, str] | None = None
+) -> bool:
     """Decide whether to colour output on ``stream``.
 
-    ``--color always`` / ``never`` win outright.  Otherwise ``NO_COLOR``
-    (non-empty) disables, ``FORCE_COLOR`` (non-empty) forces, ``TERM=dumb``
-    disables, and the fallback is whether ``stream`` is a terminal.  Reading
-    the standard 16-colour slots this enables lets the user's own terminal
-    theme set the actual contrast.
+    The rule itself is :func:`nab.env.color_enabled`; this states it in the
+    printer's own terms, a :class:`ColorChoice` and the stream written to.
+    Reading the standard 16-colour slots it enables lets the user's own
+    terminal theme set the actual contrast.
+
+    ``always`` and ``never`` decide without the stream, so a stream that
+    cannot answer ``isatty()`` is never asked.
     """
-    if choice is ColorChoice.ALWAYS:
-        return True
-    if choice is ColorChoice.NEVER:
-        return False
-    if env.get("NO_COLOR"):
-        return False
-    if env.get("FORCE_COLOR"):
-        return True
-    if env.get("TERM") == "dumb":
-        return False
-    return _isatty(stream)
+    tty = choice is ColorChoice.AUTO and _isatty(stream)
+    return color_enabled(choice.value, isatty=tty, environ=env)
 
 
 # Standard ANSI SGR codes; the terminal theme remaps these, so we never
@@ -173,11 +177,10 @@ class Printer:
         self.verbosity = verbosity
         self._out = stdout if stdout is not None else sys.stdout
         self._err = stderr if stderr is not None else sys.stderr
-        environ = env if env is not None else os.environ
-        self.color_enabled = should_color(color, self._err, environ)
+        self.color_enabled = should_color(color, self._err, env)
         self.progress_allowed = (
             progress
-            and not environ.get(NAB_NO_PROGRESS_ENV)
+            and not progress_suppressed(env)
             and verbosity is Verbosity.NORMAL
             and _isatty(self._err)
         )
@@ -263,6 +266,19 @@ class Printer:
                 self._err.write(_CLEAR_LINE)
                 self._err.flush()
                 self._progress_drawn = False
+
+
+_printer: Printer | None = None
+
+
+def printer() -> Printer:
+    """Return the run's :class:`Printer`.
+
+    :func:`begin` installs the one the global output flags resolved to.  A
+    caller that bypassed the CLI, as many tests do, gets a fresh default
+    printer reading the current process streams.
+    """
+    return _printer if _printer is not None else Printer()
 
 
 # The engine logs through ``logging.getLogger(__name__)``; these are the
@@ -363,6 +379,16 @@ def reset_log_handlers() -> None:
         logger.setLevel(logging.NOTSET)
 
 
+def reset_run() -> None:
+    """Undo :func:`begin`: drop the run's printer and its log handlers.
+
+    Both are process-wide, so the test suite clears them between tests.
+    """
+    global _printer  # noqa: PLW0603 - the run's printer is a module singleton
+    _printer = None
+    reset_log_handlers()
+
+
 _SPINNER = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
 _PROGRESS_MIN_INTERVAL = 0.05
 
@@ -453,15 +479,15 @@ class OutputOptions:
 _VERBOSITY_NAMES: dict[str, Verbosity] = {v.name.lower(): v for v in Verbosity}
 
 
-def _verbosity_from_env(env: Mapping[str, str]) -> Verbosity | None:
+def _verbosity_from_env(environ: Mapping[str, str] | None) -> Verbosity | None:
     """Read ``NAB_VERBOSITY`` as a level name, or ``None`` when unset."""
-    raw = env.get(NAB_VERBOSITY_ENV)
+    raw = verbosity_name(environ)
     if raw is None:
         return None
     name = raw.strip().lower()
     if name not in _VERBOSITY_NAMES:
         allowed = ", ".join(_VERBOSITY_NAMES)
-        msg = f"{NAB_VERBOSITY_ENV}={raw!r} is not one of {allowed}"
+        msg = f"{NAB_VERBOSITY}={raw!r} is not one of {allowed}"
         raise OutputOptionError(msg)
     return _VERBOSITY_NAMES[name]
 
@@ -484,7 +510,7 @@ def _repeated_short(arg: str, letter: str) -> bool:
     )
 
 
-def parse_output_options(  # noqa: C901, PLR0912 - a small flag scanner; each flag is one branch
+def parse_output_options(  # noqa: C901 - a small flag scanner; each flag is one branch
     argv: list[str], env: Mapping[str, str]
 ) -> tuple[OutputOptions, list[str]]:
     """Split the global output flags out of ``argv``, returning the rest.
@@ -496,7 +522,7 @@ def parse_output_options(  # noqa: C901, PLR0912 - a small flag scanner; each fl
     parser untouched.  Raises :class:`OutputOptionError` on a bad value.
     """
     verbose = quiet = 0
-    color_choice: ColorChoice | None = None
+    color: str | None = None
     no_color = False
     progress = True
     rest: list[str] = []
@@ -520,24 +546,69 @@ def parse_output_options(  # noqa: C901, PLR0912 - a small flag scanner; each fl
             if i >= len(argv):
                 msg = "--color needs a value: auto, always, or never"
                 raise OutputOptionError(msg)
-            color_choice = _color_choice(argv[i])
+            # Checked as it is read, so a bad value is an error even when a
+            # later --color would have won the last-wins reduction.
+            color = _color_choice(argv[i]).value
         elif arg.startswith("--color="):
-            color_choice = _color_choice(arg.split("=", 1)[1])
+            color = _color_choice(arg.split("=", 1)[1]).value
         else:
             rest.append(arg)
         i += 1
 
+    options = options_from_flags(
+        verbose=verbose,
+        quiet=quiet,
+        color=color,
+        no_color=no_color,
+        no_progress=not progress,
+        environ=env,
+    )
+    return options, rest
+
+
+def options_from_flags(
+    *,
+    verbose: int,
+    quiet: int,
+    color: str | None,
+    no_color: bool,
+    no_progress: bool,
+    environ: Mapping[str, str] | None = None,
+) -> OutputOptions:
+    """Fold the five global output flags into the knobs a printer takes.
+
+    A touched ``-v`` or ``-q`` beats ``NAB_VERBOSITY`` even when the two
+    cancel out, and ``--color`` beats ``--no-color`` whichever came first,
+    because a value names a choice while the flag only refuses one.
+    ``color`` is the flag's raw value; one that names no
+    :class:`ColorChoice` raises :class:`OutputOptionError`.
+    """
     if verbose or quiet:
         verbosity = verbosity_from_counts(verbose, quiet)
     else:
-        from_env = _verbosity_from_env(env)
+        from_env = _verbosity_from_env(environ)
         verbosity = from_env if from_env is not None else Verbosity.NORMAL
 
-    if color_choice is not None:
-        color = color_choice
+    if color is not None:
+        choice = _color_choice(color)
     elif no_color:
-        color = ColorChoice.NEVER
+        choice = ColorChoice.NEVER
     else:
-        color = ColorChoice.AUTO
+        choice = ColorChoice.AUTO
 
-    return OutputOptions(verbosity=verbosity, color=color, progress=progress), rest
+    return OutputOptions(verbosity=verbosity, color=choice, progress=not no_progress)
+
+
+def begin(options: OutputOptions) -> Printer:
+    """Start the run's output from the resolved global flags.
+
+    Builds the run's printer, makes it the one :func:`printer` returns, and
+    routes the engine's log records through it so a record emitted mid-run
+    lands on the same stderr instead of Python's ``lastResort`` fallback.
+    """
+    global _printer  # noqa: PLW0603 - the run's printer is a module singleton
+    _printer = Printer(
+        verbosity=options.verbosity, color=options.color, progress=options.progress
+    )
+    install_log_handler(_printer)
+    return _printer

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,8 +16,8 @@ from unittest.mock import patch
 
 import pytest
 
-from nab import cli
-from nab.output import reset_log_handlers
+from nab import _run
+from nab.output import reset_run
 from nab_project.config_sources import SourceRoots
 
 if TYPE_CHECKING:
@@ -37,15 +37,14 @@ def _reset_nab_output(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
       :func:`~nab.output.should_color`, so it forces nab's colour off here
       regardless of the ambient environment; the colour behaviour itself is
       covered by unit tests that set the choice explicitly.
-    * ``nab.cli.main`` sets a module-level printer (bound to the run's streams)
-      and installs a logging handler on the nab loggers; without the reset a
-      test that runs ``main`` would leak the printer (whose captured stream is
-      closed once the test ends) and the handler into later tests.
+    * ``nab.output.begin`` sets a module-level printer (bound to the run's
+      streams) and installs a logging handler on the nab loggers; without the
+      reset a test that runs ``main`` would leak the printer (whose captured
+      stream is closed once the test ends) and the handler into later tests.
     """
     monkeypatch.setenv("NO_COLOR", "1")
     yield
-    cli._printer = None
-    reset_log_handlers()
+    reset_run()
 
 
 @pytest.fixture
@@ -94,7 +93,7 @@ def hermetic_roots(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
             project_dir=project_dir,
         )
 
-    monkeypatch.setattr(cli, "_config_search_roots", fake_roots)
+    monkeypatch.setattr(_run, "_config_search_roots", fake_roots)
     monkeypatch.delenv("NAB_OFFLINE", raising=False)
     monkeypatch.delenv("NAB_CACHE_DIR", raising=False)
     monkeypatch.delenv("NAB_RESOLUTION", raising=False)

--- a/tests/test_cache_cmd.py
+++ b/tests/test_cache_cmd.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from nab import cli as nab_cli
+from nab import _run as nab_run
 from nab.cli import app
 from nab_index.cache import (
     CACHE_VERSION_SDIST,
@@ -51,7 +51,7 @@ def config_anchors(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> list[Path
         anchors.append(pyproject)
         return roots
 
-    monkeypatch.setattr(nab_cli, "_config_search_roots", _roots)
+    monkeypatch.setattr(nab_run, "_config_search_roots", _roots)
     monkeypatch.delenv("NAB_CACHE_DIR", raising=False)
     return anchors
 
@@ -105,7 +105,7 @@ class TestCacheDir:
         capsys: pytest.CaptureFixture[str],
     ) -> None:
         monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
-        monkeypatch.setattr(nab_cli.Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(nab_run.Path, "home", lambda: tmp_path)
         _run_cache(["dir"])
         captured = capsys.readouterr()
         assert captured.out == f"{tmp_path / '.cache' / 'nab'}\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,30 +32,33 @@ import tomli
 
 from nab import _version as nab_version
 from nab import cli
+from nab import output as nab_output
 from nab._download import download
 from nab._lock import (
     _BUILD_DEFAULT_OUTPUT,
+    _DEFAULT_OUTPUT,
     _determine_lock_anchor,
     _emit,
     _emit_or_exit,
     _emit_pylock,
     lock,
-    resolve_extra_selection,
-    resolve_group_selection,
 )
-from nab.cli import (
-    _DEFAULT_OUTPUT,
+from nab._run import (
     ConfigLadder,
     _default_cache_dir,
     _make_resolve_transport,
     _make_transport,
-    _normalize_layered_bool_flags,
     _resolve,
+    read_config_ladder,
+    resolve_extra_selection,
+    resolve_group_selection,
+)
+from nab.cli import (
+    _normalize_layered_bool_flags,
     _system_exit_status,
     app,
     console_entry,
     main,
-    read_config_ladder,
 )
 from nab.output import Printer, ProgressReporter, Verbosity
 from nab_index.atomic import atomic_write_text
@@ -675,7 +678,7 @@ class TestLockCommandSpecific:
         """Default format writes a real pylock.toml at the requested path."""
         pyproject = _make_pyproject(tmp_path)
         out = tmp_path / "pylock.toml"
-        with patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()):
+        with patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()):
             lock(pyproject, output=out)
         text = out.read_text()
         assert 'lock-version = "1.0"' in text
@@ -687,7 +690,7 @@ class TestLockCommandSpecific:
         """No --output: pylock format defaults to pylock.toml."""
         monkeypatch.chdir(tmp_path)
         pyproject = _make_pyproject(tmp_path)
-        with patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()):
+        with patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()):
             lock(pyproject)
         assert (tmp_path / "pylock.toml").exists()
 
@@ -697,7 +700,7 @@ class TestLockCommandSpecific:
         """No --output: requirements format defaults to requirements.txt."""
         monkeypatch.chdir(tmp_path)
         pyproject = _make_pyproject(tmp_path)
-        with patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()):
+        with patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()):
             lock(pyproject, format="requirements")
         text = (tmp_path / "requirements.txt").read_text()
         assert "foo==1.0" in text
@@ -709,7 +712,7 @@ class TestLockCommandSpecific:
         """requirements-without-hashes defaults to requirements.txt."""
         monkeypatch.chdir(tmp_path)
         pyproject = _make_pyproject(tmp_path)
-        with patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()):
+        with patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()):
             lock(pyproject, format="requirements-without-hashes")
         text = (tmp_path / "requirements.txt").read_text()
         assert "foo==1.0" in text
@@ -721,7 +724,7 @@ class TestLockCommandSpecific:
         """A build lock defaults clear of the runtime lock's name."""
         monkeypatch.chdir(tmp_path)
         pyproject = _make_pyproject(tmp_path, _BUILD_SYSTEM_PROJECT)
-        with patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()):
+        with patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()):
             lock(pyproject, build_requirements=True)
         assert (tmp_path / "pylock.build.toml").exists()
         assert not (tmp_path / "pylock.toml").exists()
@@ -735,7 +738,7 @@ class TestLockCommandSpecific:
         """Both requirements formats get their own default name."""
         monkeypatch.chdir(tmp_path)
         pyproject = _make_pyproject(tmp_path, _BUILD_SYSTEM_PROJECT)
-        with patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()):
+        with patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()):
             lock(pyproject, format=lock_format, build_requirements=True)
         assert (tmp_path / "build-requirements.txt").exists()
         assert not (tmp_path / "requirements.txt").exists()
@@ -757,7 +760,7 @@ class TestLockCommandSpecific:
             "[tool.nab]\ncreated-at = 2020-01-01T00:00:00+00:00\n"
         )
         pyproject = _make_pyproject(tmp_path, _BUILD_SYSTEM_PROJECT)
-        with patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()):
+        with patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()):
             lock(pyproject, build_requirements=True)
         written = tomli.loads((tmp_path / "pylock.build.toml").read_text())
         assert written["tool"]["nab"]["created-at"] == recorded
@@ -772,7 +775,7 @@ class TestLockCommandSpecific:
             '[tool.nab]\ndefault-groups = ["dev"]\nbase-group = "default"\n',
         )
         out = tmp_path / "pylock.build.toml"
-        with patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()):
+        with patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()):
             lock(pyproject, output=out, build_requirements=True)
         written = tomli.loads(out.read_text())
         assert "default-groups" not in written
@@ -788,7 +791,7 @@ class TestLockCommandSpecific:
         )
         out = tmp_path / "pylock.toml"
         with patch(
-            "nab.cli.resolve_for_targets",
+            "nab._run.resolve_for_targets",
             return_value=_stub_resolve_result(pins={"foo": V("1.0")}),
         ):
             lock(pyproject, output=out)
@@ -868,7 +871,7 @@ class TestLockCommandSpecific:
         """`requirements` format renders --hash lines."""
         pyproject = _make_pyproject(tmp_path)
         out = tmp_path / "requirements.txt"
-        with patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()):
+        with patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()):
             lock(pyproject, output=out, format="requirements")
         text = out.read_text()
         assert "foo==1.0" in text
@@ -882,7 +885,7 @@ class TestLockCommandSpecific:
     ) -> None:
         """A URL that requirements syntax would split is rejected at config load."""
         monkeypatch.setattr(
-            "nab.cli._config_search_roots",
+            "nab._run._config_search_roots",
             lambda p: SourceRoots(project_dir=p.parent, pyproject=p),
         )
         pyproject, source_url = _make_archive_source_project(
@@ -913,7 +916,7 @@ class TestLockCommandSpecific:
     ) -> None:
         """A percent-encoded local archive resolves to a parseable requirement."""
         monkeypatch.setattr(
-            "nab.cli._config_search_roots",
+            "nab._run._config_search_roots",
             lambda p: SourceRoots(project_dir=p.parent, pyproject=p),
         )
         pyproject, source_url = _make_archive_source_project(
@@ -937,7 +940,7 @@ class TestLockCommandSpecific:
         """requirements-without-hashes renders one name==version per line."""
         pyproject = _make_pyproject(tmp_path)
         out = tmp_path / "requirements.txt"
-        with patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()):
+        with patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()):
             lock(pyproject, output=out, format="requirements-without-hashes")
         text = out.read_text()
         assert text.strip() == "foo==1.0"
@@ -947,7 +950,7 @@ class TestLockCommandSpecific:
         pyproject = _make_pyproject(tmp_path)
         out = tmp_path / "requirements.txt"
         result = _hashless_resolve_result()
-        with patch("nab.cli.resolve_for_targets", return_value=result):
+        with patch("nab._run.resolve_for_targets", return_value=result):
             lock(pyproject, output=out, format="requirements-without-hashes")
         assert out.read_text().strip() == "foo==1.0"
 
@@ -959,7 +962,7 @@ class TestLockCommandSpecific:
         out = tmp_path / "pylock.toml"
         result = _hashless_resolve_result()
         with (
-            patch("nab.cli.resolve_for_targets", return_value=result),
+            patch("nab._run.resolve_for_targets", return_value=result),
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, output=out, format="pylock")
@@ -976,7 +979,7 @@ class TestLockCommandSpecific:
             target_results=[_failed(target, ResolutionError("conflict"))],
         )
         with (
-            patch("nab.cli.resolve_for_targets", return_value=result),
+            patch("nab._run.resolve_for_targets", return_value=result),
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, output=tmp_path / "pylock.toml")
@@ -1012,7 +1015,7 @@ class TestLockCommandSpecific:
             ],
         )
         with (
-            patch("nab.cli.resolve_for_targets", return_value=result),
+            patch("nab._run.resolve_for_targets", return_value=result),
             pytest.raises(SystemExit, match="1"),
         ):
             lock(
@@ -1031,7 +1034,7 @@ class TestLockCommandSpecific:
     ) -> None:
         """`--output -` routes pylock format to stdout."""
         pyproject = _make_pyproject(tmp_path)
-        with patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()):
+        with patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()):
             lock(pyproject, output=Path("-"))
         out = capsys.readouterr().out
         assert 'lock-version = "1.0"' in out
@@ -1042,7 +1045,7 @@ class TestLockCommandSpecific:
     ) -> None:
         """`--output -` routes requirements format to stdout."""
         pyproject = _make_pyproject(tmp_path)
-        with patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()):
+        with patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()):
             lock(pyproject, output=Path("-"), format="requirements")
         out = capsys.readouterr().out
         assert "foo==1.0" in out
@@ -1053,7 +1056,7 @@ class TestLockCommandSpecific:
     ) -> None:
         """`--output -` routes requirements-without-hashes to stdout."""
         pyproject = _make_pyproject(tmp_path)
-        with patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()):
+        with patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()):
             lock(pyproject, output=Path("-"), format="requirements-without-hashes")
         assert capsys.readouterr().out.strip() == "foo==1.0"
 
@@ -1063,7 +1066,7 @@ class TestLockCommandSpecific:
         pyproject = _make_pyproject(tmp_path)
         with (
             patch(
-                "nab.cli.resolve_for_targets", side_effect=ResolutionError("conflict")
+                "nab._run.resolve_for_targets", side_effect=ResolutionError("conflict")
             ),
             pytest.raises(SystemExit, match="1"),
         ):
@@ -1090,7 +1093,7 @@ class TestLockCommandSpecific:
         pyproject = _make_pyproject(tmp_path)
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 side_effect=UnsupportedVcsError("refusing direct-URL requirement"),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -1105,7 +1108,7 @@ class TestLockCommandSpecific:
         pyproject = _make_pyproject(tmp_path)
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 side_effect=InvalidUploadTimeError("foo 1.0 has a naive upload time"),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -1120,7 +1123,7 @@ class TestLockCommandSpecific:
         pyproject = _make_pyproject(tmp_path)
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 side_effect=NotImplementedError("resolver path is not implemented"),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -1135,7 +1138,7 @@ class TestLockCommandSpecific:
         pyproject = _make_pyproject(tmp_path)
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 side_effect=ConfigError("Constraints cannot have extras: idna[foo]<3"),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -1148,7 +1151,7 @@ class TestLockCommandSpecific:
     ) -> None:
         pyproject = _make_pyproject(tmp_path)
         with (
-            patch("nab.cli.resolve_for_targets", side_effect=KeyError("dependencies")),
+            patch("nab._run.resolve_for_targets", side_effect=KeyError("dependencies")),
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject)
@@ -1182,7 +1185,7 @@ class TestLockCommandSpecific:
         pyproject = _make_pyproject(tmp_path)
         with (
             patch(
-                "nab.cli.resolve_for_targets", side_effect=MissingHashError("no hash")
+                "nab._run.resolve_for_targets", side_effect=MissingHashError("no hash")
             ),
             pytest.raises(SystemExit, match="1"),
         ):
@@ -1196,7 +1199,7 @@ class TestLockCommandSpecific:
         pyproject = _make_pyproject(tmp_path)
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 side_effect=InvalidProjectRequirementError("invalid requirement 'x y'"),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -1211,7 +1214,7 @@ class TestLockCommandSpecific:
         pyproject = _make_pyproject(tmp_path)
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 side_effect=HttpError("GET https://pypi.org/simple/foo/ failed: 503"),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -1236,7 +1239,7 @@ class TestLockCommandSpecific:
 
         pyproject = _make_pyproject(tmp_path)
         with (
-            patch("nab.cli.resolve_for_targets", side_effect=caught.value),
+            patch("nab._run.resolve_for_targets", side_effect=caught.value),
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject)
@@ -1277,7 +1280,7 @@ class TestLockCommandSpecific:
 
         pyproject = _make_pyproject(tmp_path)
         with (
-            patch("nab.cli.resolve_for_targets", side_effect=caught.value),
+            patch("nab._run.resolve_for_targets", side_effect=caught.value),
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject)
@@ -1293,7 +1296,7 @@ class TestLockCommandSpecific:
         pyproject = _make_pyproject(tmp_path)
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 side_effect=MissingSdistError("foo==1.0 has no sdist"),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -1312,7 +1315,7 @@ class TestLockCommandSpecific:
         pyproject = _make_pyproject(tmp_path)
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 side_effect=LookupError("unknown group 'ghost'"),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -1327,7 +1330,7 @@ class TestLockCommandSpecific:
         pyproject = _make_pyproject(tmp_path)
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 side_effect=MissingExtraError(
                     "foo==1.0 does not provide extra 'nonexistent'"
                 ),
@@ -1400,7 +1403,7 @@ class TestLockCommandSpecific:
         pyproject = _make_pyproject(tmp_path)
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 side_effect=SiblingMetadataDivergenceError(
                     "foo 1.0 has tie-ranked wheels foo-1.0-cp311.cp312-none-any.whl "
                     "and foo-1.0-cp312.cp313-none-any.whl that declare different "
@@ -1427,7 +1430,7 @@ class TestLockCommandSpecific:
         advertising a ``core-metadata`` sha256 the sidecar bytes do not match.
         """
         monkeypatch.setattr(
-            "nab.cli._config_search_roots",
+            "nab._run._config_search_roots",
             lambda p: SourceRoots(project_dir=p.parent, pyproject=p),
         )
         pyproject = _make_pyproject(tmp_path)
@@ -1452,7 +1455,7 @@ class TestLockCommandSpecific:
         )
 
         with (
-            patch("nab.cli._make_transport", return_value=transport),
+            patch("nab._run._make_transport", return_value=transport),
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, output=tmp_path / "pylock.toml", cache=False)
@@ -1477,7 +1480,7 @@ class TestLockCommandSpecific:
         carrier of that digest.
         """
         monkeypatch.setattr(
-            "nab.cli._config_search_roots",
+            "nab._run._config_search_roots",
             lambda p: SourceRoots(project_dir=p.parent, pyproject=p),
         )
 
@@ -1515,7 +1518,7 @@ class TestLockCommandSpecific:
         transport = _SidecarTransport(bodies)
 
         with (
-            patch("nab.cli._make_transport", return_value=transport),
+            patch("nab._run._make_transport", return_value=transport),
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, output=tmp_path / "pylock.toml", cache=False)
@@ -1539,7 +1542,7 @@ class TestLockCommandSpecific:
         steps down to the whole body and checks it against that digest.
         """
         monkeypatch.setattr(
-            "nab.cli._config_search_roots",
+            "nab._run._config_search_roots",
             lambda p: SourceRoots(project_dir=p.parent, pyproject=p),
         )
         pyproject = _make_pyproject(tmp_path)
@@ -1562,7 +1565,7 @@ class TestLockCommandSpecific:
         )
 
         with (
-            patch("nab.cli._make_transport", return_value=transport),
+            patch("nab._run._make_transport", return_value=transport),
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, output=tmp_path / "pylock.toml", cache=False)
@@ -1585,7 +1588,7 @@ class TestLockCommandSpecific:
         is an sdist published with a sha256 the served archive does not match.
         """
         monkeypatch.setattr(
-            "nab.cli._config_search_roots",
+            "nab._run._config_search_roots",
             lambda p: SourceRoots(project_dir=p.parent, pyproject=p),
         )
         pyproject = _make_pyproject(tmp_path)
@@ -1608,7 +1611,7 @@ class TestLockCommandSpecific:
         )
 
         with (
-            patch("nab.cli._make_transport", return_value=transport),
+            patch("nab._run._make_transport", return_value=transport),
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, output=tmp_path / "pylock.toml", cache=False)
@@ -1911,7 +1914,7 @@ class TestLockCommandSpecific:
         out = tmp_path / "pylock.toml"
         out.mkdir()
         with (
-            patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()),
+            patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()),
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, output=out)
@@ -1924,7 +1927,7 @@ class TestLockCommandSpecific:
         pyproject = _make_pyproject(tmp_path)
         out = tmp_path / "nope" / "pylock.toml"
         with (
-            patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()),
+            patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()),
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, output=out)
@@ -1942,7 +1945,7 @@ class TestLockCommandSpecific:
         committed = b'lock-version = "1.0"\n'
         out.write_bytes(committed)
         with (
-            patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()),
+            patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()),
             cap_writes(64),
             pytest.raises(SystemExit, match="1"),
         ):
@@ -1955,7 +1958,7 @@ class TestLockCommandSpecific:
         pyproject = _make_pyproject(tmp_path)
         out = tmp_path / "pylock.toml"
         with patch(
-            "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
+            "nab._run.resolve_for_targets", return_value=_stub_resolve_result()
         ) as mock_resolve:
             lock(pyproject, output=out, project_resolution="lowest")
         kwargs = mock_resolve.call_args.kwargs
@@ -1966,7 +1969,7 @@ class TestLockCommandSpecific:
         pyproject = _make_pyproject(tmp_path)
         out = tmp_path / "pylock.toml"
         with patch(
-            "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
+            "nab._run.resolve_for_targets", return_value=_stub_resolve_result()
         ) as mock_resolve:
             lock(pyproject, output=out)
         assert mock_resolve.call_args.kwargs["resolution_strategy"] is None
@@ -1981,10 +1984,10 @@ class TestLockCommandSpecific:
         pyproject = _make_pyproject(tmp_path)
         out = tmp_path / "pylock.toml"
         monkeypatch.setattr(
-            "nab.cli._config_search_roots",
+            "nab._run._config_search_roots",
             lambda p: SourceRoots(project_dir=p.parent, pyproject=p),
         )
-        with patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()):
+        with patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()):
             lock(pyproject, output=out, project_resolution="lowest")
         err = capsys.readouterr().err
         assert "does not derive from the committed" in err
@@ -2000,10 +2003,10 @@ class TestLockCommandSpecific:
         pyproject = _make_pyproject(tmp_path)
         out = tmp_path / "pylock.toml"
         monkeypatch.setattr(
-            "nab.cli._config_search_roots",
+            "nab._run._config_search_roots",
             lambda p: SourceRoots(project_dir=p.parent, pyproject=p),
         )
-        with patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()):
+        with patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()):
             lock(pyproject, output=out)
         assert "does not derive from the committed" not in capsys.readouterr().err
 
@@ -2021,11 +2024,11 @@ class TestLockCommandSpecific:
         (tmp_path / "nab.toml").write_text('resolution = "lowest"\n')
         out = tmp_path / "pylock.toml"
         monkeypatch.setattr(
-            "nab.cli._config_search_roots",
+            "nab._run._config_search_roots",
             lambda p: SourceRoots(project_dir=p.parent, pyproject=p),
         )
         with (
-            patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()),
+            patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()),
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, output=out)
@@ -2050,11 +2053,11 @@ class TestLockCommandSpecific:
         user.write_text("offline = \n")
         out = tmp_path / "pylock.toml"
         monkeypatch.setattr(
-            "nab.cli._config_search_roots",
+            "nab._run._config_search_roots",
             lambda p: SourceRoots(user_toml=user, project_dir=p.parent, pyproject=p),
         )
         with (
-            patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()),
+            patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()),
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, output=out)
@@ -2073,11 +2076,11 @@ class TestLockCommandSpecific:
         user.write_text("typoo = 1\n")
         out = tmp_path / "pylock.toml"
         monkeypatch.setattr(
-            "nab.cli._config_search_roots",
+            "nab._run._config_search_roots",
             lambda p: SourceRoots(user_toml=user, project_dir=p.parent, pyproject=p),
         )
         with (
-            patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()),
+            patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()),
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, output=out)
@@ -2093,7 +2096,7 @@ class TestPythonFlag:
         pyproject = _make_pyproject(tmp_path)
         out = tmp_path / "pylock.toml"
         with patch(
-            "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
+            "nab._run.resolve_for_targets", return_value=_stub_resolve_result()
         ) as mock_resolve:
             lock(pyproject, output=out, python="3.11")
         config = mock_resolve.call_args.kwargs["config"]
@@ -2103,7 +2106,7 @@ class TestPythonFlag:
         pyproject = _make_pyproject(tmp_path)
         out = tmp_path / "pylock.toml"
         with patch(
-            "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
+            "nab._run.resolve_for_targets", return_value=_stub_resolve_result()
         ) as mock_resolve:
             lock(pyproject, output=out)
         assert mock_resolve.call_args.kwargs["config"].environment is None
@@ -2153,7 +2156,7 @@ class TestPythonFlag:
         out = tmp_path / "wheels"
         with (
             patch(
-                "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
+                "nab._run.resolve_for_targets", return_value=_stub_resolve_result()
             ) as mock_resolve,
             patch(
                 "nab._download.download_lock",
@@ -2184,7 +2187,7 @@ class TestPythonFlag:
         )
         out = tmp_path / "pylock.toml"
         with patch(
-            "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
+            "nab._run.resolve_for_targets", return_value=_stub_resolve_result()
         ) as mock_resolve:
             lock(pyproject, output=out, python="3.14")
         assert mock_resolve.call_args.kwargs["config"].environment.python == "3.14"
@@ -2294,7 +2297,7 @@ class TestProjectFlagErrors:
         pyproject = _make_pyproject(tmp_path)
         out = tmp_path / "pylock.toml"
         with patch(
-            "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
+            "nab._run.resolve_for_targets", return_value=_stub_resolve_result()
         ) as mock_resolve:
             lock(pyproject, output=out, project_requires_python="==3.11")
         assert mock_resolve.call_args.kwargs["config"].requires_python == "==3.11"
@@ -2325,7 +2328,7 @@ class TestLockCommandUniversal:
         out = tmp_path / "pylock.toml"
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 side_effect=InvalidProjectRequirementError("invalid requirement 'x y'"),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -2341,7 +2344,7 @@ class TestLockCommandUniversal:
         out = tmp_path / "pylock.toml"
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 side_effect=InvalidUploadTimeError("foo 1.0 has a naive upload time"),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -2357,7 +2360,7 @@ class TestLockCommandUniversal:
         out = tmp_path / "pylock.toml"
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 side_effect=ConfigError(
                     "[tool.nab].conflicts names extra 'gpuu', which the project"
                     " does not declare in [project.optional-dependencies]"
@@ -2378,7 +2381,7 @@ class TestLockCommandUniversal:
         out = tmp_path / "pylock.toml"
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 side_effect=NotImplementedError("resolver path is not implemented"),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -2482,7 +2485,7 @@ class TestLockCommandUniversal:
         pyproject = _universal_pyproject(tmp_path)
         out = tmp_path / "pylock.toml"
         with patch(
-            "nab.cli.resolve_for_targets",
+            "nab._run.resolve_for_targets",
             return_value=_universal_result(success=True),
         ):
             lock(pyproject, output=out)
@@ -2503,7 +2506,7 @@ class TestLockCommandUniversal:
         out.write_bytes(committed)
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_universal_result(success=True),
             ),
             cap_writes(4),
@@ -2528,7 +2531,7 @@ class TestLockCommandUniversal:
         )
         out = tmp_path / "pylock.toml"
         with patch(
-            "nab.cli.resolve_for_targets",
+            "nab._run.resolve_for_targets",
             return_value=_universal_result(success=True),
         ):
             lock(pyproject, output=out, groups=("test",))
@@ -2541,7 +2544,7 @@ class TestLockCommandUniversal:
         pyproject = _universal_pyproject(tmp_path)
         out = tmp_path / "pylock.toml"
         with patch(
-            "nab.cli.resolve_for_targets",
+            "nab._run.resolve_for_targets",
             return_value=_universal_result(success=True),
         ) as mock_resolve:
             lock(pyproject, output=out, http_backend="urllib3", offline=True)
@@ -2556,7 +2559,7 @@ class TestLockCommandUniversal:
         pyproject = _universal_pyproject(tmp_path)
         out = tmp_path / "requirements.txt"
         with patch(
-            "nab.cli.resolve_for_targets",
+            "nab._run.resolve_for_targets",
             return_value=_universal_result(success=True),
         ):
             lock(pyproject, format="requirements", output=out)
@@ -2572,7 +2575,7 @@ class TestLockCommandUniversal:
         """Universal + pylock + --output - writes lock text to stdout."""
         pyproject = _universal_pyproject(tmp_path)
         with patch(
-            "nab.cli.resolve_for_targets",
+            "nab._run.resolve_for_targets",
             return_value=_universal_result(success=True),
         ):
             lock(pyproject, output=Path("-"))
@@ -2586,7 +2589,7 @@ class TestLockCommandUniversal:
         monkeypatch.chdir(tmp_path)
         pyproject = _universal_pyproject(tmp_path)
         with patch(
-            "nab.cli.resolve_for_targets",
+            "nab._run.resolve_for_targets",
             return_value=_universal_result(success=True),
         ):
             lock(pyproject)
@@ -2599,7 +2602,7 @@ class TestLockCommandUniversal:
         pyproject = _universal_pyproject(tmp_path)
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_universal_result(success=True),
             ),
             patch("nab._lock.write_lock", side_effect=MissingHashError("no hash")),
@@ -2624,7 +2627,7 @@ class TestLockCommandUniversal:
         )
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_universal_result(success=True),
             ),
             patch("nab._lock.write_lock", side_effect=DisjointnessError(hint)),
@@ -2642,7 +2645,7 @@ class TestLockCommandUniversal:
         message = "conflict-respecting selections exceed 100000"
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_universal_result(success=True),
             ),
             patch("nab._lock.write_lock", side_effect=IntractableMarkerError(message)),
@@ -2725,7 +2728,7 @@ class TestLockCommandUniversal:
         )
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_universal_result(success=True),
             ),
             patch(
@@ -2769,7 +2772,7 @@ class TestLockCommandUniversal:
         )
 
         with (
-            patch("nab.cli.resolve_for_targets", return_value=result),
+            patch("nab._run.resolve_for_targets", return_value=result),
             pytest.raises(SystemExit, match="1"),
         ):
             lock(
@@ -2789,7 +2792,7 @@ class TestLockCommandUniversal:
         pyproject = _universal_pyproject(tmp_path)
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 side_effect=UnsupportedVcsError("refusing direct-URL requirement"),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -2809,7 +2812,7 @@ class TestLockCommandUniversal:
         """
         pyproject = _universal_pyproject(tmp_path)
         with patch(
-            "nab.cli.resolve_for_targets",
+            "nab._run.resolve_for_targets",
             return_value=_multi_tuple_universal_result(),
         ):
             lock(pyproject, format="requirements-without-hashes")
@@ -2831,7 +2834,7 @@ class TestLockCommandUniversal:
         pyproject = _universal_pyproject(tmp_path)
         out = tmp_path / "pins.txt"
         with patch(
-            "nab.cli.resolve_for_targets",
+            "nab._run.resolve_for_targets",
             return_value=_universal_result(success=True),
         ):
             lock(pyproject, format="requirements-without-hashes", output=out)
@@ -2845,7 +2848,7 @@ class TestLockCommandUniversal:
         """An explicit ``--output -`` prints the same per-tuple blocks."""
         pyproject = _universal_pyproject(tmp_path)
         with patch(
-            "nab.cli.resolve_for_targets",
+            "nab._run.resolve_for_targets",
             return_value=_multi_tuple_universal_result(),
         ):
             lock(pyproject, format="requirements-without-hashes", output=Path("-"))
@@ -2860,7 +2863,7 @@ class TestLockCommandUniversal:
         """Single-tuple matrix + ``--output -``: just the pins, no header."""
         pyproject = _universal_pyproject(tmp_path)
         with patch(
-            "nab.cli.resolve_for_targets",
+            "nab._run.resolve_for_targets",
             return_value=_universal_result(success=True),
         ):
             lock(pyproject, format="requirements-without-hashes", output=Path("-"))
@@ -2873,7 +2876,7 @@ class TestLockCommandUniversal:
         pyproject = _universal_pyproject(tmp_path)
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_multi_tuple_failed_result(ResolutionError("conflict")),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -2891,7 +2894,7 @@ class TestLockCommandUniversal:
         multi = "first line\nsecond line\nthird line"
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_multi_tuple_failed_result(ResolutionError(multi)),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -2909,7 +2912,7 @@ class TestLockCommandUniversal:
         pyproject = _universal_pyproject(tmp_path)
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_multi_tuple_failed_result(None),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -2929,7 +2932,7 @@ class TestLockCommandUniversal:
         pyproject = _universal_pyproject(tmp_path)
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_universal_result(
                     success=False, error=ResolutionError("conflict")
                 ),
@@ -2948,7 +2951,7 @@ class TestLockCommandUniversal:
         pyproject = _universal_pyproject(tmp_path)
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 side_effect=KeyError("dependencies"),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -2963,7 +2966,7 @@ class TestLockCommandUniversal:
         pyproject = _universal_pyproject(tmp_path)
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 side_effect=LookupError("unknown group 'ghost'"),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -2978,7 +2981,7 @@ class TestLockCommandUniversal:
         pyproject = _universal_pyproject(tmp_path)
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 side_effect=HttpError("GET https://pypi.org/simple/foo/ failed: 503"),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -2995,7 +2998,7 @@ class TestLockCommandUniversal:
         pyproject = _universal_pyproject(tmp_path)
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 side_effect=MissingExtraError(
                     "foo==1.0 does not provide extra 'nonexistent'"
                 ),
@@ -3018,7 +3021,7 @@ class TestLockCommandUniversal:
 
         pyproject = _universal_pyproject(tmp_path)
         with (
-            patch("nab.cli.resolve_for_targets", side_effect=caught.value),
+            patch("nab._run.resolve_for_targets", side_effect=caught.value),
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, format="requirements-without-hashes")
@@ -3033,7 +3036,7 @@ class TestLockCommandUniversal:
         pyproject = _universal_pyproject(tmp_path)
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_universal_result(success=True),
             ),
             patch(
@@ -3065,7 +3068,7 @@ class TestLockCommandUniversal:
             ],
         )
         with (
-            patch("nab.cli.resolve_for_targets", return_value=mixed),
+            patch("nab._run.resolve_for_targets", return_value=mixed),
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, format="requirements-without-hashes")
@@ -3098,7 +3101,7 @@ class TestLockCommandUniversal:
             ],
         )
         with (
-            patch("nab.cli.resolve_for_targets", return_value=mixed),
+            patch("nab._run.resolve_for_targets", return_value=mixed),
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, format="requirements-without-hashes")
@@ -3167,7 +3170,7 @@ class TestLockCommandUniversal:
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
         """``-v`` keeps the line and prints the clauses and the note under it."""
-        with patch("nab.cli._printer", Printer(verbosity=Verbosity.VERBOSE)):
+        with patch("nab.output._printer", Printer(verbosity=Verbosity.VERBOSE)):
             self._lock_against_a_refused_listing(
                 self._cutoff_refused(tmp_path, '"linux_x86_64"')
             )
@@ -3206,7 +3209,7 @@ class TestLockCommandUniversal:
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
         """A matrix block deepens at ``-v`` the way the single-target one does."""
-        with patch("nab.cli._printer", Printer(verbosity=Verbosity.VERBOSE)):
+        with patch("nab.output._printer", Printer(verbosity=Verbosity.VERBOSE)):
             self._lock_against_a_refused_listing(
                 self._cutoff_refused(tmp_path, '"linux_x86_64", "windows_amd64"')
             )
@@ -3229,7 +3232,7 @@ class TestLockCommandUniversal:
         pyproject = _universal_pyproject(tmp_path)
         out = tmp_path / "constraints-{python_version}.txt"
         with patch(
-            "nab.cli.resolve_for_targets",
+            "nab._run.resolve_for_targets",
             return_value=_multi_tuple_universal_result(),
         ):
             lock(pyproject, format="requirements-without-hashes", output=out)
@@ -3249,7 +3252,7 @@ class TestLockCommandUniversal:
         pyproject = _universal_pyproject(tmp_path)
         out = tmp_path / "constraints-{python_version}-{platform_id}.txt"
         with patch(
-            "nab.cli.resolve_for_targets",
+            "nab._run.resolve_for_targets",
             return_value=_multi_tuple_universal_result(),
         ):
             lock(pyproject, format="requirements-without-hashes", output=out)
@@ -3263,7 +3266,7 @@ class TestLockCommandUniversal:
         pyproject = _universal_pyproject(tmp_path)
         out = tmp_path / "req-{python_version}.txt"
         with patch(
-            "nab.cli.resolve_for_targets",
+            "nab._run.resolve_for_targets",
             return_value=_multi_tuple_universal_result(),
         ):
             lock(pyproject, format="requirements", output=out)
@@ -3289,7 +3292,7 @@ class TestLockCommandUniversal:
         out = tmp_path / "requirements.txt"
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_multi_tuple_universal_result(),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -3317,7 +3320,7 @@ class TestLockCommandUniversal:
         pyproject = _universal_pyproject(tmp_path)
         out = tmp_path / "constraints-{python_version}.txt"
         with (
-            patch("nab.cli.resolve_for_targets", return_value=result),
+            patch("nab._run.resolve_for_targets", return_value=result),
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, format="requirements-without-hashes", output=out)
@@ -3334,7 +3337,7 @@ class TestLockCommandUniversal:
         out = tmp_path / "req-{python_version}-{foo}.txt"
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_universal_result(success=True),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -3352,7 +3355,7 @@ class TestLockCommandUniversal:
         out = tmp_path / "req-{python_version}-{.txt"
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_universal_result(success=True),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -3368,7 +3371,7 @@ class TestLockCommandUniversal:
         out = tmp_path / "req-{python_version}-{platform_id:d}.txt"
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_universal_result(success=True),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -3385,7 +3388,7 @@ class TestLockCommandUniversal:
         out = tmp_path / "req-{platform_id}-{python_version!r}.txt"
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_universal_result(success=True),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -3399,7 +3402,7 @@ class TestLockCommandUniversal:
         pyproject = _universal_pyproject(tmp_path)
         out = tmp_path / "constraints-{python_version}.txt"
         with patch(
-            "nab.cli.resolve_for_targets",
+            "nab._run.resolve_for_targets",
             return_value=_universal_result(success=True),
         ):
             lock(pyproject, format="requirements-without-hashes", output=out)
@@ -3412,7 +3415,7 @@ class TestLockCommandUniversal:
         pyproject = _universal_pyproject(tmp_path)
         out = tmp_path / "req-{selection}.txt"
         with patch(
-            "nab.cli.resolve_for_targets",
+            "nab._run.resolve_for_targets",
             return_value=_forked_universal_result(),
         ):
             lock(pyproject, format="requirements-without-hashes", output=out)
@@ -3434,7 +3437,7 @@ class TestLockCommandUniversal:
         out = tmp_path / "req-{python_version}-{platform_id}.txt"
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_forked_universal_result(),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -3453,7 +3456,7 @@ class TestLockCommandUniversal:
         out = tmp_path / "requirements.txt"
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_forked_universal_result(),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -3477,7 +3480,7 @@ class TestLockCommandUniversal:
         out = tmp_path / "req-{python_version}-{platform_id}-{selection}.txt"
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_two_libc_universal_result(),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -3496,7 +3499,7 @@ class TestLockCommandUniversal:
         out = tmp_path / "requirements.txt"
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_two_libc_universal_result(),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -3514,7 +3517,7 @@ class TestLockCommandUniversal:
         out = tmp_path / "requirements.txt"
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_two_implementation_universal_result(),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -3535,7 +3538,7 @@ class TestLockCommandUniversal:
         out = tmp_path / "req-{platform_id}.txt"
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_mixed_implementation_universal_result(),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -3556,7 +3559,7 @@ class TestLockCommandUniversal:
         out = tmp_path / "req-{python_version}.txt"
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_universal_result(success=True),
             ),
             patch(
@@ -3582,7 +3585,7 @@ class TestLockCommandUniversal:
         first.write_text("stale==0.1\n")
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_late_hashless_universal_result(),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -3609,7 +3612,7 @@ class TestLockCommandUniversal:
         (tmp_path / "req-3.12.txt").mkdir()
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_multi_tuple_universal_result(),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -3631,7 +3634,7 @@ class TestLockCommandUniversal:
         first.write_text("stale==0.1\n")
         before = stat.S_IMODE(first.stat().st_mode)
         with patch(
-            "nab.cli.resolve_for_targets",
+            "nab._run.resolve_for_targets",
             return_value=_multi_tuple_universal_result(),
         ):
             lock(pyproject, format="requirements-without-hashes", output=out)
@@ -3655,7 +3658,7 @@ class TestLockCommandUniversal:
         )
         out = tmp_path / "constraints-{python_version}.txt"
         with (
-            patch("nab.cli.resolve_for_targets", return_value=mixed),
+            patch("nab._run.resolve_for_targets", return_value=mixed),
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, format="requirements-without-hashes", output=out)
@@ -3687,7 +3690,7 @@ class TestNoEmitWorkspace:
         pyproject = _workspace_pyproject(tmp_path)
         out = tmp_path / "pylock.toml"
         with patch(
-            "nab.cli.resolve_for_targets", return_value=self._alpha_and_foo_result()
+            "nab._run.resolve_for_targets", return_value=self._alpha_and_foo_result()
         ):
             lock(pyproject, output=out, no_emit_workspace=True)
         text = out.read_text()
@@ -3699,7 +3702,7 @@ class TestNoEmitWorkspace:
         pyproject = _workspace_pyproject(tmp_path)
         out = tmp_path / "pylock.toml"
         with patch(
-            "nab.cli.resolve_for_targets", return_value=self._alpha_and_foo_result()
+            "nab._run.resolve_for_targets", return_value=self._alpha_and_foo_result()
         ):
             lock(pyproject, output=out)
         text = out.read_text()
@@ -3712,7 +3715,7 @@ class TestNoEmitWorkspace:
         pyproject = _workspace_pyproject(tmp_path)
         out = tmp_path / "pylock.toml"
         with patch(
-            "nab.cli.resolve_for_targets", return_value=self._alpha_and_foo_result()
+            "nab._run.resolve_for_targets", return_value=self._alpha_and_foo_result()
         ):
             lock(pyproject, output=out, no_emit_workspace=True)
         assert "(1 packages)" in capsys.readouterr().err
@@ -3722,7 +3725,7 @@ class TestNoEmitWorkspace:
         pyproject = _workspace_pyproject(tmp_path)
         out = tmp_path / "requirements.txt"
         with patch(
-            "nab.cli.resolve_for_targets", return_value=self._alpha_and_foo_result()
+            "nab._run.resolve_for_targets", return_value=self._alpha_and_foo_result()
         ):
             lock(pyproject, output=out, format="requirements", no_emit_workspace=True)
         text = out.read_text()
@@ -3734,7 +3737,7 @@ class TestNoEmitWorkspace:
         pyproject = _workspace_pyproject(tmp_path, universal=True)
         out = tmp_path / "pylock.toml"
         with patch(
-            "nab.cli.resolve_for_targets",
+            "nab._run.resolve_for_targets",
             return_value=self._alpha_and_foo_universal(),
         ):
             lock(pyproject, output=out, no_emit_workspace=True)
@@ -3748,7 +3751,7 @@ class TestNoEmitWorkspace:
         """Universal requirements + stdout drops workspace pin lines."""
         pyproject = _workspace_pyproject(tmp_path, universal=True)
         with patch(
-            "nab.cli.resolve_for_targets",
+            "nab._run.resolve_for_targets",
             return_value=self._alpha_and_foo_universal(),
         ):
             lock(
@@ -3768,7 +3771,7 @@ class TestNoEmitWorkspace:
         pyproject = _workspace_pyproject(tmp_path, universal=True)
         out = tmp_path / "constraints-{python_version}.txt"
         with patch(
-            "nab.cli.resolve_for_targets",
+            "nab._run.resolve_for_targets",
             return_value=self._alpha_and_foo_universal(),
         ):
             lock(
@@ -3788,7 +3791,7 @@ class TestNoEmitWorkspace:
         pyproject = _workspace_pyproject(tmp_path, universal=True)
         out = tmp_path / "requirements.txt"
         with patch(
-            "nab.cli.resolve_for_targets",
+            "nab._run.resolve_for_targets",
             return_value=self._alpha_and_foo_universal(),
         ):
             lock(
@@ -3807,7 +3810,7 @@ class TestNoEmitWorkspace:
         pyproject = _make_pyproject(tmp_path)
         out = tmp_path / "pylock.toml"
         with patch(
-            "nab.cli.resolve_for_targets", return_value=self._alpha_and_foo_result()
+            "nab._run.resolve_for_targets", return_value=self._alpha_and_foo_result()
         ):
             lock(pyproject, output=out, no_emit_workspace=True)
         text = out.read_text()
@@ -3833,7 +3836,7 @@ class TestNoEmitWorkspace:
         )
         pyproject = _workspace_pyproject(tmp_path)
         out = tmp_path / "pylock.toml"
-        with patch("nab.cli.resolve_for_targets", return_value=result):
+        with patch("nab._run.resolve_for_targets", return_value=result):
             lock(pyproject, output=out, no_emit_workspace=True)
         text = out.read_text()
         assert 'name = "foo"' in text
@@ -3978,7 +3981,7 @@ class TestPylockOutputNameValidation:
         pyproject = _universal_pyproject(tmp_path)
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_universal_result(success=True),
             ),
             pytest.raises(SystemExit, match="1"),
@@ -3989,7 +3992,7 @@ class TestPylockOutputNameValidation:
     def test_specific_accepts_named_pylock(self, tmp_path: Path) -> None:
         pyproject = _make_pyproject(tmp_path)
         out = tmp_path / "pylock.dev.toml"
-        with patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()):
+        with patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()):
             lock(pyproject, output=out)
         assert out.exists()
 
@@ -4030,7 +4033,7 @@ class TestPylockOutputNameValidation:
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
         pyproject = _make_pyproject(tmp_path)
-        with patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()):
+        with patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()):
             lock(pyproject, output=Path("-"))
         assert 'lock-version = "1.0"' in capsys.readouterr().out
 
@@ -4038,7 +4041,7 @@ class TestPylockOutputNameValidation:
         """A non-pylock format is free to use any output name."""
         pyproject = _make_pyproject(tmp_path)
         out = tmp_path / "constraints.txt"
-        with patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()):
+        with patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()):
             lock(pyproject, output=out, format="requirements")
         assert out.exists()
 
@@ -4089,11 +4092,12 @@ class TestConfigErrors:
 
 
 class TestCliDocstringCommandModules:
-    """``nab.cli``'s docstring names every module that registers a subcommand."""
+    """``nab.cli``'s docstring names every ``nab._*`` module ``cli`` binds."""
 
     def test_docstring_names_every_command_module(self) -> None:
         # A command module only registers if cli.py imports it for the side
-        # effect, so cli's own module bindings are the registration set.
+        # effect, so every one of them is a binding here.  cli binds helper
+        # modules too, and the docstring has to name those as well.
         imported = {
             module.__name__
             for _, module in inspect.getmembers(cli, inspect.ismodule)
@@ -4105,8 +4109,7 @@ class TestCliDocstringCommandModules:
         named = set(re.findall(r"nab\._\w+", docstring))
 
         assert named == imported, (
-            f"docstring misses {imported - named}, "
-            f"names unregistered {named - imported}"
+            f"docstring misses {imported - named}, names unbound {named - imported}"
         )
 
 
@@ -4282,7 +4285,7 @@ class TestDetermineLockAnchor:
                 pyproject=p.resolve(),
             )
 
-        monkeypatch.setattr("nab.cli._config_search_roots", fake_roots)
+        monkeypatch.setattr("nab._run._config_search_roots", fake_roots)
         anchor = _determine_lock_anchor(
             _ladder(pyproject), output=target, format="pylock", upgrade=False
         )
@@ -4334,7 +4337,7 @@ class TestLockAnchorReuse:
         """The ``P4D`` window a re-lock over a recorded anchor resolves against."""
         prior, pyproject = self._relative_cutoff_relock(tmp_path)
         with patch(
-            "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
+            "nab._run.resolve_for_targets", return_value=_stub_resolve_result()
         ) as mock_resolve:
             lock(pyproject, output=prior, upgrade=upgrade)
 
@@ -4344,7 +4347,7 @@ class TestLockAnchorReuse:
 
     def test_relock_records_reused_anchor(self, tmp_path: Path) -> None:
         prior, pyproject = self._relative_cutoff_relock(tmp_path)
-        with patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()):
+        with patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()):
             lock(pyproject, output=prior)
         # New pylock's [tool.nab].created-at must equal the prior anchor.
         from nab_project.lockfile import read_lockfile_anchor
@@ -4353,7 +4356,7 @@ class TestLockAnchorReuse:
 
     def test_upgrade_writes_fresh_anchor(self, tmp_path: Path) -> None:
         prior, pyproject = self._relative_cutoff_relock(tmp_path)
-        with patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()):
+        with patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()):
             lock(pyproject, output=prior, upgrade=True)
         from nab_project.lockfile import read_lockfile_anchor
 
@@ -4371,7 +4374,7 @@ class TestLockAnchorReuse:
             f'[tool.nab]\nuploaded-prior-to = "{absolute.isoformat()}"\n',
         )
         out = tmp_path / "pylock.toml"
-        with patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()):
+        with patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()):
             lock(pyproject, output=out)
         from nab_project.lockfile import read_lockfile_anchor
 
@@ -4388,7 +4391,7 @@ class TestLockAnchorReuse:
             f'[tool.nab]\nuploaded-prior-to = "{absolute.isoformat()}"\n',
         )
         out = tmp_path / "pylock.toml"
-        with patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()):
+        with patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()):
             lock(pyproject, output=out)
         from nab_project.lockfile import read_lockfile_anchor
 
@@ -4487,7 +4490,7 @@ class TestLockedFlag:
         result: ResolveResult,
         *extra_args: str,
     ) -> None:
-        with patch("nab.cli.resolve_for_targets", return_value=result):
+        with patch("nab._run.resolve_for_targets", return_value=result):
             app.cli(
                 args=["lock", str(pyproject), "--output", str(out), *extra_args],
                 prog="nab",
@@ -4500,7 +4503,7 @@ class TestLockedFlag:
         result: ResolveResult,
         *extra_args: str,
     ) -> None:
-        with patch("nab.cli.resolve_for_targets", return_value=result):
+        with patch("nab._run.resolve_for_targets", return_value=result):
             app.cli(
                 args=[
                     "lock",
@@ -4657,7 +4660,7 @@ class TestLockedFlag:
         before = out.read_bytes()
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_stub_resolve_result(pins={"foo": V("1.0")}),
             ),
             patch("nab._lock.render_lock", side_effect=MissingHashError("no hash")),
@@ -4704,7 +4707,7 @@ class TestLockedFlag:
         hint = "foo: 2 entries fire under env='py311-linux_x86_64'"
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_stub_resolve_result(pins={"foo": V("1.0")}),
             ),
             patch("nab._lock.render_lock", side_effect=DisjointnessError(hint)),
@@ -4845,7 +4848,7 @@ class TestLockProvenanceCliOverrides:
     def test_cli_override_recorded_in_pylock(self, tmp_path: Path) -> None:
         pyproject = _make_pyproject(tmp_path)
         out = tmp_path / "pylock.toml"
-        with patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()):
+        with patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()):
             app.cli(
                 args=[
                     "lock",
@@ -4863,7 +4866,7 @@ class TestLockProvenanceCliOverrides:
     def test_no_cli_override_omits_key(self, tmp_path: Path) -> None:
         pyproject = _make_pyproject(tmp_path)
         out = tmp_path / "pylock.toml"
-        with patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()):
+        with patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()):
             app.cli(args=["lock", str(pyproject), "--output", str(out)], prog="nab")
         block = tomli.loads(out.read_text())["tool"]["nab"]
         assert "cli-project-overrides" not in block
@@ -4873,7 +4876,7 @@ class TestLockProvenanceCliOverrides:
         out = tmp_path / "pylock.toml"
         argv = ["/somewhere/on/this/machine/src/nab/__main__.py", "lock", "--offline"]
         with (
-            patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()),
+            patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()),
             patch.object(sys, "argv", argv),
         ):
             app.cli(args=["lock", str(pyproject), "--output", str(out)], prog="nab")
@@ -4899,7 +4902,7 @@ class TestLockNonUtf8Text:
         pyproject = _make_pyproject(tmp_path)
         out = tmp_path / "pylock.toml"
         with (
-            patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()),
+            patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()),
             patch.object(sys, "argv", self._bad_argv()),
             pytest.raises(SystemExit) as exc,
         ):
@@ -4924,7 +4927,7 @@ class TestLockNonUtf8Text:
         raw = io.BytesIO()
         stream = io.TextIOWrapper(raw, encoding="utf-8", errors="surrogateescape")
         with (
-            patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()),
+            patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()),
             patch.object(sys, "argv", self._bad_argv()),
             patch.object(sys, "stdout", stream),
             pytest.raises(SystemExit) as exc,
@@ -4962,7 +4965,7 @@ class TestLockNonUtf8Text:
         out = tmp_path / "req-{python_version}.txt"
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_multi_tuple_universal_result(),
             ),
             patch(
@@ -4984,7 +4987,7 @@ class TestLockNonUtf8Text:
         pyproject = _make_pyproject(tmp_path)
         out = tmp_path / "requirements.txt"
         with (
-            patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()),
+            patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()),
             patch.object(sys, "argv", self._bad_argv()),
         ):
             lock(
@@ -5050,7 +5053,7 @@ class TestGroupAndExtraSelection:
         pyproject = _make_pyproject(tmp_path)
         denied = PermissionError(errno.EACCES, "Permission denied", str(pyproject))
         with (
-            patch("nab._lock.read_pyproject_groups", side_effect=denied),
+            patch("nab._run.read_pyproject_groups", side_effect=denied),
             pytest.raises(SystemExit, match="1"),
         ):
             resolve_group_selection(pyproject, groups=(), all_groups=True)
@@ -5065,7 +5068,7 @@ class TestGroupAndExtraSelection:
         pyproject = _make_pyproject(tmp_path)
         denied = PermissionError(errno.EACCES, "Permission denied", str(pyproject))
         with (
-            patch("nab._lock.read_pyproject_optional_dependencies", side_effect=denied),
+            patch("nab._run.read_pyproject_optional_dependencies", side_effect=denied),
             pytest.raises(SystemExit, match="1"),
         ):
             resolve_extra_selection(pyproject, extras=(), all_extras=True)
@@ -5314,7 +5317,7 @@ class TestCacheFlags:
         pyproject = _make_pyproject(tmp_path)
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_stub_resolve_result(pins={}),
             ) as mock_resolve,
             patch("nab._lock.write_lock"),
@@ -5330,7 +5333,7 @@ class TestCacheFlags:
         cache = tmp_path / "mycache"
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_stub_resolve_result(pins={}),
             ) as mock_resolve,
             patch("nab._lock.write_lock"),
@@ -5343,7 +5346,7 @@ class TestCacheFlags:
         pyproject = _make_pyproject(tmp_path)
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_stub_resolve_result(pins={}),
             ) as mock_resolve,
             patch("nab._lock.write_lock"),
@@ -5356,7 +5359,7 @@ class TestCacheFlags:
         pyproject = _make_pyproject(tmp_path)
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_stub_resolve_result(pins={}),
             ) as mock_resolve,
             patch("nab._lock.write_lock"),
@@ -5376,7 +5379,7 @@ class TestCacheFlags:
     ) -> None:
         """Default falls back to ~/.cache/nab when XDG is unset."""
         monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
-        monkeypatch.setattr("nab.cli.Path.home", lambda: tmp_path)
+        monkeypatch.setattr("nab._run.Path.home", lambda: tmp_path)
         assert _default_cache_dir() == tmp_path / ".cache" / "nab"
 
 
@@ -5431,7 +5434,7 @@ class TestOfflineFlagContract:
         pyproject = _make_pyproject(tmp_path)
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_stub_resolve_result(pins={}),
             ) as mock_resolve,
             patch("nab._lock.write_lock"),
@@ -5514,7 +5517,7 @@ class TestMainNormalizesOfflineFlag:
         )
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_stub_resolve_result(pins={}),
             ) as mock_resolve,
             patch("nab._lock.write_lock"),
@@ -5577,11 +5580,11 @@ class TestLayeredRunKnobFlagContract:
         pyproject = _make_pyproject(tmp_path)
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_stub_resolve_result(pins={}),
             ),
             patch("nab._lock.write_lock"),
-            patch("nab.cli._make_transport") as mock_transport,
+            patch("nab._run._make_transport") as mock_transport,
         ):
             app.cli(
                 args=[
@@ -5696,7 +5699,7 @@ class TestMain:
         pyproject = _make_pyproject(tmp_path)
         config = read_pyproject_config(pyproject)
         with patch(
-            "nab.cli.resolve_for_targets",
+            "nab._run.resolve_for_targets",
             return_value=_stub_resolve_result(pins={}),
         ):
             result = _resolve(
@@ -5720,7 +5723,7 @@ class TestMain:
             enabled_during.append(gc.isenabled())
             return _stub_resolve_result(pins={})
 
-        with patch("nab.cli.resolve_for_targets", side_effect=record_gc_state):
+        with patch("nab._run.resolve_for_targets", side_effect=record_gc_state):
             _resolve(
                 pyproject,
                 config=config,
@@ -5754,7 +5757,7 @@ class TestMain:
         # generation 2 on the session's own schedule.
         gc.collect()
 
-        with patch("nab.cli.resolve_for_targets", side_effect=allocate_tracked):
+        with patch("nab._run.resolve_for_targets", side_effect=allocate_tracked):
             _resolve(
                 pyproject,
                 config=config,
@@ -5787,7 +5790,7 @@ class TestMain:
         config = read_pyproject_config(pyproject)
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 side_effect=ResolutionError("no solution"),
             ),
             pytest.raises(SystemExit),
@@ -5809,7 +5812,7 @@ class TestMain:
         config = read_pyproject_config(pyproject)
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 side_effect=ResolutionError("no solution"),
             ),
             pytest.raises(SystemExit),
@@ -5922,7 +5925,7 @@ class TestClosedStandardStreams:
         )
         monkeypatch.setattr(sys, "stderr", None)
         with (
-            patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()),
+            patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()),
             patch("nab.cli.os._exit") as mock_exit,
         ):
             console_entry()
@@ -6038,15 +6041,15 @@ class TestMainWiresOutputOptions:
 
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_stub_resolve_result(pins={}),
             ),
             patch("nab._lock.write_lock"),
         ):
             main()
 
-        assert cli._printer is not None
-        return cli._printer, stderr
+        assert nab_output._printer is not None
+        return nab_output._printer, stderr
 
     def test_default_run_reports_the_written_lockfile(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -6183,7 +6186,7 @@ class TestProgressReachesTheResolve:
         monkeypatch.setattr(sys, "stderr", stderr)
 
         with (
-            patch("nab.cli.resolve_for_targets", side_effect=resolve),
+            patch("nab._run.resolve_for_targets", side_effect=resolve),
             command_patch,
         ):
             main()
@@ -6385,7 +6388,7 @@ class TestResolveTransport:
 
     def test_online_resolve_gets_the_transport_up_front(self) -> None:
         """A resolve that may fetch is handed the real transport."""
-        with patch("nab.cli._make_transport") as make:
+        with patch("nab._run._make_transport") as make:
             transport = _make_resolve_transport("urllib3", offline=False)
 
         assert transport is make.return_value
@@ -6393,7 +6396,7 @@ class TestResolveTransport:
 
     def test_offline_httpx_resolve_gets_it_up_front_too(self) -> None:
         """Only urllib3 defers; httpx is built while the CLI can still exit."""
-        with patch("nab.cli._make_transport") as make:
+        with patch("nab._run._make_transport") as make:
             transport = _make_resolve_transport("httpx", offline=True)
 
         assert transport is make.return_value
@@ -6434,7 +6437,7 @@ class TestResolveTransport:
         pyproject = _make_pyproject(
             tmp_path, '[project]\nname = "root"\nversion = "0"\ndependencies = []\n'
         )
-        with patch("nab.cli._make_urllib3_transport") as make:
+        with patch("nab._run._make_urllib3_transport") as make:
             lock(pyproject, output=tmp_path / "pylock.toml", offline=True, cache=False)
 
         make.assert_not_called()
@@ -6442,7 +6445,7 @@ class TestResolveTransport:
     def test_first_request_builds_one_transport_and_forwards(self) -> None:
         """A deferred transport builds its inner one once, on the first get."""
         inner = _RecordingTransport()
-        with patch("nab.cli._make_urllib3_transport", return_value=inner) as make:
+        with patch("nab._run._make_urllib3_transport", return_value=inner) as make:
             transport = _make_resolve_transport("urllib3", offline=True)
             make.assert_not_called()
 
@@ -6463,7 +6466,7 @@ class TestResolveTransport:
     def test_close_closes_the_transport_it_built(self) -> None:
         """Closing a deferred transport that fetched closes the inner one."""
         inner = _RecordingTransport()
-        with patch("nab.cli._make_urllib3_transport", return_value=inner):
+        with patch("nab._run._make_urllib3_transport", return_value=inner):
             transport = _make_resolve_transport("urllib3", offline=True)
 
             async def fetch_then_close() -> None:
@@ -6476,7 +6479,7 @@ class TestResolveTransport:
 
     def test_close_without_a_request_builds_nothing(self) -> None:
         """Closing a deferred transport that never fetched builds nothing."""
-        with patch("nab.cli._make_urllib3_transport") as make:
+        with patch("nab._run._make_urllib3_transport") as make:
             transport = _make_resolve_transport("urllib3", offline=True)
             asyncio.run(transport.aclose())
 
@@ -6535,6 +6538,38 @@ class TestCliImportPath:
         )
 
 
+_PACKAGE_ENTRY_STATEMENTS = (
+    "import nab.cli",
+    "import nab._run",
+    "import nab._config_cmd",
+    "from nab._lock import lock",
+    "from nab._download import download",
+)
+
+
+class TestPackageEntryStatements:
+    """Each of these imports works in an interpreter holding no nab module."""
+
+    @pytest.mark.parametrize("statement", _PACKAGE_ENTRY_STATEMENTS)
+    def test_entry_statement_runs_in_a_fresh_interpreter(self, statement: str) -> None:
+        """``cli`` and each command module import each other.
+
+        A probe that enters through the command module runs ``cli``
+        against a half-built one, which a name import at either end of
+        the cycle cannot survive.  Nothing else in the suite can see
+        that: ``conftest`` imports ``nab.cli`` before any test runs, so
+        no test enters the package by another route.
+        """
+        probe = subprocess.run(  # noqa: S603 - the probe is this file's own source
+            [sys.executable, "-c", statement],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert probe.returncode == 0, probe.stderr
+
+
 class TestDownloadCommand:
     """Tests for the download subcommand."""
 
@@ -6543,7 +6578,7 @@ class TestDownloadCommand:
         out = tmp_path / "vendor"
         download_result = DownloadResult(written=(out / "x.whl",), skipped=())
         with (
-            patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()),
+            patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()),
             patch(
                 "nab._download.download_lock", return_value=download_result
             ) as mock_dl,
@@ -6560,7 +6595,7 @@ class TestDownloadCommand:
         out = tmp_path / "vendor"
         download_result = DownloadResult(written=(), skipped=())
         with (
-            patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()),
+            patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()),
             patch(
                 "nab._download.download_lock", return_value=download_result
             ) as mock_dl,
@@ -6579,13 +6614,13 @@ class TestDownloadCommand:
 
         with (
             patch(
-                "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
+                "nab._run.resolve_for_targets", return_value=_stub_resolve_result()
             ) as mock_resolve,
             patch(
                 "nab._download.download_lock", return_value=download_result
             ) as mock_dl,
             patch(
-                "nab.cli._make_transport",
+                "nab._download._make_transport",
                 side_effect=[resolve_transport, fetch_transport],
             ) as mock_transport,
         ):
@@ -6608,8 +6643,8 @@ class TestDownloadCommand:
         transport = _ConcurrencyProbeTransport(payloads)
 
         with (
-            patch("nab.cli.resolve_for_targets", return_value=result),
-            patch("nab.cli._make_transport", return_value=transport),
+            patch("nab._run.resolve_for_targets", return_value=result),
+            patch("nab._download._make_transport", return_value=transport),
         ):
             download(pyproject, output=out, max_concurrency=cap)
 
@@ -6623,7 +6658,7 @@ class TestDownloadCommand:
         pyproject = _make_pyproject(tmp_path)
         out = tmp_path / "vendor"
         monkeypatch.setattr(
-            "nab.cli._config_search_roots",
+            "nab._run._config_search_roots",
             lambda p: SourceRoots(project_dir=p.parent, pyproject=p),
         )
         monkeypatch.setenv("NAB_MAX_CONCURRENCY", "2")
@@ -6631,8 +6666,8 @@ class TestDownloadCommand:
         result, payloads = _fetchable_resolve_result(4)
         transport = _ConcurrencyProbeTransport(payloads)
         with (
-            patch("nab.cli.resolve_for_targets", return_value=result),
-            patch("nab.cli._make_transport", return_value=transport),
+            patch("nab._run.resolve_for_targets", return_value=result),
+            patch("nab._download._make_transport", return_value=transport),
         ):
             download(pyproject, output=out)
 
@@ -6649,9 +6684,9 @@ class TestDownloadCommand:
         def run() -> str:
             """Download into ``out`` and return what the run wrote to stderr."""
             with (
-                patch("nab.cli.resolve_for_targets", return_value=result),
+                patch("nab._run.resolve_for_targets", return_value=result),
                 patch(
-                    "nab.cli._make_transport",
+                    "nab._download._make_transport",
                     return_value=_ConcurrencyProbeTransport(payloads),
                 ),
             ):
@@ -6678,7 +6713,7 @@ class TestDownloadCommand:
         pyproject = _make_pyproject(hermetic_roots)
 
         transport = _SidecarTransport(_foo_index_bodies())
-        with patch("nab.cli._make_transport", return_value=transport):
+        with patch("nab._download._make_transport", return_value=transport):
             download(pyproject, output=tmp_path / "vendor", cache_dir=cache)
 
         assert _cached_listings(cache) == ["foo"]
@@ -6695,7 +6730,7 @@ class TestDownloadCommand:
         pyproject = _make_pyproject(hermetic_roots)
 
         transport = _SidecarTransport(_foo_index_bodies())
-        with patch("nab.cli._make_transport", return_value=transport):
+        with patch("nab._download._make_transport", return_value=transport):
             download(pyproject, output=tmp_path / "vendor")
 
         assert _cached_listings(cache) == ["foo"]
@@ -6711,7 +6746,7 @@ class TestDownloadCommand:
         pyproject = _make_pyproject(hermetic_roots)
 
         transport = _SidecarTransport(_foo_index_bodies())
-        with patch("nab.cli._make_transport", return_value=transport):
+        with patch("nab._download._make_transport", return_value=transport):
             download(
                 pyproject, output=tmp_path / "vendor", cache_dir=cache, cache=False
             )
@@ -6730,11 +6765,11 @@ class TestDownloadCommand:
         out = tmp_path / "vendor"
         download_result = DownloadResult(written=(out / "x.whl",), skipped=())
         monkeypatch.setattr(
-            "nab.cli._config_search_roots",
+            "nab._run._config_search_roots",
             lambda p: SourceRoots(project_dir=p.parent, pyproject=p),
         )
         with (
-            patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()),
+            patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()),
             patch("nab._download.download_lock", return_value=download_result),
         ):
             download(pyproject, output=out, project_resolution="lowest")
@@ -6764,7 +6799,7 @@ class TestDownloadCommand:
         download_result = DownloadResult(written=(out / "foo.whl",), skipped=())
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_multi_tuple_universal_result(),
             ),
             patch(
@@ -6785,7 +6820,7 @@ class TestDownloadCommand:
         pyproject = _universal_pyproject(tmp_path)
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 side_effect=ConfigError(
                     "exactly one of [extra 'cpu', extra 'gpu'] must be selected"
                 ),
@@ -6812,7 +6847,7 @@ class TestDownloadCommand:
         pyproject = _make_pyproject(tmp_path)
         with (
             patch(
-                "nab.cli.resolve_for_targets", side_effect=ResolutionError("conflict")
+                "nab._run.resolve_for_targets", side_effect=ResolutionError("conflict")
             ),
             pytest.raises(SystemExit, match="1"),
         ):
@@ -6826,7 +6861,7 @@ class TestDownloadCommand:
         pyproject = _make_pyproject(tmp_path)
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 side_effect=MissingExtraError(
                     "foo==1.0 does not provide extra 'nonexistent'"
                 ),
@@ -6843,7 +6878,7 @@ class TestDownloadCommand:
     ) -> None:
         pyproject = _make_pyproject(tmp_path)
         with (
-            patch("nab.cli.resolve_for_targets", side_effect=KeyError("dependencies")),
+            patch("nab._run.resolve_for_targets", side_effect=KeyError("dependencies")),
             pytest.raises(SystemExit, match="1"),
         ):
             download(pyproject)
@@ -6855,7 +6890,7 @@ class TestDownloadCommand:
         pyproject = _make_pyproject(tmp_path)
         with (
             patch(
-                "nab.cli.resolve_for_targets", side_effect=MissingHashError("no hash")
+                "nab._run.resolve_for_targets", side_effect=MissingHashError("no hash")
             ),
             pytest.raises(SystemExit, match="1"),
         ):
@@ -6867,7 +6902,7 @@ class TestDownloadCommand:
     ) -> None:
         pyproject = _make_pyproject(tmp_path)
         with (
-            patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()),
+            patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()),
             patch(
                 "nab._download.download_lock", side_effect=DownloadError("sha mismatch")
             ),
@@ -6884,7 +6919,7 @@ class TestDownloadCommand:
         out = tmp_path / "wheels"
         out.write_text("not a directory")
         with (
-            patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()),
+            patch("nab._run.resolve_for_targets", return_value=_stub_resolve_result()),
             pytest.raises(SystemExit, match="1"),
         ):
             download(pyproject, output=out)
@@ -6952,7 +6987,7 @@ class TestDownloadCommand:
         download_result = DownloadResult(written=(), skipped=())
         with (
             patch(
-                "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
+                "nab._run.resolve_for_targets", return_value=_stub_resolve_result()
             ) as mock_resolve,
             patch("nab._download.download_lock", return_value=download_result),
         ):
@@ -6968,7 +7003,7 @@ class TestDownloadCommand:
         download_result = DownloadResult(written=(), skipped=())
         with (
             patch(
-                "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
+                "nab._run.resolve_for_targets", return_value=_stub_resolve_result()
             ) as mock_resolve,
             patch("nab._download.download_lock", return_value=download_result),
         ):
@@ -6984,7 +7019,7 @@ class TestDownloadCommand:
         download_result = DownloadResult(written=(), skipped=())
         with (
             patch(
-                "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
+                "nab._run.resolve_for_targets", return_value=_stub_resolve_result()
             ) as mock_resolve,
             patch("nab._download.download_lock", return_value=download_result),
         ):
@@ -7000,7 +7035,7 @@ class TestDownloadCommand:
         download_result = DownloadResult(written=(), skipped=())
         with (
             patch(
-                "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
+                "nab._run.resolve_for_targets", return_value=_stub_resolve_result()
             ) as mock_resolve,
             patch("nab._download.download_lock", return_value=download_result),
         ):
@@ -7012,7 +7047,7 @@ class TestDownloadCommand:
         download_result = DownloadResult(written=(), skipped=())
         with (
             patch(
-                "nab.cli.resolve_for_targets",
+                "nab._run.resolve_for_targets",
                 return_value=_multi_tuple_universal_result(),
             ) as mock_resolve,
             patch("nab._download.download_lock", return_value=download_result),

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -33,11 +33,12 @@ from unittest.mock import patch
 import pytest
 
 import nab._config_cmd as config_cmd
-from nab import cli as nab_cli
+from nab import _run as nab_run
 from nab._config_cmd import config_command
 from nab._download import download
 from nab._lock import lock
-from nab.cli import app, effective_config
+from nab._run import effective_config
+from nab.cli import app
 from nab_project.config import NabProjectConfig
 from nab_project.config_sources import (
     OPTIONS,
@@ -201,7 +202,7 @@ def test_config_search_roots_uses_symlink_dir_not_target(tmp_path: Path) -> None
         link.symlink_to(real / "pyproject.toml")
     except (OSError, NotImplementedError):
         pytest.skip("symlinks not supported on this platform")
-    roots = nab_cli._config_search_roots(link)
+    roots = nab_run._config_search_roots(link)
     assert roots.project_dir == link_dir.resolve()
     assert roots.pyproject == link_dir.resolve() / "pyproject.toml"
 
@@ -836,22 +837,22 @@ def _fold_run_settings(
     cli_cache_dir: Path | None = None,
     cli_http_backend: str | None = None,
     cli_max_concurrency: int | None = None,
-) -> nab_cli.RunSettings:
+) -> nab_run.RunSettings:
     """The run knobs a subcommand folds from ``path`` under these CLI flags.
 
     The assert reports a ladder holding a config error as itself, rather
     than as a subscript failure inside the fold.
     """
-    overrides = nab_cli._cli_overrides(
+    overrides = nab_run._cli_overrides(
         cli_resolution=None,
         cli_offline=cli_offline,
         cli_cache_dir=cli_cache_dir,
         cli_http_backend=cli_http_backend,
         cli_max_concurrency=cli_max_concurrency,
     )
-    ladder = nab_cli.read_config_ladder(path, overrides)
+    ladder = nab_run.read_config_ladder(path, overrides)
     assert not isinstance(ladder, SourceConfigError), ladder
-    return nab_cli._layered_run_settings(ladder)
+    return nab_run._layered_run_settings(ladder)
 
 
 class TestEffectiveConfigBridge:
@@ -944,7 +945,7 @@ def test_default_config_search_roots_xdg(
 ) -> None:
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
     pyproject = tmp_path / "pyproject.toml"
-    roots = nab_cli._config_search_roots(pyproject)
+    roots = nab_run._config_search_roots(pyproject)
     assert roots.user_toml == tmp_path / "xdg" / "nab" / "nab.toml"
     assert roots.system_toml == Path("/etc/nab/nab.toml")
     assert roots.project_dir == tmp_path.resolve()
@@ -955,7 +956,7 @@ def test_config_search_roots_threads_custom_pyproject_name(tmp_path: Path) -> No
     # A non-default pyproject name is threaded through so the registry's
     # pyproject layer reads the file the user actually pointed at.
     custom = tmp_path / "app.toml"
-    roots = nab_cli._config_search_roots(custom)
+    roots = nab_run._config_search_roots(custom)
     assert roots.pyproject == custom.resolve()
     assert roots.project_dir == tmp_path.resolve()
 
@@ -964,8 +965,8 @@ def test_default_config_search_roots_no_xdg(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
-    monkeypatch.setattr(nab_cli.Path, "home", lambda: tmp_path)
-    roots = nab_cli._config_search_roots(tmp_path / "pyproject.toml")
+    monkeypatch.setattr(nab_run.Path, "home", lambda: tmp_path)
+    roots = nab_run._config_search_roots(tmp_path / "pyproject.toml")
     assert roots.user_toml == tmp_path / ".config" / "nab" / "nab.toml"
 
 
@@ -1006,7 +1007,7 @@ class TestNoOpLock:
 
     def _lock_bytes(self, proj: Path, out: Path) -> bytes:
         with patch(
-            "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
+            "nab._run.resolve_for_targets", return_value=_stub_resolve_result()
         ) as mock_resolve:
             lock(proj, output=out, cache=False)
         # The config layer must not perturb the resolve knobs at defaults.
@@ -1027,7 +1028,7 @@ class TestNoOpLock:
         sys_root = tmp_path / "sys" / "nab.toml"
         usr_root = tmp_path / "usr" / "nab.toml"
         monkeypatch.setattr(
-            nab_cli,
+            nab_run,
             "_config_search_roots",
             lambda pyproject: SourceRoots(
                 system_toml=sys_root,
@@ -1059,7 +1060,7 @@ class TestProjectCliOverrides:
     ) -> tuple[NabProjectConfig, Path]:
         with (
             patch(
-                "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
+                "nab._run.resolve_for_targets", return_value=_stub_resolve_result()
             ) as mock_resolve,
             patch("nab._lock.write_lock"),
         ):
@@ -1182,7 +1183,7 @@ class TestProjectCliOverrides:
         out = hermetic_roots / "pylock.toml"
         with (
             patch(
-                "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
+                "nab._run.resolve_for_targets", return_value=_stub_resolve_result()
             ) as mock_resolve,
             patch("nab._lock.write_lock"),
         ):
@@ -1224,7 +1225,7 @@ class TestProjectCliOverrides:
         proj = _project(hermetic_roots)
         out = hermetic_roots / "pylock.toml"
         with patch(
-            "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
+            "nab._run.resolve_for_targets", return_value=_stub_resolve_result()
         ) as mock_resolve:
             app.cli(
                 args=[
@@ -1247,10 +1248,10 @@ class TestProjectCliOverrides:
         self, hermetic_roots: Path
     ) -> None:
         proj = _project(hermetic_roots)
-        ladder = nab_cli.read_config_ladder(
+        ladder = nab_run.read_config_ladder(
             proj, {"uploaded-prior-to": "2024-06-01T00:00:00Z"}
         )
-        anchor = nab_cli.lock_anchor(ladder)
+        anchor = nab_run.lock_anchor(ladder)
         assert anchor == datetime(2024, 6, 1, tzinfo=timezone.utc)
 
     def test_relative_uploaded_prior_to_override_pins_no_anchor(
@@ -1259,8 +1260,8 @@ class TestProjectCliOverrides:
         # A P<n>D override sets the resolve window relative to the run but is
         # not a reusable absolute cutoff, so it pins no lock anchor.
         proj = _project(hermetic_roots)
-        ladder = nab_cli.read_config_ladder(proj, {"uploaded-prior-to": "P7D"})
-        assert nab_cli.lock_anchor(ladder) is None
+        ladder = nab_run.read_config_ladder(proj, {"uploaded-prior-to": "P7D"})
+        assert nab_run.lock_anchor(ladder) is None
 
     def test_lock_anchor_none_for_digit_run_past_int_limit(
         self, hermetic_roots: Path
@@ -1271,7 +1272,7 @@ class TestProjectCliOverrides:
         proj = _project(
             hermetic_roots, 'environment = { python = "3.' + "9" * 5000 + '" }\n'
         )
-        assert nab_cli.lock_anchor(nab_cli.read_config_ladder(proj, {})) is None
+        assert nab_run.lock_anchor(nab_run.read_config_ladder(proj, {})) is None
 
 
 class TestDownloadLadder:
@@ -1283,7 +1284,7 @@ class TestDownloadLadder:
         download_result = DownloadResult(written=(), skipped=())
         with (
             patch(
-                "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
+                "nab._run.resolve_for_targets", return_value=_stub_resolve_result()
             ) as mock_resolve,
             patch("nab._download.download_lock", return_value=download_result),
         ):
@@ -1343,7 +1344,7 @@ class TestDownloadCliOverrides:
         download_result = DownloadResult(written=(), skipped=())
         with (
             patch(
-                "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
+                "nab._run.resolve_for_targets", return_value=_stub_resolve_result()
             ) as mock_resolve,
             patch("nab._download.download_lock", return_value=download_result),
         ):

--- a/tests/test_env_layer.py
+++ b/tests/test_env_layer.py
@@ -1,20 +1,41 @@
-"""Tests for the ``NAB_*`` environment layer the config ladder reads."""
+"""Tests for the environment nab reads: the ``NAB_*`` layer and the census."""
 
 from __future__ import annotations
 
+import ast
+import os
 import sys
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 import pytest
 
+from nab import env
 from nab.cli import main
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 _PROJECT = '[project]\nname = "probe"\nversion = "0.1"\ndependencies = []\n'
 
 _TYPO_WARNING = "NAB_OFLINE is not a recognized nab setting"
+
+_ROOT = Path(__file__).resolve().parents[1]
+
+_SOURCE_TREES = {
+    "nab": _ROOT / "src" / "nab",
+    "nab_index": _ROOT / "nab-index" / "src" / "nab_index",
+    "nab_project": _ROOT / "nab-project" / "src" / "nab_project",
+    "nab_provider": _ROOT / "nab-provider" / "src" / "nab_provider",
+    "nab_resolver": _ROOT / "nab-resolver" / "src" / "nab_resolver",
+}
+
+# nab decides what it does from one module.  The nab-index and nab-project
+# reads build the environment a subprocess is handed, which the package
+# spawning it owns rather than the CLI.
+_ENVIRONMENT_READERS = {
+    "nab": {"nab/env.py"},
+    "nab_index": {"nab_index/vcs.py"},
+    "nab_project": {"nab_project/_build/env.py"},
+    "nab_provider": set[str](),
+    "nab_resolver": set[str](),
+}
 
 
 @pytest.mark.parametrize(
@@ -71,3 +92,109 @@ def test_unknown_env_warning_fires_once(
     main()
 
     assert capsys.readouterr().err.count(_TYPO_WARNING) == 1
+
+
+_ENVIRON_READS = frozenset({"environ", "getenv"})
+
+
+def _reads_the_environment(module: ast.Module) -> bool:
+    """Whether ``module`` reaches ``os.environ`` or ``os.getenv``.
+
+    Both spellings count, and under whatever name they were bound:
+    ``import os as _o`` and ``from os import environ`` are the two ways
+    past a check that only knows the literal ``os.environ``.
+    """
+    through_module: set[str] = set()
+    by_name: set[str] = set()
+    for node in ast.walk(module):
+        if isinstance(node, ast.Import):
+            through_module |= {a.asname or a.name for a in node.names if a.name == "os"}
+        elif isinstance(node, ast.ImportFrom) and node.module == "os":
+            by_name |= {
+                a.asname or a.name for a in node.names if a.name in _ENVIRON_READS
+            }
+
+    for node in ast.walk(module):
+        if isinstance(node, ast.Attribute) and node.attr in _ENVIRON_READS:
+            if isinstance(node.value, ast.Name) and node.value.id in through_module:
+                return True
+        elif isinstance(node, ast.Name) and node.id in by_name:
+            return True
+    return False
+
+
+def _environment_readers(tree: Path) -> set[str]:
+    """The modules under ``tree`` that read the process environment."""
+    return {
+        module.relative_to(tree.parent).as_posix()
+        for module in tree.rglob("*.py")
+        if _reads_the_environment(ast.parse(module.read_text(encoding="utf-8")))
+    }
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        pytest.param("import os\n\nos.environ.get('X')\n", id="attribute"),
+        pytest.param("import os\n\nos.getenv('X')\n", id="getenv"),
+        pytest.param("import os as _o\n\n_o.environ.get('X')\n", id="aliased"),
+        pytest.param("from os import environ\n\nenviron.get('X')\n", id="by-name"),
+        pytest.param("from os import getenv as _g\n\n_g('X')\n", id="renamed"),
+    ],
+)
+def test_the_census_sees_every_spelling(source: str) -> None:
+    assert _reads_the_environment(ast.parse(source)) is True
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        pytest.param("import os\n\nos.getcwd()\n", id="other-os-call"),
+        pytest.param("environ = {}\n\nenviron.get('X')\n", id="unrelated-name"),
+    ],
+)
+def test_the_census_leaves_other_code_alone(source: str) -> None:
+    assert _reads_the_environment(ast.parse(source)) is False
+
+
+@pytest.mark.parametrize("package", sorted(_SOURCE_TREES))
+def test_the_environment_is_read_where_the_census_says(package: str) -> None:
+    """A new read of the process environment has to be classified on purpose.
+
+    The list is an equality, so a module that starts reading the
+    environment fails here until it is either routed through
+    :mod:`nab.env` or recorded as a subprocess's environment.
+    """
+    assert _environment_readers(_SOURCE_TREES[package]) == _ENVIRONMENT_READERS[package]
+
+
+def test_current_falls_back_to_the_process_environment() -> None:
+    assert env.current() is os.environ
+
+
+def test_current_passes_a_supplied_mapping_through() -> None:
+    supplied = {"NAB_VERBOSITY": "debug"}
+    assert env.current(supplied) is supplied
+
+
+def test_verbosity_name_is_the_raw_value() -> None:
+    assert env.verbosity_name({env.NAB_VERBOSITY: " Debug "}) == " Debug "
+    assert env.verbosity_name({}) is None
+
+
+def test_progress_suppressed_reads_nab_no_progress() -> None:
+    assert env.progress_suppressed({env.NAB_NO_PROGRESS: "1"}) is True
+    assert env.progress_suppressed({env.NAB_NO_PROGRESS: ""}) is False
+    assert env.progress_suppressed({}) is False
+
+
+def test_cache_and_config_roots_are_the_raw_values() -> None:
+    environ = {env.XDG_CACHE_HOME: "cache", env.XDG_CONFIG_HOME: "config"}
+    assert env.cache_root(environ) == "cache"
+    assert env.config_root(environ) == "config"
+    assert env.cache_root({}) is None
+    assert env.config_root({}) is None
+
+
+def test_output_owned_names_the_two_output_variables() -> None:
+    assert sorted(env.OUTPUT_OWNED) == ["NAB_NO_PROGRESS", "NAB_VERBOSITY"]

--- a/tests/test_lock_locked.py
+++ b/tests/test_lock_locked.py
@@ -1,7 +1,7 @@
 """Flow tests for the fast-fail tier in ``nab lock --locked``.
 
 Each case drives the real CLI against a committed pylock on disk.  Most mock
-``nab.cli.resolve_for_targets``, so whether the resolver was called shows
+``nab._run.resolve_for_targets``, so whether the resolver was called shows
 whether the tier fired: a disqualifier never calls it, a fall-through does.
 The invalid-invocation cases keep the real resolve, to pin the error it
 reports when the tier defers.
@@ -79,7 +79,7 @@ def _write_pyproject(tmp_path: Path, body: str) -> Path:
 
 
 def _write_lock(pyproject: Path, out: Path, result: ResolveResult, *extra: str) -> None:
-    with patch("nab.cli.resolve_for_targets", return_value=result):
+    with patch("nab._run.resolve_for_targets", return_value=result):
         app.cli(args=["lock", str(pyproject), "--output", str(out), *extra], prog="nab")
 
 
@@ -90,7 +90,7 @@ def _locked_mock(result: ResolveResult | None = None) -> MagicMock:
 
 
 def _run_locked(pyproject: Path, out: Path, mock: MagicMock, *extra: str) -> None:
-    with patch("nab.cli.resolve_for_targets", mock):
+    with patch("nab._run.resolve_for_targets", mock):
         app.cli(
             args=["lock", str(pyproject), "--output", str(out), "--locked", *extra],
             prog="nab",
@@ -222,7 +222,7 @@ def test_locked_build_lock_checks_its_own_default_file(
     )
     capsys.readouterr()
 
-    with patch("nab.cli.resolve_for_targets", _locked_mock(_result({"foo": "1.0"}))):
+    with patch("nab._run.resolve_for_targets", _locked_mock(_result({"foo": "1.0"}))):
         app.cli(
             args=["lock", str(pyproject), "--locked", "--build-requirements"],
             prog="nab",
@@ -1434,7 +1434,7 @@ def test_following_the_remedy_makes_the_check_pass(
 
     assert f"re-run `{_remedy(*refresh)}` to update it" in capsys.readouterr().err
 
-    with patch("nab.cli.resolve_for_targets", _locked_mock(_result({"foo": "2.0"}))):
+    with patch("nab._run.resolve_for_targets", _locked_mock(_result({"foo": "2.0"}))):
         app.cli(args=["lock", *refresh], prog="nab")
     capsys.readouterr()
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -8,6 +8,7 @@ import sys
 
 import pytest
 
+from nab import env
 from nab.output import (
     ColorChoice,
     OutputOptionError,
@@ -15,10 +16,14 @@ from nab.output import (
     ProgressReporter,
     Verbosity,
     _isatty,
+    begin,
     install_log_handler,
     logging_level_for,
+    options_from_flags,
     parse_output_options,
+    printer,
     reset_log_handlers,
+    reset_run,
     should_color,
     verbosity_from_counts,
 )
@@ -105,6 +110,83 @@ def test_should_color_term_dumb_disables() -> None:
 def test_should_color_auto_follows_tty() -> None:
     assert should_color(ColorChoice.AUTO, _TTY(tty=True), {}) is True
     assert should_color(ColorChoice.AUTO, _TTY(tty=False), {}) is False
+
+
+_COLOR_TABLE = [
+    ("always", False, {"NO_COLOR": "1"}, True),
+    ("never", True, {}, False),
+    ("auto", True, {"NO_COLOR": "1"}, False),
+    ("auto", True, {"NO_COLOR": ""}, True),
+    ("auto", False, {"FORCE_COLOR": "1"}, True),
+    ("auto", False, {"FORCE_COLOR": ""}, False),
+    ("auto", True, {"NO_COLOR": "1", "FORCE_COLOR": "1"}, False),
+    ("auto", True, {"TERM": "dumb"}, False),
+    ("auto", True, {"FORCE_COLOR": "1", "TERM": "dumb"}, True),
+    ("auto", True, {}, True),
+    ("auto", False, {}, False),
+]
+
+
+@pytest.mark.parametrize(("choice", "isatty", "environ", "expected"), _COLOR_TABLE)
+def test_color_enabled_table(
+    choice: str, isatty: bool, environ: dict[str, str], expected: bool
+) -> None:
+    """The colour rule, one row per way a value can decide it."""
+    assert env.color_enabled(choice, isatty=isatty, environ=environ) is expected
+
+
+@pytest.mark.parametrize(("choice", "isatty", "environ", "expected"), _COLOR_TABLE)
+def test_should_color_agrees_with_color_enabled(
+    choice: str, isatty: bool, environ: dict[str, str], expected: bool
+) -> None:
+    """The wrapper adds the printer's types and nothing else.
+
+    Two implementations of one rule is the failure this pairing exists to
+    catch, since ``should_color`` is what every printer goes through.
+    """
+    assert should_color(ColorChoice(choice), _TTY(tty=isatty), environ) is expected
+
+
+@pytest.mark.parametrize("choice", [ColorChoice.ALWAYS, ColorChoice.NEVER])
+def test_should_color_never_asks_a_stream_it_does_not_need(
+    choice: ColorChoice,
+) -> None:
+    """``always`` and ``never`` answer without touching the stream.
+
+    A closed stream still has an ``isatty`` to call, and calling it
+    raises, so the guard has to be the choice rather than the attribute.
+    """
+    closed = io.StringIO()
+    closed.close()
+
+    assert should_color(choice, closed, {}) is (choice is ColorChoice.ALWAYS)
+
+
+def test_color_enabled_reads_the_process_environment_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NO_COLOR", "1")
+    assert env.color_enabled("auto", isatty=True) is False
+
+    monkeypatch.delenv("NO_COLOR")
+    monkeypatch.setenv("FORCE_COLOR", "1")
+    assert env.color_enabled("auto", isatty=False) is True
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [
+        (["--color", "always", "--no-color"], ColorChoice.ALWAYS),
+        (["--no-color", "--color", "always"], ColorChoice.ALWAYS),
+        (["--color", "never", "--no-color"], ColorChoice.NEVER),
+        (["--color", "auto", "--no-color"], ColorChoice.AUTO),
+        (["--color", "always", "--color", "never"], ColorChoice.NEVER),
+    ],
+)
+def test_color_flag_precedence(argv: list[str], expected: ColorChoice) -> None:
+    """``--color`` beats ``--no-color`` whatever the order; repeats last-win."""
+    opts, _rest = parse_output_options([*argv, "lock"], {})
+    assert opts.color is expected
 
 
 @pytest.mark.parametrize(
@@ -283,6 +365,12 @@ def test_flags_beat_env_verbosity() -> None:
     assert opts.verbosity is Verbosity.QUIET
 
 
+def test_a_touched_counter_beats_env_verbosity_even_when_it_cancels() -> None:
+    """``-v -q`` is NORMAL, not DEBUG: the test is touched, not non-zero."""
+    opts, _rest = parse_output_options(["-v", "-q", "lock"], {"NAB_VERBOSITY": "debug"})
+    assert opts.verbosity is Verbosity.NORMAL
+
+
 def test_parse_bad_env_verbosity() -> None:
     with pytest.raises(OutputOptionError, match="NAB_VERBOSITY"):
         parse_output_options(["lock"], {"NAB_VERBOSITY": "loud"})
@@ -361,10 +449,61 @@ def test_log_handler_untokened_level_is_bare() -> None:
 
 
 def test_reset_log_handlers_detaches() -> None:
-    printer, stream = _handler_printer()
-    install_log_handler(printer)
+    handler_printer, stream = _handler_printer()
+    install_log_handler(handler_printer)
     reset_log_handlers()
     _emit_record("nab_project.demo", logging.WARNING, "after reset")
+    assert stream.getvalue() == ""
+
+
+def _begin_run(*, quiet: int = 0) -> Printer:
+    """Start a run's output the way the CLI does, with colour off."""
+    return begin(
+        options_from_flags(
+            verbose=0,
+            quiet=quiet,
+            color="never",
+            no_color=False,
+            no_progress=True,
+            environ={},
+        )
+    )
+
+
+def test_begin_installs_the_run_printer() -> None:
+    started = _begin_run(quiet=1)
+
+    assert printer() is started
+    assert started.verbosity is Verbosity.QUIET
+
+
+def test_begin_routes_log_records_through_the_run_printer(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A record logged mid-run reads as a printer line.
+
+    ``logging.lastResort`` would write the bare message, so the token is
+    what says the handler is installed.
+    """
+    _begin_run()
+    _emit_record("nab_project.demo", logging.WARNING, "mid-run")
+
+    assert capsys.readouterr().err == "warning: mid-run\n"
+
+
+def test_reset_run_drops_the_run_printer() -> None:
+    started = _begin_run(quiet=1)
+    reset_run()
+
+    assert printer() is not started
+
+
+def test_reset_run_detaches_the_log_handler() -> None:
+    handler_printer, stream = _handler_printer()
+    install_log_handler(handler_printer)
+    reset_run()
+    _emit_record("nab_project.demo", logging.WARNING, "after reset")
+
     assert stream.getvalue() == ""
 
 


### PR DESCRIPTION
`nab/cli.py` held the entry point and everything the command modules call, so they bound it as a module and reached back through it: nineteen calls like `_cli._resolve(...)` under a `# noqa: SLF001`.

The selection helpers and the shared ones move to `nab/_run.py`, and the run's printer to `nab.output` (`begin`, `printer`, `reset_run`), so `nab._lock` imports those names directly instead of reaching them off `cli.py`. `cli.py` goes from 1,005 lines to 254.

`nab/env.py` is new: it names the seven variables that change nab's behaviour and holds the colour rule. Five direct reads of `os.environ` become one, and `tests/test_env_layer.py` parses every package's source: a new read fails until it goes through `nab.env` or into the census.
