### PR TITLE
Print the published page URL in nab config explain, not a checkout path

### DIFF
--- a/docs/reference/cache.md
+++ b/docs/reference/cache.md
@@ -90,11 +90,12 @@ formats nab cannot read.
 
 ## Verifying and clearing
 
-`nab cache verify` walks the record buckets read-only and reports any
-entry that will not parse, including a parsed blob that is not decodable.
-It checks structure only, not freshness: a stale-but-valid parsed blob is
-not corrupt, since the digest binding retires it at read time. Clones and
-extracted archives hold no nab records, so `verify` skips them.
+`nab cache verify` walks the record buckets read-only and lists on stdout
+every entry that will not parse, including a parsed blob that is not
+decodable, exiting 1 when the listing is not empty. It checks structure
+only, not freshness: a stale-but-valid parsed blob is not corrupt, since
+the digest binding retires it at read time. Clones and extracted archives
+hold no nab records, so `verify` skips them.
 
 `nab cache clear` removes every bucket, clones and archives included,
 returning the cache to cold. `verify` and `clear` both refuse a root that

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -67,9 +67,9 @@ repeatable `--project-constraint` and `--project-default-group`. Every one
 of them replaces the file value outright; repeating `--project-constraint`
 builds up that run's whole constraint list rather than adding to the
 declared one. Each changes what the run writes, so passing one prints a
-reproducibility notice on stderr and records the override in the
-lockfile's `[tool.nab]` block, since the lock no longer derives from the
-committed files alone.
+reproducibility notice on stderr, which `-q` drops, and records the
+override in the lockfile's `[tool.nab]` block, since the lock no longer
+derives from the committed files alone.
 
 ### Checking and refreshing a lock
 
@@ -188,9 +188,10 @@ directory uses: `cache-dir` is read off the config source ladder, so a
 
 * `nab cache dir` prints the resolved cache root to stdout, whether or
   not it exists yet.
-* `nab cache verify` walks the cached index records read-only and
-  reports any corrupt entry by path and reason. Cloned repositories and
-  extracted archives hold upstream files, so they are not parsed.
+* `nab cache verify` walks the cached index records read-only and lists
+  any corrupt entry on stdout by path and reason, exiting 1 when it found
+  one. Cloned repositories and extracted archives hold upstream files, so
+  they are not parsed.
 * `nab cache clear` removes every bucket under the root, including the
   cloned repositories and extracted archives, returning the cache to
   cold.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -142,11 +142,11 @@ actions:
   the source it came from.
 * `nab config get <key>` prints one effective value.
 * `nab config explain <key>` prints a header naming the key, its scope
-  and its type, then the option's own help line and the page in `docs/`
-  that documents it, then the full source stack. The winning row carries
-  a `>` gutter and the status `winner`, and every source it beats is
-  `shadowed`. A shadowed source contributes nothing to the value,
-  whatever the key's type.
+  and its type, then the option's own help line and a link to the page
+  documenting it on <https://nab.readthedocs.io/>, then the full source
+  stack. The winning row carries a `>` gutter and the status `winner`,
+  and every source it beats is `shadowed`. A shadowed source contributes
+  nothing to the value, whatever the key's type.
 
 `--include-rejected` is a flag on `nab config` itself, so every action
 takes it. Without it, a config file that sets an unknown key or a key

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,8 +263,27 @@ nab = [
 target-version = "py310"
 extend-exclude = ["**/_vendor/**"]
 
+# https://docs.astral.sh/ruff/settings/#lintflake8-tidy-importsbanned-api
+# stdout carries the artefact a command was asked for and stderr carries the
+# run, both decided by nab.output.Printer, so a write straight to a process
+# stream is outside the policy: it cannot be quieted, it is never coloured,
+# and it can land on top of the progress line.  T201 bans print for the same
+# reason.
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"sys.stdout".msg = "write through nab.output.Printer"
+"sys.stderr".msg = "write through nab.output.Printer"
+"sys.__stdout__".msg = "write through nab.output.Printer"
+"sys.__stderr__".msg = "write through nab.output.Printer"
+
 # https://docs.astral.sh/ruff/settings/#lint_per-file-ignores
 [tool.ruff.lint.per-file-ignores]
+
+# The entry point owns the run's one write per stream and the printer owns
+# every other; nothing else names a stream.  Tests read the streams back,
+# and the scripts outside the packages have no printer to write through.
+"src/nab/cli.py" = ["TID251"]
+"src/nab/output.py" = ["TID251"]
+"**/tests/**" = ["TID251"]
 
 # Benchmarks intentionally print, lack docstrings, run subprocesses, and
 # carry many scenario knobs.
@@ -280,6 +299,7 @@ extend-exclude = ["**/_vendor/**"]
     "PLR2004",  # Magic value in comparison (benchmark thresholds)
     "SLF001",   # Private member access (sibling scripts share helpers)
     "N818",     # Exception name not Error-suffixed (private signal types)
+    "TID251",   # scripts write their own output
 ]
 
 # Release tooling prints, shells out to git, and lives outside any package.
@@ -289,6 +309,7 @@ extend-exclude = ["**/_vendor/**"]
     "S607",     # subprocess with partial executable path (git)
     "INP001",   # implicit namespace package (scripts live outside packages)
     "PLC2801",  # direct __replace__ call (copy.replace is 3.13+, we support 3.10)
