### PR TITLE
Pin that -qq and NAB_VERBOSITY=silent silence the unknown NAB_* warning

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -142,11 +142,11 @@ actions:
   the source it came from.
 * `nab config get <key>` prints one effective value.
 * `nab config explain <key>` prints a header naming the key, its scope
-  and its type, then the option's own help line and the page in `docs/`
-  that documents it, then the full source stack. The winning row carries
-  a `>` gutter and the status `winner`, and every source it beats is
-  `shadowed`. A shadowed source contributes nothing to the value,
-  whatever the key's type.
+  and its type, then the option's own help line and a link to the page
+  documenting it on <https://nab.readthedocs.io/>, then the full source
+  stack. The winning row carries a `>` gutter and the status `winner`,
+  and every source it beats is `shadowed`. A shadowed source contributes
+  nothing to the value, whatever the key's type.
 
 `--include-rejected` is a flag on `nab config` itself, so every action
 takes it. Without it, a config file that sets an unknown key or a key

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1042,6 +1042,7 @@ written, like `git config` reporting configured rather than derived state.
 
 A `NAB_*` name that is not one of these (a typo, or `NAB_RESOLUTION`
 for a project-scope option) is ignored with a warning naming the
-variable. `NAB_VERBOSITY` and `NAB_NO_PROGRESS` belong to the
+variable; `-qq` and `NAB_VERBOSITY=silent` turn it off along with
+every other warning. `NAB_VERBOSITY` and `NAB_NO_PROGRESS` belong to the
 [output layer](cli.md) and pass through silently. Run
 `nab config list` to see every effective value and where it came from.

