### PR TITLE
Read a project's settings off ResolveInputs, not NabProjectConfig

### DIFF
--- a/nab-project/src/nab_project/_build/env.py
+++ b/nab-project/src/nab_project/_build/env.py
@@ -70,6 +70,7 @@ if TYPE_CHECKING:
     from nab_provider.tags import TagSet
 
     from ..config import IndexOverride, PackageOverride
+    from ..inputs import ResolveInputs
     from ..lockfile import LockInput, PinShape, SdistArtifact, TargetLock
 
     _OverrideT = TypeVar("_OverrideT", PackageOverride, IndexOverride)
@@ -219,11 +220,9 @@ class NabBuildEnv:
     one ``installer.install`` per wheel.
 
     ``requires`` is the PEP 508 string list from
-    ``[build-system].requires``. ``config`` carries the indexes,
-    ``uploaded-prior-to`` window and other nab inputs from the outer
-    resolve; it is pruned (no local sources, no workspace, no
-    marker overlay) before the inner resolve so the build env is
-    computed against PyPI alone.
+    ``[build-system].requires``.  ``config`` carries the outer resolve's
+    settings, pruned of declared sources, constraints and group selection
+    so the build env resolves against the configured indexes alone.
 
     ``offline`` refuses to populate the env at all, since every build
     requirement would have to come off the network.  An empty
@@ -248,7 +247,7 @@ class NabBuildEnv:
         self,
         requires: list[str],
         *,
-        config: NabProjectConfig,
+        config: ResolveInputs,
         offline: bool = False,
         transport_factory: Callable[[], AsyncHttpTransport] = Urllib3AsyncTransport,
         chain: BuildChain = (),
@@ -661,7 +660,7 @@ def _chain_suffix(chain: BuildChain) -> str:
 
 
 def _wheel_barring_dist_policy(
-    config: NabProjectConfig, pin: IndexPin
+    inputs: ResolveInputs, pin: IndexPin
 ) -> DistPolicy | None:
     """Return the ``dist-policy`` in force for ``pin`` when it bars wheels.
 
@@ -682,7 +681,7 @@ def _wheel_barring_dist_policy(
     policy = next(
         (
             package.dist_policy
-            for package in config.package_overrides
+            for package in inputs.package_overrides
             if package.dist_policy is not None
             and package.name == canonical
             and version in package.version_range
@@ -691,7 +690,7 @@ def _wheel_barring_dist_policy(
     )
 
     if policy is None:
-        policy = _serving_index_dist_policy(config, pin.index)
+        policy = _serving_index_dist_policy(inputs, pin.index)
 
     if policy is DistPolicy.SDIST_ONLY or policy is DistPolicy.SDIST_INSTALL:
         return policy
@@ -699,7 +698,7 @@ def _wheel_barring_dist_policy(
 
 
 def _serving_index_dist_policy(
-    config: NabProjectConfig, pin_index: str
+    inputs: ResolveInputs, pin_index: str
 ) -> DistPolicy | None:
     """Return the ``dist-policy`` the index that served ``pin_index`` sets.
 
