### PR TITLE
Import is_file_url from a module with no index client, 17% off nab config list

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1042,6 +1042,7 @@ written, like `git config` reporting configured rather than derived state.
 
 A `NAB_*` name that is not one of these (a typo, or `NAB_RESOLUTION`
 for a project-scope option) is ignored with a warning naming the
-variable. `NAB_VERBOSITY` and `NAB_NO_PROGRESS` belong to the
+variable; `-qq` and `NAB_VERBOSITY=silent` turn it off along with
+every other warning. `NAB_VERBOSITY` and `NAB_NO_PROGRESS` belong to the
 [output layer](cli.md) and pass through silently. Run
 `nab config list` to see every effective value and where it came from.

--- a/nab-index/src/nab_index/file_urls.py
+++ b/nab-index/src/nab_index/file_urls.py
@@ -1,0 +1,70 @@
+"""File-URL helpers, in a module that imports no index client.
+
+:mod:`nab_index.local_index` reads listings and wheels, so importing it pulls
+in :mod:`zipfile`, :mod:`email.parser` and the HTTP client.  Deciding whether
+a configured index URL is a ``file:`` one needs none of that, and that check
+runs while a command line is still being read, so the two live apart.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from urllib.parse import ParseResult, urlparse, urlsplit
+
+__all__ = ["is_file_url", "parse_file_url"]
+
+
+def is_file_url(url: str) -> bool:
+    """Return True when ``url`` is a ``file:`` URL in either RFC 8089 spelling.
+
+    An authority :func:`urlsplit` cannot parse, such as an unterminated IPv6
+    bracket, is not one.
+    """
+    try:
+        return urlsplit(url).scheme == "file"
+    except ValueError:
+        return False
+
+
+def parse_file_url(url: str) -> Path:
+    """Resolve a ``file://`` URL to the filesystem path it names.
+
+    Uses :func:`urllib.request.url2pathname` so Windows-style drive
+    paths (``file:///C:/...``) and percent-encoded characters round-trip
+    cleanly across platforms. An empty or ``localhost`` authority (RFC
+    8089) means the local machine; any other host becomes a UNC share on
+    Windows and is rejected elsewhere.  :mod:`pathlib` accepts a decoded
+    null character, which names no file on any platform, so it raises
+    :class:`ValueError` here instead.
+    """
+    return _parsed_file_url_path(urlparse(url), url)
+
+
+def _parsed_file_url_path(parsed: ParseResult, url: str) -> Path:
+    """:func:`parse_file_url` for a caller that already holds the parse.
+
+    ``url`` is the string ``parsed`` came from and is quoted in the errors.
+    """
+    if parsed.scheme != "file":
+        msg = f"expected file:// URL, got {url!r}"
+        raise ValueError(msg)
+
+    # Deferred to keep urllib.request off the CLI's import path.
+    from urllib.request import url2pathname  # noqa: PLC0415
+
+    netloc = parsed.netloc
+    if not netloc or netloc == "localhost":
+        netloc = ""
+    elif sys.platform == "win32":
+        netloc = "\\\\" + netloc
+    else:
+        msg = f"non-local file:// URL is not supported on this platform: {url!r}"
+        raise ValueError(msg)
+
+    path = url2pathname(netloc + parsed.path)
+    if "\x00" in path:
+        msg = f"file:// URL decodes to a path containing a null character: {url!r}"
+        raise ValueError(msg)
+
+    return Path(path)

--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -24,12 +24,11 @@ import errno
 import os
 import re
 import stat
-import sys
 import zipfile
 from email.parser import BytesParser, Parser
 from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple
-from urllib.parse import ParseResult, unquote, urljoin, urlparse, urlsplit
+from urllib.parse import unquote, urljoin, urlparse, urlsplit
 
 from packaging.utils import canonicalize_name as _canonical
 
@@ -46,6 +45,7 @@ from .client import (
     is_readable_filename,
     zip_sdist_version,
 )
+from .file_urls import _parsed_file_url_path, is_file_url, parse_file_url
 
 if TYPE_CHECKING:
     from packaging.utils import NormalizedName
@@ -97,61 +97,6 @@ class NonLocalArtifactError(LocalIndexError):
     URLs, so the listing is legal, but a filesystem-backed index cannot fetch
     a remote artifact.
     """
-
-
-def is_file_url(url: str) -> bool:
-    """Return True when ``url`` is a ``file:`` URL in either RFC 8089 spelling.
-
-    An authority :func:`urlsplit` cannot parse, such as an unterminated IPv6
-    bracket, is not one.
-    """
-    try:
-        return urlsplit(url).scheme == "file"
-    except ValueError:
-        return False
-
-
-def parse_file_url(url: str) -> Path:
-    """Resolve a ``file://`` URL to an absolute filesystem path.
-
-    Uses :func:`urllib.request.url2pathname` so Windows-style drive
-    paths (``file:///C:/...``) and percent-encoded characters round-trip
-    cleanly across platforms. An empty or ``localhost`` authority (RFC
-    8089) means the local machine; any other host becomes a UNC share on
-    Windows and is rejected elsewhere.  :mod:`pathlib` accepts a decoded
-    null character, which names no file on any platform, so it raises
-    :class:`ValueError` here instead.
-    """
-    return _parsed_file_url_path(urlparse(url), url)
-
-
-def _parsed_file_url_path(parsed: ParseResult, url: str) -> Path:
-    """:func:`parse_file_url` for a caller that already holds the parse.
-
-    ``url`` is the string ``parsed`` came from and is quoted in the errors.
-    """
-    if parsed.scheme != "file":
-        msg = f"expected file:// URL, got {url!r}"
-        raise ValueError(msg)
-
-    # Deferred to keep urllib.request off the CLI's import path.
-    from urllib.request import url2pathname  # noqa: PLC0415
-
-    netloc = parsed.netloc
-    if not netloc or netloc == "localhost":
-        netloc = ""
-    elif sys.platform == "win32":
-        netloc = "\\\\" + netloc
-    else:
-        msg = f"non-local file:// URL is not supported on this platform: {url!r}"
-        raise ValueError(msg)
-
-    path = url2pathname(netloc + parsed.path)
-    if "\x00" in path:
-        msg = f"file:// URL decodes to a path containing a null character: {url!r}"
-        raise ValueError(msg)
-
-    return Path(path)
 
 
 def _resolve_served_path(url: str) -> Path:

--- a/src/nab/config/values.py
+++ b/src/nab/config/values.py
@@ -17,7 +17,7 @@ from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar, cast
 from urllib.parse import urlsplit
 
-from nab_index.local_index import is_file_url
+from nab_index.file_urls import is_file_url
 from nab_project.conflicts import (
     ConflictKind,
     ConflictMember,

--- a/tests/test_cli_imports.py
+++ b/tests/test_cli_imports.py
@@ -130,6 +130,14 @@ _RESOLVE_STACK = (
     "tomli_w",
 )
 
+# Reading an index URL only needs to know whether it says ``file:``, which
+# is why :mod:`nab_index.file_urls` exists apart from the client.
+_INDEX_READER = (
+    "nab_index.local_index",
+    "nab_index.client",
+    "zipfile",
+)
+
 _PROJECT = '[project]\nname = "probe"\nversion = "0.1"\ndependencies = []\n'
 
 
@@ -233,3 +241,13 @@ def test_a_settings_command_loads_no_resolve_stack(
     (tmp_path / "pyproject.toml").write_text(_PROJECT, encoding="utf-8")
 
     assert _run(_HELD_PROBE, ",".join(_RESOLVE_STACK), *line, cwd=tmp_path) == ""
+
+
+@pytest.mark.parametrize("line", [("cache", "dir"), ("config", "list")])
+def test_a_settings_command_loads_no_index_reader(
+    line: tuple[str, ...], tmp_path: Path
+) -> None:
+    """Probe F: neither command holds the reader, which only fetching needs."""
+    (tmp_path / "pyproject.toml").write_text(_PROJECT, encoding="utf-8")
+
+    assert _run(_HELD_PROBE, ",".join(_INDEX_READER), *line, cwd=tmp_path) == ""

--- a/tests/test_env_layer.py
+++ b/tests/test_env_layer.py
@@ -96,6 +96,52 @@ def test_unknown_env_warning_fires_once(
     assert capsys.readouterr().err.count(_TYPO_WARNING) == 1
 
 
+@pytest.mark.parametrize(
+    ("flags", "verbosity", "warnings"),
+    [
+        pytest.param((), None, 1, id="default"),
+        pytest.param(("-q",), None, 1, id="quiet"),
+        pytest.param(("-qq",), None, 0, id="quiet-twice"),
+        pytest.param((), "silent", 0, id="env-silent"),
+    ],
+)
+def test_the_unknown_name_warning_sits_on_the_ordinary_warning_level(
+    flags: tuple[str, ...],
+    verbosity: str | None,
+    warnings: int,
+    hermetic_roots: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``-qq`` and ``NAB_VERBOSITY=silent`` turn the typo warning off too.
+
+    It reports a mistake nab has already refused to act on and names the
+    fix in its own text, so it is a warning like the rest rather than a
+    line the run cannot switch off.
+    """
+    (hermetic_roots / "pyproject.toml").write_text(_PROJECT)
+    monkeypatch.setenv("NAB_OFLINE", "1")
+    if verbosity is not None:
+        monkeypatch.setenv("NAB_VERBOSITY", verbosity)
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "nab",
+            *flags,
+            "config",
+            "list",
+            "--path",
+            str(hermetic_roots / "pyproject.toml"),
+        ],
+    )
+
+    main()
+
+    assert capsys.readouterr().err.count(_TYPO_WARNING) == warnings
+
+
 _ENVIRON_READS = frozenset({"environ", "getenv"})
 
 


### PR DESCRIPTION
`nab config list` goes from 381,899,601 instructions to 315,467,612, 17.4% off, and `nab cache dir` from 389,008,011 to 342,552,335, 11.9% off. Counted under callgrind with `PYTHONHASHSEED=0`, against this branch's own base.

Neither command opens a listing. They paid that because deciding whether a configured index URL says `file:` went through `nab_index.local_index`, which imports the HTTP client, `zipfile` and `email.parser` to read wheels:

    from nab_index.local_index import is_file_url

`is_file_url` is five lines over `urlsplit`. It moves, with `parse_file_url`, to `nab_index.file_urls`, which imports `sys`, `pathlib` and `urllib.parse` and reaches `urllib.request` only inside the call that needs it. `local_index` imports them back, so its public names are unchanged.

`config list` now loads 179 modules instead of 239, and `cache dir` 204 instead of 243.

Probe F in `tests/test_cli_imports.py` fails if either command loads the reader again.
