### PR TITLE
Read the skipped NAB_* names off nab.env, not a caller's handshake

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -141,10 +141,12 @@ actions:
 * `nab config list` prints every option with its value, scope, and
   the source it came from.
 * `nab config get <key>` prints one effective value.
-* `nab config explain <key>` prints the full source stack for one key.
-  The winning row carries a `>` gutter and the status `winner`, and
-  every source it beats is `shadowed`. A shadowed source contributes
-  nothing to the value, whatever the key's type.
+* `nab config explain <key>` prints a header naming the key, its scope
+  and its type, then the option's own help line and the page in `docs/`
+  that documents it, then the full source stack. The winning row carries
+  a `>` gutter and the status `winner`, and every source it beats is
+  `shadowed`. A shadowed source contributes nothing to the value,
+  whatever the key's type.
 
 `--include-rejected` is a flag on `nab config` itself, so every action
 takes it. Without it, a config file that sets an unknown key or a key

--- a/src/nab/_run.py
+++ b/src/nab/_run.py
@@ -40,7 +40,7 @@ from .config.ladder import (
     resolve_config,
 )
 from .config.values import SourceConfigError
-from .output import OUTPUT_ENV_VARS, printer
+from .output import printer
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -128,9 +128,7 @@ def effective_config(
     # values (the resolve path uses its lockfile anchor instead).
     with inspector_anchor():
         layers = discover_layers(roots, rejections=sink, read_pyproject=read_pyproject)
-        env_layer = read_env_layer(
-            env.current(), reserved_env=OUTPUT_ENV_VARS, rejections=sink
-        )
+        env_layer = read_env_layer(rejections=sink)
         cli_layer = build_cli_layer(cli_overrides or {})
         if rejected_out is not None:
             rejected_out.extend(rejected)

--- a/src/nab/config/ladder.py
+++ b/src/nab/config/ladder.py
@@ -19,10 +19,10 @@ readers is for.
 
 The renderers close the loop.  ``list`` prints every row with the value that
 won and where it came from, ``get`` prints one row's value alone, and
-``explain`` prints one row's whole stack with the winner marked.  All three
-read what :func:`resolve_config` returns, so what is printed is what the run
-would use, and a rejected source reaches them only as a
-:class:`RejectedLayer`.
+``explain`` prints one row's help, the page documenting it and its whole
+stack, with the winner marked.  All three read what :func:`resolve_config`
+returns, so what is printed is what the run would use, and a rejected source
+reaches them only as a :class:`RejectedLayer`.
 """
 
 from __future__ import annotations
@@ -63,6 +63,7 @@ __all__ = [
     "build_cli_overrides",
     "config_search_roots",
     "discover_layers",
+    "docs_path",
     "orphan_rejections",
     "project_cli_override_notice",
     "project_cli_override_records",
@@ -712,10 +713,18 @@ def build_cli_layer(values: Mapping[str, Any]) -> Layer:
     unset flag is omitted, so it does not shadow lower layers).  Each
     value is normalised through its registry row so the effective value
     carries the typed form regardless of how the flag was spelled.
+
+    A row that declares no command (``commands`` is empty) is set from a
+    file alone, so a value for one is the caller's mistake and raises
+    ``ValueError`` rather than the user-facing ``SourceConfigError``.
     """
     parsed: dict[str, Any] = {}
     for key, value in values.items():
         spec = BY_KEY[key]
+        if not spec.commands:
+            msg = f"{key} takes no command line, so no CLI layer can set it"
+            raise ValueError(msg)
+
         # A repeatable flag arrives as a tuple; the parse hooks expect a
         # TOML list, so normalise it here.
         raw = list(value) if isinstance(value, tuple) else value
@@ -799,15 +808,21 @@ def render_explain(
     *,
     include_rejected: bool = False,
 ) -> str:
-    """Render the full shadowed stack for ``key``.
+    """Render the row's help, its documentation page and its shadowed stack.
 
-    The highest source is the ``winner`` and carries a ``>`` gutter;
-    every source it beats is ``shadowed``.  With ``include_rejected`` the
+    The header names the key, its scope and its type; under it come the
+    row's own help line and the page that documents it.  The highest
+    source is the ``winner`` and carries a ``>`` gutter; every source it
+    beats is ``shadowed``.  With ``include_rejected`` the
     category-rejected sources (a source that tried to set ``key`` but was
     not allowed) are listed too, labelled ``rejected``.
     """
     ev = _require_key(effective, key)
-    lines = [f"{key} ({ev.spec.scope_name}, {_type_label(ev.spec)})"]
+    lines = [
+        f"{key} ({ev.spec.scope_name}, {_type_label(ev.spec)})",
+        f"  {ev.spec.help}",
+        f"  see {docs_path(ev.spec)}",
+    ]
     winner_index = len(ev.stack) - 1
     for i, (origin, value) in enumerate(ev.stack):
         gutter = ">" if i == winner_index else " "
@@ -824,6 +839,15 @@ def render_explain(
             for rej in ev.rejected
         )
     return "\n".join(lines) + "\n"
+
+
+def docs_path(row: Opt) -> str:
+    """Return the page ``row`` names, as a path from the repository root.
+
+    Shared with the generator's page check, so the string ``explain``
+    prints and the string that gets checked cannot differ.
+    """
+    return f"docs/{row.docs}"
 
 
 def _type_label(row: Opt) -> str:

--- a/src/nab/config/ladder.py
+++ b/src/nab/config/ladder.py
@@ -418,26 +418,27 @@ def _read_raw_table(path: Path, kind: SourceKind) -> Mapping[str, Any]:
 
 
 def read_env_layer(
-    environ: Mapping[str, str],
+    environ: Mapping[str, str] | None = None,
     *,
-    reserved_env: Iterable[str] = (),
     rejections: list[RejectedLayer] | None = None,
 ) -> Layer:
     """Read ``NAB_*`` for every registry row that declares an env var.
 
-    PROJECT options never declare an env var, so the env layer carries
-    USER options only.  A ``NAB_<KEY>`` naming a PROJECT option (e.g.
-    ``NAB_RESOLUTION``) draws a warning from :func:`_warn_renamed_env`;
-    any other unknown ``NAB_*`` name (e.g. a typo) one from
-    :func:`_warn_unknown_env`.  Neither is applied, and neither is fatal.
-    ``reserved_env`` names the ``NAB_*`` vars other layers own (nab's
-    output layer consumes ``NAB_VERBOSITY`` and ``NAB_NO_PROGRESS``), so
-    the guard skips them silently.  When ``rejections`` is supplied
-    (``nab config --include-rejected``) those env casualties are recorded
-    there instead of warned, mirroring the TOML loader.
+    ``environ`` defaults to the process environment through
+    :func:`nab.env.current`.  PROJECT options never declare an env var, so
+    the env layer carries USER options only.  A ``NAB_<KEY>`` naming a
+    PROJECT option (e.g. ``NAB_RESOLUTION``) draws a warning from
+    :func:`_warn_renamed_env`; any other unknown ``NAB_*`` name (e.g. a
+    typo) one from :func:`_warn_unknown_env`.  Neither is applied, and
+    neither is fatal.  The two names the output layer owns
+    (:data:`nab.env.OUTPUT_OWNED`) are skipped silently and bind nothing.
+    When ``rejections`` is supplied (``nab config --include-rejected``)
+    those env casualties are recorded there instead of warned, mirroring
+    the TOML loader.
     """
+    environ = env.current(environ)
     _warn_renamed_env(environ, rejections=rejections)
-    _warn_unknown_env(environ, reserved_env=reserved_env, rejections=rejections)
+    _warn_unknown_env(environ, rejections=rejections)
     values: dict[str, Any] = {}
     for spec in OPTIONS:
         if spec.env_var is None:
@@ -451,7 +452,6 @@ def read_env_layer(
 def _warn_unknown_env(
     environ: Mapping[str, str],
     *,
-    reserved_env: Iterable[str] = (),
     rejections: list[RejectedLayer] | None = None,
 ) -> None:
     """Warn about any ``NAB_*`` var that is neither a known nor renamed name.
@@ -460,26 +460,26 @@ def _warn_unknown_env(
     (e.g. ``NAB_OFLINE``) is ignored with a warning naming the variable,
     never applied and never fatal.  Renamed PROJECT names are left for
     :func:`_warn_renamed_env`, which gives the more specific
-    not-env-settable message.  ``reserved_env`` names ``NAB_*`` vars owned
-    by other layers (the output layer's ``NAB_VERBOSITY`` and
-    ``NAB_NO_PROGRESS``); those are skipped silently.  When ``rejections``
-    is supplied the var is recorded there instead of warned.
+    not-env-settable message.  The names the output layer owns
+    (:data:`nab.env.OUTPUT_OWNED`) set no registry row, so they are skipped
+    here, but the message still offers them: a user who mistyped
+    ``NAB_VERBOSITY`` is reaching for a variable nab honours.  When
+    ``rejections`` is supplied the var is recorded there instead of warned.
     """
     known = {spec.env_var for spec in OPTIONS if spec.env_var is not None}
     renamed = set(_renamed_env_names())
-    reserved = set(reserved_env)
+    honoured = ", ".join(sorted(known | env.OUTPUT_OWNED))
     for name in environ:
         if (
             not name.startswith("NAB_")
             or name in known
             or name in renamed
-            or name in reserved
+            or name in env.OUTPUT_OWNED
         ):
             continue
-        valid = sorted(known)
         msg = (
             f"{name} is not a recognized nab setting and was ignored; the"
-            f" known NAB_* variables are {valid!r}."
+            f" known NAB_* variables are {honoured}."
         )
         if rejections is not None:
             rejections.append(RejectedLayer(Origin(SourceKind.ENV, name), name, msg))

--- a/src/nab/output.py
+++ b/src/nab/output.py
@@ -25,7 +25,6 @@ from typing_extensions import override
 
 from .env import (
     NAB_VERBOSITY,
-    OUTPUT_OWNED,
     color_enabled,
     progress_suppressed,
     verbosity_name,
@@ -35,7 +34,6 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
 
 __all__ = [
-    "OUTPUT_ENV_VARS",
     "ColorChoice",
     "OutputOptionError",
     "OutputOptions",
@@ -52,9 +50,6 @@ __all__ = [
     "should_color",
     "verbosity_from_counts",
 ]
-
-OUTPUT_ENV_VARS: frozenset[str] = OUTPUT_OWNED
-"""The names the config ladder is told to skip, because this layer owns them."""
 
 
 class Verbosity(enum.IntEnum):

--- a/tasks/gen_cli.py
+++ b/tasks/gen_cli.py
@@ -25,6 +25,7 @@ import sys
 from pathlib import Path
 
 from nab import optiondefs
+from nab.config.ladder import docs_path
 from nab.optiondefs import COMMANDS, UNSET, Kind, Opt
 from nab.optiontable import ALL
 
@@ -143,11 +144,14 @@ def _flag_table() -> str:
 
 
 def _check_pages() -> None:
-    """Check that every row names a documentation page that exists."""
+    """Check that every row names a documentation page that exists.
+
+    The path checked is the one ``nab config explain`` prints.
+    """
     for row in ALL:
-        page = _DOCS / row.docs
-        if not page.is_file():
-            msg = f"{row.name} names {row.docs}, which is not a documentation page"
+        printed = docs_path(row)
+        if not (_ROOT / printed).is_file():
+            msg = f"{row.name} names {printed}, which is not a documentation page"
             raise SystemExit(msg)
 
 

--- a/tests/test_cli_docs.py
+++ b/tests/test_cli_docs.py
@@ -418,7 +418,7 @@ class TestCliReferenceDocumentsOutputPolicy:
 
 
 class TestConfigExplainReferenceDocs:
-    """The CLI reference names every status ``explain`` prints."""
+    """The CLI reference describes what ``explain`` prints."""
 
     def test_reference_names_every_status(
         self, hermetic_roots: Path, tmp_path: Path
@@ -448,6 +448,20 @@ class TestConfigExplainReferenceDocs:
         for status in ("winner", "shadowed", "rejected"):
             assert status in printed, status
             assert f"`{status}`" in section, status
+
+    def test_reference_names_the_documentation_line(self, hermetic_roots: Path) -> None:
+        _write(
+            hermetic_roots / "pyproject.toml",
+            '[project]\nname = "x"\nversion = "0"\ndependencies = []\n',
+        )
+
+        printed = _run_config(
+            ["explain", "resolution", "--path", str(hermetic_roots / "pyproject.toml")]
+        )
+
+        section = _reference_section(_CLI_REFERENCE, "## `nab config`")
+        assert "see docs/" in printed
+        assert "`docs/`" in section
 
 
 class TestLockReferenceDocumentsProjectOverrides:

--- a/tests/test_cli_generated.py
+++ b/tests/test_cli_generated.py
@@ -294,7 +294,7 @@ def test_the_generator_refuses_a_row_that_names_no_page(
         generator._check_pages()
 
     assert str(caught.value) == (
-        "probe names reference/nope.md, which is not a documentation page"
+        "probe names docs/reference/nope.md, which is not a documentation page"
     )
 
 

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -342,6 +342,43 @@ class TestConfigExplain:
         assert any(line.startswith(">") for line in out.splitlines())
         assert "shadowed" in out
 
+    def test_explain_prints_help_and_docs_under_the_header(
+        self, hermetic_roots: Path
+    ) -> None:
+        """The two lines the row itself carries sit between header and stack."""
+        _project(hermetic_roots)
+        row = next(spec for spec in OPTIONS if spec.key == "resolution")
+
+        out = _run_config(
+            ["explain", "resolution", "--path", str(hermetic_roots / "pyproject.toml")]
+        )
+
+        header, help_line, docs_line, first_rung = out.splitlines()[:4]
+        assert header.startswith("resolution (")
+        assert help_line == f"  {row.help}"
+        assert docs_line == f"  see docs/{row.docs}"
+        assert first_rung.startswith(">")
+
+    def test_explain_help_and_docs_never_carry_the_rung_gutter(
+        self, hermetic_roots: Path
+    ) -> None:
+        """A gutter would read the row's own prose as a source that set it."""
+        _project(hermetic_roots, 'resolution = "lowest"\n')
+        out = _run_config(
+            [
+                "explain",
+                "resolution",
+                "--path",
+                str(hermetic_roots / "pyproject.toml"),
+                "--project-resolution",
+                "highest",
+            ]
+        )
+
+        gutters = [line for line in out.splitlines() if line.startswith(">")]
+        assert len(gutters) == 1
+        assert "winner" in gutters[0]
+
     def test_explain_marks_a_deprecated_key(self, hermetic_roots: Path) -> None:
         """The header appends the row's own ``deprecated`` field."""
         _project(hermetic_roots)

--- a/tests/test_config_sources.py
+++ b/tests/test_config_sources.py
@@ -721,6 +721,22 @@ class TestDiscoverAndMissing:
         assert layers[0].values["resolution"] is ResolutionStrategy.LOWEST
 
 
+class TestCliLayerPreconditions:
+    """``build_cli_layer`` only ever carries rows a command line can set."""
+
+    def test_file_only_key_is_refused(self) -> None:
+        spec = next(s for s in OPTIONS if s.key == "vcs")
+        assert spec.commands == ()
+
+        with pytest.raises(ValueError, match="takes no command line"):
+            build_cli_layer({"vcs": {"policy": "allow"}})
+
+    def test_cli_settable_key_is_parsed(self) -> None:
+        layer = build_cli_layer({"resolution": "lowest"})
+
+        assert layer.values["resolution"] is ResolutionStrategy.LOWEST
+
+
 class TestRenderers:
     def test_render_list(self, tmp_path: Path) -> None:
         _project(tmp_path, 'resolution = "lowest"\n')
@@ -818,6 +834,19 @@ class TestRenderers:
         assert lines[0].startswith("resolution (project,")
         assert any(line.startswith(">") and "winner" in line for line in lines)
         assert any("shadowed" in line for line in lines)
+
+    def test_every_row_explains_with_its_own_help_and_page(
+        self, tmp_path: Path
+    ) -> None:
+        """The help and page lines come off the row asked for, not a constant."""
+        _project(tmp_path)
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+
+        for row in OPTIONS:
+            help_line, docs_line = render_explain(eff, row.key).splitlines()[1:3]
+
+            assert help_line == f"  {row.help}", row.key
+            assert docs_line == f"  see docs/{row.docs}", row.key
 
     def test_render_explain_default_only(self, tmp_path: Path) -> None:
         _project(tmp_path)

--- a/tests/test_env_layer.py
+++ b/tests/test_env_layer.py
@@ -11,6 +11,7 @@ import pytest
 
 from nab import env
 from nab.cli import main
+from nab.config.ladder import OPTIONS, RejectedLayer, read_env_layer
 
 _PROJECT = '[project]\nname = "probe"\nversion = "0.1"\ndependencies = []\n'
 
@@ -26,11 +27,10 @@ _SOURCE_TREES = {
     "nab_resolver": _ROOT / "nab-resolver" / "src" / "nab_resolver",
 }
 
-# nab decides what it does from one module, and the help renderer reads
-# COLUMNS, which is a width rather than a decision and which must not pull
-# nab/env.py onto the --help path.  The nab-index and nab-project reads
-# build the environment a subprocess is handed, which the package spawning
-# it owns rather than the CLI.
+# nab decides what it does from one module; the help renderer reads COLUMNS,
+# a width rather than a decision, and must not pull nab/env.py onto the
+# --help path.  The other two build a subprocess's environment, which the
+# package spawning it owns.
 _ENVIRONMENT_READERS = {
     "nab": {"nab/env.py", "nab/_cli/render.py"},
     "nab_index": {"nab_index/vcs.py"},
@@ -200,3 +200,50 @@ def test_cache_and_config_roots_are_the_raw_values() -> None:
 
 def test_output_owned_names_the_two_output_variables() -> None:
     assert sorted(env.OUTPUT_OWNED) == ["NAB_NO_PROGRESS", "NAB_VERBOSITY"]
+
+
+def _rejections(environ: dict[str, str]) -> list[RejectedLayer]:
+    """What the env layer refuses out of ``environ``, in place of warning."""
+    collected: list[RejectedLayer] = []
+    read_env_layer(environ, rejections=collected)
+    return collected
+
+
+def test_the_unknown_name_message_names_every_variable_nab_honours() -> None:
+    """The message set is every ``NAB_*`` name that takes effect.
+
+    The four keyed rows that declare an env var plus the two the output
+    layer owns, which the layer skips but nab still reads.  The text is
+    pinned whole because it is the list a user reads to find the name they
+    meant.
+    """
+    [rejected] = _rejections({"NAB_OFLINE": "1"})
+
+    assert rejected.reason == (
+        "NAB_OFLINE is not a recognized nab setting and was ignored; the known"
+        " NAB_* variables are NAB_CACHE_DIR, NAB_HTTP_BACKEND,"
+        " NAB_MAX_CONCURRENCY, NAB_NO_PROGRESS, NAB_OFFLINE, NAB_VERBOSITY."
+    )
+
+
+def test_the_output_variables_are_skipped_in_silence() -> None:
+    """The skip set is read off :mod:`nab.env`, not handed in by the caller.
+
+    Both names are written out rather than taken from ``OUTPUT_OWNED``, so
+    dropping one from that set fails here instead of shrinking the case.
+    """
+    assert _rejections({env.NAB_VERBOSITY: "debug", env.NAB_NO_PROGRESS: "1"}) == []
+
+
+def test_the_skip_set_names_nothing_the_registry_declares() -> None:
+    """The two sets are disjoint, so no variable is both skipped and offered.
+
+    A ``NAB_VERBOSITY`` row in the registry would put it in ``nab config
+    list`` and make the skip silently shadow it.
+    """
+    would_be = {"NAB_" + spec.name.upper().replace("-", "_") for spec in OPTIONS}
+
+    assert env.OUTPUT_OWNED.isdisjoint(would_be)
+    assert env.OUTPUT_OWNED.isdisjoint(
+        {spec.env_var for spec in OPTIONS if spec.env_var is not None}
+    )


### PR DESCRIPTION
`NAB_VERBOSTY=silent` drew a warning whose list of known names did not contain `NAB_VERBOSITY`. The message offered only the four registry rows that declare an env var, as a Python repr; it now names all six `NAB_*` variables nab honours, in plain text:

    warning: NAB_VERBOSTY is not a recognized nab setting and was ignored; the known
    NAB_* variables are NAB_CACHE_DIR, NAB_HTTP_BACKEND, NAB_MAX_CONCURRENCY,
    NAB_NO_PROGRESS, NAB_OFFLINE, NAB_VERBOSITY.

The two added names are the output layer's, and `read_env_layer` used to learn them from its caller: a `reserved_env` argument `nab/_run.py` filled from `nab.output.OUTPUT_ENV_VARS`, an alias of `nab.env.OUTPUT_OWNED`. `read_env_layer` and `_warn_unknown_env` now read `nab.env.OUTPUT_OWNED` directly, still skipping both rather than binding them; `reserved_env` and `OUTPUT_ENV_VARS` are gone. `environ` defaults to `None` through `nab.env.current`, so no caller fetches the process environment first.
