### PR TITLE
Resolve against targets and ResolveInputs, not a NabProjectConfig

### DIFF
--- a/nab-project/benchmarks/benchmark_config.py
+++ b/nab-project/benchmarks/benchmark_config.py
@@ -7,8 +7,9 @@ from typing import TYPE_CHECKING, NamedTuple
 
 from nab_index.local_index import is_file_url
 from nab_index.multi_index import IndexConfig
-from nab_project.config import NabProjectConfig, PackageOverride
+from nab_project.config import PackageOverride
 from nab_project.fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL, IndexRoute
+from nab_project.inputs import ResolveInputs
 from nab_provider._vendor.packaging.ranges import VersionRange
 from nab_provider._vendor.packaging.requirements import Requirement
 from nab_provider._vendor.packaging.utils import InvalidName, canonicalize_name
@@ -33,7 +34,7 @@ if TYPE_CHECKING:
 
 
 DEFAULT_SCENARIO_TRUST_UNVERIFIED_SDIST_DEPS = (
-    NabProjectConfig().trust_unverified_sdist_deps
+    ResolveInputs().trust_unverified_sdist_deps
 )
 DEFAULT_INDEXES: tuple[IndexConfig, ...] = (
     IndexConfig(DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL),
@@ -667,9 +668,9 @@ def build_benchmark_config(
     build_policy_overrides: Mapping[str, BuildPolicy] | None = None,
     resolution: ResolutionStrategy = ResolutionStrategy.HIGHEST,
     vcs: VcsConfig | None = None,
-) -> NabProjectConfig:
-    """Build the project config represented by one benchmark scenario."""
-    return NabProjectConfig(
+) -> ResolveInputs:
+    """Build the settings one benchmark scenario resolves under."""
+    return ResolveInputs(
         uploaded_prior_to=uploaded_prior_to,
         dist_policy=DistPolicy.WHEEL_OR_SDIST,
         build_policy=BuildPolicy.NEVER,
@@ -736,11 +737,11 @@ def build_benchmark_resolver_inputs(
 def build_benchmark_provider(
     coordinator: FetchCoordinator,
     *,
-    config: NabProjectConfig,
+    config: ResolveInputs,
     target: ResolveTarget,
     inputs: _BenchmarkResolveInputs,
 ) -> Provider:
-    """Build a provider from a benchmark project config and its roots."""
+    """Build a provider from a benchmark scenario's settings and roots."""
     return Provider(
         coordinator,
         target=target,

--- a/nab-project/benchmarks/canary.py
+++ b/nab-project/benchmarks/canary.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple
 
 if TYPE_CHECKING:
-    from nab_project.config import NabProjectConfig
+    from nab_project.inputs import ResolveInputs
     from nab_provider.target import ResolveTarget
 
 if sys.version_info >= (3, 11):
@@ -103,7 +103,7 @@ class PreparedCanaryExecution(NamedTuple):
 
     requirements: dict[str, VersionRange]
     constraints: dict[str, VersionRange] | None
-    config: NabProjectConfig
+    config: ResolveInputs
     target: ResolveTarget
     host: BenchmarkHost
 
@@ -309,7 +309,7 @@ def run_one(
     requirements: dict[str, VersionRange],
     constraints: dict[str, VersionRange] | None,
     *,
-    config: NabProjectConfig,
+    config: ResolveInputs,
     target: ResolveTarget,
     host: BenchmarkHost,
 ) -> dict:

--- a/nab-project/benchmarks/deterministic_smoke.py
+++ b/nab-project/benchmarks/deterministic_smoke.py
@@ -22,7 +22,7 @@ import sys
 import tempfile
 import time
 import zipfile
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn
 from urllib.parse import urlparse
@@ -41,8 +41,8 @@ else:
 from nab_index.multi_index import IndexConfig
 from nab_index.urllib3_async_transport import Urllib3AsyncTransport
 from nab_project.build_policy import enforce_build_policy_for_targets
-from nab_project.config import NabProjectConfig
 from nab_project.fetch import FetchCoordinator
+from nab_project.inputs import ResolveInputs
 from nab_project.lockfile import LOCK_VERSION, build_pylock
 from nab_project.resolve import (
     ResolveResult,
@@ -248,7 +248,7 @@ class PreparedScenario:
     scenario: Scenario
     targets: tuple[ResolveTarget, ...]
     index: IndexConfig
-    config: NabProjectConfig
+    config: ResolveInputs
     requirements: tuple[Requirement, ...]
     expected: Mapping[str, Mapping[str, str]]
     align_across_targets: bool
@@ -1067,7 +1067,7 @@ def _expected_fixture_edges(
 def _validate_lock_environments(
     lock: Pylock,
     result: ResolveResult,
-    config: NabProjectConfig,
+    config: ResolveInputs,
     requirements: Sequence[Requirement],
     fixture: Mapping[tuple[str, str], Distribution],
 ) -> None:
@@ -1271,7 +1271,7 @@ def _project_lock_targets(
 def validate_nab_lock(
     lock: Pylock,
     result: ResolveResult,
-    config: NabProjectConfig,
+    config: ResolveInputs,
     requirements: Sequence[Requirement],
     distributions: Sequence[Distribution],
     index_root: Path,
@@ -1296,13 +1296,13 @@ def validate_nab_lock(
 
 def _lock_projection(
     result: ResolveResult,
-    config: NabProjectConfig,
+    config: ResolveInputs,
     requirements: Sequence[Requirement],
     distributions: Sequence[Distribution],
     index_root: Path,
 ) -> dict[str, dict[str, str]]:
     """Emit the lock for one resolve and validate it end to end."""
-    lock_input = build_lock_input(result, config=config)
+    lock_input = build_lock_input(result, inputs=config)
     lock = build_pylock(lock_input, lock_dir=index_root)
     lock.validate()
     return validate_nab_lock(
@@ -1341,13 +1341,13 @@ def prepare_scenario(scenario: Scenario, index_root: Path) -> PreparedScenario:
     ).expand()
 
     index = IndexConfig("smoke", index_root.resolve().as_uri())
-    config = NabProjectConfig(
+    config = ResolveInputs(
         constraints=scenario.constraints,
         requires_python=scenario.python,
         indexes=(index,),
     )
     if scenario.resolution is not None:
-        config = replace(config, resolution=scenario.resolution)
+        config = config.replace(resolution=scenario.resolution)
 
     build_policy = enforce_build_policy_for_targets(
         targets=targets,
@@ -1356,7 +1356,7 @@ def prepare_scenario(scenario: Scenario, index_root: Path) -> PreparedScenario:
         package_overrides=config.package_overrides,
         index_overrides=config.index_overrides,
     )
-    config = replace(config, build_policy=build_policy)
+    config = config.replace(build_policy=build_policy)
 
     expected = _expected(scenario)
     labels = {target.label for target in targets}
@@ -1463,11 +1463,11 @@ def _resolve_once(
         # Omitting the argument entirely is the only way to measure the shipped
         # default; passing its current value would pin the test to today's choice.
         if prepared.scenario.align_across_targets is None:
-            result = resolve_with_coordinator(*arguments, config=prepared.config)
+            result = resolve_with_coordinator(*arguments, inputs=prepared.config)
         else:
             result = resolve_with_coordinator(
                 *arguments,
-                config=prepared.config,
+                inputs=prepared.config,
                 align_across_targets=prepared.scenario.align_across_targets,
             )
         elapsed = time.perf_counter_ns() - start

--- a/nab-project/benchmarks/scenarios.py
+++ b/nab-project/benchmarks/scenarios.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
 
     from nab_index.multi_index import IndexConfig
-    from nab_project.config import NabProjectConfig
+    from nab_project.inputs import ResolveInputs
     from nab_provider.target import ResolveTarget
 
 if sys.version_info >= (3, 11):
@@ -523,7 +523,7 @@ class PreparedStandardExecution(NamedTuple):
 
     requirement_strings: list[str]
     constraint_strings: list[str]
-    config: NabProjectConfig
+    config: ResolveInputs
     target: ResolveTarget
     expected_input: dict[str, object]
 
@@ -1334,7 +1334,7 @@ def resolve_scenario(
     requirements: dict[str, VersionRange],
     constraints: dict[str, VersionRange] | None = None,
     *,
-    config: NabProjectConfig,
+    config: ResolveInputs,
     target: ResolveTarget,
     host: BenchmarkHost,
 ) -> dict:

--- a/nab-project/benchmarks/universal_scenarios.py
+++ b/nab-project/benchmarks/universal_scenarios.py
@@ -26,7 +26,6 @@ import subprocess
 import sys
 import time
 from contextlib import contextmanager
-from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -50,8 +49,8 @@ from universal_result import (
 
 from nab_index.urllib3_async_transport import Urllib3AsyncTransport
 from nab_project.build_policy import enforce_build_policy_for_targets
-from nab_project.config import NabProjectConfig
 from nab_project.fetch import FetchCoordinator
+from nab_project.inputs import ResolveInputs
 from nab_project.lockfile import build_pylock, render_lock
 from nab_project.resolve import (
     ResolveResult,
@@ -364,7 +363,7 @@ def process_scenario(
         python_order=python_order,
     )
     targets = matrix.expand()
-    config = NabProjectConfig(
+    config = ResolveInputs(
         constraints=tuple(constraint_strings),
         uploaded_prior_to=uploaded_prior_to,
     )
@@ -375,7 +374,7 @@ def process_scenario(
         package_overrides=config.package_overrides,
         index_overrides=config.index_overrides,
     )
-    config = replace(config, build_policy=build_policy)
+    config = config.replace(build_policy=build_policy)
 
     output_dir = output_dir or RESULTS_DIR / commit / "universal"
     output_path = output_dir / f"{scenario_name}.json"
@@ -448,7 +447,7 @@ def process_scenario(
                 coordinator,
                 targets,
                 [Requirement(text) for text in requirement_strings],
-                config=config,
+                inputs=config,
                 cache_dir=CACHE_DIR,
                 resolution_strategy=ResolutionStrategy(resolution_strategy),
                 align_across_targets=align,

--- a/nab-project/src/nab_project/_build/env.py
+++ b/nab-project/src/nab_project/_build/env.py
@@ -51,10 +51,11 @@ from nab_provider._vendor.packaging.version import Version
 from nab_provider.errors import MissingExtraError
 from nab_provider.policy import BuildPolicy, DistPolicy
 from nab_provider.requirements_file import InvalidProjectRequirementError
+from nab_provider.target import ResolveTarget
 from nab_provider.vcs_admission import UnsupportedVcsError
 
-from ..config import NabProjectConfig
 from ..download import DownloadError, download_lock
+from ..inputs import ResolveInputs
 from ..lockfile import IndexPin, strip_userinfo
 from .errors import BuildBackendError
 
@@ -70,7 +71,6 @@ if TYPE_CHECKING:
     from nab_provider.overrides import IndexOverride, PackageOverride
     from nab_provider.tags import TagSet
 
-    from ..inputs import ResolveInputs
     from ..lockfile import LockInput, PinShape, SdistArtifact, TargetLock
 
     _OverrideT = TypeVar("_OverrideT", PackageOverride, IndexOverride)
@@ -418,8 +418,8 @@ class NabBuildEnv:
         The inner resolve runs against a synthetic pyproject so it
         can reuse :func:`nab_project.resolve.resolve_for_targets` and
         :func:`nab_project.download.download_lock` end-to-end.  No
-        local sources / workspace / marker overlay; build deps
-        come from the configured indexes only.
+        local sources and no marker overlay; build deps come from the
+        configured indexes only.
 
         It admits wheels and sdists, like any resolve, so the version
         it settles on is the one the requirement asked for rather than
@@ -452,7 +452,7 @@ class NabBuildEnv:
         synthetic = synthetic_dir / "pyproject.toml"
         synthetic.write_text(_render_synthetic_pyproject(requires), encoding="utf-8")
 
-        inner_config = _inner_resolve_config(self._config)
+        inner_inputs = _inner_resolve_inputs(self._config)
 
         # download_lock closes its transport, and ``install`` may call
         # this again for ``get_requires_for_build_wheel`` follow-ups;
@@ -462,7 +462,8 @@ class NabBuildEnv:
             result = resolve_for_targets(
                 synthetic,
                 transport,
-                config=inner_config,
+                targets=(ResolveTarget.for_host(),),
+                inputs=inner_inputs,
             )
             # The build env resolves for the host alone, so its one
             # target's failure is the whole resolve's.
@@ -481,7 +482,7 @@ class NabBuildEnv:
             raise BuildEnvError(msg) from exc
 
         lock_input, to_build = self._plan_install(
-            build_lock_input(result, config=inner_config)
+            build_lock_input(result, inputs=inner_inputs)
         )
 
         try:
@@ -741,19 +742,16 @@ def _without_build_permission(override: _OverrideT) -> _OverrideT:
     return replace(override, build_policy=None)
 
 
-def _inner_resolve_config(inputs: ResolveInputs) -> NabProjectConfig:
-    """Return the config the build-requires resolve runs under.
+def _inner_resolve_inputs(inputs: ResolveInputs) -> ResolveInputs:
+    """Return the settings the build-requires resolve runs under.
 
     Only the fields named here cross into it: build deps come from the
     configured indexes alone, so the outer run's own requirements and
     sources stay out.  The cutoff and the decision order cross because
     this resolve picks the backend that writes the metadata the outer
     resolve reads, and a lock reproduces only if this search does too.
-
-    It is a ``NabProjectConfig`` because the inner resolve enters
-    through ``resolve_for_targets``, which plans its own targets.
     """
-    return NabProjectConfig(
+    return ResolveInputs(
         indexes=inputs.indexes,
         package_overrides=tuple(
             _without_build_permission(override) for override in inputs.package_overrides

--- a/nab-project/src/nab_project/_build/runner.py
+++ b/nab-project/src/nab_project/_build/runner.py
@@ -60,7 +60,7 @@ from .errors import BuildBackendError
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-    from ..config import NabProjectConfig
+    from ..inputs import ResolveInputs
 
 __all__ = [
     "BuildBackendError",
@@ -78,7 +78,7 @@ _DEFAULT_REQUIRES = ("setuptools >= 40.8.0",)
 def run_build_backend(
     source_dir: Path,
     *,
-    config: NabProjectConfig,
+    config: ResolveInputs,
     offline: bool = False,
     chain: BuildChain = (),
 ) -> WheelMetadata:
@@ -122,7 +122,7 @@ def build_wheel_for_install(
     source_dir: Path,
     *,
     output_dir: Path,
-    config: NabProjectConfig,
+    config: ResolveInputs,
     offline: bool = False,
     chain: BuildChain = (),
 ) -> Path:
@@ -172,7 +172,7 @@ def _prepared_project(
     source_dir: Path,
     data: dict,
     *,
-    config: NabProjectConfig,
+    config: ResolveInputs,
     offline: bool,
     chain: BuildChain,
 ) -> Iterator[tuple[build.ProjectBuilder, str]]:

--- a/nab-project/src/nab_project/_build_remote.py
+++ b/nab-project/src/nab_project/_build_remote.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from nab_provider.fetch_port import FetchPort
     from nab_provider.metadata import WheelMetadata
 
-    from .config import NabProjectConfig
+    from .inputs import ResolveInputs
 
 
 def build_remote_sdist(
@@ -30,7 +30,7 @@ def build_remote_sdist(
     version: str,
     url: str,
     sdist_hashes: tuple[tuple[str, str], ...],
-    build_config: NabProjectConfig | None,
+    build_config: ResolveInputs | None,
 ) -> WheelMetadata:
     """Download the sdist at ``url``, extract it, and build it.
 

--- a/nab-project/src/nab_project/_sources.py
+++ b/nab-project/src/nab_project/_sources.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
     from nab_provider.metadata import WheelMetadata
     from nab_provider.policy import ArchiveSource, SourceRequest
 
-    from .config import NabProjectConfig
+    from .inputs import ResolveInputs
 
 # The archive names everything under _TREE_DIR, so the cache's own bookkeeping
 # sits beside that directory rather than inside it.
@@ -109,7 +109,7 @@ def _source_for_build(path: Path, persistent_root: Path | None) -> Iterator[Path
 def materialize_source(
     port: FetchPort,
     request: SourceRequest,
-    build_config: NabProjectConfig | None,
+    build_config: ResolveInputs | None,
 ) -> SourceMaterialization:
     """Materialise ``request``'s declared source and read its metadata.
 
@@ -128,7 +128,7 @@ def materialize_source(
 def _materialize_local(
     request: SourceRequest,
     source: LocalSource,
-    build_config: NabProjectConfig | None,
+    build_config: ResolveInputs | None,
     *,
     port: FetchPort,
 ) -> SourceMaterialization:
@@ -150,7 +150,7 @@ def _materialize_local(
 def _materialize_vcs(
     request: SourceRequest,
     source: VcsSource,
-    build_config: NabProjectConfig | None,
+    build_config: ResolveInputs | None,
     *,
     port: FetchPort,
 ) -> SourceMaterialization:
@@ -210,7 +210,7 @@ def extract_source_metadata(
     policy: BuildPolicy,
     kind: str,
     offline: bool,
-    build_config: NabProjectConfig | None,
+    build_config: ResolveInputs | None,
     persistent_root: Path | None = None,
 ) -> WheelMetadata:
     """Read metadata from a directory; gates the backend path on ``policy``.
@@ -383,7 +383,7 @@ def _verified_hashes(target: Path) -> set[tuple[str, str]]:
 def _materialize_archive(
     request: SourceRequest,
     source: ArchiveSource,
-    build_config: NabProjectConfig | None,
+    build_config: ResolveInputs | None,
     *,
     port: FetchPort,
 ) -> SourceMaterialization:  # pragma: no cover (tar data filter)

--- a/nab-project/src/nab_project/build_backend.py
+++ b/nab-project/src/nab_project/build_backend.py
@@ -4,8 +4,8 @@ Hand a source directory to :func:`extract_metadata` and get back a
 :class:`WheelMetadata`. The static pyproject.toml reader runs first;
 a directory :func:`extract_static_metadata` returns ``None`` for falls
 through to a PEP 517 backend invocation inside
-:class:`~nab_project._build.env.NabBuildEnv`. The dynamic path needs a
-:class:`NabProjectConfig`.
+:class:`~nab_project._build.env.NabBuildEnv`. The dynamic path needs the
+settings a resolve runs under.
 """
 
 from __future__ import annotations
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 
     from nab_provider._vendor.packaging.requirements import Requirement
 
-    from .config import NabProjectConfig
+    from .inputs import ResolveInputs
 
 __all__ = [
     "BuildBackendError",
@@ -231,7 +231,7 @@ def _collect_provides_extra(project: dict) -> set[str]:
 def extract_metadata(
     source_dir: Path,
     *,
-    config: NabProjectConfig | None = None,
+    config: ResolveInputs | None = None,
     offline: bool = False,
 ) -> WheelMetadata:
     """Extract metadata for a source directory.
@@ -240,9 +240,10 @@ def extract_metadata(
     When that returns ``None``, the dynamic-build path is taken:
     the project's PEP 517 backend is invoked in an isolated venv
     via :func:`nab_project._build.runner.run_build_backend`.  That
-    needs a :class:`NabProjectConfig`; callers that cannot provide
-    one get a :class:`BuildBackendError` instead.  ``offline`` bars
-    that path from fetching the backend's build requirements.
+    needs a :class:`~nab_project.inputs.ResolveInputs`; callers that
+    cannot provide one get a :class:`BuildBackendError` instead.
+    ``offline`` bars that path from fetching the backend's build
+    requirements.
 
     The build env owns its own HTTP transport (see
     :class:`~nab_project._build.env.NabBuildEnv` for why); callers
@@ -253,7 +254,7 @@ def extract_metadata(
         return static
     if config is None:
         msg = (
-            "dynamic-metadata path requires a NabProjectConfig;"
+            "dynamic-metadata path requires a ResolveInputs;"
             f" the static reader returned None for {source_dir}."
             "  Pass one through ``extract_metadata`` or use a"
             " build-policy that does not enter the dynamic path."

--- a/nab-project/src/nab_project/config.py
+++ b/nab-project/src/nab_project/config.py
@@ -73,6 +73,7 @@ from .conflicts import (
     validate_conflict_minimums,
 )
 from .fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL
+from .inputs import ResolveInputs
 from .paths import realpath
 from .values import (
     ENVIRONMENT_KEYS,
@@ -206,6 +207,12 @@ class NabProjectConfig:
     # ``local_sources``, which also carries explicit
     # ``[[tool.nab.local-sources]]`` entries.
     workspace_member_names: frozenset[str] = field(default_factory=frozenset)
+
+    def resolve_inputs(self) -> ResolveInputs:
+        """Return the settings nab-project resolves this project under."""
+        return ResolveInputs(
+            **{name: getattr(self, name) for name in ResolveInputs.__match_args__}
+        )
 
 
 def read_pyproject_config(
@@ -678,11 +685,10 @@ def with_python_override(
 ) -> NabProjectConfig:
     """Return ``config`` with its resolve target moved onto ``python``.
 
-    The ``--python`` flag (and the ``python_version`` argument of
-    :func:`~nab_project.resolve.resolve_for_targets`) retargets the python
-    axis for one run, leaving any declared platform in place.  The
-    build-policy guard runs again over the new plan, so a runtime retarget
-    is held to the same rule as a declared one.  ``None`` is a no-op.
+    The ``--python`` flag retargets the python axis for one run, leaving
+    any declared platform in place.  The build-policy guard runs again over
+    the new plan, so a runtime retarget is held to the same rule as a
+    declared one.  ``None`` is a no-op.
 
     A matrix already declares the python axis for every target it names, so
     retargeting one of them would resolve for a python the matrix does not

--- a/nab-project/src/nab_project/fetch.py
+++ b/nab-project/src/nab_project/fetch.py
@@ -143,9 +143,6 @@ def index_routes(inputs: ResolveInputs) -> list[IndexRoute]:
     bare-name requirement (parse-time guarantee), and the parse-time
     non-overlap check forbids two routes for one package, so the resulting
     route map has at most one entry per name.
-
-    Only ``package_overrides`` is read, so a ``NabProjectConfig`` satisfies
-    the parameter as well.
     """
     return [
         IndexRoute(name=override.name, index=override.index)
@@ -155,11 +152,7 @@ def index_routes(inputs: ResolveInputs) -> list[IndexRoute]:
 
 
 def index_cache_floors(inputs: ResolveInputs) -> dict[str, int]:
-    """Project per-index cache-freshness floors, keyed by index name.
-
-    Only ``index_overrides`` is read, so a ``NabProjectConfig`` satisfies
-    the parameter as well.
-    """
+    """Project per-index cache-freshness floors, keyed by index name."""
     return {
         name: override.assume_fresh_seconds
         for name, override in inputs.index_overrides.items()

--- a/nab-project/src/nab_project/resolve.py
+++ b/nab-project/src/nab_project/resolve.py
@@ -1,12 +1,11 @@
 """Resolve a project's dependencies for the environments it targets.
 
-:func:`~nab_project.config.plan_targets` hands back one
-:class:`~nab_provider.target.ResolveTarget` per environment, whether
-``[tool.nab.matrix]`` declares many or a bare project declares none (the
-host is the target).  Each gets a single-environment resolve against a
-shared :class:`~nab_project.fetch.FetchCoordinator`, so a package's
-listing is read once across them, a version's wheel metadata once per
-wheel they pick, and an sdist's ``PKG-INFO`` once for the version.
+The host hands in one :class:`~nab_provider.target.ResolveTarget` per
+environment, whether it read a matrix declaring many or a bare project
+declaring none.  Each gets a single-environment resolve against a shared
+:class:`~nab_project.fetch.FetchCoordinator`, so a package's listing is
+read once across them, a version's wheel metadata once per wheel they
+pick, and an sdist's ``PKG-INFO`` once for the version.
 
 A declared conflict, matrix or not, is where a resolve produces more than
 one result for an environment.  Directly co-selecting two members of an
@@ -26,7 +25,7 @@ import logging
 import tempfile
 from collections import defaultdict
 from contextlib import contextmanager, suppress
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -70,12 +69,6 @@ from ._resolve.engine import (
     _resolve_with_micro_narrowing,
     env_signature,
 )
-from .config import (
-    NabProjectConfig,
-    plan_targets,
-    read_pyproject_config,
-    with_python_override,
-)
 from .conflicts import (
     ConflictFork,
     ConflictKind,
@@ -107,7 +100,7 @@ __all__ = [
     "TargetResult",
     "active_group_names",
     "build_lock_input",
-    "config_for_build_requirements",
+    "inputs_for_build_requirements",
     "resolve_for_targets",
     "resolve_with_coordinator",
 ]
@@ -129,39 +122,30 @@ class _ConfiguredContext:
     requirements: tuple[Requirement, ...]
 
 
-def _resolve_inputs(config: NabProjectConfig) -> ResolveInputs:
-    """Copy the settings nab-project resolves with off ``config``."""
-    return ResolveInputs(
-        **{name: getattr(config, name) for name in ResolveInputs.__match_args__}
-    )
-
-
 def resolve_for_targets(  # noqa: PLR0913 - the knobs of a project resolve
     path: Path,
     transport: AsyncHttpTransport,
     *,
-    config: NabProjectConfig | None = None,
+    targets: Sequence[ResolveTarget],
+    inputs: ResolveInputs | None = None,
     cache_dir: Path | None = None,
     offline: bool = False,
-    python_version: str | None = None,
     groups: Sequence[str] = (),
     extras: Sequence[str] = (),
     build_requirements: bool = False,
     resolution_strategy: ResolutionStrategy | None = None,
     progress: ProgressSink | None = None,
 ) -> ResolveResult:
-    """Resolve the project at ``path`` for every environment it targets.
+    """Resolve the project at ``path`` for each of ``targets``.
 
-    ``config`` defaults to :func:`read_pyproject_config(path)`.
-    ``transport`` is the caller's, so the HTTP library choice stays outside
-    nab-project.  ``cache_dir`` and ``offline`` are runtime overrides from
-    the CLI; ``python_version`` applies
-    :func:`~nab_project.config.with_python_override`, moving the target
-    onto that Python.
+    ``targets`` are the environments the host chose to resolve for and
+    ``inputs`` the settings it read out of the project.  ``transport`` is
+    the caller's, so the HTTP library choice stays outside nab-project;
+    ``cache_dir`` and ``offline`` are runtime overrides from the CLI.
 
     ``groups`` and ``extras`` name PEP 735 groups and
     ``[project.optional-dependencies]`` keys to fold in;
-    ``resolution_strategy`` overrides ``config.resolution`` when set.
+    ``resolution_strategy`` overrides ``inputs.resolution`` when set.
 
     ``build_requirements`` resolves ``[build-system].requires`` instead of
     the project's dependencies; neither ``groups`` nor ``extras`` mean
@@ -172,28 +156,27 @@ def resolve_for_targets(  # noqa: PLR0913 - the knobs of a project resolve
     the first.  Everything else (an unreadable pyproject, a conflicting
     selection, an unsupported source) raises.
     """
-    if config is None:
-        config = read_pyproject_config(path)
+    inputs = ResolveInputs() if inputs is None else inputs
     if build_requirements:
         if groups or extras:
             msg = "a build-requirements resolve has no groups or extras to select"
             raise ValueError(msg)
-        config = config_for_build_requirements(config)
-    config = with_python_override(config, python_version)
-    targets = plan_targets(config)
+        inputs = inputs_for_build_requirements(inputs)
 
-    tables = _project_tables(path, config, build_requirements=build_requirements)
+    tables = _project_tables(
+        path, build_group=inputs.build_group, build_requirements=build_requirements
+    )
 
     # ``default-groups`` is project policy: a default install activates
     # them, so they join the CLI selection.
     effective_groups = active_group_names(
-        groups, config.default_groups, config.base_group
+        groups, inputs.default_groups, inputs.base_group
     )
 
     forks, base_requirements = _plan_forks(
         path,
         tables,
-        config,
+        inputs,
         targets,
         extras=tuple(extras),
         groups=effective_groups,
@@ -201,18 +184,18 @@ def resolve_for_targets(  # noqa: PLR0913 - the knobs of a project resolve
 
     with FetchCoordinator(
         transport,
-        indexes=list(config.indexes),
+        indexes=list(inputs.indexes),
         cache_dir=cache_dir,
         offline=offline,
-        index_routes=index_routes(config),
-        index_cache_floors=index_cache_floors(config),
+        index_routes=index_routes(inputs),
+        index_cache_floors=index_cache_floors(inputs),
         on_fetch=progress.on_fetch if progress is not None else None,
-        build_config=_resolve_inputs(config),
+        build_config=inputs,
     ) as coordinator:
         return resolve_with_coordinator(
             coordinator,
             targets,
-            config=config,
+            inputs=inputs,
             cache_dir=cache_dir,
             forks=forks,
             base_requirements=base_requirements,
@@ -226,7 +209,7 @@ def resolve_with_coordinator(  # noqa: PLR0913 - the knobs of a bare resolve
     targets: Sequence[ResolveTarget],
     requirements: Sequence[Requirement] = (),
     *,
-    config: NabProjectConfig | None = None,
+    inputs: ResolveInputs | None = None,
     cache_dir: Path | None = None,
     forks: Sequence[ResolveFork] | None = None,
     base_requirements: Sequence[Requirement] | None = None,
@@ -257,7 +240,7 @@ def resolve_with_coordinator(  # noqa: PLR0913 - the knobs of a bare resolve
     with its own marker machinery passes that instead and keeps
     ``packaging.markersets`` off the engine's path.
     """
-    inputs = _resolve_inputs(config) if config is not None else ResolveInputs()
+    inputs = ResolveInputs() if inputs is None else inputs
     with _source_root(cache_dir, inputs) as source_root:
         settings = _EngineSettings(
             coordinator=coordinator,
@@ -337,7 +320,7 @@ def active_group_names(
 def build_lock_input(
     result: ResolveResult,
     *,
-    config: NabProjectConfig | None = None,
+    inputs: ResolveInputs | None = None,
     extras: Sequence[str] = (),
     dependency_groups: Sequence[str] = (),
     created_by: str = "nab",
@@ -351,9 +334,9 @@ def build_lock_input(
 
     ``extras`` and ``dependency_groups`` are this run's selection;
     ``default-groups``, the conflicts and ``base-group`` are project
-    policy and come from ``config``.
+    policy and come from ``inputs``.
     """
-    effective = config if config is not None else NabProjectConfig()
+    inputs = ResolveInputs() if inputs is None else inputs
     targets: dict[str, TargetLock] = {}
     consulted: dict[EnvSignature, set[Marker]] = {}
     declaring: list[ResolveTarget] = []
@@ -375,14 +358,14 @@ def build_lock_input(
         targets=targets,
         env_base_names=dict(result.env_base_names),
         environments=_declared_environments(declaring, consulted),
-        requires_python=effective.requires_python,
+        requires_python=inputs.requires_python,
         created_by=created_by,
         extras=tuple(extras),
         dependency_groups=tuple(dependency_groups),
-        default_groups=effective.default_groups,
-        conflicts=effective.conflicts,
-        base_group=effective.base_group,
-        build_group=effective.build_group,
+        default_groups=inputs.default_groups,
+        conflicts=inputs.conflicts,
+        base_group=inputs.base_group,
+        build_group=inputs.build_group,
     )
 
 
@@ -452,17 +435,17 @@ class _ProjectTables:
 
 
 def _configured_contexts(
-    config: NabProjectConfig, tables: _ProjectTables
+    inputs: ResolveInputs, tables: _ProjectTables
 ) -> tuple[_ConfiguredContext, tuple[_ConfiguredContext, ...]]:
     """Split the configured install contexts into the project's and the rest.
 
     The project's own dependencies are always a context, named or not.  The
     build requirements are one only when ``build-group`` names them.
     """
-    project = _ConfiguredContext(config.base_group, tuple(tables.dependencies))
+    project = _ConfiguredContext(inputs.base_group, tuple(tables.dependencies))
     selectors = (
-        (_ConfiguredContext(config.build_group, tuple(tables.build_requires)),)
-        if config.build_group is not None
+        (_ConfiguredContext(inputs.build_group, tuple(tables.build_requires)),)
+        if inputs.build_group is not None
         else ()
     )
     return project, selectors
@@ -485,7 +468,7 @@ def _carried_by(
 
 
 def _project_tables(
-    path: Path, config: NabProjectConfig, *, build_requirements: bool
+    path: Path, *, build_group: str | None, build_requirements: bool
 ) -> _ProjectTables:
     """Read every table the resolve needs off one parse of ``path``.
 
@@ -502,7 +485,7 @@ def _project_tables(
         project_name=pyproject_files.project_name(document),
         build_requires=(
             pyproject_files.build_system_requires(document, path)
-            if config.build_group is not None
+            if build_group is not None
             else []
         ),
     )
@@ -525,18 +508,14 @@ def _tables_for_build_requires(
     )
 
 
-def config_for_build_requirements(config: NabProjectConfig) -> NabProjectConfig:
-    """Return ``config`` with the settings a build-requirements lock cannot use.
+def inputs_for_build_requirements(inputs: ResolveInputs) -> ResolveInputs:
+    """Return ``inputs`` with the settings a build-requirements lock cannot use.
 
-    ``default-groups`` and the conflicts over groups and extras describe a
-    selection ``[build-system].requires`` does not have, and ``base-group``
-    names project dependencies a build lock holds none of.  Left in they
-    fail the run: :func:`_tables_for_build_requires` supplies no group or
-    extra table to resolve them against.  ``build-group`` goes too: its
-    roots already are the build requirements.
+    ``default-groups``, ``base-group`` and the conflicts over groups and
+    extras describe a selection ``[build-system].requires`` does not have,
+    and ``build-group``'s roots already are the build requirements.
     """
-    return replace(
-        config,
+    return inputs.replace(
         conflicts=(),
         default_groups=(),
         base_group=None,
@@ -544,17 +523,17 @@ def config_for_build_requirements(config: NabProjectConfig) -> NabProjectConfig:
     )
 
 
-def _configured_group_names(config: NabProjectConfig) -> tuple[str, ...]:
+def _configured_group_names(inputs: ResolveInputs) -> tuple[str, ...]:
     """Return the group names active by configuration rather than by selection."""
     return tuple(
-        name for name in (config.base_group, config.build_group) if name is not None
+        name for name in (inputs.base_group, inputs.build_group) if name is not None
     )
 
 
 def _plan_forks(
     path: Path,
     tables: _ProjectTables,
-    config: NabProjectConfig,
+    inputs: ResolveInputs,
     targets: Sequence[ResolveTarget],
     *,
     extras: tuple[str, ...],
@@ -570,29 +549,29 @@ def _plan_forks(
     The second element is the no-member requirement list, needed only when
     the plan forked; see :func:`resolve_with_coordinator`.
     """
-    configured = _configured_group_names(config)
-    project_context, selector_contexts = _configured_contexts(config, tables)
-    if config.conflicts:
+    configured = _configured_group_names(inputs)
+    project_context, selector_contexts = _configured_contexts(inputs, tables)
+    if inputs.conflicts:
         _validate_conflict_members_exist(
-            config.conflicts, tables.optional, tables.groups, configured
+            inputs.conflicts, tables.optional, tables.groups, configured
         )
         _check_conflict_minimums(
-            config.conflicts,
+            inputs.conflicts,
             tables,
             extras,
             [*expand_group_includes(tables.groups, groups), *configured],
             targets,
         )
 
-    plan = conflict_forks(extras, groups, config.conflicts, configured)
+    plan = conflict_forks(extras, groups, inputs.conflicts, configured)
     forks: list[ResolveFork] = []
     # Forks of an extra-based conflict share a group selection, so the
     # group-pair scan runs once per distinct one.
     scanned_group_selections: set[tuple[str, ...]] = set()
     for fork in plan:
-        if config.conflicts:
+        if inputs.conflicts:
             _check_conflict_exclusions(
-                config.conflicts,
+                inputs.conflicts,
                 tables,
                 fork.active_extras,
                 (*fork.active_groups, *fork.active_configured),
@@ -623,7 +602,7 @@ def _plan_forks(
                     selectors=_selector_requirements(
                         path, tables, fork, contexts=carried
                     ),
-                    name_project=config.base_group is not None,
+                    name_project=inputs.base_group is not None,
                 ),
             )
         )
@@ -784,7 +763,7 @@ def _validate_conflict_members_exist(
 
     A member naming an undeclared extra or group can never match, so
     the conflict would be silently inert.  Names compare canonicalised,
-    as the config stores them.
+    as ``conflicts`` stores them.
     """
     known_extras = {canonicalize_name(name) for name in optional}
     known_groups = {canonicalize_name(name) for name in groups} | {

--- a/nab-project/tests/benchmark/test_benchmark_strategy_matrix.py
+++ b/nab-project/tests/benchmark/test_benchmark_strategy_matrix.py
@@ -1481,7 +1481,7 @@ def test_scenario_sdist_trust_default_matches_the_product_default() -> None:
 
     assert (
         module.DEFAULT_SCENARIO_TRUST_UNVERIFIED_SDIST_DEPS
-        is module.NabProjectConfig().trust_unverified_sdist_deps
+        is module.ResolveInputs().trust_unverified_sdist_deps
     )
 
 

--- a/nab-project/tests/test_build_backend.py
+++ b/nab-project/tests/test_build_backend.py
@@ -3,8 +3,8 @@
 Covers the static path (``extract_static_metadata``) and the
 dynamic dispatch in ``extract_metadata``, including the
 ``BuildBackendError`` raised when the caller did not supply the
-``NabProjectConfig`` the runner needs, and the build-policy page's
-account of when the dynamic path runs.
+``ResolveInputs`` the runner needs, and the build-policy page's account
+of when the dynamic path runs.
 """
 
 from __future__ import annotations
@@ -521,7 +521,9 @@ class TestExtractMetadata:
             dynamic = ["dependencies"]
             """,
         )
-        with pytest.raises(BuildBackendError, match="dynamic-metadata path"):
+        with pytest.raises(
+            BuildBackendError, match="dynamic-metadata path requires a ResolveInputs"
+        ):
             extract_metadata(tmp_path)
 
     def test_dynamic_path_with_config_invokes_runner(self, tmp_path: Path) -> None:

--- a/nab-project/tests/test_build_runner.py
+++ b/nab-project/tests/test_build_runner.py
@@ -59,12 +59,9 @@ from nab_project._build.runner import (
     build_wheel_for_install,
     run_build_backend,
 )
-from nab_project.config import (
-    IndexOverride,
-    NabProjectConfig,
-    PackageOverride,
-)
+from nab_project.config import IndexOverride, PackageOverride
 from nab_project.download import DownloadError, DownloadResult, iter_artifacts
+from nab_project.inputs import ResolveInputs
 from nab_project.lockfile import (
     IndexPin,
     LocalPin,
@@ -75,7 +72,6 @@ from nab_project.lockfile import (
     WheelArtifact,
 )
 from nab_project.resolve import ResolveResult, TargetResult
-from nab_project.workspace import WorkspaceConfig
 from nab_provider._provider.metadata_resolver import pick_dist
 from nab_provider._vendor.packaging.requirements import Requirement
 from nab_provider._vendor.packaging.utils import canonicalize_name
@@ -391,14 +387,14 @@ def _tempdir_denying(denied: str) -> Callable[..., tempfile.TemporaryDirectory[s
 
 
 @pytest.fixture
-def config() -> NabProjectConfig:
-    """A minimal :class:`NabProjectConfig` for the tests."""
-    return NabProjectConfig()
+def config() -> ResolveInputs:
+    """A minimal :class:`ResolveInputs` for the tests."""
+    return ResolveInputs()
 
 
 class TestRunBuildBackend:
     def test_prepare_metadata_happy_path(
-        self, tmp_path: Path, config: NabProjectConfig
+        self, tmp_path: Path, config: ResolveInputs
     ) -> None:
         """The fake backend's ``prepare_metadata_for_build_wheel`` runs,
         produces a valid METADATA, and we parse it into
@@ -414,13 +410,13 @@ class TestRunBuildBackend:
         assert names == ["click", "rich"]
 
     def test_missing_pyproject_and_setup_py(
-        self, tmp_path: Path, config: NabProjectConfig
+        self, tmp_path: Path, config: ResolveInputs
     ) -> None:
         with pytest.raises(BuildBackendError, match="no pyproject.toml or setup.py"):
             run_build_backend(tmp_path, config=config)
 
     def test_oversized_integer_pyproject(
-        self, tmp_path: Path, config: NabProjectConfig, oversized_integer: str
+        self, tmp_path: Path, config: ResolveInputs, oversized_integer: str
     ) -> None:
         (tmp_path / "pyproject.toml").write_text(
             f"[tool.other]\ncount = {oversized_integer}\n", encoding="utf-8"
@@ -431,7 +427,7 @@ class TestRunBuildBackend:
     def test_unsearchable_pyproject_reports_the_errno(
         self,
         tmp_path: Path,
-        config: NabProjectConfig,
+        config: ResolveInputs,
         deny_access: Callable[[Path], AbstractContextManager[None]],
     ) -> None:
         # The presence check must not read EACCES as absence: the file is
@@ -444,7 +440,7 @@ class TestRunBuildBackend:
             run_build_backend(tmp_path, config=config)
 
     def test_directory_pyproject_reports_not_a_regular_file(
-        self, tmp_path: Path, config: NabProjectConfig
+        self, tmp_path: Path, config: ResolveInputs
     ) -> None:
         (tmp_path / "pyproject.toml").mkdir()
 
@@ -464,7 +460,7 @@ class TestRunBuildBackend:
     def test_unsearchable_setup_py_takes_the_legacy_branch(
         self,
         tmp_path: Path,
-        config: NabProjectConfig,
+        config: ResolveInputs,
         deny_access: Callable[[Path], AbstractContextManager[None]],
     ) -> None:
         # Same for the setup.py fallback: an unreadable one is a legacy
@@ -481,7 +477,7 @@ class TestRunBuildBackend:
             run_build_backend(tmp_path, config=config)
 
     def test_legacy_setup_py_returns_parsed_metadata(
-        self, tmp_path: Path, config: NabProjectConfig
+        self, tmp_path: Path, config: ResolveInputs
     ) -> None:
         """A tree with only ``setup.py`` builds through to parsed metadata.
 
@@ -520,16 +516,14 @@ class TestRunBuildBackend:
         assert metadata.name == "legacy-pkg"
         assert str(metadata.version) == "0.1"
 
-    def test_malformed_pyproject(
-        self, tmp_path: Path, config: NabProjectConfig
-    ) -> None:
+    def test_malformed_pyproject(self, tmp_path: Path, config: ResolveInputs) -> None:
         (tmp_path / "pyproject.toml").write_text(
             "not = valid = toml = [", encoding="utf-8"
         )
         with pytest.raises(BuildBackendError, match="could not read"):
             run_build_backend(tmp_path, config=config)
 
-    def test_non_utf8_pyproject(self, tmp_path: Path, config: NabProjectConfig) -> None:
+    def test_non_utf8_pyproject(self, tmp_path: Path, config: ResolveInputs) -> None:
         (tmp_path / "pyproject.toml").write_bytes(
             b"[build-system]\nrequires = []\n# \xe9\n"
         )
@@ -537,7 +531,7 @@ class TestRunBuildBackend:
             run_build_backend(tmp_path, config=config)
 
     def test_backend_metadata_missing_version_raises(
-        self, tmp_path: Path, config: NabProjectConfig
+        self, tmp_path: Path, config: ResolveInputs
     ) -> None:
         """A backend that returns a METADATA without ``Version`` triggers a
         clean :class:`BuildBackendError`, not an obscure parse traceback.
@@ -560,7 +554,7 @@ class TestRunBuildBackend:
     def test_hatchling_with_dynamic_deps_skips_prepare(
         self,
         tmp_path: Path,
-        config: NabProjectConfig,
+        config: ResolveInputs,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """When a hatchling-based project has ``dynamic =
@@ -591,7 +585,7 @@ class TestRunBuildBackend:
         assert str(metadata.version) == "9.9.9"
 
     def test_build_env_setup_error_wrapped(
-        self, tmp_path: Path, config: NabProjectConfig
+        self, tmp_path: Path, config: ResolveInputs
     ) -> None:
         """BuildEnvError during env setup is wrapped as BuildBackendError."""
         (tmp_path / "pyproject.toml").write_text(
@@ -609,7 +603,7 @@ class TestRunBuildBackend:
             run_build_backend(tmp_path, config=config)
 
     def test_build_env_resolution_error_wrapped(
-        self, tmp_path: Path, config: NabProjectConfig
+        self, tmp_path: Path, config: ResolveInputs
     ) -> None:
         """ResolutionError from build deps is wrapped as BuildBackendError."""
         (tmp_path / "pyproject.toml").write_text(
@@ -629,7 +623,7 @@ class TestRunBuildBackend:
             run_build_backend(tmp_path, config=config)
 
     def test_build_system_table_rejected_wrapped(
-        self, tmp_path: Path, config: NabProjectConfig
+        self, tmp_path: Path, config: ResolveInputs
     ) -> None:
         """build.BuildSystemTableValidationError is wrapped as BuildBackendError.
 
@@ -664,7 +658,7 @@ class TestRunBuildBackend:
     def test_bad_requires_fails_before_the_build_env(
         self,
         tmp_path: Path,
-        config: NabProjectConfig,
+        config: ResolveInputs,
         monkeypatch: pytest.MonkeyPatch,
         table: str,
         message: str,
@@ -682,7 +676,7 @@ class TestRunBuildBackend:
             run_build_backend(tmp_path, config=config)
 
     def test_build_system_not_a_table(
-        self, tmp_path: Path, config: NabProjectConfig
+        self, tmp_path: Path, config: ResolveInputs
     ) -> None:
         """A scalar build-system key fails the build."""
         (tmp_path / "pyproject.toml").write_text(
@@ -692,7 +686,7 @@ class TestRunBuildBackend:
             run_build_backend(tmp_path, config=config)
 
     def test_backend_path_outside_source_tree_rejected(
-        self, tmp_path: Path, config: NabProjectConfig
+        self, tmp_path: Path, config: ResolveInputs
     ) -> None:
         """A backend-path that leaves the source tree fails the build."""
         source = tmp_path / "member"
@@ -708,7 +702,7 @@ class TestRunBuildBackend:
             run_build_backend(source, config=config)
 
     def test_absolute_backend_path_rejected(
-        self, tmp_path: Path, config: NabProjectConfig
+        self, tmp_path: Path, config: ResolveInputs
     ) -> None:
         """backend-path entries are relative to the project root."""
         source = tmp_path / "member"
@@ -740,7 +734,7 @@ class TestRunBuildBackend:
     def test_venv_creation_oserror_wrapped(
         self,
         tmp_path: Path,
-        config: NabProjectConfig,
+        config: ResolveInputs,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """An OSError building the venv is wrapped as BuildBackendError."""
@@ -766,7 +760,7 @@ class TestRunBuildBackend:
     def test_temp_root_oserror_wrapped(
         self,
         tmp_path: Path,
-        config: NabProjectConfig,
+        config: ResolveInputs,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """An OSError creating the env's temp root is wrapped as BuildBackendError."""
@@ -785,7 +779,7 @@ class TestRunBuildBackend:
     def test_metadata_directory_oserror_wrapped(
         self,
         tmp_path: Path,
-        config: NabProjectConfig,
+        config: ResolveInputs,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """An OSError creating the metadata directory is wrapped the same way."""
@@ -804,7 +798,7 @@ class TestRunBuildBackend:
     def test_non_string_build_requirement_wrapped(
         self,
         tmp_path: Path,
-        config: NabProjectConfig,
+        config: ResolveInputs,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """A non-string build requirement is wrapped as BuildBackendError."""
@@ -846,7 +840,7 @@ class TestRunBuildBackend:
     def test_unencodable_build_requirement_wrapped(
         self,
         tmp_path: Path,
-        config: NabProjectConfig,
+        config: ResolveInputs,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """A build requirement with no UTF-8 encoding is wrapped.
@@ -1345,9 +1339,7 @@ class TestRunBuildBackendCorruptBuiltWheel:
         project.build.side_effect = fake_build
         return project
 
-    def _run(
-        self, tmp_path: Path, config: NabProjectConfig, project: MagicMock
-    ) -> None:
+    def _run(self, tmp_path: Path, config: ResolveInputs, project: MagicMock) -> None:
         with (
             patch(
                 "nab_project._build.runner.NabBuildEnv",
@@ -1362,7 +1354,7 @@ class TestRunBuildBackendCorruptBuiltWheel:
             run_build_backend(tmp_path, config=config)
 
     def test_default_path_corrupt_wheel_wrapped(
-        self, tmp_path: Path, config: NabProjectConfig
+        self, tmp_path: Path, config: ResolveInputs
     ) -> None:
         """The backend has no prepare hook, so the runner builds a wheel and
         reads it with ``zipfile.ZipFile`` after the hook wrapper; a corrupt
@@ -1374,7 +1366,7 @@ class TestRunBuildBackendCorruptBuiltWheel:
         )
 
     def test_invalid_wheel_name_wrapped(
-        self, tmp_path: Path, config: NabProjectConfig
+        self, tmp_path: Path, config: ResolveInputs
     ) -> None:
         """``parse_wheel_filename`` raises a bare ``ValueError`` when the built
         wheel's name does not parse; the runner normalizes it.
@@ -1385,7 +1377,7 @@ class TestRunBuildBackendCorruptBuiltWheel:
     def test_skip_prepare_corrupt_wheel_wrapped(
         self,
         tmp_path: Path,
-        config: NabProjectConfig,
+        config: ResolveInputs,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """On the skip-prepare path the runner's own ``_build_wheel_and_extract``
@@ -1400,7 +1392,7 @@ class TestRunBuildBackendCorruptBuiltWheel:
     def test_skip_prepare_invalid_wheel_name_wrapped(
         self,
         tmp_path: Path,
-        config: NabProjectConfig,
+        config: ResolveInputs,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """The skip-prepare path parses the wheel filename too, so a readable
@@ -1423,7 +1415,7 @@ class TestRunBuildBackendCorruptBuiltWheel:
     def test_unreadable_dist_info_member_wrapped(
         self,
         tmp_path: Path,
-        config: NabProjectConfig,
+        config: ResolveInputs,
         monkeypatch: pytest.MonkeyPatch,
         kind: str,
         skip_prepare: bool,
@@ -1513,7 +1505,7 @@ class TestRunBuildBackendBuildTaggedWheel:
     def test_build_tag_does_not_hide_the_dist_info(
         self,
         tmp_path: Path,
-        config: NabProjectConfig,
+        config: ResolveInputs,
         monkeypatch: pytest.MonkeyPatch,
         wheel_name: str,
         skip_prepare: bool,
@@ -1589,7 +1581,7 @@ class TestRunBuildBackendNonStringHookPath:
             lambda *_a, **_k: build_wheel,
         )
 
-    def _run(self, tmp_path: Path, config: NabProjectConfig) -> None:
+    def _run(self, tmp_path: Path, config: ResolveInputs) -> None:
         env = MagicMock()
         env.__enter__ = MagicMock(return_value=env)
         env.__exit__ = MagicMock(return_value=None)
@@ -1603,7 +1595,7 @@ class TestRunBuildBackendNonStringHookPath:
     def test_prepare_hook_non_string_wrapped(
         self,
         tmp_path: Path,
-        config: NabProjectConfig,
+        config: ResolveInputs,
         monkeypatch: pytest.MonkeyPatch,
         value: object,
     ) -> None:
@@ -1614,7 +1606,7 @@ class TestRunBuildBackendNonStringHookPath:
     def test_build_wheel_fallback_non_string_wrapped(
         self,
         tmp_path: Path,
-        config: NabProjectConfig,
+        config: ResolveInputs,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """With no prepare hook, the runner falls back to ``build_wheel``,
@@ -1627,7 +1619,7 @@ class TestRunBuildBackendNonStringHookPath:
     def test_skip_prepare_non_string_wrapped(
         self,
         tmp_path: Path,
-        config: NabProjectConfig,
+        config: ResolveInputs,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """The skip-prepare path calls ``build_wheel`` from the runner itself."""
@@ -1654,7 +1646,7 @@ class TestRunBuildBackendDefaults:
         """
         index_dir = tmp_path / "index"
         _make_local_index(index_dir, "buildstub", "1.0")
-        config = NabProjectConfig(indexes=(IndexConfig("local", index_dir.as_uri()),))
+        config = ResolveInputs(indexes=(IndexConfig("local", index_dir.as_uri()),))
 
         def fake_download_lock(
             lock_input: LockInput, _transport: object, wheel_dir: Path, *_a: object
@@ -1689,7 +1681,7 @@ class TestRunBuildBackendDefaults:
     def test_backend_exception_remapped(
         self,
         tmp_path: Path,
-        config: NabProjectConfig,
+        config: ResolveInputs,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Any ``build.BuildBackendException`` from the inner call is
@@ -1870,7 +1862,7 @@ class TestNabBuildEnvOutsideContext:
     """Accessors and ``install`` raise when used outside ``with`` scope."""
 
     def _env(self) -> NabBuildEnv:
-        return NabBuildEnv(requires=[], config=NabProjectConfig())
+        return NabBuildEnv(requires=[], config=ResolveInputs())
 
     def test_python_executable_outside_context(self) -> None:
         env = self._env()
@@ -1900,7 +1892,7 @@ class TestNabBuildEnvInstall:
         the venv state).  We assert by checking the resolve helper is
         not called.
         """
-        env = NabBuildEnv(requires=[], config=NabProjectConfig())
+        env = NabBuildEnv(requires=[], config=ResolveInputs())
         # Avoid real venv creation by short-circuiting __enter__.
         env._venv_path = tmp_path  # type: ignore[attr-defined]
         env._python_executable = tmp_path / "python"  # type: ignore[attr-defined]
@@ -1920,7 +1912,7 @@ class TestNabBuildEnvInstall:
         """
         from installer.sources import WheelFile
 
-        env = NabBuildEnv(requires=[], config=NabProjectConfig())
+        env = NabBuildEnv(requires=[], config=ResolveInputs())
         venv_path = tmp_path / "venv"
         venv_path.mkdir()
         wheel_dir = tmp_path / "wheels"
@@ -1952,7 +1944,7 @@ class TestNabBuildEnvInstall:
 
     def test_install_wraps_unlistable_wheel_dir(self, tmp_path: Path) -> None:
         """An OSError listing the wheel directory surfaces as BuildEnvError."""
-        env = NabBuildEnv(requires=[], config=NabProjectConfig())
+        env = NabBuildEnv(requires=[], config=ResolveInputs())
         venv_path = tmp_path / "venv"
         venv_path.mkdir()
         env._venv_path = venv_path  # type: ignore[attr-defined]
@@ -1968,10 +1960,10 @@ class TestResolveAndDownload:
     """What the inner build-requires resolve is allowed to see and do."""
 
     @staticmethod
-    def _capture_inner_config(
+    def _capture_inner_inputs(
         env: NabBuildEnv, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> NabProjectConfig:
-        """Run the inner resolve against stubs and return the config it got."""
+    ) -> ResolveInputs:
+        """Run the inner resolve against stubs and return the settings it got."""
         from nab_project.resolve import ResolveResult, TargetResult
 
         env._tmpdir = MagicMock()  # type: ignore[attr-defined]
@@ -2006,8 +1998,8 @@ class TestResolveAndDownload:
         wheel_dir.mkdir()
 
         env._resolve_and_download(wheel_dir)
-        inner = captured["config"]
-        assert isinstance(inner, NabProjectConfig)
+        inner = captured["inputs"]
+        assert isinstance(inner, ResolveInputs)
         return inner
 
     def test_inner_resolve_admits_both_artifact_kinds(
@@ -2020,9 +2012,9 @@ class TestResolveAndDownload:
         say nothing about it; whether the one it settles on can be
         installed is decided after the resolve, by ``_plan_install``.
         """
-        env = NabBuildEnv(requires=["foo"], config=NabProjectConfig())
+        env = NabBuildEnv(requires=["foo"], config=ResolveInputs())
 
-        inner = self._capture_inner_config(env, tmp_path, monkeypatch)
+        inner = self._capture_inner_inputs(env, tmp_path, monkeypatch)
 
         assert inner.dist_policy is DistPolicy.WHEEL_OR_SDIST
 
@@ -2037,7 +2029,7 @@ class TestResolveAndDownload:
         """
         env = NabBuildEnv(
             requires=["foo"],
-            config=NabProjectConfig(
+            config=ResolveInputs(
                 build_policy=BuildPolicy.BUILD_REMOTE,
                 package_overrides=(
                     pkg_override("foo", build_policy=BuildPolicy.BUILD_REMOTE),
@@ -2049,7 +2041,7 @@ class TestResolveAndDownload:
             ),
         )
 
-        inner = self._capture_inner_config(env, tmp_path, monkeypatch)
+        inner = self._capture_inner_inputs(env, tmp_path, monkeypatch)
 
         assert inner.build_policy is BuildPolicy.NEVER
         assert [o.build_policy for o in inner.package_overrides] == [
@@ -2071,7 +2063,7 @@ class TestResolveAndDownload:
         from nab_project.resolve import ResolveResult, TargetResult
         from nab_provider.target import ResolveTarget
 
-        env = NabBuildEnv(requires=["foo"], config=NabProjectConfig())
+        env = NabBuildEnv(requires=["foo"], config=ResolveInputs())
         env._tmpdir = MagicMock()  # type: ignore[attr-defined]
         env._venv_path = tmp_path / "venv"  # type: ignore[attr-defined]
         env._python_executable = tmp_path / "venv" / "bin" / "python"  # type: ignore[attr-defined]
@@ -2109,11 +2101,10 @@ class TestResolveAndDownload:
     def test_inner_resolve_takes_indexes_cutoff_order_and_overrides_only(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The inner config forwards the indexes, cutoff, order and overrides.
+        """The inner settings forward the indexes, cutoff, order and overrides.
 
         Build deps come from the configured indexes alone, so the outer
-        run's constraints, dist policy, local sources and workspace do
-        not reach it.
+        run's constraints, dist policy and local sources do not reach it.
         """
         cutoff = datetime(2026, 5, 1, tzinfo=timezone.utc)
         index = IndexConfig("internal", "https://example.invalid/simple/")
@@ -2121,7 +2112,7 @@ class TestResolveAndDownload:
         index_override = IndexOverride(uploaded_prior_to=cutoff)
         env = NabBuildEnv(
             requires=["hatchling"],
-            config=NabProjectConfig(
+            config=ResolveInputs(
                 indexes=(index,),
                 uploaded_prior_to=cutoff,
                 decision_order=DecisionOrder.STABLE,
@@ -2130,11 +2121,10 @@ class TestResolveAndDownload:
                 constraints=("setuptools<70",),
                 dist_policy=DistPolicy.SDIST_ONLY,
                 local_sources=(LocalSource("plugin", str(tmp_path / "plugin")),),
-                workspace=WorkspaceConfig(members=("packages/plugin",)),
             ),
         )
 
-        inner = self._capture_inner_config(env, tmp_path, monkeypatch)
+        inner = self._capture_inner_inputs(env, tmp_path, monkeypatch)
 
         assert inner.indexes == (index,)
         assert inner.uploaded_prior_to == cutoff
@@ -2145,15 +2135,14 @@ class TestResolveAndDownload:
         assert inner.constraints == ()
         assert inner.dist_policy is DistPolicy.WHEEL_OR_SDIST
         assert inner.local_sources == ()
-        assert inner.workspace is None
 
     def test_inner_resolve_keeps_the_default_decision_order(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A project that did not ask for ``stable`` does not get it inside."""
-        env = NabBuildEnv(requires=["hatchling"], config=NabProjectConfig())
+        env = NabBuildEnv(requires=["hatchling"], config=ResolveInputs())
 
-        inner = self._capture_inner_config(env, tmp_path, monkeypatch)
+        inner = self._capture_inner_inputs(env, tmp_path, monkeypatch)
 
         assert inner.decision_order is DecisionOrder.ARRIVAL
 
@@ -2165,7 +2154,7 @@ class TestResolveAndDownload:
         """
         env = NabBuildEnv(
             requires=["plugin @ https://example.com/plugin-1.0.tar.gz"],
-            config=NabProjectConfig(),
+            config=ResolveInputs(),
         )
         env._tmpdir = MagicMock()  # type: ignore[attr-defined]
         env._venv_path = tmp_path / "venv"  # type: ignore[attr-defined]
@@ -2181,7 +2170,7 @@ class TestResolveAndDownload:
         """
         env = NabBuildEnv(
             requires=["setuptools\n>=61"],
-            config=NabProjectConfig(),
+            config=ResolveInputs(),
         )
         env._tmpdir = MagicMock()  # type: ignore[attr-defined]
         env._venv_path = tmp_path / "venv"  # type: ignore[attr-defined]
@@ -2202,7 +2191,7 @@ class TestResolveAndDownload:
         from nab_project.resolve import ResolveResult, TargetResult
         from nab_provider.target import ResolveTarget
 
-        env = NabBuildEnv(requires=["foo"], config=NabProjectConfig())
+        env = NabBuildEnv(requires=["foo"], config=ResolveInputs())
         env._tmpdir = MagicMock()  # type: ignore[attr-defined]
         env._venv_path = tmp_path / "venv"  # type: ignore[attr-defined]
         env._python_executable = tmp_path / "venv" / "bin" / "python"  # type: ignore[attr-defined]
@@ -2278,7 +2267,7 @@ class TestBuildEnvMissingExtra:
             "nab_project.resolve.resolve_for_targets", _raise_missing_extra
         )
 
-        env = NabBuildEnv(requires=["dummyreq[nope]"], config=NabProjectConfig())
+        env = NabBuildEnv(requires=["dummyreq[nope]"], config=ResolveInputs())
         env._tmpdir = MagicMock()  # type: ignore[attr-defined]
         env._venv_path = tmp_path / "venv"  # type: ignore[attr-defined]
         env._python_executable = tmp_path / "venv" / "bin" / "python"  # type: ignore[attr-defined]
@@ -2318,7 +2307,7 @@ class TestBuildEnvMissingExtra:
             match=r"build env setup for 'dummyreq\.backend' failed: build env"
             r" resolve failed: dummyreq==1\.0 does not provide extra 'nope'",
         ):
-            run_build_backend(source, config=NabProjectConfig())
+            run_build_backend(source, config=ResolveInputs())
 
 
 class TestBuildEnvOffline:
@@ -2332,7 +2321,7 @@ class TestBuildEnvOffline:
     def test_refuses_before_the_inner_resolve(self, tmp_path: Path) -> None:
         env = NabBuildEnv(
             requires=["foo"],
-            config=NabProjectConfig(),
+            config=ResolveInputs(),
             offline=True,
             transport_factory=_no_network,  # type: ignore[arg-type]
         )
@@ -2353,7 +2342,7 @@ class TestBuildEnvOffline:
         with pytest.raises(
             BuildBackendError, match=r"unavailable in offline mode: hatchling"
         ):
-            run_build_backend(source, config=NabProjectConfig(), offline=True)
+            run_build_backend(source, config=ResolveInputs(), offline=True)
 
     def test_legacy_setup_py_refusal_names_both_defaults(self, tmp_path: Path) -> None:
         """The refusal names the default backend and the default requirement."""
@@ -2367,10 +2356,10 @@ class TestBuildEnvOffline:
             r" build requirements unavailable in offline mode:"
             r" setuptools >= 40\.8\.0$",
         ):
-            run_build_backend(tmp_path, config=NabProjectConfig(), offline=True)
+            run_build_backend(tmp_path, config=ResolveInputs(), offline=True)
 
     def test_backend_with_no_build_requirements_still_builds(
-        self, tmp_path: Path, config: NabProjectConfig
+        self, tmp_path: Path, config: ResolveInputs
     ) -> None:
         """Nothing to fetch, so the offline run is served."""
         source = _write_fake_backend_project(tmp_path)
@@ -2411,7 +2400,7 @@ class TestBuildEnvOffline:
                 ),
                 pytest.raises(BuildBackendError) as excinfo,
             ):
-                run_build_backend(tmp_path, config=NabProjectConfig(), offline=True)
+                run_build_backend(tmp_path, config=ResolveInputs(), offline=True)
             messages.add(str(excinfo.value))
 
         assert messages == {
@@ -2505,7 +2494,7 @@ class TestResolveAndDownloadSiblingWheels:
 
         monkeypatch.setattr("nab_project._build.env.download_lock", _fake_download)
 
-        env = NabBuildEnv(requires=["demo"], config=NabProjectConfig())
+        env = NabBuildEnv(requires=["demo"], config=ResolveInputs())
         env._tmpdir = MagicMock()  # type: ignore[attr-defined]
         env._venv_path = tmp_path / "venv"  # type: ignore[attr-defined]
         env._python_executable = tmp_path / "venv" / "bin" / "python"  # type: ignore[attr-defined]
@@ -2630,7 +2619,7 @@ class TestBuildEnvInstallsOnePreferredWheel:
         """The listing order does not decide which wheel's code wins."""
         index_dir = tmp_path / "index"
         self._index(index_dir, order)
-        config = NabProjectConfig(indexes=(IndexConfig("local", index_dir.as_uri()),))
+        config = ResolveInputs(indexes=(IndexConfig("local", index_dir.as_uri()),))
 
         with NabBuildEnv(requires=["demo"], config=config) as env:
             venv_path = env._venv_path
@@ -2707,7 +2696,7 @@ class TestInstallPickIsNotTheMetadataPick:
     @staticmethod
     def _env(depth: int = 0) -> NabBuildEnv:
         return NabBuildEnv(
-            requires=[], config=NabProjectConfig(build_requires_depth=depth)
+            requires=[], config=ResolveInputs(build_requires_depth=depth)
         )
 
     @classmethod
@@ -2798,7 +2787,7 @@ class TestInstallPickIsNotTheMetadataPick:
         """
         env = NabBuildEnv(
             requires=[],
-            config=NabProjectConfig(build_requires_depth=depth),
+            config=ResolveInputs(build_requires_depth=depth),
             chain=("demo 1.0",),
         )
 
@@ -2814,7 +2803,7 @@ class TestInstallPickIsNotTheMetadataPick:
     def test_a_refusal_names_the_builds_that_led_to_it(self) -> None:
         """Nested refusals are unreadable without the path that reached them."""
         env = NabBuildEnv(
-            requires=[], config=NabProjectConfig(), chain=("meson 1.4.2", "ninja 1.11")
+            requires=[], config=ResolveInputs(), chain=("meson 1.4.2", "ninja 1.11")
         )
 
         with pytest.raises(BuildEnvError, match=r"chain: meson 1\.4\.2 -> ninja 1\.11"):
@@ -2868,7 +2857,7 @@ class TestRefusalNamesTheDistPolicyThatBarsTheWheels:
         ``indexes``.
         """
         fields.setdefault("indexes", (IndexConfig(self.INDEX_NAME, self.INDEX_URL),))
-        config = NabProjectConfig(**fields)
+        config = ResolveInputs(**fields)
         env = NabBuildEnv(requires=[], config=config)
 
         with pytest.raises(BuildEnvError) as excinfo:
@@ -2977,11 +2966,11 @@ class TestDistPolicyExcludesAWheelTheHostCanInstall:
     VERSION = "1.0"
     WHEEL = "buildstub-1.0-py3-none-any.whl"
 
-    def _config(self, tmp_path: Path, **fields: Any) -> NabProjectConfig:
+    def _config(self, tmp_path: Path, **fields: Any) -> ResolveInputs:
         """Config over an index serving a wheel beside a PEP 643 sdist."""
         index_dir = tmp_path / "index"
         _make_local_index(index_dir, self.NAME, self.VERSION)
-        return NabProjectConfig(
+        return ResolveInputs(
             indexes=(IndexConfig("local", index_dir.as_uri()),), **fields
         )
 
@@ -3000,7 +2989,7 @@ class TestDistPolicyExcludesAWheelTheHostCanInstall:
         monkeypatch.setattr("nab_project._build.env.download_lock", fake_download_lock)
         return planned
 
-    def _resolve(self, config: NabProjectConfig, tmp_path: Path) -> None:
+    def _resolve(self, config: ResolveInputs, tmp_path: Path) -> None:
         """Run the inner resolve and its install plan, nothing further."""
         wheel_dir = tmp_path / "wheels"
         wheel_dir.mkdir()
@@ -3055,7 +3044,7 @@ class TestDistPolicyOverAPackageThatPublishesNoWheel:
         """Return the message an index-wide ``sdist-only`` refuses with."""
         index_dir = tmp_path / "index"
         _make_local_index(index_dir, self.NAME, self.VERSION, sdist_only=True)
-        config = NabProjectConfig(
+        config = ResolveInputs(
             indexes=(IndexConfig("local", index_dir.as_uri()),),
             index_overrides={"local": IndexOverride(dist_policy=DistPolicy.SDIST_ONLY)},
         )
@@ -3092,10 +3081,10 @@ class TestBuildRequirementNeedingItsOwnBuild:
     NAME = "buildstub"
     VERSION = "1.0"
 
-    def _config(self, tmp_path: Path, depth: int) -> NabProjectConfig:
+    def _config(self, tmp_path: Path, depth: int) -> ResolveInputs:
         index_dir = tmp_path / "index"
         _make_local_index(index_dir, self.NAME, self.VERSION, sdist_only=True)
-        return NabProjectConfig(
+        return ResolveInputs(
             indexes=(IndexConfig("local", index_dir.as_uri()),),
             build_requires_depth=depth,
         )
@@ -3187,13 +3176,13 @@ class TestBuildRequirementTwoLevelsDown:
     INNER = "deepstub"
     VERSION = "1.0"
 
-    def _config(self, tmp_path: Path, depth: int) -> NabProjectConfig:
+    def _config(self, tmp_path: Path, depth: int) -> ResolveInputs:
         index_dir = tmp_path / "index"
         _make_local_index(
             index_dir, self.OUTER, self.VERSION, sdist_only=True, requires=(self.INNER,)
         )
         _make_local_index(index_dir, self.INNER, self.VERSION, sdist_only=True)
-        return NabProjectConfig(
+        return ResolveInputs(
             indexes=(IndexConfig("local", index_dir.as_uri()),),
             build_requires_depth=depth,
         )
@@ -3250,7 +3239,7 @@ class TestBuildRequirementBuildFailures:
 
     @staticmethod
     def _env() -> NabBuildEnv:
-        return NabBuildEnv(requires=[], config=NabProjectConfig(build_requires_depth=1))
+        return NabBuildEnv(requires=[], config=ResolveInputs(build_requires_depth=1))
 
     def test_missing_archive(self, tmp_path: Path) -> None:
         """The download step promised a file that is not there."""
@@ -3361,7 +3350,7 @@ class TestBuildRequirementBuildFailures:
 
         with pytest.raises(BuildBackendError, match="non-string path"):
             build_wheel_for_install(
-                source_dir, output_dir=tmp_path / "out", config=NabProjectConfig()
+                source_dir, output_dir=tmp_path / "out", config=ResolveInputs()
             )
 
 
@@ -3405,7 +3394,7 @@ class TestBuiltWheelIdentity:
             "build_wheel_for_install",
             MagicMock(return_value=tmp_path / filename),
         )
-        env = NabBuildEnv(requires=[], config=NabProjectConfig(build_requires_depth=1))
+        env = NabBuildEnv(requires=[], config=ResolveInputs(build_requires_depth=1))
 
         return env._build_requirement(pending, tmp_path)
 
@@ -3484,7 +3473,7 @@ def _build_env_with_cleanup_error(
         _CleanupErrorTemporaryDirectory,
     )
     monkeypatch.setattr(NabBuildEnv, "_provision", lambda self, _root: None)
-    return NabBuildEnv(requires=[], config=NabProjectConfig())
+    return NabBuildEnv(requires=[], config=ResolveInputs())
 
 
 class TestNabBuildEnvLifecycle:
@@ -3497,7 +3486,7 @@ class TestNabBuildEnvLifecycle:
         helpers that call ``with`` against an env construction failure
         do not double-fault.
         """
-        env = NabBuildEnv(requires=[], config=NabProjectConfig())
+        env = NabBuildEnv(requires=[], config=ResolveInputs())
         env.__exit__(None, None, None)
         assert env._tmpdir is None  # type: ignore[attr-defined]
 
@@ -3545,10 +3534,10 @@ class TestNabBuildEnvLifecycle:
 
         if cancel:
             with pytest.raises(KeyboardInterrupt):
-                run_build_backend(Path("/tmp/source"), config=NabProjectConfig())
+                run_build_backend(Path("/tmp/source"), config=ResolveInputs())
         else:
             assert (
-                run_build_backend(Path("/tmp/source"), config=NabProjectConfig())
+                run_build_backend(Path("/tmp/source"), config=ResolveInputs())
                 is metadata
             )
 
@@ -3631,7 +3620,7 @@ class TestNabBuildEnvEnterInstall:
             "installer_install",
             lambda **kwargs: installer_calls.append(kwargs),
         )
-        with NabBuildEnv(requires=["pip"], config=NabProjectConfig()):
+        with NabBuildEnv(requires=["pip"], config=ResolveInputs()):
             pass
         assert len(installer_calls) == 1
 
@@ -3667,7 +3656,7 @@ class TestNabBuildEnvEnterInstall:
             raise RuntimeError(msg)
 
         monkeypatch.setattr(NabBuildEnv, "_resolve_and_download", _boom)
-        env = NabBuildEnv(requires=["pip"], config=NabProjectConfig())
+        env = NabBuildEnv(requires=["pip"], config=ResolveInputs())
         with pytest.raises(RuntimeError, match="resolve failed"):
             env.__enter__()
         assert env._tmpdir is None  # type: ignore[attr-defined]
@@ -3690,7 +3679,7 @@ class TestNabBuildEnvEnterInstall:
         import venv as venv_mod
 
         monkeypatch.setattr(venv_mod, "EnvBuilder", _Builder)
-        env = NabBuildEnv(requires=[], config=NabProjectConfig())
+        env = NabBuildEnv(requires=[], config=ResolveInputs())
         with pytest.raises(BuildEnvError, match="build venv"):
             env.__enter__()
         assert env._tmpdir is None  # type: ignore[attr-defined]
@@ -3706,7 +3695,7 @@ class TestNabBuildEnvEnterInstall:
         which is where a TMPDIR named with one puts it.
         """
         monkeypatch.setattr("venv.EnvBuilder", _PathsepRefusingEnvBuilder)
-        env = NabBuildEnv(requires=[], config=NabProjectConfig())
+        env = NabBuildEnv(requires=[], config=ResolveInputs())
         with pytest.raises(BuildEnvError, match="build venv"):
             env.__enter__()
         assert env._tmpdir is None  # type: ignore[attr-defined]
@@ -3747,7 +3736,7 @@ class TestNabBuildEnvEnterInstall:
 
         monkeypatch.setattr(Path, "write_text", _deny_inner_project)
 
-        env = NabBuildEnv(requires=["pip"], config=NabProjectConfig())
+        env = NabBuildEnv(requires=["pip"], config=ResolveInputs())
         with pytest.raises(BuildEnvError, match="could not populate the build env"):
             env.__enter__()
         assert env._tmpdir is None  # type: ignore[attr-defined]
@@ -3762,7 +3751,7 @@ class TestInstallWheelsCorruptArtifact:
     """
 
     def _env(self, tmp_path: Path) -> NabBuildEnv:
-        env = NabBuildEnv(requires=[], config=NabProjectConfig())
+        env = NabBuildEnv(requires=[], config=ResolveInputs())
         venv_path = tmp_path / "venv"
         venv_path.mkdir()
         env._python_executable = venv_path / "bin" / "python"  # type: ignore[attr-defined]
@@ -3819,7 +3808,7 @@ class TestInstallWheelsCorruptArtifact:
     def test_run_build_backend_wraps_corrupt_build_dep(
         self,
         tmp_path: Path,
-        config: NabProjectConfig,
+        config: ResolveInputs,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """A corrupt build-dep wheel makes ``run_build_backend`` raise
@@ -3914,7 +3903,7 @@ class TestBuildEnvHeaderScheme:
     def test_header_payload_lands_under_the_dist_include_dir(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        env = NabBuildEnv(requires=[], config=NabProjectConfig())
+        env = NabBuildEnv(requires=[], config=ResolveInputs())
         venv_path = tmp_path / "venv"
         venv_path.mkdir()
         (tmp_path / "wheels").mkdir()
@@ -3961,7 +3950,7 @@ class TestBuildEnvFollowUpInstall:
     ) -> tuple[NabBuildEnv, dict[str, str], Path]:
         from nab_project._build import env as env_mod
 
-        env = NabBuildEnv(requires=["probefoo"], config=NabProjectConfig())
+        env = NabBuildEnv(requires=["probefoo"], config=ResolveInputs())
         venv_path = tmp_path / "venv"
         venv_path.mkdir()
         (tmp_path / "wheels").mkdir()
@@ -4189,7 +4178,7 @@ class TestRunBuildBackendVenvRefused:
             match=r"build env setup for 'dummyreq\.backend' failed: could not"
             r" create build venv at .*: Refusing to create a venv",
         ):
-            run_build_backend(source, config=NabProjectConfig())
+            run_build_backend(source, config=ResolveInputs())
 
 
 @pytest.mark.skipif(
@@ -4231,7 +4220,7 @@ class TestEndToEndAirflow:
 
         metadata = run_build_backend(
             task_sdk,
-            config=NabProjectConfig(),
+            config=ResolveInputs(),
         )
         assert metadata.name == "apache-airflow-task-sdk"
         assert str(metadata.version) == "1.3.0"

--- a/nab-project/tests/test_config.py
+++ b/nab-project/tests/test_config.py
@@ -3285,7 +3285,7 @@ class TestPackageSugar:
             '[tool.nab.packages.acme-core]\nindex = "internal"\n',
         )
         config = read_pyproject_config(path, discover_workspace=False)
-        assert index_routes(config) == [
+        assert index_routes(config.resolve_inputs()) == [
             IndexRoute(name="acme-core", index="internal"),
         ]
 
@@ -3472,7 +3472,7 @@ class TestPackageSugar:
     def test_non_routing_entry_skipped_in_routes(self, tmp_path: Path) -> None:
         path = write(tmp_path, '[tool.nab.packages.foo]\ndist-policy = "sdist-only"\n')
         config = read_pyproject_config(path, discover_workspace=False)
-        assert index_routes(config) == []
+        assert index_routes(config.resolve_inputs()) == []
 
     def test_uppercase_name_and_specifier_in_one_key(self, tmp_path: Path) -> None:
         # The key is Requirement()-parsed before only its .name is
@@ -3558,7 +3558,7 @@ class TestPackageRules:
             'index = "internal"\n',
         )
         config = read_pyproject_config(path, discover_workspace=False)
-        assert index_routes(config) == [
+        assert index_routes(config.resolve_inputs()) == [
             IndexRoute(name="acme-core", index="internal"),
             IndexRoute(name="acme-utils", index="internal"),
         ]
@@ -4289,7 +4289,7 @@ class TestIndexCacheFloorsProjection:
             + '[tool.nab.index.pypi]\ndist-policy = "wheel-only"\n',
         )
         config = read_pyproject_config(path, discover_workspace=False)
-        assert index_cache_floors(config) == {"internal": 120}
+        assert index_cache_floors(config.resolve_inputs()) == {"internal": 120}
 
     def test_empty_when_none_set(self, tmp_path: Path) -> None:
         path = write(
@@ -4297,7 +4297,7 @@ class TestIndexCacheFloorsProjection:
             self._two_indexes() + '[tool.nab.index.pypi]\ndist-policy = "wheel-only"\n',
         )
         config = read_pyproject_config(path, discover_workspace=False)
-        assert index_cache_floors(config) == {}
+        assert index_cache_floors(config.resolve_inputs()) == {}
 
 
 class TestMatrixReferenceDocs:

--- a/nab-project/tests/test_decision_order_engine.py
+++ b/nab-project/tests/test_decision_order_engine.py
@@ -11,7 +11,7 @@ import threading
 from typing import TYPE_CHECKING, NamedTuple
 
 from nab_project._testing.coordinator_fake import make_coordinator
-from nab_project.config import NabProjectConfig
+from nab_project.inputs import ResolveInputs
 from nab_project.resolve import resolve_with_coordinator
 from nab_provider._vendor.packaging.requirements import Requirement
 from nab_provider.provider import BuildPolicy, DecisionOrder
@@ -122,7 +122,7 @@ def _engine_counters(decision_order: DecisionOrder) -> _Counters:
         _fetching_coordinator(pending, metadata_by_url=dict(sidecars)),
         Matrix(python="==3.11", platforms=(PlatformSpec("linux_x86_64"),)).expand(),
         [Requirement("alpha"), Requirement("beta")],
-        config=NabProjectConfig(
+        inputs=ResolveInputs(
             build_policy=BuildPolicy.NEVER, decision_order=decision_order
         ),
     )

--- a/nab-project/tests/test_deterministic_smoke_core.py
+++ b/nab-project/tests/test_deterministic_smoke_core.py
@@ -14,7 +14,7 @@ from types import ModuleType
 
 import pytest
 
-from nab_project.config import NabProjectConfig
+from nab_project.inputs import ResolveInputs
 from nab_project.lockfile import IndexPin, TargetLock, WheelArtifact
 from nab_project.resolve import ResolveResult, TargetResult
 from nab_provider._vendor.packaging.pylock import Pylock
@@ -57,7 +57,7 @@ class _LockValidationCase:
     harness: ModuleType
     lock: Pylock
     result: ResolveResult
-    config: NabProjectConfig
+    config: ResolveInputs
     requirements: Sequence[Requirement]
     distributions: Sequence[object]
     fixture: Path
@@ -156,7 +156,7 @@ def basic_lock_case(smoke_index: Path) -> _LockValidationCase:
     )
 
     lock = harness.build_pylock(
-        harness.build_lock_input(result, config=prepared.config),
+        harness.build_lock_input(result, inputs=prepared.config),
         lock_dir=fixture,
     )
     return _LockValidationCase(
@@ -657,7 +657,7 @@ def test_the_walk_seeds_constraints_and_unions_across_releases(tmp_path: Path) -
     prepared = harness.prepare_scenario(ceiling, tmp_path)
     widened = replace(
         prepared,
-        config=replace(prepared.config, constraints=("nab-smoke-pip-a<2.0.0",)),
+        config=prepared.config.replace(constraints=("nab-smoke-pip-a<2.0.0",)),
     )
 
     assert set(harness._scenario_root_names(widened)) == {

--- a/nab-project/tests/test_fetch.py
+++ b/nab-project/tests/test_fetch.py
@@ -36,7 +36,6 @@ from nab_index.local_index import LocalIndexClient
 from nab_index.multi_index import IndexConfig, MultiIndexClient
 from nab_index.parsed_listing import encode as encode_parsed
 from nab_index.transport import HttpError, HttpResponse
-from nab_project.config import NabProjectConfig
 from nab_project.fetch import (
     _WARM_SYNC_MIN_BLOB_BYTES,
     FetchCoordinator,
@@ -48,6 +47,7 @@ from nab_project.fetch import (
     _builds_remote_sdists,
     _resolve_routes,
 )
+from nab_project.inputs import ResolveInputs
 from nab_provider._vendor.packaging.version import Version
 from nab_provider.metadata import WheelMetadata
 from nab_provider.overrides import IndexOverride
@@ -1831,7 +1831,7 @@ class TestFetchCoordinator:
             return built
 
         monkeypatch.setattr("nab_project.build_backend.extract_metadata", fake_build)
-        config = NabProjectConfig()
+        config = ResolveInputs()
         with _coord(build_config=config) as coord:
             event = coord.request_built_metadata(
                 "pkg", "1.0", "https://files.example.com/pkg-1.0.tar.gz", ()
@@ -3921,10 +3921,10 @@ class TestSdistArchiveHolding:
         ("config", "holds"),
         [
             (None, False),
-            (NabProjectConfig(), False),
-            (NabProjectConfig(build_policy=BuildPolicy.BUILD_REMOTE), True),
+            (ResolveInputs(), False),
+            (ResolveInputs(build_policy=BuildPolicy.BUILD_REMOTE), True),
             (
-                NabProjectConfig(
+                ResolveInputs(
                     package_overrides=(
                         pkg_override("foo", build_policy=BuildPolicy.BUILD_REMOTE),
                     )
@@ -3932,7 +3932,7 @@ class TestSdistArchiveHolding:
                 True,
             ),
             (
-                NabProjectConfig(
+                ResolveInputs(
                     index_overrides={
                         "pypi": IndexOverride(build_policy=BuildPolicy.BUILD_REMOTE)
                     }
@@ -3940,7 +3940,7 @@ class TestSdistArchiveHolding:
                 True,
             ),
             (
-                NabProjectConfig(
+                ResolveInputs(
                     package_overrides=(
                         pkg_override("foo", build_policy=BuildPolicy.NEVER),
                     )
@@ -3950,12 +3950,12 @@ class TestSdistArchiveHolding:
         ],
     )
     def test_build_remote_anywhere_in_the_config_holds(
-        self, config: NabProjectConfig | None, holds: bool
+        self, config: ResolveInputs | None, holds: bool
     ) -> None:
         assert _builds_remote_sdists(config) is holds
 
     def _fetched_with_pyproject(
-        self, pyproject: str | None, config: NabProjectConfig | None
+        self, pyproject: str | None, config: ResolveInputs | None
     ) -> tuple[FetchCoordinator, SdistArchiveHold]:
         """Fetch one version's sdist files with its archive already held.
 
@@ -3983,7 +3983,7 @@ class TestSdistArchiveHolding:
 
     def test_a_static_pyproject_releases_the_archive(self) -> None:
         """A pyproject that declares the deps means the version never builds."""
-        config = NabProjectConfig(build_policy=BuildPolicy.BUILD_REMOTE)
+        config = ResolveInputs(build_policy=BuildPolicy.BUILD_REMOTE)
         coord, hold = self._fetched_with_pyproject(
             '[project]\nname = "pkg"\ndependencies = []\n', config
         )
@@ -3993,7 +3993,7 @@ class TestSdistArchiveHolding:
 
     def test_a_dynamic_pyproject_keeps_the_archive(self) -> None:
         """A table that defers its deps leaves the build's bytes in place."""
-        config = NabProjectConfig(build_policy=BuildPolicy.BUILD_REMOTE)
+        config = ResolveInputs(build_policy=BuildPolicy.BUILD_REMOTE)
         _, hold = self._fetched_with_pyproject(
             '[project]\nname = "pkg"\ndynamic = ["dependencies"]\n', config
         )
@@ -4001,7 +4001,7 @@ class TestSdistArchiveHolding:
         assert hold.take("pkg", "1.0") == b"archive bytes"
 
     def test_an_sdist_without_a_pyproject_keeps_the_archive(self) -> None:
-        config = NabProjectConfig(build_policy=BuildPolicy.BUILD_REMOTE)
+        config = ResolveInputs(build_policy=BuildPolicy.BUILD_REMOTE)
         _, hold = self._fetched_with_pyproject(None, config)
 
         assert hold.take("pkg", "1.0") == b"archive bytes"
@@ -4011,7 +4011,7 @@ class TestSdistArchiveHolding:
 
         The source here starts with a UTF-8 BOM, which tomli rejects.
         """
-        config = NabProjectConfig(build_policy=BuildPolicy.BUILD_REMOTE)
+        config = ResolveInputs(build_policy=BuildPolicy.BUILD_REMOTE)
         coord, hold = self._fetched_with_pyproject(
             '\ufeff[project]\nname = "pkg"\ndependencies = []\n', config
         )
@@ -4048,7 +4048,7 @@ class TestSdistArchiveHolding:
         archive = self._sdist_bytes()
         url = "https://files.example.com/pkg-1.0.tar.gz"
         route = respx.get(url).mock(return_value=httpx.Response(200, content=archive))
-        config = NabProjectConfig(build_policy=BuildPolicy.BUILD_REMOTE)
+        config = ResolveInputs(build_policy=BuildPolicy.BUILD_REMOTE)
 
         with _coord(build_config=config) as coord:
             coord.request_sdist("pkg", "1.0", url).wait(timeout=5)
@@ -4073,7 +4073,7 @@ class TestSdistArchiveHolding:
 
     def test_the_fetcher_loop_drops_what_it_still_holds(self) -> None:
         """Nothing takes from the hold once the loop is gone."""
-        config = NabProjectConfig(build_policy=BuildPolicy.BUILD_REMOTE)
+        config = ResolveInputs(build_policy=BuildPolicy.BUILD_REMOTE)
         coord = _coord(build_config=config)
         coord.start()
 

--- a/nab-project/tests/test_lockfile.py
+++ b/nab-project/tests/test_lockfile.py
@@ -44,10 +44,10 @@ from nab_project.config import (
     ConflictPolicy,
     ConflictSet,
     IndexOverride,
-    NabProjectConfig,
     conflict_exclusion_groups,
     conflict_member_groups,
 )
+from nab_project.inputs import ResolveInputs
 from nab_project.lockfile import (
     BASE_MEMBER,
     LOCK_VERSION,
@@ -5077,10 +5077,10 @@ def test_lock_input_ignores_vcs_policy() -> None:
     )
 
     allow = build_lock_input(
-        result, config=NabProjectConfig(vcs=VcsConfig(policy=VcsPolicy.ALLOW))
+        result, inputs=ResolveInputs(vcs=VcsConfig(policy=VcsPolicy.ALLOW))
     )
     block = build_lock_input(
-        result, config=NabProjectConfig(vcs=VcsConfig(policy=VcsPolicy.BLOCK))
+        result, inputs=ResolveInputs(vcs=VcsConfig(policy=VcsPolicy.BLOCK))
     )
 
     assert allow == block
@@ -5222,7 +5222,7 @@ class TestDependencyGraph:
             ),
             [_HOST],
             [Requirement("app[cli]")],
-            config=NabProjectConfig(build_policy=BuildPolicy.NEVER),
+            inputs=ResolveInputs(build_policy=BuildPolicy.NEVER),
         )
         assert result.success
 
@@ -5729,7 +5729,7 @@ class TestLockWheelPrunePredicate:
             coordinator,
             list(targets),
             [Requirement("pkg")],
-            config=NabProjectConfig(build_policy=BuildPolicy.NEVER),
+            inputs=ResolveInputs(build_policy=BuildPolicy.NEVER),
         )
 
     def test_property_union_over_seeded_subsets(self) -> None:
@@ -5833,7 +5833,7 @@ class TestLockWheelPrunePredicate:
             coordinator,
             [_PRUNE_LINUX],
             [Requirement("pkg")],
-            config=NabProjectConfig(build_policy=BuildPolicy.NEVER),
+            inputs=ResolveInputs(build_policy=BuildPolicy.NEVER),
         )
         assert result.success
         lock = result.target_results[0].lock
@@ -5870,7 +5870,7 @@ class TestLockPruneObservability:
                 coordinator,
                 [_PRUNE_LINUX],
                 [Requirement("pruner"), Requirement("clean")],
-                config=NabProjectConfig(build_policy=BuildPolicy.NEVER),
+                inputs=ResolveInputs(build_policy=BuildPolicy.NEVER),
             )
         assert result.success
         messages = [r.getMessage() for r in caplog.records if r.name == _BUILDER_LOGGER]

--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -44,7 +44,6 @@ from nab_project._resolve.engine import _raise_for_source_python
 from nab_project._testing.coordinator_fake import FakeFetchPort, make_coordinator
 from nab_project.config import (
     IndexOverride,
-    NabProjectConfig,
     OverrideConflictError,
     PackageOverride,
 )
@@ -53,6 +52,7 @@ from nab_project.fetch import (
     FetchCoordinator,
     IndexRoute,
 )
+from nab_project.inputs import ResolveInputs
 from nab_project.resolve import build_resolver_inputs, resolve_with_coordinator
 from nab_provider._provider import build_remote, metadata_resolver
 from nab_provider._provider import listing as listing_mod
@@ -4277,9 +4277,7 @@ class TestLocalSources:
         (tmp_path / "pyproject.toml").write_bytes(
             b'[project]\nname = "foo"\nversion = "1.0"\ndescription = "\xe9"\n'
         )
-        coordinator = make_coordinator(
-            [], package="foo", build_config=NabProjectConfig()
-        )
+        coordinator = make_coordinator([], package="foo", build_config=ResolveInputs())
         provider = Provider(
             coordinator,
             local_sources=[LocalSource("foo", str(tmp_path))],
@@ -4517,7 +4515,7 @@ class TestLocalSources:
 
         monkeypatch.setattr("nab_project.resolve.resolve_for_targets", _boom)
         coordinator = make_coordinator(
-            [], package="foo", build_config=NabProjectConfig(), offline=True
+            [], package="foo", build_config=ResolveInputs(), offline=True
         )
         provider = Provider(
             coordinator,
@@ -11217,7 +11215,7 @@ class TestBuildRemoteFailureModes:
         with_sdist: bool,
         overrides: tuple[PackageOverride, ...] = (),
         target: ResolveTarget = _PY312,
-        build_config: NabProjectConfig | None = None,
+        build_config: ResolveInputs | None = None,
         sdist_archive: bytes | None = None,
         sdist_archive_error: BaseException | None = None,
         offline: bool = False,
@@ -11367,7 +11365,7 @@ class TestBuildRemoteFailureModes:
 
         provider = self._provider(
             with_sdist=True,
-            build_config=NabProjectConfig(),
+            build_config=ResolveInputs(),
             sdist_archive=_DYNAMIC_SDIST_TARGZ,
             offline=True,
         )
@@ -12614,7 +12612,7 @@ class TestSiblingMetadataDivergence:
                 coordinator,
                 [_LINUX311],
                 [Requirement("pkg")],
-                config=NabProjectConfig(build_policy=BuildPolicy.NEVER),
+                inputs=ResolveInputs(build_policy=BuildPolicy.NEVER),
             )
 
     def test_resolve_aborts_not_downgrades_past_divergent(self) -> None:
@@ -12645,7 +12643,7 @@ class TestSiblingMetadataDivergence:
                 coordinator,
                 [_LINUX311],
                 [Requirement("pkg")],
-                config=NabProjectConfig(build_policy=BuildPolicy.NEVER),
+                inputs=ResolveInputs(build_policy=BuildPolicy.NEVER),
             )
 
 
@@ -12804,7 +12802,7 @@ class TestNoTagAxisPythonNarrowing:
             coordinator,
             [_overlay_target()],
             [Requirement("pkg")],
-            config=NabProjectConfig(build_policy=BuildPolicy.NEVER),
+            inputs=ResolveInputs(build_policy=BuildPolicy.NEVER),
         )
         assert result.success
         assert result.target_results[0].pins == {"pkg": self._V}

--- a/nab-project/tests/test_range_metadata_integration.py
+++ b/nab-project/tests/test_range_metadata_integration.py
@@ -22,8 +22,8 @@ import pytest
 from nab_index.client import WheelHashMismatchError
 from nab_index.lazy_wheel import RangeOutcome
 from nab_index.transport import HttpError
-from nab_project.config import NabProjectConfig
 from nab_project.fetch import FetchCoordinator
+from nab_project.inputs import ResolveInputs
 from nab_project.resolve import ResolveResult, resolve_with_coordinator
 from nab_provider._vendor.packaging.requirements import Requirement
 from nab_provider._vendor.packaging.version import Version
@@ -176,7 +176,7 @@ class FakeRangeTransport:
 _TARGET = ResolveTarget.for_declared(
     python_version="3.11", spec=PlatformSpec("linux_x86_64")
 )
-_NO_BUILD = NabProjectConfig(build_policy=BuildPolicy.NEVER)
+_NO_BUILD = ResolveInputs(build_policy=BuildPolicy.NEVER)
 
 
 def _resolve(coordinator: FetchCoordinator) -> ResolveResult:
@@ -184,7 +184,7 @@ def _resolve(coordinator: FetchCoordinator) -> ResolveResult:
         coordinator,
         [_TARGET],
         [Requirement("widget")],
-        config=_NO_BUILD,
+        inputs=_NO_BUILD,
     )
     result.raise_for_failure()
     return result

--- a/nab-project/tests/test_resolve.py
+++ b/nab-project/tests/test_resolve.py
@@ -29,11 +29,11 @@ from nab_project.config import (
     ConflictMember,
     ConflictSelectionError,
     ConflictSet,
-    MatrixConfig,
-    NabProjectConfig,
-    ResolveMode,
+    plan_targets,
     read_pyproject_config,
+    with_python_override,
 )
+from nab_project.inputs import ResolveInputs
 from nab_project.lockfile import LockInput, PinShape, build_pylock
 from nab_project.pyproject_files import (
     read_pyproject_groups,
@@ -49,10 +49,9 @@ from nab_project.resolve import (
     _group_requirements,
     _group_requirements_by_group,
     _ProjectTables,
-    _resolve_inputs,
     build_lock_input,
     build_resolver_inputs,
-    config_for_build_requirements,
+    inputs_for_build_requirements,
     resolve_for_targets,
 )
 from nab_provider._provider import listing_diagnosis
@@ -77,7 +76,7 @@ from nab_provider.requirements_file import (
     expand_extra_requirements,
 )
 from nab_provider.tags import PlatformSpec
-from nab_provider.target import ResolveTarget
+from nab_provider.target import Matrix, ResolveTarget
 from nab_resolver.errors import ResolutionError
 from nab_resolver.ranges import Range
 from nab_resolver.types import Incompatibility, IncompatibilityCause, Term
@@ -95,14 +94,32 @@ _FORTY = "0123456789abcdef0123456789abcdef01234567"
 
 
 def _resolved(
-    path: Path, transport: object = _FAKE_TRANSPORT, **kwargs: object
+    path: Path,
+    transport: object = _FAKE_TRANSPORT,
+    *,
+    python_version: str | None = None,
+    **kwargs: object,
 ) -> ResolveResult:
     """Resolve and surface a failed target's error.
+
+    nab-project takes the targets and the settings from its caller, so
+    whichever of the two is not passed is planned off ``path`` the way a
+    host does.  ``python_version`` retargets that plan the way ``--python``
+    does, and has nothing to retarget once both are passed.
 
     The engine records a target that did not resolve rather than raising,
     so a caller resolving for one environment re-raises it; that is what
     every test below asserts against.
     """
+    planned = {"targets", "inputs"} - kwargs.keys()
+    if planned:
+        config = with_python_override(read_pyproject_config(path), python_version)
+        kwargs.setdefault("targets", plan_targets(config))
+        kwargs.setdefault("inputs", config.resolve_inputs())
+    elif python_version is not None:
+        msg = "python_version retargets a planned target; both were passed"
+        raise TypeError(msg)
+
     result = resolve_for_targets(path, transport, **kwargs)  # type: ignore[arg-type]
     result.raise_for_failure()
     return result
@@ -153,16 +170,16 @@ def _tables(path: Path) -> _ProjectTables:
 
 
 def _build_constraints(
-    config: NabProjectConfig, *, environment: dict[str, str]
+    inputs: ResolveInputs, *, environment: dict[str, str]
 ) -> dict[str, Range]:
-    """The resolver-input ranges ``config``'s constraints fold to.
+    """The resolver-input ranges ``inputs``'s constraints fold to.
 
     The parser is shared with the requirement side; ``kind`` is what
     tells the two apart.
     """
     return build_resolver_inputs(
-        [Requirement(text) for text in config.constraints],
-        config.vcs,
+        [Requirement(text) for text in inputs.constraints],
+        inputs.vcs,
         environment=environment,
         marker_holds=dependency_marker_holds,
         kind="constraint",
@@ -327,7 +344,9 @@ class TestSpecificModeConflictValidation:
         assert label_for["2.0.0"].endswith("-extra-gpu")
         # Both forks land in the lock under their own selection.
         lock_input = build_lock_input(
-            result, config=read_pyproject_config(path), extras=("cpu", "gpu")
+            result,
+            inputs=read_pyproject_config(path).resolve_inputs(),
+            extras=("cpu", "gpu"),
         )
         assert len(lock_input.targets) == 2
 
@@ -1127,7 +1146,7 @@ class TestResolvePyproject:
     @patch("nab_project._resolve.engine.Resolver")
     @patch("nab_project._resolve.engine.Provider")
     @patch("nab_project.resolve.FetchCoordinator")
-    def test_explicit_config_arg_skips_file_read(
+    def test_the_constraints_reach_the_resolver(
         self,
         mock_coord_cls: MagicMock,
         mock_provider_cls: MagicMock,
@@ -1135,19 +1154,18 @@ class TestResolvePyproject:
         mock_build_lock: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """An explicit config arg bypasses [tool.nab] parsing on disk."""
+        """``inputs`` carries the constraints the search runs under."""
         pyproject = tmp_path / "pyproject.toml"
-        # File has no [tool.nab] table on disk; the explicit config wins.
+        # No [tool.nab] on disk, so the constraint can only be the caller's.
         pyproject.write_text('[project]\ndependencies = ["foo"]\n')
         mock_coord_cls.return_value.__enter__ = lambda s: s
         mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
         mock_resolver_cls.return_value.resolve.return_value = {}
 
-        explicit = NabProjectConfig(constraints=("urllib3<2",))
         _resolved(
             pyproject,
             _FAKE_TRANSPORT,
-            config=explicit,
+            inputs=ResolveInputs(constraints=("urllib3<2",)),
             python_version="3.12.0",
         )
 
@@ -1299,7 +1317,7 @@ class TestResolvePyproject:
 
         lock_input = build_lock_input(
             result,
-            config=read_pyproject_config(pyproject),
+            inputs=read_pyproject_config(pyproject).resolve_inputs(),
             dependency_groups=("test",),
         )
         assert lock_input.dependency_groups == ("test",)
@@ -1332,7 +1350,7 @@ class TestResolvePyproject:
 
         lock_input = build_lock_input(
             result,
-            config=read_pyproject_config(pyproject),
+            inputs=read_pyproject_config(pyproject).resolve_inputs(),
             dependency_groups=("test",),
         )
         assert lock_input.default_groups == ()
@@ -1392,21 +1410,20 @@ class TestResolveUniversalPyproject:
         assert [t.python_full_version for t in targets] == ["3.11.4", "3.12.0"]
 
     @patch("nab_project.resolve.resolve_with_coordinator")
-    def test_explicit_config_arg(
+    def test_explicit_targets_reach_the_engine(
         self,
         mock_engine: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """Caller can pass a constructed config rather than reading the file."""
+        """The caller says which environments to resolve for, not the file."""
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text('[project]\ndependencies = ["foo"]\n')
-        config = NabProjectConfig(
-            mode=ResolveMode.UNIVERSAL,
-            matrix=MatrixConfig(
-                python=">=3.12,<3.14", platforms=(PlatformSpec("linux_x86_64"),)
-            ),
-        )
-        _resolved(pyproject, config=config)
+        declared = Matrix(
+            python=">=3.12,<3.14", platforms=(PlatformSpec("linux_x86_64"),)
+        ).expand()
+
+        _resolved(pyproject, targets=declared, inputs=ResolveInputs())
+
         targets = mock_engine.call_args.args[1]
         assert [t.label for t in targets] == [
             "py312-linux_x86_64",
@@ -2363,7 +2380,9 @@ class TestSpecificModeTargetPlan:
         target = mock_provider_cls.call_args.kwargs["target"]
         assert target == ResolveTarget.for_host()
         assert (
-            build_lock_input(result, config=read_pyproject_config(pyproject))
+            build_lock_input(
+                result, inputs=read_pyproject_config(pyproject).resolve_inputs()
+            )
         ).requires_python == ">=3.9"
 
     @patch("nab_project._resolve.engine.build_target_lock")
@@ -2801,7 +2820,7 @@ class TestBuildConstraints:
     def test_duplicate_constraint_intersects(self) -> None:
         """Two constraint lines for one package combine to their overlap."""
         out = _build_constraints(
-            NabProjectConfig(constraints=("foo>=2.0", "foo<3.0")), environment={}
+            ResolveInputs(constraints=("foo>=2.0", "foo<3.0")), environment={}
         )
         assert V("2.5") in out["foo"]
         assert V("1.0") not in out["foo"]
@@ -2811,14 +2830,14 @@ class TestBuildConstraints:
         """Pinned-but-different constraint lines for one package raise."""
         with pytest.raises(ResolutionError, match="conflicting constraints"):
             _build_constraints(
-                NabProjectConfig(constraints=("foo==1.0", "foo==2.0")), environment={}
+                ResolveInputs(constraints=("foo==1.0", "foo==2.0")), environment={}
             )
 
     def test_marker_false_constraint_dropped(self) -> None:
         """A constraint whose marker is False is not applied."""
         env = {"python_version": "3.12"}
         out = _build_constraints(
-            NabProjectConfig(constraints=('foo<2.0 ; python_version < "3.0"',)),
+            ResolveInputs(constraints=('foo<2.0 ; python_version < "3.0"',)),
             environment=env,
         )
         assert "foo" not in out
@@ -2827,7 +2846,7 @@ class TestBuildConstraints:
         """A constraint whose marker is True still restricts the range."""
         env = {"python_version": "3.12"}
         out = _build_constraints(
-            NabProjectConfig(constraints=('foo<2.0 ; python_version >= "3.0"',)),
+            ResolveInputs(constraints=('foo<2.0 ; python_version >= "3.0"',)),
             environment=env,
         )
         assert V("1.0") in out["foo"]
@@ -2837,7 +2856,7 @@ class TestBuildConstraints:
         """A constraint carrying extras is rejected, matching pip."""
         with pytest.raises(ConfigError, match="extras"):
             _build_constraints(
-                NabProjectConfig(constraints=("foo[dev]<2.0",)), environment={}
+                ResolveInputs(constraints=("foo[dev]<2.0",)), environment={}
             )
 
     def test_constraint_with_extras_rejected_under_false_marker(self) -> None:
@@ -2849,16 +2868,14 @@ class TestBuildConstraints:
         """
         with pytest.raises(ConfigError, match="extras"):
             _build_constraints(
-                NabProjectConfig(
-                    constraints=('foo[dev]<2.0 ; python_version < "3.0"',)
-                ),
+                ResolveInputs(constraints=('foo[dev]<2.0 ; python_version < "3.0"',)),
                 environment={"python_version": "3.12"},
             )
 
     def test_set_marker_constraint_dropped(self) -> None:
         """A constraint gated on a lockfile-only set marker drops, not crashes."""
         out = _build_constraints(
-            NabProjectConfig(constraints=('foo<2.0 ; "x" in extras',)), environment={}
+            ResolveInputs(constraints=('foo<2.0 ; "x" in extras',)), environment={}
         )
         assert "foo" not in out
 
@@ -2871,7 +2888,7 @@ class TestBuildConstraints:
         """The one warning a membership-gated constraint logs when dropped."""
         with caplog.at_level("WARNING", logger="nab_provider.resolver_inputs"):
             out = _build_constraints(
-                NabProjectConfig(constraints=(constraint,)),
+                ResolveInputs(constraints=(constraint,)),
                 environment={} if environment is None else environment,
             )
 
@@ -2918,8 +2935,10 @@ class TestBuildConstraints:
             "so drop the membership test from the marker and keep the rest."
         )
 
-        config = read_pyproject_config(_constraints_pyproject(tmp_path, '"foo<2.0"'))
-        out = _build_constraints(config, environment={})
+        inputs = read_pyproject_config(
+            _constraints_pyproject(tmp_path, '"foo<2.0"')
+        ).resolve_inputs()
+        out = _build_constraints(inputs, environment={})
         assert V("1.0") in out["foo"]
         assert V("5.0") not in out["foo"]
 
@@ -2942,15 +2961,15 @@ class TestBuildConstraints:
             "so drop the membership test from the marker and keep the rest."
         )
 
-        config = read_pyproject_config(
+        inputs = read_pyproject_config(
             _constraints_pyproject(tmp_path, "\"foo<2.0 ; python_version < '3.10'\"")
-        )
-        out = _build_constraints(config, environment=on_39)
+        ).resolve_inputs()
+        out = _build_constraints(inputs, environment=on_39)
         assert V("1.0") in out["foo"]
         assert V("5.0") not in out["foo"]
 
         on_311 = {"python_version": "3.11", "python_full_version": "3.11.2"}
-        assert "foo" not in _build_constraints(config, environment=on_311)
+        assert "foo" not in _build_constraints(inputs, environment=on_311)
 
 
 class TestResolvePyprojectConflicts:
@@ -3310,7 +3329,7 @@ class TestResolvePyprojectGroupConflict:
             resolve_for_targets(
                 pyproject,
                 _FAKE_TRANSPORT,
-                python_version="3.12.0",
+                targets=(ResolveTarget.for_host_python("3.12.0"),),
                 groups=["alpha", "beta"],
             )
         assert str(info.value) == (
@@ -4823,7 +4842,9 @@ class TestLockDeclaresItsEnvironment:
             mock_coord_cls.return_value.__enter__ = lambda _self: coordinator
             mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
             result = _resolved(path, _FAKE_TRANSPORT)
-        return build_lock_input(result, config=read_pyproject_config(path))
+        return build_lock_input(
+            result, inputs=read_pyproject_config(path).resolve_inputs()
+        )
 
     _PYPROJECT = (
         '[project]\nname = "proj"\ndependencies = ["foo"]\n'
@@ -5091,18 +5112,18 @@ class TestExtraAndGroupMembershipMarkers:
             mock_coord_cls.return_value.__enter__ = lambda _self: make_coordinator([])
             mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
             path = tmp_path / "pyproject.toml"
-            config = read_pyproject_config(path)
+            inputs = read_pyproject_config(path).resolve_inputs()
             result = _resolved(
                 path,
                 _FAKE_TRANSPORT,
-                config=config,
+                inputs=inputs,
                 extras=extras,
                 groups=groups,
             )
         pylock = build_pylock(
             build_lock_input(
                 result,
-                config=config,
+                inputs=inputs,
                 extras=extras,
                 dependency_groups=groups,
             ),
@@ -5736,7 +5757,7 @@ class TestBuildRequirementsResolve:
         assert _pins(result) == {"hatchling": V("2.0")}
 
     @patch("nab_project.resolve.resolve_with_coordinator")
-    def test_the_matrix_still_expands(
+    def test_every_target_gets_the_build_requires(
         self, mock_engine: MagicMock, tmp_path: Path
     ) -> None:
         """A static requires list needs no interpreter to read, so it goes wide."""
@@ -5751,7 +5772,12 @@ class TestBuildRequirementsResolve:
             'platforms = ["linux_x86_64"]\n'
         )
 
-        resolve_for_targets(pyproject, _FAKE_TRANSPORT, build_requirements=True)
+        resolve_for_targets(
+            pyproject,
+            _FAKE_TRANSPORT,
+            targets=plan_targets(read_pyproject_config(pyproject)),
+            build_requirements=True,
+        )
 
         targets = mock_engine.call_args.args[1]
         assert [t.label for t in targets] == [
@@ -5786,7 +5812,7 @@ class TestBuildRequirementsResolve:
 class TestBuildRequirementsConfig:
     def test_drops_every_selection_setting(self) -> None:
         """Nothing describing a group or extra survives into a build lock."""
-        config = NabProjectConfig(
+        inputs = ResolveInputs(
             default_groups=("dev",),
             base_group="default",
             conflicts=(
@@ -5799,7 +5825,7 @@ class TestBuildRequirementsConfig:
             ),
         )
 
-        pruned = config_for_build_requirements(config)
+        pruned = inputs_for_build_requirements(inputs)
 
         assert pruned.default_groups == ()
         assert pruned.base_group is None
@@ -5807,9 +5833,9 @@ class TestBuildRequirementsConfig:
 
     def test_keeps_the_settings_a_resolve_still_needs(self) -> None:
         """Constraints and the resolve window are not part of the selection."""
-        config = NabProjectConfig(constraints=("urllib3<2",), requires_python=">=3.10")
+        inputs = ResolveInputs(constraints=("urllib3<2",), requires_python=">=3.10")
 
-        pruned = config_for_build_requirements(config)
+        pruned = inputs_for_build_requirements(inputs)
 
         assert pruned.constraints == ("urllib3<2",)
         assert pruned.requires_python == ">=3.10"
@@ -5887,10 +5913,12 @@ class TestBuildGroup:
         """
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text(self._PYPROJECT + _BOTH_GROUPS)
-        config = config_for_build_requirements(read_pyproject_config(pyproject))
+        inputs = inputs_for_build_requirements(
+            read_pyproject_config(pyproject).resolve_inputs()
+        )
 
         result = self._mocked_resolve(pyproject, build_requirements=True)
-        lock_input = build_lock_input(result, config=config)
+        lock_input = build_lock_input(result, inputs=inputs)
 
         assert _pins(result) == {"hatchling": V("2.0")}
         assert lock_input.build_group is None
@@ -6055,7 +6083,11 @@ class TestConfiguredGroupConflicts:
             mock_coord_cls.return_value.__enter__ = lambda coordinator: coordinator
             mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
             resolve_for_targets(
-                pyproject, _FAKE_TRANSPORT, python_version="3.12.0", **kwargs
+                pyproject,
+                _FAKE_TRANSPORT,
+                targets=(ResolveTarget.for_host_python("3.12.0"),),
+                inputs=read_pyproject_config(pyproject).resolve_inputs(),
+                **kwargs,
             )
         return mock_engine
 
@@ -6334,10 +6366,10 @@ class TestConfiguredGroupConflictDivergentPins:
         with patch("nab_project.resolve.FetchCoordinator") as mock_coord_cls:
             mock_coord_cls.return_value.__enter__ = lambda _self: coordinator
             mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
-            config = read_pyproject_config(pyproject)
-            result = _resolved(pyproject, _FAKE_TRANSPORT, config=config)
+            inputs = read_pyproject_config(pyproject).resolve_inputs()
+            result = _resolved(pyproject, _FAKE_TRANSPORT, inputs=inputs)
         pylock = build_pylock(
-            build_lock_input(result, config=config), lock_dir=tmp_path
+            build_lock_input(result, inputs=inputs), lock_dir=tmp_path
         )
         pylock.validate()
         return pylock
@@ -6434,7 +6466,7 @@ class TestBuildConfigPlumbing:
     ) -> None:
         """``resolve_for_targets`` hands its own settings to the build."""
         pyproject = self._project(tmp_path)
-        config = read_pyproject_config(pyproject)
+        inputs = read_pyproject_config(pyproject).resolve_inputs()
         built = WheelMetadata(name="dyn", version=Version("7.0"))
 
         with patch(
@@ -6443,14 +6475,15 @@ class TestBuildConfigPlumbing:
             result = resolve_for_targets(
                 pyproject,
                 _NoIndexTransport(),
-                config=config,
+                targets=(ResolveTarget.for_host(),),
+                inputs=inputs,
                 cache_dir=tmp_path / "cache",
             )
 
         assert result.success
         assert _pins(result) == {"dyn": Version("7.0")}
 
-        assert runner.call_args.kwargs["config"] == _resolve_inputs(config)
+        assert runner.call_args.kwargs["config"] == inputs
 
 
 class TestTrustUnverifiedSdistDeps:
@@ -6555,7 +6588,11 @@ class TestPyprojectParsedOnce:
         config = read_pyproject_config(pyproject, discover_workspace=False)
 
         with record_parses() as parsed:
-            _resolved(pyproject, config=config)
+            _resolved(
+                pyproject,
+                targets=plan_targets(config),
+                inputs=config.resolve_inputs(),
+            )
 
         assert parsed.count(body) == 1
 
@@ -6578,7 +6615,8 @@ class TestPyprojectParsedOnce:
             resolve_for_targets(
                 pyproject,
                 _FAKE_TRANSPORT,  # type: ignore[arg-type]
-                config=config,
+                targets=plan_targets(config),
+                inputs=config.resolve_inputs(),
                 build_requirements=True,
             ).raise_for_failure()
 

--- a/nab-project/tests/test_resolve_targets.py
+++ b/nab-project/tests/test_resolve_targets.py
@@ -32,11 +32,11 @@ from nab_project.config import (
     ConflictMember,
     ConflictPolicy,
     ConflictSet,
-    NabProjectConfig,
     conflict_forks,
     read_pyproject_config,
 )
 from nab_project.fetch import DEFAULT_INDEX_URL
+from nab_project.inputs import ResolveInputs
 from nab_project.lockfile import (
     DisjointnessError,
     IndexPin,
@@ -57,7 +57,6 @@ from nab_project.resolve import (
     ResolveFork,
     ResolveResult,
     TargetResult,
-    _resolve_inputs,
     build_lock_input,
     build_resolver_inputs,
     resolve_with_coordinator,
@@ -135,23 +134,23 @@ def _reqs(*texts: str) -> list[Requirement]:
     return [Requirement(text) for text in texts]
 
 
-def _no_build(**kwargs: object) -> NabProjectConfig:
-    """A project config that never builds, so a test resolve stays offline."""
-    return NabProjectConfig(build_policy=BuildPolicy.NEVER, **kwargs)  # type: ignore[arg-type]
+def _no_build(**kwargs: object) -> ResolveInputs:
+    """Settings that never build, so a test resolve stays offline."""
+    return ResolveInputs(build_policy=BuildPolicy.NEVER, **kwargs)  # type: ignore[arg-type]
 
 
 def _settings(
     coordinator: FakeFetchPort,
-    config: NabProjectConfig | None = None,
+    inputs: ResolveInputs | None = None,
     *,
     align: bool = True,
     source_root: Path | None = None,
 ) -> _EngineSettings:
     """The settings one bare ``_resolve_one_target`` or ``_run_pass`` needs."""
-    effective = config if config is not None else NabProjectConfig()
+    effective = inputs if inputs is not None else ResolveInputs()
     return _EngineSettings(
         coordinator=coordinator,
-        inputs=_resolve_inputs(effective),
+        inputs=effective,
         source_root=source_root,
         align=align,
         resolution=effective.resolution,
@@ -385,7 +384,7 @@ class TestConflictForkResolve:
             self._black_coordinator(),
             _one_target(),
             forks=self._black_forks(),
-            config=_no_build(),
+            inputs=_no_build(),
         )
         assert result.success
         by_label = {tr.target.label: tr.pins for tr in result.target_results}
@@ -399,11 +398,11 @@ class TestConflictForkResolve:
             self._black_coordinator(),
             _one_target(),
             forks=self._black_forks(),
-            config=_no_build(),
+            inputs=_no_build(),
         )
         lock_input = build_lock_input(
             result,
-            config=_no_build(conflicts=(_group_set("black22", "black23"),)),
+            inputs=_no_build(conflicts=(_group_set("black22", "black23"),)),
             dependency_groups=("black22", "black23"),
         )
         # Must not raise DisjointnessError: the conflict prunes the
@@ -424,7 +423,7 @@ class TestConflictForkResolve:
             self._black_coordinator(),
             _one_target(),
             forks=self._black_forks(),
-            config=_no_build(),
+            inputs=_no_build(),
         )
         lock_input = build_lock_input(
             result,
@@ -441,11 +440,11 @@ class TestConflictForkResolve:
             self._black_coordinator(),
             _one_target(),
             forks=self._black_forks(),
-            config=_no_build(),
+            inputs=_no_build(),
         )
         lock_input = build_lock_input(
             result,
-            config=_no_build(default_groups=("black22", "black23")),
+            inputs=_no_build(default_groups=("black22", "black23")),
         )
         with pytest.raises(DisjointnessError, match="black"):
             build_pylock(lock_input)
@@ -458,11 +457,11 @@ class TestConflictForkResolve:
             self._black_coordinator(),
             _one_target(),
             forks=self._black_forks(),
-            config=_no_build(),
+            inputs=_no_build(),
         )
         lock_input = build_lock_input(
             result,
-            config=_no_build(conflicts=(_group_set("black22", "black23"),)),
+            inputs=_no_build(conflicts=(_group_set("black22", "black23"),)),
             dependency_groups=("black22", "black23"),
         )
         assert len(lock_input.environments) == 1
@@ -498,7 +497,7 @@ class TestConflictForkResolve:
                 self._black_coordinator(),
                 _one_target(),
                 forks=self._black_forks(),
-                config=_no_build(),
+                inputs=_no_build(),
                 align_across_targets=align_across_targets,
             )
         assert result.success
@@ -548,7 +547,7 @@ class TestConflictForkBaseNames:
             _one_target(),
             forks=self._forks(),
             base_requirements=_reqs("base"),
-            config=_no_build(),
+            inputs=_no_build(),
         )
         assert result.success
         (names,) = result.env_base_names.values()
@@ -561,11 +560,11 @@ class TestConflictForkBaseNames:
             _one_target(),
             forks=self._forks(),
             base_requirements=_reqs("base"),
-            config=_no_build(),
+            inputs=_no_build(),
         )
         lock_input = build_lock_input(
             result,
-            config=_no_build(conflicts=(_extra_set("cpu", "gpu"),)),
+            inputs=_no_build(conflicts=(_extra_set("cpu", "gpu"),)),
             extras=("cpu", "gpu"),
         )
         pylock = build_pylock(lock_input)
@@ -612,13 +611,13 @@ class TestConflictForkBaseNames:
             _one_target(),
             forks=forks,
             base_requirements=_reqs("base"),
-            config=_no_build(),
+            inputs=_no_build(),
         )
         assert result.success
 
         lock_input = build_lock_input(
             result,
-            config=_no_build(
+            inputs=_no_build(
                 conflicts=(
                     _extra_set("cpu", "gpu"),
                     _group_set("mon", "debug"),
@@ -662,7 +661,7 @@ class TestConflictForkBaseNames:
             _one_target(),
             forks=self._forks(),
             base_requirements=_reqs("base==9.9"),
-            config=_no_build(),
+            inputs=_no_build(),
         )
         assert not result.success
         assert result.env_base_names == {}
@@ -680,7 +679,7 @@ class TestConflictForkBaseNames:
                 _one_target(),
                 forks=self._forks(),
                 base_requirements=_reqs("base==9.9"),
-                config=_no_build(),
+                inputs=_no_build(),
             )
         assert any("Base attribution skipped" in rec.message for rec in caplog.records)
 
@@ -752,14 +751,14 @@ class TestTwoConflictSetsPartialInstall:
             _one_target(),
             forks=self._forks(),
             base_requirements=_reqs("base"),
-            config=_no_build(),
+            inputs=_no_build(),
         )
         assert result.success
 
         pylock = build_pylock(
             build_lock_input(
                 result,
-                config=_no_build(
+                inputs=_no_build(
                     conflicts=(_extra_set("a1", "a2"), _extra_set(*b_members))
                 ),
                 extras=("a1", "a2", "b1", "b2"),
@@ -836,7 +835,7 @@ class TestDroppedMembershipMarkerWarnedOnce:
                 self._two_targets(),
                 forks=self._forks(),
                 base_requirements=_reqs("base", 'gated ; extra == "test"'),
-                config=_no_build(),
+                inputs=_no_build(),
             )
         assert result.success
         warnings = [rec for rec in caplog.records if "membership marker" in rec.message]
@@ -851,7 +850,7 @@ class TestDroppedMembershipMarkerWarnedOnce:
                 self._coordinator(),
                 self._two_targets(),
                 reqs,
-                config=_no_build(),
+                inputs=_no_build(),
             )
         assert result.success
         warned = [
@@ -878,7 +877,7 @@ class TestDroppedMembershipMarkerWarnedOnce:
                 self._two_targets(),
                 forks=forks,
                 base_requirements=plain,
-                config=_no_build(constraints=('base<2.0 ; extra == "test"',)),
+                inputs=_no_build(constraints=('base<2.0 ; extra == "test"',)),
             )
         assert result.success
         warned = [
@@ -970,7 +969,7 @@ class TestLowestDirectAcrossTargets:
             self._coordinator(),
             targets,
             _reqs('foo; sys_platform == "win32"', "bar"),
-            config=_no_build(),
+            inputs=_no_build(),
             resolution_strategy=ResolutionStrategy.LOWEST_DIRECT,
         )
         assert result.success
@@ -1060,7 +1059,7 @@ class TestMatrixPerTargetWheelDivergence:
             platforms=(PlatformSpec("linux_x86_64"), PlatformSpec("windows_amd64")),
         ).expand()
         result = resolve_with_coordinator(
-            self._coordinator(), targets, _reqs("pkg"), config=_no_build()
+            self._coordinator(), targets, _reqs("pkg"), inputs=_no_build()
         )
         assert result.success
         pins = {
@@ -1107,7 +1106,7 @@ class TestMatrixMetadataReadGranularity:
         assert len(targets) == 3
 
         result = resolve_with_coordinator(
-            coordinator, targets, _reqs("pkg"), config=_no_build()
+            coordinator, targets, _reqs("pkg"), inputs=_no_build()
         )
         assert result.success
 
@@ -1660,7 +1659,7 @@ class TestVcsConfigPlumbing:
                 _make_coordinator({}),
                 _one_target(),
                 _reqs("pkg"),
-                config=_no_build(
+                inputs=_no_build(
                     vcs=VcsConfig(policy=VcsPolicy.BLOCK),
                     vcs_sources=(self._source(),),
                 ),
@@ -1707,7 +1706,7 @@ class TestVcsConfigPlumbing:
             _make_coordinator({}),
             _one_target(),
             _reqs("pkg"),
-            config=_no_build(vcs=self._allow(), vcs_sources=(self._source(),)),
+            inputs=_no_build(vcs=self._allow(), vcs_sources=(self._source(),)),
             cache_dir=None,
         )
 
@@ -1742,7 +1741,7 @@ class TestVcsConfigPlumbing:
             _make_coordinator({}),
             _one_target(),
             _reqs("pkg"),
-            config=_no_build(vcs=self._allow(), vcs_sources=(self._source(),)),
+            inputs=_no_build(vcs=self._allow(), vcs_sources=(self._source(),)),
             cache_dir=Path("relcache"),
         )
 
@@ -1782,7 +1781,7 @@ class TestVcsConfigPlumbing:
             _make_coordinator({}),
             _one_target(),
             _reqs("pkg"),
-            config=_no_build(vcs=self._allow(), vcs_sources=(self._source(),)),
+            inputs=_no_build(vcs=self._allow(), vcs_sources=(self._source(),)),
             cache_dir=tmp_path,
         )
 
@@ -1833,7 +1832,7 @@ class TestCutoffAndOverridePlumbing:
             self._coordinator(),
             _one_target(),
             _reqs("foo"),
-            config=read_pyproject_config(path),
+            inputs=read_pyproject_config(path).resolve_inputs(),
         )
         assert result.success
 
@@ -2133,13 +2132,13 @@ class TestBuildLockInput:
             },
         )
         result = resolve_with_coordinator(
-            coordinator, [_linux_311()], _reqs("foo"), config=_no_build()
+            coordinator, [_linux_311()], _reqs("foo"), inputs=_no_build()
         )
 
         assert result.success
         assert set(result.target_results[0].pins) == {"foo"}
 
-        merged = build_lock_input(result, config=_no_build())
+        merged = build_lock_input(result, inputs=_no_build())
         assert set(merged.targets) == {"py311-linux_x86_64"}
         assert [str(row) for row in merged.environments] == [
             (
@@ -2171,7 +2170,7 @@ class TestServingIndexInLock:
         coordinator.index.store_listing_index("foo", "internal")
 
         result = resolve_with_coordinator(
-            coordinator, _one_target(), _reqs("foo", "bar"), config=_no_build()
+            coordinator, _one_target(), _reqs("foo", "bar"), inputs=_no_build()
         )
 
         assert result.success
@@ -2315,7 +2314,7 @@ class TestResolveWithCoordinator:
             coordinator,
             _one_target(),
             _reqs("pkg"),
-            config=NabProjectConfig(constraints=("pkg<2.0",)),
+            inputs=ResolveInputs(constraints=("pkg<2.0",)),
         )
         assert result.success
         assert result.target_results[0].pins == {"pkg": Version("1.0")}
@@ -2356,7 +2355,7 @@ class TestResolveWithCoordinator:
             self._dropped_extra_coordinator(),
             _one_target(),
             _reqs("aaa[x]"),
-            config=NabProjectConfig(constraints=(constraint,)),
+            inputs=ResolveInputs(constraints=(constraint,)),
         )
         assert result.success
         assert result.target_results[0].pins == {
@@ -2374,7 +2373,7 @@ class TestResolveWithCoordinator:
             self._dropped_extra_coordinator(),
             _one_target(),
             _reqs("aaa[x]"),
-            config=NabProjectConfig(constraints=("aaa<0.5",)),
+            inputs=ResolveInputs(constraints=("aaa<0.5",)),
         )
         assert not result.success
         message = str(result.target_results[0].error)
@@ -2393,7 +2392,7 @@ class TestResolveWithCoordinator:
                 self._dropped_extra_coordinator(),
                 _one_target(),
                 _reqs("aaa[x]"),
-                config=NabProjectConfig(constraints=("aaa==3.0",)),
+                inputs=ResolveInputs(constraints=("aaa==3.0",)),
             )
 
     @staticmethod
@@ -2452,7 +2451,7 @@ class TestResolveWithCoordinator:
             ),
             _one_target(),
             _reqs("ccc"),
-            config=NabProjectConfig(constraints=("aaa<3.0",)),
+            inputs=ResolveInputs(constraints=("aaa<3.0",)),
         )
         assert result.success
         assert result.target_results[0].pins == {
@@ -2474,7 +2473,7 @@ class TestResolveWithCoordinator:
                 self._transitive_proxy_coordinator(),
                 _one_target(),
                 _reqs("ccc"),
-                config=NabProjectConfig(constraints=("aaa<3.0",)),
+                inputs=ResolveInputs(constraints=("aaa<3.0",)),
             )
 
         assert result.success
@@ -2496,7 +2495,7 @@ class TestResolveWithCoordinator:
             self._transitive_proxy_coordinator(),
             _one_target(),
             _reqs("ccc"),
-            config=NabProjectConfig(constraints=("aaa<0.5",)),
+            inputs=ResolveInputs(constraints=("aaa<0.5",)),
         )
         assert not result.success
 
@@ -2519,7 +2518,7 @@ class TestResolveWithCoordinator:
             coordinator,
             _one_target(),
             _reqs("pkg"),
-            config=NabProjectConfig(resolution=ResolutionStrategy.HIGHEST),
+            inputs=ResolveInputs(resolution=ResolutionStrategy.HIGHEST),
             resolution_strategy=ResolutionStrategy.LOWEST,
         )
         assert result.success
@@ -2545,7 +2544,7 @@ class TestLocalVcsRequiresPython:
             coordinator,
             matrix.expand(),
             _reqs("foo"),
-            config=NabProjectConfig(local_sources=(local,)),
+            inputs=ResolveInputs(local_sources=(local,)),
         )
 
     def test_excluding_python_fails_the_target(self, tmp_path: Path) -> None:
@@ -2678,7 +2677,7 @@ class TestArchiveSourceAcrossTargets:
                 python=">=3.11, <3.13", platforms=(PlatformSpec("linux_x86_64"),)
             ).expand(),
             _reqs("foo"),
-            config=NabProjectConfig(archive_sources=(source,)),
+            inputs=ResolveInputs(archive_sources=(source,)),
             cache_dir=tmp_path,
         )
 
@@ -2713,7 +2712,7 @@ class TestArchiveSourceAcrossTargets:
             coord,
             _one_target(),
             _reqs("foo"),
-            config=NabProjectConfig(archive_sources=(source,)),
+            inputs=ResolveInputs(archive_sources=(source,)),
             cache_dir=tmp_path,
         )
 
@@ -2740,7 +2739,7 @@ class TestArchiveSourceAcrossTargets:
             coord,
             _one_target(),
             _reqs("foo"),
-            config=NabProjectConfig(archive_sources=(source,)),
+            inputs=ResolveInputs(archive_sources=(source,)),
             cache_dir=None,
         )
 
@@ -2765,7 +2764,7 @@ class TestArchiveSourceAcrossTargets:
             coord,
             Matrix(python="==3.10", platforms=(PlatformSpec("linux_x86_64"),)).expand(),
             _reqs("foo"),
-            config=NabProjectConfig(archive_sources=(source,)),
+            inputs=ResolveInputs(archive_sources=(source,)),
             cache_dir=tmp_path,
         )
 
@@ -2842,7 +2841,7 @@ class TestSharedListingFilter:
                 self._coordinator(wheels),
                 self._targets("==3.11"),
                 _reqs("pkg"),
-                config=_no_build(),
+                inputs=_no_build(),
             )
 
         assert result.success
@@ -2862,7 +2861,7 @@ class TestSharedListingFilter:
                 self._coordinator(wheels),
                 self._targets("==3.11"),
                 _reqs("pkg"),
-                config=_no_build(),
+                inputs=_no_build(),
             )
 
         assert result.success
@@ -2882,7 +2881,7 @@ class TestSharedListingFilter:
                 self._coordinator(wheels),
                 self._targets(">=3.11,<3.13"),
                 _reqs("pkg"),
-                config=_no_build(),
+                inputs=_no_build(),
                 align_across_targets=False,
             )
 
@@ -2909,7 +2908,7 @@ class TestSharedListingFilter:
                 self._coordinator(wheels),
                 self._targets(">=3.11,<3.13"),
                 _reqs("pkg"),
-                config=_no_build(),
+                inputs=_no_build(),
                 align_across_targets=False,
             )
 
@@ -2941,7 +2940,7 @@ class TestSharedListingFilter:
                     )
                 ],
                 _reqs("pkg"),
-                config=_no_build(),
+                inputs=_no_build(),
                 align_across_targets=False,
             )
 
@@ -2957,7 +2956,7 @@ class TestSharedListingFilter:
             self._coordinator(wheels),
             self._targets("==3.11"),
             _reqs("pkg"),
-            config=_no_build(),
+            inputs=_no_build(),
         )
 
         assert result.success
@@ -3012,7 +3011,7 @@ class TestMicroBoundaryNarrowing:
             wraps=engine_mod._resolve_one_target,
         ) as spy:
             result = resolve_with_coordinator(
-                coordinator, targets, _reqs("foo"), config=_no_build()
+                coordinator, targets, _reqs("foo"), inputs=_no_build()
             )
 
         assert result.success
@@ -3044,7 +3043,7 @@ class TestMicroBoundaryNarrowing:
                 coordinator,
                 [ResolveTarget.for_host()],
                 _reqs("foo"),
-                config=_no_build(),
+                inputs=_no_build(),
             )
 
         assert result.success
@@ -3073,13 +3072,13 @@ class TestMicroBoundaryNarrowing:
         ).expand()
 
         result = resolve_with_coordinator(
-            coordinator, targets, _reqs("foo"), config=_no_build()
+            coordinator, targets, _reqs("foo"), inputs=_no_build()
         )
 
         assert result.success
         assert self._pins_by_label(result) == {"py310-linux_x86_64": {"foo"}}
 
-        merged = build_lock_input(result, config=_no_build())
+        merged = build_lock_input(result, inputs=_no_build())
         assert [str(row) for row in merged.environments] == [
             (
                 'python_version == "3.10" and sys_platform == "linux"'
@@ -3116,7 +3115,7 @@ class TestMicroBoundaryNarrowing:
         target = ResolveTarget.for_host_python("3.11", env_source=self._linux_host_env)
 
         result = resolve_with_coordinator(
-            coordinator, [target], _reqs("foo"), config=_no_build()
+            coordinator, [target], _reqs("foo"), inputs=_no_build()
         )
 
         assert result.success
@@ -3124,7 +3123,7 @@ class TestMicroBoundaryNarrowing:
             "py311-host-pf3110": {"foo", "mid"},
             "py311-host-pf3114": {"foo"},
         }
-        rows = build_lock_input(result, config=_no_build()).environments
+        rows = build_lock_input(result, inputs=_no_build()).environments
         assert len(rows) == 2
         real_3119 = {
             "python_version": "3.11",
@@ -3153,12 +3152,12 @@ class TestMicroBoundaryNarrowing:
         ).expand()
 
         result = resolve_with_coordinator(
-            coordinator, targets, _reqs("foo"), config=_no_build()
+            coordinator, targets, _reqs("foo"), inputs=_no_build()
         )
 
         assert result.success
         assert self._pins_by_label(result) == {"py310-linux_x86_64": {"foo"}}
-        rows = build_lock_input(result, config=_no_build()).environments
+        rows = build_lock_input(result, inputs=_no_build()).environments
         assert len(rows) == 1
 
     def test_an_epoch_tagged_marker_does_not_fail_the_resolve(self) -> None:
@@ -3178,7 +3177,7 @@ class TestMicroBoundaryNarrowing:
         ).expand()
 
         result = resolve_with_coordinator(
-            coordinator, targets, _reqs("foo"), config=_no_build()
+            coordinator, targets, _reqs("foo"), inputs=_no_build()
         )
 
         assert result.success
@@ -3205,7 +3204,7 @@ class TestMicroBoundaryNarrowing:
         ).expand()
 
         result = resolve_with_coordinator(
-            self._fixpoint_coordinator(), targets, _reqs("foo"), config=_no_build()
+            self._fixpoint_coordinator(), targets, _reqs("foo"), inputs=_no_build()
         )
 
         assert result.success
@@ -3230,7 +3229,7 @@ class TestMicroBoundaryNarrowing:
                 self._fixpoint_coordinator(),
                 targets,
                 _reqs("foo"),
-                config=_no_build(),
+                inputs=_no_build(),
             )
 
     def test_divergent_slice_pins_validate_as_disjoint(self) -> None:
@@ -3256,7 +3255,7 @@ class TestMicroBoundaryNarrowing:
                 'bar==1.0 ; python_full_version < "3.10.4"',
                 'bar==2.0 ; python_full_version >= "3.10.4"',
             ),
-            config=_no_build(),
+            inputs=_no_build(),
         )
 
         assert result.success
@@ -3268,7 +3267,7 @@ class TestMicroBoundaryNarrowing:
             "py310-linux_x86_64-pf3104": "2.0",
         }
 
-        pylock = build_pylock(build_lock_input(result, config=_no_build()))
+        pylock = build_pylock(build_lock_input(result, inputs=_no_build()))
         pylock.validate()
         bars = [pkg for pkg in pylock.packages if str(pkg.name) == "bar"]
         assert len(bars) == 2
@@ -3289,7 +3288,7 @@ class TestMicroBoundaryNarrowing:
         ).expand()
 
         result = resolve_with_coordinator(
-            coordinator, targets, _reqs("foo"), config=_no_build()
+            coordinator, targets, _reqs("foo"), inputs=_no_build()
         )
 
         assert result.success
@@ -3297,7 +3296,7 @@ class TestMicroBoundaryNarrowing:
             "py310-linux_x86_64-pf3100": {"foo", "mid"},
             "py310-linux_x86_64-pf3104": {"foo"},
         }
-        rows = build_lock_input(result, config=_no_build()).environments
+        rows = build_lock_input(result, inputs=_no_build()).environments
         assert len(rows) == 2
         for micro in ("3.10.0", "3.10.3", "3.10.4", "3.10.19"):
             env = {
@@ -3365,7 +3364,7 @@ class TestMicroSliceAlignmentDirection:
             self._coordinator('python_full_version >= "3.11.4"'),
             targets,
             _reqs("foo", "bar", 'bar<2.0 ; sys_platform == "win32"'),
-            config=_no_build(),
+            inputs=_no_build(),
         )
 
         assert result.success
@@ -3391,7 +3390,7 @@ class TestMicroSliceAlignmentDirection:
             ),
             targets,
             _reqs("foo", "bar", 'bar<2.0 ; python_version == "3.11"'),
-            config=_no_build(),
+            inputs=_no_build(),
         )
 
         assert result.success
@@ -3413,7 +3412,7 @@ class TestMicroSliceAlignmentDirection:
             self._coordinator('python_full_version >= "3.11.4"'),
             targets,
             _reqs("foo", "bar", 'bar<2.0 ; python_version == "3.10"'),
-            config=_no_build(),
+            inputs=_no_build(),
         )
 
         assert result.success
@@ -3444,7 +3443,7 @@ class TestMicroSliceAlignmentDirection:
             ),
             targets,
             forks=forks,
-            config=_no_build(),
+            inputs=_no_build(),
         )
 
         assert result.success

--- a/nab-project/tests/test_seam_partition.py
+++ b/nab-project/tests/test_seam_partition.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from nab_project._build.env import _inner_resolve_config, _without_build_permission
+from nab_project._build.env import _inner_resolve_inputs, _without_build_permission
 from nab_project.config import (
     ConflictKind,
     ConflictMember,
@@ -19,7 +19,6 @@ from nab_project.config import (
     NabProjectConfig,
 )
 from nab_project.inputs import ResolveInputs
-from nab_project.resolve import _resolve_inputs
 from nab_provider.overrides import IndexOverride
 from nab_provider.policy import (
     ArchiveSource,
@@ -131,7 +130,7 @@ def _config_off_every_slot_default(tmp_path: Path) -> NabProjectConfig:
 
 def _inputs_off_every_default(tmp_path: Path) -> ResolveInputs:
     """The same settings, across the seam."""
-    return _resolve_inputs(_config_off_every_slot_default(tmp_path))
+    return _config_off_every_slot_default(tmp_path).resolve_inputs()
 
 
 class TestSeamPartition:
@@ -150,7 +149,7 @@ class TestSeamPartition:
         """
         config = _config_off_every_slot_default(tmp_path)
 
-        inputs = _resolve_inputs(config)
+        inputs = config.resolve_inputs()
 
         assert {name: getattr(inputs, name) for name in ResolveInputs.__slots__} == {
             name: getattr(config, name) for name in ResolveInputs.__slots__
@@ -171,7 +170,7 @@ class TestSeamPartition:
         """A forwarded setting arrives, less any build permission it granted."""
         outer = _inputs_off_every_default(tmp_path)
 
-        inner = _inner_resolve_config(outer)
+        inner = _inner_resolve_inputs(outer)
 
         expected = {name: getattr(outer, name) for name in _INNER_FORWARDS}
         expected["package_overrides"] = tuple(
@@ -188,7 +187,7 @@ class TestSeamPartition:
         """A pinned setting holds its fixed value whatever the outer one was."""
         outer = _inputs_off_every_default(tmp_path)
 
-        inner = _inner_resolve_config(outer)
+        inner = _inner_resolve_inputs(outer)
 
         assert {name: getattr(inner, name) for name in _INNER_PINS} == _INNER_PINNED
 
@@ -203,11 +202,10 @@ class TestSeamPartition:
         )
         assert not at_default
 
-        inner = _inner_resolve_config(outer)
+        inner = _inner_resolve_inputs(outer)
 
-        default = NabProjectConfig()
         assert {name: getattr(inner, name) for name in _INNER_DROPS} == {
-            name: getattr(default, name) for name in _INNER_DROPS
+            name: getattr(bare, name) for name in _INNER_DROPS
         }
 
 

--- a/nab-project/tests/test_value_types.py
+++ b/nab-project/tests/test_value_types.py
@@ -1,23 +1,21 @@
-"""The hand-written value types of the ``[tool.nab]`` config surface.
+"""The hand-written value types of the ``[tool.nab]`` surface.
 
-:mod:`nab_project.config`, :mod:`nab_project.config_sources` and
-:mod:`nab_project.values` write their value types against
-:class:`nab_project._value.ValueType` rather than applying
-``@dataclass(slots=True)``.  Field order, equality, hashing, repr and the
-defaults are what the rest of nab reads off them, so each one is pinned
-here instead of being left to the decorator.
+They subclass :class:`nab_project._value.ValueType` rather than applying
+``@dataclass(slots=True)``, so field order, equality, hashing, repr and the
+defaults are pinned here instead of left to the decorator.
 """
 
 from __future__ import annotations
 
 import copy
 import pickle
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, NamedTuple
 
 import pytest
 
-from nab_project import config, config_sources, values
+from nab_project import config, config_sources, conflicts, inputs, values
 from nab_project._value import ValueType
 from nab_project.config import (
     ConflictFork,
@@ -37,7 +35,21 @@ from nab_project.config_sources import (
     SourceKind,
     SourceRoots,
 )
+from nab_project.inputs import ResolveInputs
+from nab_provider._vendor.packaging.requirements import Requirement
+from nab_provider.overrides import IndexOverride, PackageOverride
+from nab_provider.policy import (
+    ArchiveSource,
+    BuildPolicy,
+    DecisionOrder,
+    DistPolicy,
+    LocalSource,
+    ResolutionStrategy,
+    VcsSource,
+)
+from nab_provider.records import IndexConfig
 from nab_provider.tags import PlatformSpec
+from nab_provider.vcs_admission import VcsConfig, VcsPolicy
 
 
 def _parse(value: Any, where: str) -> Any:
@@ -52,6 +64,13 @@ def _round_trip_pickle(instance: Any) -> Any:
     """A pickled and restored copy of ``instance``."""
     return pickle.loads(pickle.dumps(instance))  # noqa: S301
 
+
+_OVERRIDDEN_REQUIREMENT = Requirement("foo>=1")
+PACKAGE_OVERRIDE = PackageOverride(
+    requirement=_OVERRIDDEN_REQUIREMENT,
+    name="foo",
+    version_range=_OVERRIDDEN_REQUIREMENT.specifier.to_range(),
+)
 
 ORIGIN = Origin(SourceKind.PYPROJECT, "/p/pyproject.toml")
 OTHER_ORIGIN = Origin(SourceKind.USER_TOML, "/u/nab.toml")
@@ -74,14 +93,16 @@ class Case(NamedTuple):
     ``fields`` is in declaration order, which is what ``__match_args__``
     and ``__slots__`` are checked against.  ``alternates`` supplies one
     differing value per field so equality can be varied a field at a
-    time.  ``hashable`` is False where one of the field values is
-    itself unhashable.
+    time.  ``hashable`` is False where one of the field values is itself
+    unhashable, and ``positional`` False where the constructor takes
+    keywords only.
     """
 
     cls: type[ValueType]
     fields: dict[str, Any]
     alternates: dict[str, Any]
     hashable: bool = True
+    positional: bool = True
 
     @property
     def id(self) -> str:
@@ -209,6 +230,59 @@ CASES = [
         },
     ),
     Case(
+        ResolveInputs,
+        {
+            "archive_sources": (ArchiveSource("acme", "https://acme.test/a-1.zip"),),
+            "base_group": "project",
+            "build_group": "build",
+            "build_policy": BuildPolicy.BUILD_REMOTE,
+            "build_requires_depth": 1,
+            "conflicts": (ConflictSet((ConflictMember(ConflictKind.EXTRA, "cpu"),)),),
+            "constraints": ("pip<26",),
+            "decision_order": DecisionOrder.STABLE,
+            "default_groups": ("dev",),
+            "dist_policy": DistPolicy.WHEEL_ONLY,
+            "index_overrides": {
+                "private": IndexOverride(build_policy=BuildPolicy.NEVER)
+            },
+            "indexes": (IndexConfig("private", "https://private.test/simple/"),),
+            "local_sources": (LocalSource("alpha", "alpha"),),
+            # A ``PackageOverride`` holds a ``VersionRange``, which refuses to
+            # rebuild from a pickle, so the copy cases carry none.
+            "package_overrides": (),
+            "requires_python": ">=3.10",
+            "resolution": ResolutionStrategy.LOWEST,
+            "trust_unverified_sdist_deps": True,
+            "uploaded_prior_to": datetime(2026, 1, 1, tzinfo=timezone.utc),
+            "vcs": VcsConfig(policy=VcsPolicy.ALLOW),
+            "vcs_sources": (VcsSource("beta", "git+https://beta.test/beta"),),
+        },
+        {
+            "archive_sources": (ArchiveSource("acme", "https://acme.test/a-2.zip"),),
+            "base_group": "runtime",
+            "build_group": "buildreqs",
+            "build_policy": BuildPolicy.NEVER,
+            "build_requires_depth": 2,
+            "conflicts": (ConflictSet((ConflictMember(ConflictKind.GROUP, "cpu"),)),),
+            "constraints": ("pip<25",),
+            "decision_order": DecisionOrder.ARRIVAL,
+            "default_groups": ("docs",),
+            "dist_policy": DistPolicy.SDIST_ONLY,
+            "index_overrides": {"private": IndexOverride(build_policy=None)},
+            "indexes": (IndexConfig("public", "https://public.test/simple/"),),
+            "local_sources": (LocalSource("beta", "beta"),),
+            "package_overrides": (PACKAGE_OVERRIDE,),
+            "requires_python": ">=3.11",
+            "resolution": ResolutionStrategy.HIGHEST,
+            "trust_unverified_sdist_deps": False,
+            "uploaded_prior_to": None,
+            "vcs": VcsConfig(policy=VcsPolicy.BLOCK),
+            "vcs_sources": (VcsSource("beta", "git+https://beta.test/gamma"),),
+        },
+        hashable=False,
+        positional=False,
+    ),
+    Case(
         SourceRoots,
         {
             "system_toml": Path("/etc/nab.toml"),
@@ -262,10 +336,10 @@ DEFAULTS = [
 
 
 def test_the_cases_cover_every_value_type() -> None:
-    """A subclass added later and left out of ``CASES`` would go unchecked."""
+    """A subclass these modules name and ``CASES`` omits would go unchecked."""
     declared = {
         obj
-        for module in (config, config_sources, values)
+        for module in (config, config_sources, conflicts, inputs, values)
         for obj in vars(module).values()
         if isinstance(obj, type) and issubclass(obj, ValueType) and obj is not ValueType
     }
@@ -291,6 +365,11 @@ def test_instances_carry_no_dict(case: Case) -> None:
 @BY_ID
 def test_positional_construction_binds_the_declared_order(case: Case) -> None:
     """A signature binding in a different order than the field tuple shows up here."""
+    if not case.positional:
+        with pytest.raises(TypeError):
+            case.cls(*case.fields.values())
+        return
+
     assert case.cls(*case.fields.values()) == case.build()
 
 
@@ -302,7 +381,7 @@ def test_repr_names_every_field_in_order(case: Case) -> None:
 
 
 def test_repr_leads_with_the_qualified_name() -> None:
-    """All ten are module-level, so only a nested class separates the two names."""
+    """All eleven are module-level, so only a nested class separates the two names."""
 
     class Nested(ValueType):
         __slots__ = __match_args__ = ("value",)

--- a/nab-project/tests/test_vcs.py
+++ b/nab-project/tests/test_vcs.py
@@ -27,8 +27,8 @@ from nab_index.vcs import (
     prepare_clone,
 )
 from nab_project._testing.coordinator_fake import FakeFetchPort, make_coordinator
-from nab_project.config import NabProjectConfig
 from nab_project.fetch import FetchCoordinator
+from nab_project.inputs import ResolveInputs
 from nab_project.lockfile import VcsPin, build_target_lock
 from nab_provider._vendor.packaging.requirements import Requirement
 from nab_provider._vendor.packaging.version import Version
@@ -1555,7 +1555,7 @@ class TestProviderVcsIntegration:
         monkeypatch.setattr("nab_project.resolve.resolve_for_targets", _boom)
 
         provider = Provider(
-            make_coordinator(build_config=NabProjectConfig(), offline=True),
+            make_coordinator(build_config=ResolveInputs(), offline=True),
             vcs_config=VcsConfig(
                 policy=VcsPolicy.ALLOW,
                 allowed_schemes=frozenset({"git+https"}),

--- a/nab-project/tests/universal/test_external_scenarios.py
+++ b/nab-project/tests/universal/test_external_scenarios.py
@@ -2,12 +2,10 @@
 
 from __future__ import annotations
 
-from dataclasses import replace
-
 from nab_index.client import WheelFile
 from nab_project._testing.coordinator_fake import make_coordinator
 from nab_project.build_policy import enforce_build_policy_for_targets
-from nab_project.config import NabProjectConfig
+from nab_project.inputs import ResolveInputs
 from nab_project.lockfile import build_pylock
 from nab_project.resolve import build_lock_input, resolve_with_coordinator
 from nab_provider._vendor.packaging.pylock import Package, Pylock
@@ -118,13 +116,13 @@ def test_overlapping_root_markers_cover_each_python_partition() -> None:
         Requirement("a>=1.1.0; python_version >= '3.13'"),
         Requirement("a>=1.2.0; python_version >= '3.14'"),
     ]
-    config = NabProjectConfig(requires_python=python)
+    inputs = ResolveInputs(requires_python=python)
 
     result = resolve_with_coordinator(
         coordinator,
         targets,
         requirements,
-        config=config,
+        inputs=inputs,
     )
 
     assert result.success
@@ -137,7 +135,7 @@ def test_overlapping_root_markers_cover_each_python_partition() -> None:
         "py314-linux_x86_64": {"a": Version("1.2.0")},
     }
 
-    pylock = build_pylock(build_lock_input(result, config=config))
+    pylock = build_pylock(build_lock_input(result, inputs=inputs))
     pylock.validate()
     assert len(pylock.environments) == len(targets) == 3
     for target in targets:
@@ -190,13 +188,13 @@ def test_transitive_prerelease_admission_stays_in_its_fork() -> None:
             PlatformSpec("windows_amd64"),
         ),
     ).expand()
-    config = NabProjectConfig(requires_python=project_python)
+    inputs = ResolveInputs(requires_python=project_python)
 
     result = resolve_with_coordinator(
         coordinator,
         targets,
         [Requirement("a")],
-        config=config,
+        inputs=inputs,
     )
 
     assert result.success
@@ -214,7 +212,7 @@ def test_transitive_prerelease_admission_stays_in_its_fork() -> None:
         },
     }
 
-    pylock = build_pylock(build_lock_input(result, config=config))
+    pylock = build_pylock(build_lock_input(result, inputs=inputs))
     pylock.validate()
     assert len(pylock.environments) == len(targets) == 2
     for target in targets:
@@ -280,7 +278,7 @@ def test_conditional_dependency_stays_in_its_package_fork() -> None:
             PlatformSpec("macos_arm64"),
         ),
     ).expand()
-    config = NabProjectConfig(requires_python=project_python)
+    inputs = ResolveInputs(requires_python=project_python)
 
     result = resolve_with_coordinator(
         coordinator,
@@ -289,7 +287,7 @@ def test_conditional_dependency_stays_in_its_package_fork() -> None:
             Requirement("a>=2 ; sys_platform == 'linux'"),
             Requirement("a<2 ; sys_platform == 'darwin'"),
         ],
-        config=config,
+        inputs=inputs,
     )
 
     assert result.success
@@ -304,7 +302,7 @@ def test_conditional_dependency_stays_in_its_package_fork() -> None:
         "py312-macos_arm64": {"a": Version("1.0.0")},
     }
 
-    pylock = build_pylock(build_lock_input(result, config=config))
+    pylock = build_pylock(build_lock_input(result, inputs=inputs))
     pylock.validate()
     assert len(pylock.environments) == len(targets) == 2
     for target in targets:
@@ -361,22 +359,22 @@ def test_platform_marked_root_keeps_its_compatible_wheel() -> None:
         ),
     ).expand()
     root = Requirement("win-only ; sys_platform == 'win32'")
-    config = NabProjectConfig(requires_python=project_python)
+    inputs = ResolveInputs(requires_python=project_python)
     build_policy = enforce_build_policy_for_targets(
         targets=targets,
-        build_policy=config.build_policy,
+        build_policy=inputs.build_policy,
         build_policy_set=False,
-        package_overrides=config.package_overrides,
-        index_overrides=config.index_overrides,
+        package_overrides=inputs.package_overrides,
+        index_overrides=inputs.index_overrides,
     )
     assert build_policy is BuildPolicy.NEVER
-    config = replace(config, build_policy=build_policy)
+    inputs = inputs.replace(build_policy=build_policy)
 
     result = resolve_with_coordinator(
         coordinator,
         targets,
         [root],
-        config=config,
+        inputs=inputs,
     )
 
     assert result.success
@@ -404,7 +402,7 @@ def test_platform_marked_root_keeps_its_compatible_wheel() -> None:
         for target_result in result.target_results
     )
 
-    pylock = build_pylock(build_lock_input(result, config=config))
+    pylock = build_pylock(build_lock_input(result, inputs=inputs))
     pylock.validate()
     assert pylock.requires_python is not None
     assert str(pylock.requires_python) == project_python
@@ -482,7 +480,7 @@ def test_platform_and_implementation_forks_keep_transitive_dependencies() -> Non
         ),
         implementations=("cpython", "pypy"),
     ).expand()
-    config = NabProjectConfig(requires_python=python)
+    inputs = ResolveInputs(requires_python=python)
 
     result = resolve_with_coordinator(
         coordinator,
@@ -491,7 +489,7 @@ def test_platform_and_implementation_forks_keep_transitive_dependencies() -> Non
             Requirement("a>=2 ; sys_platform == 'linux'"),
             Requirement("a<2 ; sys_platform == 'darwin'"),
         ],
-        config=config,
+        inputs=inputs,
     )
 
     assert result.success
@@ -512,7 +510,7 @@ def test_platform_and_implementation_forks_keep_transitive_dependencies() -> Non
         },
     }
 
-    pylock = build_pylock(build_lock_input(result, config=config))
+    pylock = build_pylock(build_lock_input(result, inputs=inputs))
     pylock.validate()
     assert pylock.environments is not None
     assert len(pylock.environments) == len(targets) == 4

--- a/src/nab/_download.py
+++ b/src/nab/_download.py
@@ -145,7 +145,7 @@ def download(  # noqa: PLR0913 - one keyword per flag is the public surface
     )
     lock_input = build_lock_input(
         result,
-        config=config,
+        inputs=config.resolve_inputs(),
         extras=selected_extras,
         dependency_groups=selected_groups,
     )

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -67,7 +67,7 @@ from nab_project.pyproject_files import (
 from nab_project.resolve import (
     active_group_names,
     build_lock_input,
-    config_for_build_requirements,
+    inputs_for_build_requirements,
 )
 from nab_provider.requirements_file import (
     InvalidProjectRequirementError,
@@ -111,6 +111,7 @@ from .output import ProgressReporter, printer
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Mapping, Sequence
 
+    from nab_project.inputs import ResolveInputs
     from nab_provider.target import ResolveTarget
 
 
@@ -278,8 +279,9 @@ def lock(  # noqa: PLR0913 - one keyword per flag is the public surface
         anchor=anchor,
         cli_overrides=project_overrides,
     )
+    inputs = config.resolve_inputs()
     if build_requirements:
-        config = config_for_build_requirements(config)
+        inputs = inputs_for_build_requirements(inputs)
     if locked and config.mode is ResolveMode.UNIVERSAL:
         printer().error("--locked is not supported in universal mode.")
         sys.exit(1)
@@ -324,7 +326,9 @@ def lock(  # noqa: PLR0913 - one keyword per flag is the public surface
     )
 
     if locked:
-        _fast_fail_locked(run, config=config, workspace_to_drop=workspace_to_drop)
+        _fast_fail_locked(
+            run, config=config, inputs=inputs, workspace_to_drop=workspace_to_drop
+        )
 
     transport = _make_resolve_transport(settings.http_backend, offline=settings.offline)
     result = _resolve(
@@ -345,7 +349,7 @@ def lock(  # noqa: PLR0913 - one keyword per flag is the public surface
     lock_input = drop_workspace_pins(
         build_lock_input(
             result,
-            config=config,
+            inputs=inputs,
             extras=selected_extras,
             dependency_groups=selected_groups,
         ),
@@ -440,7 +444,7 @@ def _refuse_group_selection_with_build_requirements(
     Refusing is what keeps the flags honest.  ``--project-default-group``,
     ``--project-base-group`` and ``--project-build-group`` would otherwise
     be dropped by
-    :func:`~nab_project.resolve.config_for_build_requirements` after the run had
+    :func:`~nab_project.resolve.inputs_for_build_requirements` after the run had
     already printed a reproducibility notice and recorded them in the lock,
     claiming an override that changed nothing.
     """
@@ -559,6 +563,7 @@ def _fast_fail_locked(
     run: _LockRun,
     *,
     config: NabProjectConfig,
+    inputs: ResolveInputs,
     workspace_to_drop: frozenset[str],
 ) -> None:
     """Fast-fail ``nab lock --locked`` before any resolve when a mismatch is proven.
@@ -566,6 +571,10 @@ def _fast_fail_locked(
     Reads and parses the committed lock, then runs the envelope and validity
     checks.  On the first disqualification it prints the reason and exits
     non-zero; otherwise it returns and the full resolve runs.
+
+    ``config`` says which environment the checks evaluate markers against
+    and ``inputs`` carries the settings the lock records, already narrowed
+    for a build-requirements run.
 
     ``--python`` is applied first so a rejected value reports as the flag
     error: reporting a stale lock instead would point at a refresh command
@@ -584,10 +593,10 @@ def _fast_fail_locked(
             run.path,
             extras=run.extras,
             groups=run.groups,
-            default_groups=config.default_groups,
-            base_group=config.base_group,
+            default_groups=inputs.default_groups,
+            base_group=inputs.base_group,
             build_requirements=run.build_requirements,
-            build_group=config.build_group,
+            build_group=inputs.build_group,
         )
     except (
         InvalidProjectTableError,
@@ -610,14 +619,14 @@ def _fast_fail_locked(
     try:
         disqualification = check_locked(
             target,
-            requires_python=config.requires_python,
+            requires_python=inputs.requires_python,
             extras=run.extras,
             dependency_groups=run.groups,
-            default_groups=config.default_groups,
-            base_group=config.base_group,
-            build_group=config.build_group,
+            default_groups=inputs.default_groups,
+            base_group=inputs.base_group,
+            build_group=inputs.build_group,
             roots=roots,
-            constraints=config.constraints,
+            constraints=inputs.constraints,
             resolve_target=resolve_target,
             exclude=workspace_to_drop,
         )

--- a/src/nab/_resolve.py
+++ b/src/nab/_resolve.py
@@ -21,6 +21,7 @@ from nab_project.config import (
     ConfigError,
     NabProjectConfig,
     ResolveMode,
+    plan_targets,
     read_pyproject_config,
     with_python_override,
 )
@@ -319,11 +320,13 @@ def _resolve(  # noqa: PLR0913, PLR0912, C901 - one wrapper per resolve_for_targ
     config = _python_override_or_exit(config, python)
     try:
         try:
+            targets = plan_targets(config)
             with _collector_paused():
                 result = resolve_for_targets(
                     path,
                     transport,
-                    config=config,
+                    targets=targets,
+                    inputs=config.resolve_inputs(),
                     cache_dir=cache_dir,
                     offline=offline,
                     groups=groups,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2144,8 +2144,9 @@ class TestPythonFlag:
             "nab._resolve.resolve_for_targets", return_value=_stub_resolve_result()
         ) as mock_resolve:
             lock(pyproject, output=out, python="3.11")
-        config = mock_resolve.call_args.kwargs["config"]
-        assert config.environment.python == "3.11"
+
+        (target,) = mock_resolve.call_args.kwargs["targets"]
+        assert target.python_version == "3.11"
 
     def test_absent_flag_leaves_the_host_target(self, tmp_path: Path) -> None:
         pyproject = _make_pyproject(tmp_path)
@@ -2154,7 +2155,8 @@ class TestPythonFlag:
             "nab._resolve.resolve_for_targets", return_value=_stub_resolve_result()
         ) as mock_resolve:
             lock(pyproject, output=out)
-        assert mock_resolve.call_args.kwargs["config"].environment is None
+
+        assert mock_resolve.call_args.kwargs["targets"] == (ResolveTarget.for_host(),)
 
     def test_invalid_value_is_a_flag_error(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -2209,8 +2211,9 @@ class TestPythonFlag:
             ),
         ):
             download(pyproject, output=out, python="3.11")
-        config = mock_resolve.call_args.kwargs["config"]
-        assert config.environment.python == "3.11"
+
+        (target,) = mock_resolve.call_args.kwargs["targets"]
+        assert target.python_version == "3.11"
 
     def test_retargets_a_free_threaded_platform_onto_a_new_python(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -2235,7 +2238,9 @@ class TestPythonFlag:
             "nab._resolve.resolve_for_targets", return_value=_stub_resolve_result()
         ) as mock_resolve:
             lock(pyproject, output=out, python="3.14")
-        assert mock_resolve.call_args.kwargs["config"].environment.python == "3.14"
+
+        (target,) = mock_resolve.call_args.kwargs["targets"]
+        assert target.python_version == "3.14"
 
     def test_download_rejects_it_in_universal_mode(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -2339,13 +2344,15 @@ class TestProjectFlagErrors:
         assert "error: --project-build-group:" in capsys.readouterr().err
 
     def test_valid_override_threads_through(self, tmp_path: Path) -> None:
+        """The value has to admit the host: the run plans its target first."""
         pyproject = _make_pyproject(tmp_path)
         out = tmp_path / "pylock.toml"
         with patch(
             "nab._resolve.resolve_for_targets", return_value=_stub_resolve_result()
         ) as mock_resolve:
-            lock(pyproject, output=out, project_requires_python="==3.11")
-        assert mock_resolve.call_args.kwargs["config"].requires_python == "==3.11"
+            lock(pyproject, output=out, project_requires_python=">=3.10")
+
+        assert mock_resolve.call_args.kwargs["inputs"].requires_python == ">=3.10"
 
     def test_bad_file_value_still_reads_as_a_table_error(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -4375,7 +4382,7 @@ class TestLockAnchorReuse:
         ) as mock_resolve:
             lock(pyproject, output=prior, upgrade=upgrade)
 
-        cutoff = mock_resolve.call_args.kwargs["config"].uploaded_prior_to
+        cutoff = mock_resolve.call_args.kwargs["inputs"].uploaded_prior_to
         assert isinstance(cutoff, datetime)
         return cutoff
 

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -36,7 +36,6 @@ from nab._download import download
 from nab._lock import lock
 from nab._run import effective_config
 from nab.cli import run
-from nab_project.config import NabProjectConfig
 from nab_project.config_sources import (
     OPTIONS,
     OptionSpec,
@@ -45,6 +44,7 @@ from nab_project.config_sources import (
     SourceRoots,
 )
 from nab_project.download import DownloadResult
+from nab_project.inputs import ResolveInputs
 from nab_project.lockfile import (
     IndexPin,
     SdistArtifact,
@@ -59,7 +59,6 @@ from nab_provider.provider import (
     DecisionOrder,
     DistPolicy,
     ResolutionStrategy,
-    ResolveMode,
 )
 from nab_provider.target import ResolveTarget
 
@@ -100,7 +99,9 @@ _DOWNLOAD_PROJECT_ARGV: tuple[tuple[str, str], ...] = (
     ("--project-default-group", "dev"),
     ("--project-base-group", "main-deps"),
     ("--project-build-group", "build-reqs"),
-    ("--project-requires-python", ">=3.11"),
+    # >=3.10, not >=3.11: the host plans the targets now, so a floor above
+    # the running interpreter fails the run before the assertions.
+    ("--project-requires-python", ">=3.10"),
     ("--project-uploaded-prior-to", "2024-06-01T00:00:00Z"),
     ("--project-dist-policy", "sdist-only"),
     ("--project-build-policy", "never"),
@@ -1059,9 +1060,10 @@ class TestNoOpLock:
 class TestProjectCliOverrides:
     """``--project-*`` overrides flow through ``nab lock`` into the resolve."""
 
-    def _lock_config(
+    def _lock_call(
         self, proj: Path, out: Path, extra: list[str]
-    ) -> tuple[NabProjectConfig, Path]:
+    ) -> Mapping[str, object]:
+        """The keywords this ``nab lock`` argv hands ``resolve_for_targets``."""
         with (
             patch(
                 "nab._resolve.resolve_for_targets", return_value=_stub_resolve_result()
@@ -1069,17 +1071,22 @@ class TestProjectCliOverrides:
             patch("nab._lock.write_lock"),
         ):
             _cli("lock", str(proj), "--no-cache", "--output", str(out), *extra)
-        call = mock_resolve.call_args
-        return call.kwargs["config"], call.args[0]
+        return mock_resolve.call_args.kwargs
+
+    def _lock_inputs(self, proj: Path, out: Path, extra: list[str]) -> ResolveInputs:
+        """The settings that argv hands the resolve."""
+        inputs = self._lock_call(proj, out, extra)["inputs"]
+        assert isinstance(inputs, ResolveInputs)
+        return inputs
 
     def test_project_dist_policy_reaches_resolve(self, hermetic_roots: Path) -> None:
         proj = _project(hermetic_roots)
-        config, _ = self._lock_config(
+        inputs = self._lock_inputs(
             proj,
             hermetic_roots / "pylock.toml",
             ["--project-dist-policy", "sdist-only"],
         )
-        assert config.dist_policy is DistPolicy.SDIST_ONLY
+        assert inputs.dist_policy is DistPolicy.SDIST_ONLY
 
     def test_project_dist_policy_override_replaces_trust(
         self, hermetic_roots: Path
@@ -1091,36 +1098,36 @@ class TestProjectCliOverrides:
             'dist-policy = { policy = "wheel-or-sdist",'
             " trust-unverified-deps = true }\n",
         )
-        config, _ = self._lock_config(
+        inputs = self._lock_inputs(
             proj,
             hermetic_roots / "pylock.toml",
             ["--project-dist-policy", "sdist-only"],
         )
-        assert config.dist_policy is DistPolicy.SDIST_ONLY
-        assert config.trust_unverified_sdist_deps is False
+        assert inputs.dist_policy is DistPolicy.SDIST_ONLY
+        assert inputs.trust_unverified_sdist_deps is False
 
     def test_project_build_requires_depth_reaches_resolve(
         self, hermetic_roots: Path
     ) -> None:
         # The file declares 1, so a resolve seeing 3 read it off the flag.
         proj = _project(hermetic_roots, "build-requires-depth = 1\n")
-        config, _ = self._lock_config(
+        inputs = self._lock_inputs(
             proj,
             hermetic_roots / "pylock.toml",
             ["--project-build-requires-depth", "3"],
         )
-        assert config.build_requires_depth == 3
+        assert inputs.build_requires_depth == 3
 
     def test_project_build_policy_reaches_resolve(self, hermetic_roots: Path) -> None:
         # The file declares build-remote, so a resolve seeing never read it
         # off the flag.
         proj = _project(hermetic_roots, 'build-policy = "build-remote"\n')
-        config, _ = self._lock_config(
+        inputs = self._lock_inputs(
             proj,
             hermetic_roots / "pylock.toml",
             ["--project-build-policy", "never"],
         )
-        assert config.build_policy is BuildPolicy.NEVER
+        assert inputs.build_policy is BuildPolicy.NEVER
 
     def test_project_mode_specific_takes_one_lock_from_a_matrix(
         self, hermetic_roots: Path
@@ -1129,15 +1136,14 @@ class TestProjectCliOverrides:
         # --project-mode outranks [tool.nab], so the declared matrix does
         # not apply and --python names the environment to resolve for.
         proj = _project(hermetic_roots, _UNIVERSAL_TOOL_NAB)
-        config, _ = self._lock_config(
+        call = self._lock_call(
             proj,
             hermetic_roots / "pylock.toml",
             ["--project-mode", "specific", "--python", "3.13"],
         )
-        assert config.mode is ResolveMode.SPECIFIC
-        assert config.matrix is None
-        assert config.environment is not None
-        assert config.environment.python == "3.13"
+
+        (target,) = call["targets"]
+        assert target.python_version == "3.13"
 
     def test_project_mode_universal_needs_a_declared_matrix(
         self, hermetic_roots: Path, capsys: pytest.CaptureFixture[str]
@@ -1165,12 +1171,12 @@ class TestProjectCliOverrides:
     def test_project_decision_order_reaches_resolve(self, hermetic_roots: Path) -> None:
         # The file declares stable, so a resolve seeing arrival read the flag.
         proj = _project(hermetic_roots, 'decision-order = "stable"\n')
-        config, _ = self._lock_config(
+        inputs = self._lock_inputs(
             proj,
             hermetic_roots / "pylock.toml",
             ["--project-decision-order", "arrival"],
         )
-        assert config.decision_order is DecisionOrder.ARRIVAL
+        assert inputs.decision_order is DecisionOrder.ARRIVAL
 
     def test_project_constraint_repeats_replace_the_file_list(
         self, hermetic_roots: Path
@@ -1178,12 +1184,12 @@ class TestProjectCliOverrides:
         # Repeats accumulate into the flag's own value, which then replaces
         # the declared list rather than extending it.
         proj = _project(hermetic_roots, 'constraints = ["a<1"]\n')
-        config, _ = self._lock_config(
+        inputs = self._lock_inputs(
             proj,
             hermetic_roots / "pylock.toml",
             ["--project-constraint", "b<2", "--project-constraint", "c<3"],
         )
-        assert config.constraints == ("b<2", "c<3")
+        assert inputs.constraints == ("b<2", "c<3")
 
     def test_append_flag_does_not_swallow_positional_path(
         self, hermetic_roots: Path
@@ -1210,13 +1216,13 @@ class TestProjectCliOverrides:
             )
         call = mock_resolve.call_args
         assert call.args[0] == proj
-        assert call.kwargs["config"].constraints == ("a<1", "b<2")
+        assert call.kwargs["inputs"].constraints == ("a<1", "b<2")
 
     def test_project_override_prints_reproducibility_notice(
         self, hermetic_roots: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
         proj = _project(hermetic_roots)
-        self._lock_config(
+        self._lock_inputs(
             proj,
             hermetic_roots / "pylock.toml",
             ["--project-dist-policy", "sdist-only"],
@@ -1244,7 +1250,7 @@ class TestProjectCliOverrides:
                 "2024-06-01T00:00:00Z",
             )
         expected = datetime(2024, 6, 1, tzinfo=timezone.utc)
-        assert mock_resolve.call_args.kwargs["config"].uploaded_prior_to == expected
+        assert mock_resolve.call_args.kwargs["inputs"].uploaded_prior_to == expected
         assert read_lockfile_anchor(out) == expected
         assert "--project-uploaded-prior-to -> 2024-06-01" in capsys.readouterr().err
 
@@ -1355,11 +1361,11 @@ class TestDownloadCliOverrides:
             _cli("download", str(proj), "--output", str(proj.parent / "out"), *extra)
         return mock_resolve.call_args.kwargs
 
-    def _config(self, proj: Path, extra: list[str]) -> NabProjectConfig:
-        """The merged config the resolve reads for this argv."""
-        config = self._resolve_kwargs(proj, extra)["config"]
-        assert isinstance(config, NabProjectConfig)
-        return config
+    def _inputs(self, proj: Path, extra: list[str]) -> ResolveInputs:
+        """The merged settings the resolve reads for this argv."""
+        inputs = self._resolve_kwargs(proj, extra)["inputs"]
+        assert isinstance(inputs, ResolveInputs)
+        return inputs
 
     def test_project_overrides_reach_the_config(self, hermetic_roots: Path) -> None:
         # The file declares something other than each flag's value, so a value
@@ -1382,26 +1388,26 @@ class TestDownloadCliOverrides:
         kwargs = self._resolve_kwargs(
             proj, [arg for pair in _DOWNLOAD_PROJECT_ARGV for arg in pair]
         )
-        config = kwargs["config"]
-        assert isinstance(config, NabProjectConfig)
+        inputs = kwargs["inputs"]
+        assert isinstance(inputs, ResolveInputs)
 
         # --project-resolution keeps its own path into the resolver, so it is
         # the one flag here that does not land in the merged config.
         assert kwargs["resolution_strategy"] is ResolutionStrategy.LOWEST
-        assert config.decision_order is DecisionOrder.ARRIVAL
+        assert inputs.decision_order is DecisionOrder.ARRIVAL
 
         # Repeated --project-constraint accumulates, then replaces the list.
-        assert config.constraints == ("b<2", "c<3")
-        assert config.default_groups == ("dev",)
-        assert config.base_group == "main-deps"
-        assert config.build_group == "build-reqs"
+        assert inputs.constraints == ("b<2", "c<3")
+        assert inputs.default_groups == ("dev",)
+        assert inputs.base_group == "main-deps"
+        assert inputs.build_group == "build-reqs"
 
-        assert config.requires_python == ">=3.11"
-        assert config.uploaded_prior_to == datetime(2024, 6, 1, tzinfo=timezone.utc)
+        assert inputs.requires_python == ">=3.10"
+        assert inputs.uploaded_prior_to == datetime(2024, 6, 1, tzinfo=timezone.utc)
 
-        assert config.dist_policy is DistPolicy.SDIST_ONLY
-        assert config.build_policy is BuildPolicy.NEVER
-        assert config.build_requires_depth == 3
+        assert inputs.dist_policy is DistPolicy.SDIST_ONLY
+        assert inputs.build_policy is BuildPolicy.NEVER
+        assert inputs.build_requires_depth == 3
 
     def test_every_project_flag_has_a_case(self) -> None:
         exercised = {flag for flag, _ in _DOWNLOAD_PROJECT_ARGV} | {"--project-mode"}
@@ -1417,11 +1423,12 @@ class TestDownloadCliOverrides:
         # Same as the lock path: --project-mode specific shadows the declared
         # matrix, and --python names the environment to download for.
         proj = _project(hermetic_roots, _UNIVERSAL_TOOL_NAB)
-        config = self._config(proj, ["--project-mode", "specific", "--python", "3.13"])
-        assert config.mode is ResolveMode.SPECIFIC
-        assert config.matrix is None
-        assert config.environment is not None
-        assert config.environment.python == "3.13"
+        kwargs = self._resolve_kwargs(
+            proj, ["--project-mode", "specific", "--python", "3.13"]
+        )
+
+        (target,) = kwargs["targets"]
+        assert target.python_version == "3.13"
 
     def test_cache_dir_flag_reaches_the_resolve(self, hermetic_roots: Path) -> None:
         proj = _project(hermetic_roots)
@@ -1445,9 +1452,6 @@ class TestDownloadCliOverrides:
             hermetic_roots / "alpha" / "pyproject.toml",
             '[project]\nname = "alpha"\nversion = "0"\ndependencies = []\n',
         )
-        assert self._config(proj, []).workspace_member_names == frozenset({"alpha"})
+        assert [s.name for s in self._inputs(proj, []).local_sources] == ["alpha"]
 
-        assert (
-            self._config(proj, ["--no-workspace-discovery"]).workspace_member_names
-            == frozenset()
-        )
+        assert self._inputs(proj, ["--no-workspace-discovery"]).local_sources == ()

--- a/tests/test_lock_locked.py
+++ b/tests/test_lock_locked.py
@@ -298,6 +298,39 @@ def test_a_renamed_build_group_is_out_of_date(
     mock.assert_not_called()
 
 
+def test_a_build_requirements_lock_ignores_the_project_group_names(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A build lock records no group names, so the checks must read none.
+
+    A check reading ``base-group``, ``build-group`` or ``default-groups`` off
+    the project would call every build lock stale for omitting them.
+    """
+    pyproject = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "proj"\nversion = "0.1"\ndependencies = ["bar"]\n'
+        '[build-system]\nrequires = ["foo"]\n'
+        "[dependency-groups]\n"
+        'dev = ["bb"]\n'
+        "[tool.nab]\n"
+        'base-group = "base"\n'
+        'build-group = "build"\n'
+        'default-groups = ["dev"]\n',
+    )
+    out = tmp_path / "pylock.build.toml"
+    _write_lock(pyproject, out, _result({"foo": "1.0"}), "--build-requirements")
+    capsys.readouterr()
+    written = tomli.loads(out.read_text())
+    assert "default-groups" not in written
+    assert "dependency-groups" not in written
+
+    mock = _locked_mock(_result({"foo": "1.0"}))
+    _run_locked(pyproject, out, mock, "--build-requirements")
+
+    assert f"Lockfile {out} is up to date." in capsys.readouterr().err
+    mock.assert_called_once()
+
+
 def test_tightened_constraint_fires_without_resolving(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -707,23 +740,27 @@ def test_unreadable_requirement_falls_through(
     mock.assert_called_once()
 
 
-def test_requires_python_excludes_host_falls_through(
+def test_requires_python_excludes_host_reports_the_declaration_not_staleness(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    # requires-python that excludes the host cannot build a target, so
-    # validity is skipped and the resolve runs.
+    # A requires-python excluding the host skips the validity check, so the run
+    # fails on the declaration rather than reporting a stale lock; the lock is
+    # written under a --python the declaration admits.
     pyproject = _write_pyproject(
         tmp_path,
         '[project]\ndependencies = ["foo"]\n[tool.nab]\nrequires-python = ">=99"\n',
     )
     out = tmp_path / "pylock.toml"
-    _write_lock(pyproject, out, _result({"foo": "1.0"}))
+    _write_lock(pyproject, out, _result({"foo": "1.0"}), "--python", "99.0")
     capsys.readouterr()
 
     mock = _locked_mock(_result({"foo": "1.0"}))
-    _run_locked(pyproject, out, mock)
+    _run_locked(pyproject, out, mock, status=1)
 
-    mock.assert_called_once()
+    err = capsys.readouterr().err
+    assert "excludes the resolve target" in err
+    assert "out of date" not in err
+    mock.assert_not_called()
 
 
 def test_dropped_workspace_member_direct_dep_falls_through(


### PR DESCRIPTION
`nab_project.resolve.resolve_for_targets` now takes `targets` and `inputs` instead of the host's `NabProjectConfig`, which carried `workspace`, `matrix`, `mode` and `environment` that no resolve reads. It no longer reads the config out of the pyproject, and no longer plans its own targets.

`nab` plans the targets with `plan_targets` and passes the new `NabProjectConfig.resolve_inputs()`. The same swap runs through `resolve_with_coordinator`, `build_lock_input`, `materialize_source`, `extract_metadata` and the `_build` runners, so `NabProjectConfig` is left in nab-project's source only in `config.py`.

For callers:

- `config=` becomes `targets=` and `inputs=`, and `targets` is required.
- With no `inputs`, the resolve runs on bare `ResolveInputs` defaults instead of the project's own settings.
- `python_version` is gone; apply `with_python_override` before planning.
- `config_for_build_requirements` is now `inputs_for_build_requirements`.