+    "TID251",   # scripts write their own output
 ]
 
 # Tests use their own per-directory ruff.toml that extends this config.

--- a/src/nab/_cache_cmd.py
+++ b/src/nab/_cache_cmd.py
@@ -1,9 +1,9 @@
 """``nab cache`` subcommand: inspect and clear the on-disk cache.
 
 ``dir`` prints the resolved cache root, whether or not it exists.
-``verify`` walks the record buckets read-only and reports corrupt
-entries by path and reason. ``clear`` removes every bucket nab owns,
-including the cloned and extracted source trees.
+``verify`` walks the record buckets read-only and lists corrupt entries
+by path and reason, exiting 1 when it found any. ``clear`` removes every
+bucket nab owns, including the cloned and extracted source trees.
 
 ``verify`` and ``clear`` descend only into the buckets nab owns, never
 follow a symlink out of the root, and refuse a root that holds foreign
@@ -30,12 +30,12 @@ def cache_command(
     """Inspect and clear nab's on-disk cache.
 
     ``nab cache dir`` prints the resolved cache root. ``nab cache verify``
-    walks the cache read-only and reports corrupt entries. ``nab cache
+    walks the cache read-only and lists corrupt entries. ``nab cache
     clear`` removes every recognized bucket.
     """
     root = _cache_root(cache_dir)
     if action == "dir":
-        sys.stdout.write(f"{root}\n")
+        printer().data(f"{root}\n")
         return
     if action == "verify":
         _verify(root)
@@ -71,12 +71,24 @@ def _cache_root(cache_dir: Path | None) -> Path:
 
 
 def _verify(root: Path) -> None:
+    """List every corrupt entry on stdout, and exit 1 when there was one.
+
+    The listing is what the verb was run to get, so it is the artefact and
+    ``nab cache verify > report.txt`` captures it.  A clean cache prints
+    nothing, so the status is what a script reads to learn the cache is
+    not clean.
+    """
     _refuse_foreign_root(root)
     cache = OnDiskCache(root, "")
+    corrupt = 0
     for entry in cache.iter_cache_entries():
         reason = cache.read_cache_entry(entry)
         if reason is not None:
-            printer().error(f"{entry}: {reason}")
+            printer().data(f"{entry}: {reason}\n")
+            corrupt += 1
+
+    if corrupt:
+        sys.exit(1)
 
 
 def _clear(root: Path) -> None:

--- a/src/nab/_config_cmd.py
+++ b/src/nab/_config_cmd.py
@@ -131,10 +131,10 @@ def config_command(  # noqa: PLR0913 - one keyword per flag is the public surfac
     # lock, so the notice is worded for inspection (produces_lock=False).
     notice = project_cli_override_notice(effective, produces_lock=False)
     if notice is not None:
-        sys.stderr.write(notice)
+        printer().stderr_line(notice)
 
     if action == "list":
-        sys.stdout.write(render_list(effective, rejected=rejected))
+        printer().data(render_list(effective, rejected=rejected))
         return
     if action in {"get", "explain"}:
         _require_key_arg(key, action)
@@ -147,7 +147,7 @@ def config_command(  # noqa: PLR0913 - one keyword per flag is the public surfac
                 )
         except SourceConfigError as exc:
             _fail_config(exc)
-        sys.stdout.write(rendered)
+        printer().data(rendered)
         return
 
     printer().error(

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -145,7 +145,7 @@ def _print_lock(text: str) -> None:
     failing.
     """
     text.encode("utf-8")