--- a/src/nab/config/ladder.py
+++ b/src/nab/config/ladder.py
@@ -64,6 +64,7 @@ __all__ = [
     "config_search_roots",
     "discover_layers",
     "docs_path",
+    "docs_url",
     "orphan_rejections",
     "project_cli_override_notice",
     "project_cli_override_records",
@@ -745,6 +746,12 @@ _LIST_SCOPE_W = 9
 # Status column width for ``nab config explain`` (winner/shadowed/rejected).
 _EXPLAIN_STATUS_W = 9
 
+# Where the pages live in the checkout, and where they are published:
+# [project.urls].Documentation from pyproject.toml, at the released version
+# its bare URL redirects to.
+_DOCS_DIR = "docs/"
+_DOCS_SITE = "https://nab.readthedocs.io/en/stable/"
+
 
 def orphan_rejections(
     rejected: Iterable[RejectedLayer],
@@ -821,7 +828,7 @@ def render_explain(
     lines = [
         f"{key} ({ev.spec.scope_name}, {_type_label(ev.spec)})",
         f"  {ev.spec.help}",
-        f"  see {docs_path(ev.spec)}",
+        f"  see {docs_url(ev.spec)}",
     ]
     winner_index = len(ev.stack) - 1
     for i, (origin, value) in enumerate(ev.stack):
@@ -844,10 +851,24 @@ def render_explain(
 def docs_path(row: Opt) -> str:
     """Return the page ``row`` names, as a path from the repository root.
 
-    Shared with the generator's page check, so the string ``explain``
-    prints and the string that gets checked cannot differ.
+    ``tasks/gen_cli.py`` resolves this against the checkout and
+    :func:`docs_url` publishes it, so a row naming a page nobody wrote
+    fails the generator.
     """
-    return f"docs/{row.docs}"
+    return f"{_DOCS_DIR}{row.docs}"
+
+
+def docs_url(row: Opt) -> str:
+    """Return the published page ``row`` names, as a URL to open.
+
+    Built from :func:`docs_path`, so the page the generator checks on
+    disk is the page a reader is sent to.  The path alone names nothing
+    an installed nab has: the sdist ships ``src/nab`` and ``tests``.
+    Sphinx builds with ``-b html``, so each page is served under its own
+    name.
+    """
+    page = docs_path(row).removeprefix(_DOCS_DIR).removesuffix(".md")
+    return f"{_DOCS_SITE}{page}.html"
 
 
 def _type_label(row: Opt) -> str:

--- a/tasks/gen_cli.py
+++ b/tasks/gen_cli.py
@@ -144,14 +144,16 @@ def _flag_table() -> str:
 
 
 def _check_pages() -> None:
-    """Check that every row names a documentation page that exists.
+    """Check that every row names a documentation page in the checkout.
 
-    The path checked is the one ``nab config explain`` prints.
+    The path checked is the checkout half of the URL ``nab config
+    explain`` prints, so the page a reader is sent to is one that was
+    written.
     """
     for row in ALL:
-        printed = docs_path(row)
-        if not (_ROOT / printed).is_file():
-            msg = f"{row.name} names {printed}, which is not a documentation page"
+        page = docs_path(row)
+        if not (_ROOT / page).is_file():
+            msg = f"{row.name} names {page}, which is not a documentation page"
             raise SystemExit(msg)
 
 

--- a/tests/test_cli_docs.py
+++ b/tests/test_cli_docs.py
@@ -55,6 +55,10 @@ _LOCKFILE_REFERENCE = _DOCS / "reference" / "lockfile.md"
 _CONFLICTS_DOC = _DOCS / "explanation" / "conflicts.md"
 _README = Path(__file__).resolve().parents[1] / "README.md"
 
+# The published documentation, which is what ``nab config explain`` sends a
+# reader to and what the reference page tells them to expect.
+_DOCS_SITE = "https://nab.readthedocs.io/"
+
 _SUBCOMMANDS = ("lock", "download", "config", "cache")
 
 # The shortest line each subcommand accepts, so a case that only wants to
@@ -459,9 +463,11 @@ class TestConfigExplainReferenceDocs:
             ["explain", "resolution", "--path", str(hermetic_roots / "pyproject.toml")]
         )
 
+        docs_line = printed.splitlines()[2]
         section = _reference_section(_CLI_REFERENCE, "## `nab config`")
-        assert "see docs/" in printed
-        assert "`docs/`" in section
+
+        assert docs_line.startswith(f"  see {_DOCS_SITE}")
+        assert _DOCS_SITE in section
 
 
 class TestLockReferenceDocumentsProjectOverrides:

--- a/tests/test_cli_table.py
+++ b/tests/test_cli_table.py
@@ -9,17 +9,21 @@ top, for the shape the rest of the CLI derives from it.
 from __future__ import annotations
 
 import enum
+from pathlib import Path
 from typing import Any
 
 import pytest
+import tomli
 
 from nab import optiondefs
 from nab.config import hooks, values
-from nab.config.ladder import SourceKind
+from nab.config.ladder import SourceKind, docs_path, docs_url
 from nab.optiondefs import COMMANDS, GLOBAL, UNSET, Kind, Opt, Scope, VType
 from nab.optionrows import rows
 from nab.optiontable import ALL, TABLES
 from nab_provider import policy
+
+_PYPROJECT = Path(__file__).resolve().parents[1] / "pyproject.toml"
 
 # The declared rows, paired with the ``Opt`` each lowers to: ``table_rows``
 # lowers them in this order, so the two lists index each other.
@@ -190,6 +194,30 @@ class TestTheDeclaredTable:
 
     def test_every_row_keeps_the_page_it_was_written_with(self) -> None:
         assert tuple((row.name, row.docs) for row in ALL) == _PAGES
+
+    def test_a_row_names_its_page_on_the_published_site(self) -> None:
+        """What ``explain`` prints is the checked path, published.
+
+        The site is ``[project.urls].Documentation`` and the path under it
+        is the one ``tasks/gen_cli.py`` resolves against the checkout, so
+        a reader's page and the checked page cannot differ.  Sphinx builds
+        with ``-b html``, and a row names a page rather than a section, so
+        no URL carries a fragment.
+        """
+        urls = tomli.loads(_PYPROJECT.read_text(encoding="utf-8"))["project"]["urls"]
+        resolution = next(row for row in ALL if row.name == "resolution")
+
+        assert docs_url(resolution) == (
+            "https://nab.readthedocs.io/en/stable/reference/configuration.html"
+        )
+
+        for row in ALL:
+            url = docs_url(row)
+
+            assert url.startswith(urls["Documentation"]), row.name
+            assert url.endswith(f"/{row.docs.removesuffix('.md')}.html"), row.name
+            assert "#" not in url, row.name
+            assert docs_path(row) == f"docs/{row.docs}", row.name
 
     def test_the_written_type_labels_are_the_ones_the_rows_carry(self) -> None:
         """The 15 labels a row spells out, which nothing else reads back.

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -34,7 +34,7 @@ from nab._download import download
 from nab._lock import lock
 from nab._run import effective_config
 from nab.cli import run
-from nab.config.ladder import OPTIONS, Scope, SourceRoots
+from nab.config.ladder import OPTIONS, Scope, SourceRoots, docs_url
 from nab.config.values import SourceConfigError
 from nab_project.download import DownloadResult
 from nab_project.inputs import ResolveInputs
@@ -356,7 +356,7 @@ class TestConfigExplain:
         header, help_line, docs_line, first_rung = out.splitlines()[:4]
         assert header.startswith("resolution (")
         assert help_line == f"  {row.help}"
-        assert docs_line == f"  see docs/{row.docs}"
+        assert docs_line == f"  see {docs_url(row)}"
         assert first_rung.startswith(">")
 
     def test_explain_help_and_docs_never_carry_the_rung_gutter(

--- a/tests/test_config_sources.py
+++ b/tests/test_config_sources.py
@@ -34,6 +34,7 @@ from nab.config.ladder import (
     build_cli_layer,
     build_cli_overrides,
     discover_layers,
+    docs_url,
     orphan_rejections,
     project_cli_override_notice,
     project_cli_override_records,
@@ -846,7 +847,7 @@ class TestRenderers:
             help_line, docs_line = render_explain(eff, row.key).splitlines()[1:3]
 
             assert help_line == f"  {row.help}", row.key
-            assert docs_line == f"  see docs/{row.docs}", row.key
+            assert docs_line == f"  see {docs_url(row)}", row.key
 
     def test_render_explain_default_only(self, tmp_path: Path) -> None:
         _project(tmp_path)

--- a/tests/test_env_layer.py
+++ b/tests/test_env_layer.py
@@ -96,6 +96,52 @@ def test_unknown_env_warning_fires_once(
     assert capsys.readouterr().err.count(_TYPO_WARNING) == 1
 
 
+@pytest.mark.parametrize(
+    ("flags", "verbosity", "warnings"),
+    [
+        pytest.param((), None, 1, id="default"),
+        pytest.param(("-q",), None, 1, id="quiet"),
+        pytest.param(("-qq",), None, 0, id="quiet-twice"),
+        pytest.param((), "silent", 0, id="env-silent"),
+    ],
+)
+def test_the_unknown_name_warning_sits_on_the_ordinary_warning_level(
+    flags: tuple[str, ...],
+    verbosity: str | None,
+    warnings: int,
+    hermetic_roots: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``-qq`` and ``NAB_VERBOSITY=silent`` turn the typo warning off too.
+
+    It reports a mistake nab has already refused to act on and names the
+    fix in its own text, so it is a warning like the rest rather than a
+    line the run cannot switch off.
+    """
+    (hermetic_roots / "pyproject.toml").write_text(_PROJECT)
+    monkeypatch.setenv("NAB_OFLINE", "1")
+    if verbosity is not None:
+        monkeypatch.setenv("NAB_VERBOSITY", verbosity)
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "nab",
+            *flags,
+            "config",
+            "list",
+            "--path",
+            str(hermetic_roots / "pyproject.toml"),
+        ],
+    )
+
+    main()
+
+    assert capsys.readouterr().err.count(_TYPO_WARNING) == warnings
+
+
 _ENVIRON_READS = frozenset({"environ", "getenv"})
 
 


### PR DESCRIPTION
The unknown-`NAB_*` warning sits on the ordinary warning level: the default and `-q` print it, `-qq` and `NAB_VERBOSITY=silent` (one level, two spellings) turn it off. No code changes. This pins those four settings as a parametrized test in `tests/test_env_layer.py` and records the two silencing ones in `docs/reference/configuration.md`.

The message names the variable, says it was ignored, and lists the `NAB_*` names nab does honour, so silencing it hides a report of something nab already refused to do. Of eleven CLIs read (pip, uv, poetry, pdm, pex, cargo, ruff, gh, git, npm, ripgrep), none keeps a warning back from its own quiet flag on a run that exits 0.