@@ -709,18 +708,18 @@ def _serving_index_dist_policy(
     indistinguishable to a pin, so neither is read.
     """
     serving = [
-        index for index in config.indexes if strip_userinfo(index.url) == pin_index
+        index for index in inputs.indexes if strip_userinfo(index.url) == pin_index
     ]
     if len(serving) != 1:
         return None
 
-    override = config.index_overrides.get(serving[0].name)
+    override = inputs.index_overrides.get(serving[0].name)
     return override.dist_policy if override is not None else None
 
 
-def _no_wheel_clause(config: NabProjectConfig, pin: IndexPin, label: str) -> str:
+def _no_wheel_clause(inputs: ResolveInputs, pin: IndexPin, label: str) -> str:
     """Return the opening of a refusal: why the env has no wheel of ``label``."""
-    barred_by = _wheel_barring_dist_policy(config, pin)
+    barred_by = _wheel_barring_dist_policy(inputs, pin)
     if barred_by is None:
         return f"{label} publishes no wheel this build host can install"
     return (
@@ -742,7 +741,7 @@ def _without_build_permission(override: _OverrideT) -> _OverrideT:
     return replace(override, build_policy=None)
 
 
-def _inner_resolve_config(config: NabProjectConfig) -> NabProjectConfig:
+def _inner_resolve_config(inputs: ResolveInputs) -> NabProjectConfig:
     """Return the config the build-requires resolve runs under.
 
     Only the fields named here cross into it: build deps come from the
@@ -750,18 +749,21 @@ def _inner_resolve_config(config: NabProjectConfig) -> NabProjectConfig:
     sources stay out.  The cutoff and the decision order cross because
     this resolve picks the backend that writes the metadata the outer
     resolve reads, and a lock reproduces only if this search does too.
+
+    It is a ``NabProjectConfig`` because the inner resolve enters
+    through ``resolve_for_targets``, which plans its own targets.
     """
     return NabProjectConfig(
-        indexes=config.indexes,
+        indexes=inputs.indexes,
         package_overrides=tuple(
-            _without_build_permission(override) for override in config.package_overrides
+            _without_build_permission(override) for override in inputs.package_overrides
         ),
         index_overrides={
             name: _without_build_permission(override)
-            for name, override in config.index_overrides.items()
+            for name, override in inputs.index_overrides.items()
         },
-        uploaded_prior_to=config.uploaded_prior_to,
-        decision_order=config.decision_order,
+        uploaded_prior_to=inputs.uploaded_prior_to,
+        decision_order=inputs.decision_order,
         dist_policy=DistPolicy.WHEEL_OR_SDIST,
         build_policy=BuildPolicy.NEVER,
     )

--- a/nab-project/src/nab_project/_resolve/engine.py
+++ b/nab-project/src/nab_project/_resolve/engine.py
@@ -42,8 +42,8 @@ if TYPE_CHECKING:
     from nab_provider.target import ResolveTarget
     from nab_resolver.types import Incompatibility
 
-    from ..config import NabProjectConfig
     from ..fetch import FetchCoordinator
+    from ..inputs import ResolveInputs
     from ..lockfile import TargetLock
 
 
@@ -477,7 +477,7 @@ class _EngineSettings:
     """What every per-target resolve in one run shares."""
 
     coordinator: FetchCoordinator
-    config: NabProjectConfig
+    inputs: ResolveInputs
 
     # Where a declared VCS clone or archive extraction lands, ``None`` when
     # the project declares neither.
@@ -548,19 +548,19 @@ def _resolve_one_target(
     contexts: InstallContexts | None = None,
 ) -> TargetResult:
     """Run one single-environment resolve for ``target``."""
-    config = settings.config
+    inputs = settings.inputs
     environment = target.marker_env
     try:
         root_requirements, resolver_requirements, root_extras = build_resolver_inputs(
             requirements,
-            config.vcs,
+            inputs.vcs,
             environment=environment,
             marker_holds=settings.marker_holds,
             warned=settings.warned_dropped_markers,
         )
         constraint_ranges = build_resolver_inputs(
             constraints,
-            config.vcs,
+            inputs.vcs,
             environment=environment,
             marker_holds=settings.marker_holds,
             kind="constraint",
@@ -577,21 +577,21 @@ def _resolve_one_target(
         root_requirements=resolver_requirements,
         constraints=resolver_constraints,
         root_extras=root_extras,
-        uploaded_prior_to=config.uploaded_prior_to,
-        dist_policy=config.dist_policy,
-        build_policy=config.build_policy,
-        package_overrides=config.package_overrides,
-        index_overrides=config.index_overrides,
-        trust_unverified_sdist_deps=config.trust_unverified_sdist_deps,
-        vcs_config=config.vcs,
-        local_sources=list(config.local_sources) or None,
-        vcs_sources=list(config.vcs_sources) or None,
+        uploaded_prior_to=inputs.uploaded_prior_to,
+        dist_policy=inputs.dist_policy,
+        build_policy=inputs.build_policy,
+        package_overrides=inputs.package_overrides,
+        index_overrides=inputs.index_overrides,
+        trust_unverified_sdist_deps=inputs.trust_unverified_sdist_deps,
+        vcs_config=inputs.vcs,
+        local_sources=list(inputs.local_sources) or None,
+        vcs_sources=list(inputs.vcs_sources) or None,
         vcs_cache_dir=source_root / VCS_BUCKET if source_root is not None else None,
-        archive_sources=list(config.archive_sources) or None,
+        archive_sources=list(inputs.archive_sources) or None,
         archive_cache_dir=(
             source_root / ARCHIVE_BUCKET if source_root is not None else None
         ),
-        decision_order=config.decision_order,
+        decision_order=inputs.decision_order,
         resolution_strategy=settings.resolution,
         direct_packages=frozenset(
             name for name in resolver_requirements if split_extra(name)[1] is None

--- a/nab-project/src/nab_project/fetch.py
+++ b/nab-project/src/nab_project/fetch.py
@@ -85,7 +85,7 @@ if TYPE_CHECKING:
     from nab_provider.metadata import WheelMetadata
     from nab_provider.policy import SourceRequest
 
-    from .config import NabProjectConfig
+    from .inputs import ResolveInputs
 
 logger = logging.getLogger(__name__)
 
@@ -133,18 +133,18 @@ def _resolve_routes(routes: list[IndexRoute]) -> dict[str, str]:
     return {canonicalize_name(entry.name): entry.index for entry in routes}
 
 
-def _builds_remote_sdists(config: NabProjectConfig | None) -> bool:
-    """Whether ``config`` names ``build-remote`` anywhere.
+def _builds_remote_sdists(inputs: ResolveInputs | None) -> bool:
+    """Whether ``inputs`` names ``build-remote`` anywhere.
 
     Coarser than :meth:`~nab_provider.provider.Provider.effective_build_policy`,
     which decides per version. Holding sdist archives is a whole-run decision,
     so an upper bound on what could reach a build is enough.
     """
-    if config is None:
+    if inputs is None:
         return False
-    if config.build_policy is BuildPolicy.BUILD_REMOTE:
+    if inputs.build_policy is BuildPolicy.BUILD_REMOTE:
         return True
-    overrides = (*config.package_overrides, *config.index_overrides.values())
+    overrides = (*inputs.package_overrides, *inputs.index_overrides.values())
     return any(o.build_policy is BuildPolicy.BUILD_REMOTE for o in overrides)
 
 
@@ -213,7 +213,7 @@ class FetchCoordinator:
         index_routes: list[IndexRoute] | None = None,
         index_cache_floors: Mapping[str, int] | None = None,
         on_fetch: Callable[[], None] | None = None,
-        build_config: NabProjectConfig | None = None,
+        build_config: ResolveInputs | None = None,
     ) -> None:
         """Create a coordinator that wraps ``transport``.
 
@@ -232,7 +232,7 @@ class FetchCoordinator:
         as ``min_fresh_seconds``.  Indexes absent from the map, and the
         ``file://`` local client, get no floor.
 
-        ``build_config`` is the project config a :pep:`517` build runs under;
+        ``build_config`` is the settings a :pep:`517` build runs under;
         a caller that resolves without building leaves it ``None``.
 
         ``cache_backend`` wins over ``cache_dir`` if both are given;

--- a/nab-project/src/nab_project/inputs.py
+++ b/nab-project/src/nab_project/inputs.py
@@ -1,0 +1,135 @@
+"""What nab-project reads out of a project's configuration.
+
+Declared here rather than by the host because nab-project may not import ``nab``.
+"""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import TYPE_CHECKING
+
+from nab_provider.policy import (
+    BuildPolicy,
+    DecisionOrder,
+    DistPolicy,
+    ResolutionStrategy,
+)
+from nab_provider.records import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL, IndexConfig
+from nab_provider.vcs_admission import VcsConfig
+
+from ._value import ValueType
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from datetime import datetime
+
+    from nab_provider.overrides import IndexOverride, PackageOverride
+    from nab_provider.policy import ArchiveSource, LocalSource, VcsSource
+
+    from .config import ConflictSet
+
+__all__ = ["ResolveInputs"]
+
+
+_DEFAULT_INDEXES = (IndexConfig(DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL),)
+_NO_INDEX_OVERRIDES: Mapping[str, IndexOverride] = MappingProxyType({})
+_DEFAULT_VCS = VcsConfig()
+
+
+class ResolveInputs(ValueType):
+    """The settings one resolve runs under."""
+
+    __slots__ = __match_args__ = (
+        "archive_sources",
+        "base_group",
+        "build_group",
+        "build_policy",
+        "build_requires_depth",
+        "conflicts",
+        "constraints",
+        "decision_order",
+        "default_groups",
+        "dist_policy",
+        "index_overrides",
+        "indexes",
+        "local_sources",
+        "package_overrides",
+        "requires_python",
+        "resolution",
+        "trust_unverified_sdist_deps",
+        "uploaded_prior_to",
+        "vcs",
+        "vcs_sources",
+    )
+
+    archive_sources: tuple[ArchiveSource, ...]
+    base_group: str | None
+    build_group: str | None
+    build_policy: BuildPolicy
+    build_requires_depth: int
+    conflicts: tuple[ConflictSet, ...]
+    constraints: tuple[str, ...]
+    decision_order: DecisionOrder
+    default_groups: tuple[str, ...]
+    dist_policy: DistPolicy
+    index_overrides: Mapping[str, IndexOverride]
+    indexes: tuple[IndexConfig, ...]
+    local_sources: tuple[LocalSource, ...]
+    package_overrides: tuple[PackageOverride, ...]
+    requires_python: str | None
+    resolution: ResolutionStrategy
+    trust_unverified_sdist_deps: bool
+    uploaded_prior_to: datetime | None
+    vcs: VcsConfig
+    vcs_sources: tuple[VcsSource, ...]
+
+    def __init__(  # noqa: PLR0913 - one keyword per setting a resolve reads
+        self,
+        *,
+        archive_sources: tuple[ArchiveSource, ...] = (),
+        base_group: str | None = None,
+        build_group: str | None = None,
+        build_policy: BuildPolicy = BuildPolicy.BUILD_LOCAL,
+        build_requires_depth: int = 0,
+        conflicts: tuple[ConflictSet, ...] = (),
+        constraints: tuple[str, ...] = (),
+        decision_order: DecisionOrder = DecisionOrder.ARRIVAL,
+        default_groups: tuple[str, ...] = (),
+        dist_policy: DistPolicy = DistPolicy.WHEEL_OR_SDIST,
+        index_overrides: Mapping[str, IndexOverride] = _NO_INDEX_OVERRIDES,
+        indexes: tuple[IndexConfig, ...] = _DEFAULT_INDEXES,
+        local_sources: tuple[LocalSource, ...] = (),
+        package_overrides: tuple[PackageOverride, ...] = (),
+        requires_python: str | None = None,
+        resolution: ResolutionStrategy = ResolutionStrategy.HIGHEST,
+        trust_unverified_sdist_deps: bool = False,
+        uploaded_prior_to: datetime | None = None,
+        vcs: VcsConfig = _DEFAULT_VCS,
+        vcs_sources: tuple[VcsSource, ...] = (),
+    ) -> None:
+        """Record the settings, each defaulting to what a bare project gets."""
+        self.archive_sources = archive_sources
+        self.base_group = base_group
+        self.build_group = build_group
+        self.build_policy = build_policy
+        self.build_requires_depth = build_requires_depth
+        self.conflicts = conflicts
+        self.constraints = constraints
+        self.decision_order = decision_order
+        self.default_groups = default_groups
+        self.dist_policy = dist_policy
+        self.index_overrides = index_overrides
+        self.indexes = indexes
+        self.local_sources = local_sources
+        self.package_overrides = package_overrides
+        self.requires_python = requires_python
+        self.resolution = resolution
+        self.trust_unverified_sdist_deps = trust_unverified_sdist_deps
+        self.uploaded_prior_to = uploaded_prior_to
+        self.vcs = vcs
+        self.vcs_sources = vcs_sources
+
+    def replace(self, **changes: object) -> ResolveInputs:
+        """Return a copy with ``changes`` applied, as ``dataclasses.replace`` would."""
+        kept = {name: getattr(self, name) for name in self.__match_args__}
+        return ResolveInputs(**{**kept, **changes})

--- a/nab-project/src/nab_project/resolve.py
+++ b/nab-project/src/nab_project/resolve.py
@@ -87,6 +87,7 @@ from .config import (
     with_python_override,
 )
 from .fetch import FetchCoordinator
+from .inputs import ResolveInputs
 from .lockfile import LockInput, TargetLock
 
 if TYPE_CHECKING:
@@ -127,6 +128,13 @@ class _ConfiguredContext:
 
     name: str | None
     requirements: tuple[Requirement, ...]
+
+
+def _resolve_inputs(config: NabProjectConfig) -> ResolveInputs:
+    """Copy the settings nab-project resolves with off ``config``."""
+    return ResolveInputs(
+        **{name: getattr(config, name) for name in ResolveInputs.__match_args__}
+    )
 
 
 def resolve_for_targets(  # noqa: PLR0913 - the knobs of a project resolve
@@ -200,7 +208,7 @@ def resolve_for_targets(  # noqa: PLR0913 - the knobs of a project resolve
         index_routes=index_routes_from_config(config),
         index_cache_floors=index_cache_floors_from_config(config),
         on_fetch=progress.on_fetch if progress is not None else None,
-        build_config=config,
+        build_config=_resolve_inputs(config),
     ) as coordinator:
         return resolve_with_coordinator(
             coordinator,
@@ -250,17 +258,17 @@ def resolve_with_coordinator(  # noqa: PLR0913 - the knobs of a bare resolve
     with its own marker machinery passes that instead and keeps
     ``packaging.markersets`` off the engine's path.
     """