-    sys.stdout.write(text)
+    printer().data(text)
 
 
 def lock(  # noqa: PLR0913 - one keyword per flag is the public surface

--- a/src/nab/_resolve.py
+++ b/src/nab/_resolve.py
@@ -400,7 +400,7 @@ def _report_failures(result: ResolveResult) -> None:
     resolve with several (a matrix's tuples, or a conflict fork's members,
     which fork in specific mode too) has one error per target, and the pins
     that did resolve are as informative as the failures, so each target gets
-    a labelled block.
+    a labelled block under the same ``error: resolution failed:`` line.
     """
     if len(result.target_results) <= 1:
         first = next(tr.error for tr in result.every_result if tr.error is not None)
@@ -425,7 +425,7 @@ def _report_failures(result: ResolveResult) -> None:
         blocks.append(f"# base/{br.target.label}: FAILED")
         blocks.extend(_error_lines(br.error))
 
-    sys.stderr.write("\n".join(blocks) + "\n")
+    printer().error("resolution failed:\n" + "\n".join(blocks))
 
 
 def _error_lines(error: ResolutionError | None) -> list[str]:

--- a/src/nab/_run.py
+++ b/src/nab/_run.py
@@ -310,7 +310,7 @@ def _layered_run_settings_or_exit(
     settings = _layered_run_settings(ladder)
     notice = project_cli_override_notice(ladder, produces_lock=produces_lock)
     if notice is not None:
-        sys.stderr.write(notice)
+        printer().stderr_line(notice)
     return settings
 
 

--- a/src/nab/config/ladder.py
+++ b/src/nab/config/ladder.py
@@ -64,6 +64,7 @@ __all__ = [
     "config_search_roots",
     "discover_layers",
     "docs_path",
+    "docs_url",
     "orphan_rejections",
     "project_cli_override_notice",
     "project_cli_override_records",
@@ -745,6 +746,12 @@ _LIST_SCOPE_W = 9
 # Status column width for ``nab config explain`` (winner/shadowed/rejected).
 _EXPLAIN_STATUS_W = 9
 
+# Where the pages live in the checkout, and where they are published:
+# [project.urls].Documentation from pyproject.toml, at the released version
+# its bare URL redirects to.
+_DOCS_DIR = "docs/"
+_DOCS_SITE = "https://nab.readthedocs.io/en/stable/"
+
 
 def orphan_rejections(
     rejected: Iterable[RejectedLayer],
@@ -821,7 +828,7 @@ def render_explain(
     lines = [
         f"{key} ({ev.spec.scope_name}, {_type_label(ev.spec)})",
         f"  {ev.spec.help}",
-        f"  see {docs_path(ev.spec)}",
+        f"  see {docs_url(ev.spec)}",
     ]
     winner_index = len(ev.stack) - 1
     for i, (origin, value) in enumerate(ev.stack):
@@ -844,10 +851,24 @@ def render_explain(
 def docs_path(row: Opt) -> str:
     """Return the page ``row`` names, as a path from the repository root.
 
-    Shared with the generator's page check, so the string ``explain``
-    prints and the string that gets checked cannot differ.
+    ``tasks/gen_cli.py`` resolves this against the checkout and
+    :func:`docs_url` publishes it, so a row naming a page nobody wrote
+    fails the generator.
     """
-    return f"docs/{row.docs}"
+    return f"{_DOCS_DIR}{row.docs}"
+
+
+def docs_url(row: Opt) -> str:
+    """Return the published page ``row`` names, as a URL to open.
+
+    Built from :func:`docs_path`, so the page the generator checks on
+    disk is the page a reader is sent to.  The path alone names nothing
+    an installed nab has: the sdist ships ``src/nab`` and ``tests``.
+    Sphinx builds with ``-b html``, so each page is served under its own
+    name.
+    """
+    page = docs_path(row).removeprefix(_DOCS_DIR).removesuffix(".md")
+    return f"{_DOCS_SITE}{page}.html"
 
 
 def _type_label(row: Opt) -> str:

--- a/src/nab/output.py
+++ b/src/nab/output.py
@@ -146,9 +146,10 @@ class Printer:
     """The single output seam: stream routing, level gating, and colour.
 
     ``data`` is the stdout channel and always prints, even under ``--quiet``,
-    because it is the output the user ran the command to get.  ``error`` /
-    ``warning`` / ``note`` / ``done`` write to stderr, gated on the verbosity
-    level, with only the leading token coloured.
+    because it is the output the user ran the command to get.  ``error``,
+    ``warning``, ``note`` and ``done`` write to stderr, gated on the verbosity
+    level, with only the leading token coloured; ``stderr_line`` takes the
+    same gate without a token, for text that brings its own.
     """
 
     def __init__(
@@ -181,11 +182,6 @@ class Printer:
         self._err_lock = threading.Lock()
         self._progress_drawn = False
 
-    @property
-    def stderr(self) -> IO[str]:
-        """The stderr stream this printer writes diagnostics and progress to."""
-        return self._err
-
     def _paint(self, token: str, name: str) -> str:
         """Wrap ``token`` in the ``name`` SGR code when colour is on."""
         if not self.color_enabled:
@@ -199,7 +195,12 @@ class Printer:
         self.stderr_write(f"{self._paint(token, color)} {message}\n")
 
     def data(self, text: str) -> None:
-        """Write requested output to stdout verbatim (the pipeable channel)."""
+        """Write requested output to stdout verbatim (the pipeable channel).
+
+        Wipes a live progress line first, since both streams can share a
+        terminal and the artefact would otherwise print on top of it.
+        """
+        self.clear_progress()
         self._out.write(text)
 
     def error(self, message: str) -> None:
@@ -228,8 +229,9 @@ class Printer:
     def stderr_line(self, message: str) -> None:
         """Write a raw normal-level line to stderr with no token or colour.
 
-        For multi-line diagnostics a command builds itself (the per-tuple
-        matrix report), where the leading-token shape does not fit.
+        For text that carries its own prefix, such as the reproducibility
+        notice ``nab lock`` and ``nab config`` emit, where a second leading
+        token would read as ``note: notice:``.
         """
         if self.verbosity >= Verbosity.NORMAL:
             self.stderr_write(message)
@@ -254,12 +256,19 @@ class Printer:
             self._progress_drawn = True
 
     def clear_progress(self) -> None:
-        """Wipe the progress line so the next stderr write starts clean."""
+        """Wipe the progress line so the next write starts on a clean line."""
         with self._err_lock:
             if self._progress_drawn:
                 self._err.write(_CLEAR_LINE)
                 self._err.flush()
                 self._progress_drawn = False
+
+    def flush_stderr(self) -> None:
+        """Flush stderr for a caller writing through :meth:`stderr_write`.
+
+        The stream stays private, so nothing can write around the printer.
+        """
+        self._err.flush()
 
 
 _printer: Printer | None = None
@@ -297,7 +306,7 @@ class _PrinterStream:
         self._printer.stderr_write(text)
 
     def flush(self) -> None:
-        self._printer.stderr.flush()
+        self._printer.flush_stderr()
 
 
 class _NabLogHandler(logging.StreamHandler):  # type: ignore[type-arg]

--- a/tasks/gen_cli.py
+++ b/tasks/gen_cli.py
@@ -144,14 +144,16 @@ def _flag_table() -> str:
 
 
 def _check_pages() -> None:
-    """Check that every row names a documentation page that exists.
+    """Check that every row names a documentation page in the checkout.
 
-    The path checked is the one ``nab config explain`` prints.
+    The path checked is the checkout half of the URL ``nab config
+    explain`` prints, so the page a reader is sent to is one that was
+    written.
     """
     for row in ALL:
-        printed = docs_path(row)
-        if not (_ROOT / printed).is_file():
-            msg = f"{row.name} names {printed}, which is not a documentation page"
+        page = docs_path(row)
+        if not (_ROOT / page).is_file():
+            msg = f"{row.name} names {page}, which is not a documentation page"
             raise SystemExit(msg)
 
 

--- a/tests/test_cache_cmd.py
+++ b/tests/test_cache_cmd.py
@@ -99,6 +99,22 @@ class TestCacheDir:
         assert captured.out == f"{tmp_path / 'xc' / 'nab'}\n"
         assert captured.err == ""
 
+    def test_the_path_survives_quiet(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """stdout is the artefact, so ``-qq`` does not suppress it.
+
+        The path is the whole point of the verb; quieting it would leave
+        ``$(nab cache dir -qq)`` empty.
+        """
+        monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xc"))
+        _run_cache(["dir", "-qq"])
+
+        assert capsys.readouterr().out == f"{tmp_path / 'xc' / 'nab'}\n"
+
     def test_default_falls_back_to_home(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -193,8 +209,8 @@ class TestLayeredCacheDir:
         policy_path = root / SIMPLE_BUCKET / "pypi" / "foo.policy"
         policy_path.write_bytes(b"not json")
         monkeypatch.setenv("NAB_CACHE_DIR", str(root))
-        _run_cache(["verify"])
-        assert str(policy_path) in capsys.readouterr().err
+        _run_cache(["verify"], status=1)
+        assert str(policy_path) in capsys.readouterr().out
 
     def test_clear_empties_layered_root(
         self,
@@ -276,10 +292,29 @@ class TestCacheVerify:
         _populate(root)
         policy_path = root / SIMPLE_BUCKET / "pypi" / "foo.policy"
         policy_path.write_bytes(b"not json")
-        _run_cache(["verify", "--cache-dir", str(root)])
-        err = capsys.readouterr().err
-        assert str(policy_path) in err
-        assert "decodable" in err
+        _run_cache(["verify", "--cache-dir", str(root)], status=1)
+        captured = capsys.readouterr()
+
+        assert str(policy_path) in captured.out
+        assert "decodable" in captured.out
+        assert captured.err == ""
+
+    def test_the_listing_survives_quiet_and_the_status_reports_it(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The listing is the artefact, so ``-qq`` keeps it.
+
+        A script redirecting stdout still gets the report, and reads the
+        status rather than the stream to learn the cache is not clean.
+        """
+        root = tmp_path / "cache"
+        _populate(root)
+        parsed_path = root / "simple-parsed-v0" / "pypi" / "foo.parsed"
+        parsed_path.write_bytes(b"not json data")
+
+        _run_cache(["verify", "-qq", "--cache-dir", str(root)], status=1)
+
+        assert str(parsed_path) in capsys.readouterr().out
 
     def test_silent_on_clean_cache(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -298,10 +333,11 @@ class TestCacheVerify:
         _populate(root)
         parsed_path = root / "simple-parsed-v0" / "pypi" / "foo.parsed"
         parsed_path.write_bytes(b"not json data")
-        _run_cache(["verify", "--cache-dir", str(root)])
-        err = capsys.readouterr().err
-        assert str(parsed_path) in err
-        assert "not valid JSON" in err
+        _run_cache(["verify", "--cache-dir", str(root)], status=1)
+        out = capsys.readouterr().out
+
+        assert str(parsed_path) in out
+        assert "not valid JSON" in out
 
     def test_reports_over_nested_parsed_entry(
         self,
@@ -314,10 +350,11 @@ class TestCacheVerify:
         parsed_path = root / "simple-parsed-v0" / "pypi" / "foo.parsed"
         parsed_path.write_bytes(_OVER_NESTED)
         with refuse_over_nested(_OVER_NESTED):
-            _run_cache(["verify", "--cache-dir", str(root)])
-        err = capsys.readouterr().err
-        assert str(parsed_path) in err
-        assert "nested too deeply to decode" in err
+            _run_cache(["verify", "--cache-dir", str(root)], status=1)
+        out = capsys.readouterr().out
+
+        assert str(parsed_path) in out
+        assert "nested too deeply to decode" in out
 
     def test_does_not_read_through_symlinked_bucket(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -329,7 +366,8 @@ class TestCacheVerify:
         root.mkdir()
         _symlink_or_skip(root / SIMPLE_BUCKET, outside, target_is_directory=True)
         _run_cache(["verify", "--cache-dir", str(root)])
-        assert capsys.readouterr().err == ""
+
+        assert capsys.readouterr().out == ""
 
     def test_refuses_file_root(self, tmp_path: Path) -> None:
         target = tmp_path / "file"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -162,6 +162,37 @@ def _failed(target: ResolveTarget, error: ResolutionError | None) -> TargetResul
     return TargetResult(target=target, success=False, pins={}, error=error, lock=None)
 
 
+def _one_tuple_failed() -> ResolveResult:
+    """A two-tuple resolve where linux pins ``foo==1.0`` and windows fails."""
+    ok_tuple = _target()
+    bad_tuple = _target(platform_id="windows_amd64")
+    return ResolveResult(
+        targets=(ok_tuple, bad_tuple),
+        target_results=[
+            _resolved(ok_tuple, {"foo": V("1.0")}),
+            _failed(bad_tuple, ResolutionError("conflict")),
+        ],
+    )
+
+
+def _begin_quiet(quiet: int) -> None:
+    """Start the run's output at ``-q`` repeated ``quiet`` times, colour off.
+
+    A direct call to ``lock`` never reaches ``begin``, so a test that wants
+    the run's verbosity to matter has to install the printer itself.
+    """
+    nab_output.begin(
+        nab_output.options_from_flags(
+            verbose=0,
+            quiet=quiet,
+            color="never",
+            no_color=False,
+            no_progress=True,
+            environ={},
+        )
+    )
+
+
 def _lock_input(pins: dict[str, PinShape]) -> LockInput:
     """The lock input one host-target resolve of ``pins`` produces."""
     target = ResolveTarget.for_host()
@@ -2031,6 +2062,31 @@ class TestLockCommandSpecific:
         assert "does not derive from the committed" in err
         assert "--project-resolution -> lowest" in err
 
+    def test_cli_project_override_notice_is_quietable(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The notice sits at the normal level, so ``-q`` drops it.
+
+        It fires only when the user typed a ``--project-*`` flag on this
+        line, so a ``-q`` they also typed is not hiding a surprise.
+        """
+        _begin_quiet(1)
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        monkeypatch.setattr(
+            "nab._run.config_search_roots",
+            lambda p: SourceRoots(project_dir=p.parent, pyproject=p),
+        )
+        with patch(
+            "nab._resolve.resolve_for_targets", return_value=_stub_resolve_result()
+        ):
+            lock(pyproject, output=out, project_resolution="lowest")
+
+        assert "--project-resolution -> lowest" not in capsys.readouterr().err
+
     def test_no_cli_project_override_prints_no_notice(
         self,
         tmp_path: Path,
@@ -3110,15 +3166,7 @@ class TestLockCommandUniversal:
         successful tuple's ``# label`` + pins block.
         """
         pyproject = _universal_pyproject(tmp_path)
-        ok_tuple = _target()
-        bad_tuple = _target(platform_id="windows_amd64")
-        mixed = ResolveResult(
-            targets=(ok_tuple, bad_tuple),
-            target_results=[
-                _resolved(ok_tuple, {"foo": V("1.0")}),
-                _failed(bad_tuple, ResolutionError("conflict")),
-            ],
-        )
+        mixed = _one_tuple_failed()
         with (
             patch("nab._resolve.resolve_for_targets", return_value=mixed),
             pytest.raises(SystemExit, match="1"),
@@ -3128,6 +3176,44 @@ class TestLockCommandUniversal:
         assert "# py311-linux_x86_64" in err
         assert "foo==1.0" in err
         assert "# py311-windows_amd64: FAILED" in err
+
+    def test_print_blocks_open_with_the_error_token(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The many-target report reads as one error, like the one-target one.
+
+        Both shapes open with ``error: resolution failed:``, so a reader
+        does not have to count targets to recognize a failed run.
+        """
+        pyproject = _universal_pyproject(tmp_path)
+        mixed = _one_tuple_failed()
+        with (
+            patch("nab._resolve.resolve_for_targets", return_value=mixed),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, format="requirements-without-hashes")
+
+        err = capsys.readouterr().err
+        assert "error: resolution failed:\n# py311-linux_x86_64\nfoo==1.0\n" in err
+
+    def test_print_blocks_survive_the_quietest_level(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A failure report is an error, so ``-qq`` does not drop it.
+
+        Going through the printer is what put the blocks on a level at all;
+        the level they went onto has to be the one nothing suppresses.
+        """
+        _begin_quiet(2)
+        pyproject = _universal_pyproject(tmp_path)
+        mixed = _one_tuple_failed()
+        with (
+            patch("nab._resolve.resolve_for_targets", return_value=mixed),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, format="requirements-without-hashes")
+
+        assert "# py311-windows_amd64: FAILED" in capsys.readouterr().err
 
     def test_print_blocks_surfaces_base_pass_failure(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]

--- a/tests/test_cli_docs.py
+++ b/tests/test_cli_docs.py
@@ -55,6 +55,10 @@ _LOCKFILE_REFERENCE = _DOCS / "reference" / "lockfile.md"
 _CONFLICTS_DOC = _DOCS / "explanation" / "conflicts.md"
 _README = Path(__file__).resolve().parents[1] / "README.md"
 
+# The published documentation, which is what ``nab config explain`` sends a
+# reader to and what the reference page tells them to expect.
+_DOCS_SITE = "https://nab.readthedocs.io/"
+
 _SUBCOMMANDS = ("lock", "download", "config", "cache")
 
 # The shortest line each subcommand accepts, so a case that only wants to
@@ -459,9 +463,11 @@ class TestConfigExplainReferenceDocs:
             ["explain", "resolution", "--path", str(hermetic_roots / "pyproject.toml")]
         )
 
+        docs_line = printed.splitlines()[2]
         section = _reference_section(_CLI_REFERENCE, "## `nab config`")
-        assert "see docs/" in printed
-        assert "`docs/`" in section
+
+        assert docs_line.startswith(f"  see {_DOCS_SITE}")
+        assert _DOCS_SITE in section
 
 
 class TestLockReferenceDocumentsProjectOverrides:

--- a/tests/test_cli_table.py
+++ b/tests/test_cli_table.py
@@ -9,17 +9,21 @@ top, for the shape the rest of the CLI derives from it.
 from __future__ import annotations
 
 import enum
+from pathlib import Path
 from typing import Any
 
 import pytest
+import tomli
 
 from nab import optiondefs
 from nab.config import hooks, values
-from nab.config.ladder import SourceKind
+from nab.config.ladder import SourceKind, docs_path, docs_url
 from nab.optiondefs import COMMANDS, GLOBAL, UNSET, Kind, Opt, Scope, VType
 from nab.optionrows import rows
 from nab.optiontable import ALL, TABLES
 from nab_provider import policy
+
+_PYPROJECT = Path(__file__).resolve().parents[1] / "pyproject.toml"
 
 # The declared rows, paired with the ``Opt`` each lowers to: ``table_rows``
 # lowers them in this order, so the two lists index each other.
@@ -190,6 +194,30 @@ class TestTheDeclaredTable:
 
     def test_every_row_keeps_the_page_it_was_written_with(self) -> None:
         assert tuple((row.name, row.docs) for row in ALL) == _PAGES
+
+    def test_a_row_names_its_page_on_the_published_site(self) -> None:
+        """What ``explain`` prints is the checked path, published.
+
+        The site is ``[project.urls].Documentation`` and the path under it
+        is the one ``tasks/gen_cli.py`` resolves against the checkout, so
+        a reader's page and the checked page cannot differ.  Sphinx builds
+        with ``-b html``, and a row names a page rather than a section, so
+        no URL carries a fragment.
+        """
+        urls = tomli.loads(_PYPROJECT.read_text(encoding="utf-8"))["project"]["urls"]
+        resolution = next(row for row in ALL if row.name == "resolution")
+
+        assert docs_url(resolution) == (
+            "https://nab.readthedocs.io/en/stable/reference/configuration.html"
+        )
+
+        for row in ALL:
+            url = docs_url(row)
+
+            assert url.startswith(urls["Documentation"]), row.name
+            assert url.endswith(f"/{row.docs.removesuffix('.md')}.html"), row.name
+            assert "#" not in url, row.name
+            assert docs_path(row) == f"docs/{row.docs}", row.name
 
     def test_the_written_type_labels_are_the_ones_the_rows_carry(self) -> None:
         """The 15 labels a row spells out, which nothing else reads back.

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -34,7 +34,7 @@ from nab._download import download
 from nab._lock import lock
 from nab._run import effective_config
 from nab.cli import run
-from nab.config.ladder import OPTIONS, Scope, SourceRoots
+from nab.config.ladder import OPTIONS, Scope, SourceRoots, docs_url
 from nab.config.values import SourceConfigError
 from nab_project.download import DownloadResult
 from nab_project.inputs import ResolveInputs
@@ -356,7 +356,7 @@ class TestConfigExplain:
         header, help_line, docs_line, first_rung = out.splitlines()[:4]
         assert header.startswith("resolution (")
         assert help_line == f"  {row.help}"
-        assert docs_line == f"  see docs/{row.docs}"
+        assert docs_line == f"  see {docs_url(row)}"
         assert first_rung.startswith(">")
 
     def test_explain_help_and_docs_never_carry_the_rung_gutter(

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -749,6 +749,33 @@ class TestConfigErrors:
         assert "reflect that override" in captured.err
         assert "--project-resolution -> lowest" in captured.err
 
+    def test_quiet_drops_the_notice_and_keeps_the_value(
+        self, hermetic_roots: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """``-q`` silences the notice; the value asked for still prints.
+
+        The value is the artefact and carries no level.  The notice is a
+        normal-level line about the run, so the two part company here.
+        """
+        _project(hermetic_roots)
+        cache_dir = Path("/c/cli")
+        _cli(
+            "config",
+            "get",
+            "cache-dir",
+            "--path",
+            str(hermetic_roots / "pyproject.toml"),
+            "--project-resolution",
+            "lowest",
+            "--cache-dir",
+            str(cache_dir),
+            "-q",
+        )
+        captured = capsys.readouterr()
+
+        assert captured.out == f"{cache_dir}\n"
+        assert "--project-resolution -> lowest" not in captured.err
+
 
 class TestConfigProjectFileConflict:
     """The cross-file conflict surfaced through the config command."""

--- a/tests/test_config_sources.py
+++ b/tests/test_config_sources.py
@@ -34,6 +34,7 @@ from nab.config.ladder import (
     build_cli_layer,
     build_cli_overrides,
     discover_layers,
+    docs_url,
     orphan_rejections,
     project_cli_override_notice,
     project_cli_override_records,
@@ -846,7 +847,7 @@ class TestRenderers:
             help_line, docs_line = render_explain(eff, row.key).splitlines()[1:3]
 
             assert help_line == f"  {row.help}", row.key
-            assert docs_line == f"  see docs/{row.docs}", row.key
+            assert docs_line == f"  see {docs_url(row)}", row.key
 
     def test_render_explain_default_only(self, tmp_path: Path) -> None:
         _project(tmp_path)

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -623,6 +623,30 @@ def test_printer_message_wipes_live_progress_line() -> None:
     assert err.getvalue().endswith("\r\033[Kwarning: metadata cannot be parsed\n")
 
 
+def test_stdout_data_wipes_live_progress_line() -> None:
+    """The artefact shares a terminal with the progress line it must not land on.
+
+    ``nab lock --output -`` paints progress on stderr while the lock goes
+    to stdout, so ``data`` wipes the line the way a stderr message does.
+    """
+    out = io.StringIO()
+    err = _TTY(tty=True)
+    printer = Printer(
+        stdout=out,
+        stderr=err,
+        verbosity=Verbosity.NORMAL,
+        color=ColorChoice.NEVER,
+        env={},
+    )
+    reporter = ProgressReporter(printer, clock=lambda: 0.0)
+    reporter.on_fetch()
+
+    printer.data('lock-version = "1.0"\n')
+
+    assert err.getvalue().endswith("\r\033[K")
+    assert out.getvalue() == 'lock-version = "1.0"\n'
+
+
 def test_log_record_wipes_live_progress_line() -> None:
     printer, err = _live_progress_printer()
     reporter = ProgressReporter(printer, clock=lambda: 0.0)

--- a/tests/test_output_policy.py
+++ b/tests/test_output_policy.py
@@ -1,0 +1,250 @@
+"""What nab's output policy promises, read off the two streams.
+
+stdout carries the artefact the command was asked to produce and stderr
+carries everything about the run, at a level ``-q`` and ``-v`` act on.  Each
+case runs a real command line through :func:`nab.cli.run` with the streams
+apart and reads both back, so a write counts for where it lands rather than
+for how it was spelled.
+
+The source-level half of the policy is ruff's ``TID251`` ban on naming a
+process stream, configured in ``pyproject.toml``; ``T201`` covers ``print``.
+"""
+
+from __future__ import annotations
+
+import io
+from typing import TYPE_CHECKING
+
+import pytest
+import tomli
+
+from nab.cli import run
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_PROJECT = '[project]\nname = "probe"\nversion = "0.1"\ndependencies = []\n'
+
+# A dependency no index can offer, so an offline resolve fails on it.
+_UNRESOLVABLE = (
+    '[project]\nname = "probe"\nversion = "0.1"\ndependencies = ["nosuchpkg-xyz"]\n'
+)
+
+# Two interpreters on one platform, so a failure renders the per-target
+# block report rather than a single line.
+_UNIVERSAL = (
+    'mode = "universal"\n\n[matrix]\npython = ">=3.11,<3.13"\n'
+    'platforms = ["linux_x86_64"]\n'
+)
+
+_TYPO_WARNING = "NAB_OFLINE is not a recognized nab setting"
+
+_YELLOW = "\033[33m"
+
+# What a message about the run leads with, on whichever stream it lands.
+_RUN_TOKENS = ("error:", "warning:", "note:", "notice:", "Wrote", "Downloaded")
+
+
+@pytest.fixture
+def project(hermetic_roots: Path) -> Path:
+    """A project directory holding a lockable pyproject with no dependencies."""
+    (hermetic_roots / "pyproject.toml").write_text(_PROJECT, encoding="utf-8")
+    return hermetic_roots
+
+
+def _lock_to_stdout(project: Path, *flags: str) -> int:
+    """Lock ``project`` to stdout under ``flags``, returning the status."""
+    return run(
+        (
+            *flags,
+            "lock",
+            str(project / "pyproject.toml"),
+            "--output",
+            "-",
+            "--offline",
+            "--cache-dir",
+            str(project / "cache"),
+        )
+    )
+
+
+def _streams(capsys: pytest.CaptureFixture[str]) -> tuple[str, str]:
+    """The run's stdout and stderr, read back apart."""
+    captured = capsys.readouterr()
+    return captured.out, captured.err
+
+
+def _assert_only_the_artefact(out: str) -> None:
+    """Fail if anything the run had to say about itself reached stdout."""
+    for token in _RUN_TOKENS:
+        assert token not in out, f"{token!r} reached stdout"
+
+
+def test_a_lock_to_stdout_is_the_lockfile_and_nothing_else(
+    project: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``nab lock --output -`` writes a pylock a pipe can read."""
+    status = _lock_to_stdout(project)
+    out, err = _streams(capsys)
+
+    assert status == 0
+    assert tomli.loads(out)["lock-version"] == "1.0"
+
+    _assert_only_the_artefact(out)
+    assert err == ""
+
+
+def test_a_failed_lock_leaves_stdout_empty(
+    project: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A resolve that fails produces no artefact, so stdout takes nothing.
+
+    The diagnosis is the per-target block report, which is what nab#128 was
+    about: redirected to a file it would fill the lock the run never wrote.
+    """
+    (project / "pyproject.toml").write_text(_UNRESOLVABLE, encoding="utf-8")
+    (project / "nab.toml").write_text(_UNIVERSAL, encoding="utf-8")
+
+    status = _lock_to_stdout(project)
+    out, err = _streams(capsys)
+
+    assert status == 1
+    assert out == ""
+
+    assert "error: resolution failed:" in err
+    assert "py311-linux_x86_64: FAILED" in err
+
+
+def test_cache_dir_prints_the_path_alone(
+    project: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``$(nab cache dir)`` has to be the path, so stderr stays empty."""
+    cache = project / "cache"
+    monkeypatch.setenv("NAB_CACHE_DIR", str(cache))
+
+    status = run(("cache", "dir"))
+    out, err = _streams(capsys)
+
+    assert status == 0
+    assert out == f"{cache}\n"
+    assert err == ""
+
+
+def test_config_list_puts_the_table_on_stdout_and_the_notice_on_stderr(
+    project: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The listing is what was asked for; the notice is about the run."""
+    status = run(
+        (
+            "config",
+            "list",
+            "--path",
+            str(project / "pyproject.toml"),
+            "--project-resolution",
+            "lowest",
+        )
+    )
+    out, err = _streams(capsys)
+
+    assert status == 0
+    assert out.startswith("key ")
+    assert "resolution           lowest" in out
+
+    _assert_only_the_artefact(out)
+    assert err.startswith("notice: project-scope overrides were applied from the CLI")
+
+
+def test_config_get_prints_the_value_alone(
+    project: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    status = run(
+        ("config", "get", "resolution", "--path", str(project / "pyproject.toml"))
+    )
+    out, err = _streams(capsys)
+
+    assert status == 0
+    assert out == "highest\n"
+    assert err == ""
+
+
+def test_download_reports_on_stderr_because_its_artefact_is_on_disk(
+    project: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``nab download`` writes files, so its summary has no claim on stdout."""
+    status = run(
+        (
+            "download",
+            str(project / "pyproject.toml"),
+            "--output",
+            str(project / "wheels"),
+            "--offline",
+            "--cache-dir",
+            str(project / "cache"),
+        )
+    )
+    out, err = _streams(capsys)
+
+    assert status == 0
+    assert out == ""
+    assert err.startswith("Downloaded 0 files")
+
+
+def test_quiet_keeps_the_artefact_and_drops_the_run_summary(
+    project: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``-q`` is a level on stderr, and the artefact is not on the level."""
+    monkeypatch.setenv("NAB_OFLINE", "1")
+
+    status = _lock_to_stdout(project, "-q")
+    out, err = _streams(capsys)
+
+    assert status == 0
+    assert tomli.loads(out)["lock-version"] == "1.0"
+    assert _TYPO_WARNING in err
+
+
+def test_the_second_quiet_drops_the_warning_too(
+    project: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``-qq`` reaches the warning, and still not the artefact."""
+    monkeypatch.setenv("NAB_OFLINE", "1")
+
+    status = _lock_to_stdout(project, "-qq")
+    out, err = _streams(capsys)
+
+    assert status == 0
+    assert tomli.loads(out)["lock-version"] == "1.0"
+    assert err == ""
+
+
+class _Stream(io.StringIO):
+    """A stream that answers ``isatty()`` with what it was built with."""
+
+    def __init__(self, *, tty: bool) -> None:
+        super().__init__()
+        self._tty = tty
+
+    def isatty(self) -> bool:
+        return self._tty
+
+
+def test_a_warning_is_coloured_and_the_piped_artefact_is_not(
+    project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Each stream is asked on its own, so a redirect decides only its own colour."""
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("NAB_OFLINE", "1")
+
+    out_stream, err_stream = _Stream(tty=False), _Stream(tty=True)
+    monkeypatch.setattr("sys.stdout", out_stream)
+    monkeypatch.setattr("sys.stderr", err_stream)
+
+    status = _lock_to_stdout(project)
+    out, err = out_stream.getvalue(), err_stream.getvalue()
+
+    assert status == 0
+    assert err.startswith(f"{_YELLOW}warning:")
+    assert _TYPO_WARNING in err
+
+    assert "\033[" not in out
+    assert tomli.loads(out)["lock-version"] == "1.0"


### PR DESCRIPTION
`nab config explain resolution` printed `see docs/reference/configuration.md`, a path an installed nab does not have: the sdist ships `src/nab` and `tests`, not `docs/`. It now prints the page as published:

    see https://nab.readthedocs.io/en/stable/reference/configuration.html

`docs_path` still names the checkout path, which `tasks/gen_cli.py` resolves against the tree and `docs_url` publishes, so the checked page and the read page cannot differ.

A test walks all 56 rows: every URL starts with `[project.urls].Documentation` and ends at the row's own page.