-    effective = config if config is not None else NabProjectConfig()
-    with _source_root(cache_dir, effective) as source_root:
+    inputs = _resolve_inputs(config) if config is not None else ResolveInputs()
+    with _source_root(cache_dir, inputs) as source_root:
         settings = _EngineSettings(
             coordinator=coordinator,
-            config=effective,
+            inputs=inputs,
             source_root=source_root,
             align=align_across_targets,
             resolution=(
                 resolution_strategy
                 if resolution_strategy is not None
-                else effective.resolution
+                else inputs.resolution
             ),
             marker_holds=(
                 dependency_marker_holds if marker_holds is None else marker_holds
@@ -274,7 +282,7 @@ def resolve_with_coordinator(  # noqa: PLR0913 - the knobs of a bare resolve
         fork_list = (
             list(forks) if forks is not None else [ResolveFork((), tuple(requirements))]
         )
-        constraints = [parse_requirement(text) for text in effective.constraints]
+        constraints = [parse_requirement(text) for text in inputs.constraints]
 
         return _resolve_with_micro_narrowing(
             list(targets),
@@ -288,7 +296,7 @@ def resolve_with_coordinator(  # noqa: PLR0913 - the knobs of a bare resolve
 
 @contextmanager
 def _source_root(
-    cache_dir: Path | None, config: NabProjectConfig
+    cache_dir: Path | None, inputs: ResolveInputs
 ) -> Iterator[Path | None]:
     """Yield the directory a declared VCS or archive source materialises under.
 
@@ -296,7 +304,7 @@ def _source_root(
     materialised to read its version and dependencies, so the run gets a
     temporary directory.
     """
-    if cache_dir is not None or not (config.vcs_sources or config.archive_sources):
+    if cache_dir is not None or not (inputs.vcs_sources or inputs.archive_sources):
         yield cache_dir
         return
 

--- a/nab-project/tests/test_build_runner.py
+++ b/nab-project/tests/test_build_runner.py
@@ -27,7 +27,7 @@ import tempfile
 import zipfile
 from collections.abc import Callable
 from contextlib import AbstractContextManager
-from dataclasses import fields, replace
+from dataclasses import replace
 from datetime import datetime, timezone
 from importlib.util import cache_from_source, module_from_spec, spec_from_file_location
 from pathlib import Path
@@ -60,15 +60,9 @@ from nab_project._build.runner import (
     run_build_backend,
 )
 from nab_project.config import (
-    ConflictKind,
-    ConflictMember,
-    ConflictSet,
-    EnvironmentConfig,
     IndexOverride,
-    MatrixConfig,
     NabProjectConfig,
     PackageOverride,
-    ResolveMode,
 )
 from nab_project.download import DownloadError, DownloadResult, iter_artifacts
 from nab_project.lockfile import (
@@ -87,16 +81,11 @@ from nab_provider._vendor.packaging.requirements import Requirement
 from nab_provider._vendor.packaging.utils import canonicalize_name
 from nab_provider._vendor.packaging.version import Version
 from nab_provider.provider import (
-    ArchiveSource,
     BuildPolicy,
     DecisionOrder,
     DistPolicy,
     LocalSource,
     MissingExtraError,
-    ResolutionStrategy,
-    VcsConfig,
-    VcsPolicy,
-    VcsSource,
 )
 from nab_provider.tags import PlatformSpec, TagSet
 from nab_provider.target import ResolveTarget
@@ -1975,85 +1964,6 @@ class TestNabBuildEnvInstall:
             env.install(["pip"])
 
 
-# Every ``NabProjectConfig`` field, grouped by what the inner build-requires
-# config does with it: forward the outer value, pin a fixed one, or leave the
-# default.  A field in none of the three fails the test below.
-_INNER_FORWARDS = frozenset(
-    {
-        "decision_order",
-        "index_overrides",
-        "indexes",
-        "package_overrides",
-        "uploaded_prior_to",
-    }
-)
-_INNER_PINS = frozenset({"build_policy", "dist_policy"})
-_INNER_DROPS = frozenset(
-    {
-        "archive_sources",
-        "base_group",
-        "build_group",
-        "build_requires_depth",
-        "conflicts",
-        "constraints",
-        "default_groups",
-        "environment",
-        "local_sources",
-        "matrix",
-        "mode",
-        "requires_python",
-        "requires_python_source",
-        "resolution",
-        "trust_unverified_sdist_deps",
-        "vcs",
-        "vcs_sources",
-        "workspace",
-        "workspace_member_names",
-    }
-)
-
-
-def _config_off_every_default(tmp_path: Path) -> NabProjectConfig:
-    """A project config with every field set away from its default.
-
-    No parser produces this combination (``environment`` and ``matrix``
-    are exclusive).  Every value is off-default so that a dropped field
-    leaking into the inner config reads back as the outer value rather
-    than as one that happens to match the default.
-    """
-    cutoff = datetime(2026, 5, 1, tzinfo=timezone.utc)
-    return NabProjectConfig(
-        mode=ResolveMode.UNIVERSAL,
-        constraints=("setuptools<70",),
-        default_groups=("dev",),
-        base_group="project",
-        build_group="build",
-        requires_python=">=3.11",
-        requires_python_source="[project] requires-python",
-        uploaded_prior_to=cutoff,
-        dist_policy=DistPolicy.SDIST_ONLY,
-        build_policy=BuildPolicy.BUILD_REMOTE,
-        build_requires_depth=1,
-        trust_unverified_sdist_deps=True,
-        environment=EnvironmentConfig(python="3.12"),
-        indexes=(IndexConfig("internal", "https://example.invalid/simple/"),),
-        vcs=VcsConfig(policy=VcsPolicy.ALLOW),
-        local_sources=(LocalSource("plugin", str(tmp_path / "plugin")),),
-        vcs_sources=(VcsSource("tool", "git+https://example.invalid/tool.git@v1"),),
-        archive_sources=(
-            ArchiveSource("blob", "https://example.invalid/b-1.0.tar.gz"),
-        ),
-        matrix=MatrixConfig(python=">=3.11", platforms=(PlatformSpec("linux_x86_64"),)),
-        resolution=ResolutionStrategy.LOWEST,
-        decision_order=DecisionOrder.STABLE,
-        workspace=WorkspaceConfig(members=("packages/plugin",)),
-        conflicts=(ConflictSet(members=(ConflictMember(ConflictKind.EXTRA, "cpu"),)),),
-        package_overrides=(pkg_override("hatchling", uploaded_prior_to=cutoff),),
-        index_overrides={"internal": IndexOverride(uploaded_prior_to=cutoff)},
-        workspace_member_names=frozenset({"plugin"}),
-    )
-
-
 class TestResolveAndDownload:
     """What the inner build-requires resolve is allowed to see and do."""
 
@@ -2246,34 +2156,6 @@ class TestResolveAndDownload:
         inner = self._capture_inner_config(env, tmp_path, monkeypatch)
 
         assert inner.decision_order is DecisionOrder.ARRIVAL
-
-    def test_every_config_field_is_forwarded_pinned_or_dropped(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """A field crosses into the build env only by being named.
-
-        ``_inner_resolve_config`` copies the fields it lists, so a field
-        added to ``NabProjectConfig`` takes its default inside the build
-        env until someone sorts it into one of the three sets above.
-        """
-        names = {f.name for f in fields(NabProjectConfig)}
-        assert names == _INNER_FORWARDS | _INNER_PINS | _INNER_DROPS
-
-        outer = _config_off_every_default(tmp_path)
-        default = NabProjectConfig()
-
-        # A field left at its default would make the leak check below vacuous.
-        at_default = sorted(
-            name for name in names if getattr(outer, name) == getattr(default, name)
-        )
-        assert not at_default
-
-        env = NabBuildEnv(requires=["hatchling"], config=outer)
-        inner = self._capture_inner_config(env, tmp_path, monkeypatch)
-
-        assert {name: getattr(inner, name) for name in _INNER_DROPS} == {
-            name: getattr(default, name) for name in _INNER_DROPS
-        }
 
     def test_url_build_requirement_wrapped(self, tmp_path: Path) -> None:
         """A direct-URL build requirement the inner resolve refuses is

--- a/nab-project/tests/test_resolve.py
+++ b/nab-project/tests/test_resolve.py
@@ -49,6 +49,7 @@ from nab_project.resolve import (
     _group_requirements,
     _group_requirements_by_group,
     _ProjectTables,
+    _resolve_inputs,
     build_lock_input,
     build_resolver_inputs,
     config_for_build_requirements,
@@ -6431,7 +6432,7 @@ class TestBuildConfigPlumbing:
     def test_dynamic_local_source_builds_under_the_project_config(
         self, tmp_path: Path
     ) -> None:
-        """``resolve_for_targets`` hands its config to the coordinator it opens."""
+        """``resolve_for_targets`` hands its own settings to the build."""
         pyproject = self._project(tmp_path)
         config = read_pyproject_config(pyproject)
         built = WheelMetadata(name="dyn", version=Version("7.0"))
@@ -6449,7 +6450,7 @@ class TestBuildConfigPlumbing:
         assert result.success
         assert _pins(result) == {"dyn": Version("7.0")}
 
-        assert runner.call_args.kwargs["config"] is config
+        assert runner.call_args.kwargs["config"] == _resolve_inputs(config)
 
 
 class TestTrustUnverifiedSdistDeps:

--- a/nab-project/tests/test_resolve_targets.py
+++ b/nab-project/tests/test_resolve_targets.py
@@ -57,6 +57,7 @@ from nab_project.resolve import (
     ResolveFork,
     ResolveResult,
     TargetResult,
+    _resolve_inputs,
     build_lock_input,
     build_resolver_inputs,
     resolve_with_coordinator,
@@ -150,7 +151,7 @@ def _settings(
     effective = config if config is not None else NabProjectConfig()
     return _EngineSettings(
         coordinator=coordinator,
-        config=effective,
+        inputs=_resolve_inputs(effective),
         source_root=source_root,
         align=align,
         resolution=effective.resolution,

--- a/nab-project/tests/test_seam_partition.py
+++ b/nab-project/tests/test_seam_partition.py
@@ -1,0 +1,244 @@
+"""The seam type, and the partition of ``NabProjectConfig`` behind it.
+
+Every config field is either a ``ResolveInputs`` slot or a name the host keeps.
+"""
+
+from __future__ import annotations
+
+from dataclasses import fields
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+import pytest
+
+from nab_project._build.env import _inner_resolve_config, _without_build_permission
+from nab_project.config import (
+    ConflictKind,
+    ConflictMember,
+    ConflictSet,
+    NabProjectConfig,
+)
+from nab_project.inputs import ResolveInputs
+from nab_project.resolve import _resolve_inputs
+from nab_provider.overrides import IndexOverride
+from nab_provider.policy import (
+    ArchiveSource,
+    BuildPolicy,
+    DecisionOrder,
+    DistPolicy,
+    LocalSource,
+    ResolutionStrategy,
+    VcsSource,
+)
+from nab_provider.records import IndexConfig
+from nab_provider.testing import pkg_override
+from nab_provider.vcs_admission import VcsConfig, VcsPolicy
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# Every slot, grouped by what the inner build-requires config does with it:
+# forward the outer value, pin a fixed one, or leave the default.
+_INNER_FORWARDS = frozenset(
+    {
+        "decision_order",
+        "index_overrides",
+        "indexes",
+        "package_overrides",
+        "uploaded_prior_to",
+    }
+)
+_INNER_PINNED: dict[str, object] = {
+    "build_policy": BuildPolicy.NEVER,
+    "dist_policy": DistPolicy.WHEEL_OR_SDIST,
+}
+_INNER_PINS = frozenset(_INNER_PINNED)
+_INNER_DROPS = frozenset(
+    {
+        "archive_sources",
+        "base_group",
+        "build_group",
+        "build_requires_depth",
+        "conflicts",
+        "constraints",
+        "default_groups",
+        "local_sources",
+        "requires_python",
+        "resolution",
+        "trust_unverified_sdist_deps",
+        "vcs",
+        "vcs_sources",
+    }
+)
+
+# The ``NabProjectConfig`` fields nothing outside ``config.py`` reads.
+_STAYS_IN_NAB = frozenset(
+    {
+        "environment",
+        "matrix",
+        "mode",
+        "requires_python_source",
+        "workspace",
+        "workspace_member_names",
+    }
+)
+
+_CUTOFF = datetime(2026, 5, 1, tzinfo=timezone.utc)
+
+
+def _config_off_every_slot_default(tmp_path: Path) -> NabProjectConfig:
+    """A project config with every seam slot set away from its default.
+
+    A slot left at its default would make the checks below vacuous: a value
+    that failed to cross would read back as the one it was meant to carry.
+    """
+    return NabProjectConfig(
+        archive_sources=(
+            ArchiveSource("blob", "https://example.invalid/b-1.0.tar.gz"),
+        ),
+        base_group="project",
+        build_group="build",
+        build_policy=BuildPolicy.BUILD_REMOTE,
+        build_requires_depth=1,
+        conflicts=(ConflictSet(members=(ConflictMember(ConflictKind.EXTRA, "cpu"),)),),
+        constraints=("setuptools<70",),
+        decision_order=DecisionOrder.STABLE,
+        default_groups=("dev",),
+        dist_policy=DistPolicy.SDIST_ONLY,
+        index_overrides={
+            "internal": IndexOverride(
+                uploaded_prior_to=_CUTOFF, build_policy=BuildPolicy.BUILD_REMOTE
+            )
+        },
+        indexes=(IndexConfig("internal", "https://example.invalid/simple/"),),
+        local_sources=(LocalSource("plugin", str(tmp_path / "plugin")),),
+        package_overrides=(
+            pkg_override(
+                "hatchling",
+                uploaded_prior_to=_CUTOFF,
+                build_policy=BuildPolicy.BUILD_REMOTE,
+            ),
+        ),
+        requires_python=">=3.11",
+        resolution=ResolutionStrategy.LOWEST,
+        trust_unverified_sdist_deps=True,
+        uploaded_prior_to=_CUTOFF,
+        vcs=VcsConfig(policy=VcsPolicy.ALLOW),
+        vcs_sources=(VcsSource("tool", "git+https://example.invalid/tool.git@v1"),),
+    )
+
+
+def _inputs_off_every_default(tmp_path: Path) -> ResolveInputs:
+    """The same settings, across the seam."""
+    return _resolve_inputs(_config_off_every_slot_default(tmp_path))
+
+
+class TestSeamPartition:
+    """What crosses into nab-project, and what the build env may see."""
+
+    def test_every_config_field_crosses_the_seam_or_stays_in_nab(self) -> None:
+        """A new ``[tool.nab]`` setting is either a slot or named as the host's."""
+        names = {f.name for f in fields(NabProjectConfig)}
+
+        assert names == set(ResolveInputs.__slots__) | _STAYS_IN_NAB
+
+    def test_the_projection_carries_every_slot(self, tmp_path: Path) -> None:
+        """Every slot arrives holding what the project declared.
+
+        The name sets can agree while a value never crosses.
+        """
+        config = _config_off_every_slot_default(tmp_path)
+
+        inputs = _resolve_inputs(config)
+
+        assert {name: getattr(inputs, name) for name in ResolveInputs.__slots__} == {
+            name: getattr(config, name) for name in ResolveInputs.__slots__
+        }
+
+    def test_every_slot_is_forwarded_pinned_or_dropped(self) -> None:
+        """A setting reaches the build env only by being named.
+
+        A slot in none of the three sets takes its default inside the build env.
+        """
+        slots = set(ResolveInputs.__slots__)
+
+        assert slots == _INNER_FORWARDS | _INNER_PINS | _INNER_DROPS
+
+    def test_the_inner_resolve_carries_every_forwarded_setting(
+        self, tmp_path: Path
+    ) -> None:
+        """A forwarded setting arrives, less any build permission it granted."""
+        outer = _inputs_off_every_default(tmp_path)
+
+        inner = _inner_resolve_config(outer)
+
+        expected = {name: getattr(outer, name) for name in _INNER_FORWARDS}
+        expected["package_overrides"] = tuple(
+            _without_build_permission(override) for override in outer.package_overrides
+        )
+        expected["index_overrides"] = {
+            name: _without_build_permission(override)
+            for name, override in outer.index_overrides.items()
+        }
+
+        assert {name: getattr(inner, name) for name in _INNER_FORWARDS} == expected
+
+    def test_the_inner_resolve_pins_the_policies_it_fixes(self, tmp_path: Path) -> None:
+        """A pinned setting holds its fixed value whatever the outer one was."""
+        outer = _inputs_off_every_default(tmp_path)
+
+        inner = _inner_resolve_config(outer)
+
+        assert {name: getattr(inner, name) for name in _INNER_PINS} == _INNER_PINNED
+
+    def test_the_inner_resolve_leaks_no_dropped_setting(self, tmp_path: Path) -> None:
+        """A dropped setting reads back at its default inside the build env."""
+        outer = _inputs_off_every_default(tmp_path)
+        bare = ResolveInputs()
+        at_default = sorted(
+            name
+            for name in ResolveInputs.__slots__
+            if getattr(outer, name) == getattr(bare, name)
+        )
+        assert not at_default
+
+        inner = _inner_resolve_config(outer)
+
+        default = NabProjectConfig()
+        assert {name: getattr(inner, name) for name in _INNER_DROPS} == {
+            name: getattr(default, name) for name in _INNER_DROPS
+        }
+
+
+class TestResolveInputs:
+    """The value type itself."""
+
+    def test_a_bare_instance_takes_the_configs_defaults(self) -> None:
+        """What a project declaring no ``[tool.nab]`` resolves under."""
+        bare = ResolveInputs()
+        default = NabProjectConfig()
+
+        assert {name: getattr(bare, name) for name in ResolveInputs.__slots__} == {
+            name: getattr(default, name) for name in ResolveInputs.__slots__
+        }
+
+    def test_replace_changes_the_named_slots_and_keeps_the_rest(
+        self, tmp_path: Path
+    ) -> None:
+        """``replace`` is ``dataclasses.replace`` for a slotted value type."""
+        outer = _inputs_off_every_default(tmp_path)
+
+        narrowed = outer.replace(
+            build_policy=BuildPolicy.NEVER, constraints=("pip<26",)
+        )
+
+        assert narrowed.build_policy is BuildPolicy.NEVER
+        assert narrowed.constraints == ("pip<26",)
+        assert narrowed.indexes == outer.indexes
+        assert outer.build_policy is BuildPolicy.BUILD_REMOTE
+
+    def test_replace_refuses_a_name_the_type_does_not_declare(self) -> None:
+        """A misspelled setting raises rather than being dropped."""
+        with pytest.raises(TypeError, match="workspace"):
+            ResolveInputs().replace(workspace=None)


### PR DESCRIPTION
nab-project's resolve, fetch and build-environment code all took `NabProjectConfig`, the whole `[tool.nab]` table, and read 20 of its 26 fields. The other six drive target planning, lock mode and workspace discovery rather than the resolve: `environment`, `matrix`, `mode`, `requires_python_source`, `workspace` and `workspace_member_names`.

`nab_project/inputs.py` declares `ResolveInputs`, one slot per setting a resolve reads, and `_resolve/engine.py`, `fetch.py` and `_build/env.py` read it instead. `resolve_for_targets` and `resolve_with_coordinator` keep their `config=` parameter and project it, so nothing outside nab-project changes. `resolve.py` itself still reads six settings off the config: `base_group`, `build_group` and `default_groups` for group selection, `conflicts` for the fork plan, `indexes` for the coordinator it opens, and `requires_python` for the lock.

`tests/test_seam_partition.py` replaces `test_build_runner.py`'s `test_every_config_field_is_forwarded_pinned_or_dropped`. It pins that split, so a new `[tool.nab]` key fails until it is sorted into a slot or named as the host's; what `_inner_resolve_config` forwards, pins and drops; and that a bare `ResolveInputs()` matches `NabProjectConfig()` slot for slot, which is what `resolve_with_coordinator(config=None)` now builds.
