### PR TITLE
Refuse an unknown cache or config action in the parser, not the command

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -300,7 +300,7 @@ It shows only at normal verbosity on an stderr terminal; `--no-progress`
 | Code | Meaning |
 | ---- | ------- |
 | `0`  | Success. |
-| `1`  | Resolution failed, lockfile cannot be written (a missing hash, or text that is not valid UTF-8), download failed, missing `[project].dependencies`, a `--build-requirements` run whose project declares no `[build-system]`, invalid `[tool.nab]` configuration, an unrecognised `cache` or `config` action, or `--locked` found the lockfile out of date or missing. |
-| `2`  | Bad usage: an unrecognised flag or subcommand, or a malformed `--color` value or `NAB_VERBOSITY`. |
+| `1`  | Resolution failed, lockfile cannot be written (a missing hash, or text that is not valid UTF-8), download failed, missing `[project].dependencies`, a `--build-requirements` run whose project declares no `[build-system]`, invalid `[tool.nab]` configuration, or `--locked` found the lockfile out of date or missing. |
+| `2`  | Bad usage: an unrecognised flag, subcommand or `cache`/`config` action, or a malformed `--color` value or `NAB_VERBOSITY`. |
 | `120` | Output was lost: writing to stdout or stderr failed, `nab` wrote to one that was closed before it started, or flushing one of them at exit failed. |
 | `130` | Interrupted with Ctrl-C. `nab` prints `error: interrupted` and exits. |

--- a/src/nab/_cache_cmd.py
+++ b/src/nab/_cache_cmd.py
@@ -36,17 +36,13 @@ def cache_command(
     root = _cache_root(cache_dir)
     if action == "dir":
         printer().data(f"{root}\n")
-        return
-    if action == "verify":
+    elif action == "verify":
         _verify(root)
-        return
-    if action == "clear":
+    elif action == "clear":
         _clear(root)
-        return
-    printer().error(
-        f"unknown cache action {action!r}; expected one of 'dir', 'verify', 'clear'"
-    )
-    sys.exit(1)
+    else:  # pragma: no cover - the parser refuses any other verb
+        msg = f"unreachable cache action {action!r}"
+        raise AssertionError(msg)
 
 
 def _cache_root(cache_dir: Path | None) -> Path:

--- a/src/nab/_cli/parse.py
+++ b/src/nab/_cli/parse.py
@@ -589,7 +589,7 @@ def _token(row: Row, value: object, prog: str) -> object:
     if row.vtype == "bool":
         return _boolean(row, value, prog)
 
-    if row.vtype == "choice" and value not in row.choices:
+    if row.choices and value not in row.choices:
         raise _bad_choice(prog, row, value, row.choices)
 
     return value

--- a/src/nab/_config_cmd.py
+++ b/src/nab/_config_cmd.py
@@ -136,24 +136,19 @@ def config_command(  # noqa: PLR0913 - one keyword per flag is the public surfac
     if action == "list":
         printer().data(render_list(effective, rejected=rejected))
         return
-    if action in {"get", "explain"}:
-        _require_key_arg(key, action)
-        try:
-            if action == "get":
-                rendered = render_get(effective, key)
-            else:
-                rendered = render_explain(
-                    effective, key, include_rejected=include_rejected
-                )
-        except SourceConfigError as exc:
-            _fail_config(exc)
-        printer().data(rendered)
-        return
+    if action not in {"get", "explain"}:  # pragma: no cover - the parser refuses it
+        msg = f"unreachable config action {action!r}"
+        raise AssertionError(msg)
 
-    printer().error(
-        f"unknown config action {action!r}; expected one of 'list', 'get', 'explain'"
-    )
-    sys.exit(1)
+    _require_key_arg(key, action)
+    try:
+        if action == "get":
+            rendered = render_get(effective, key)
+        else:
+            rendered = render_explain(effective, key, include_rejected=include_rejected)
+    except SourceConfigError as exc:
+        _fail_config(exc)
+    printer().data(rendered)
 
 
 def _require_key_arg(key: str, action: str) -> None:

--- a/tests/test_cache_cmd.py
+++ b/tests/test_cache_cmd.py
@@ -495,10 +495,12 @@ class TestCacheSourceTrees:
 
 
 class TestCacheUnknownAction:
-    def test_unknown_action_exits_one(
+    def test_unknown_action_is_a_usage_refusal(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
+        """The parser refuses a verb outside the declared set, so the body never runs."""
+        _run_cache(["frobnicate", "--cache-dir", str(tmp_path)], status=2)
 
-        _run_cache(["frobnicate", "--cache-dir", str(tmp_path)], status=1)
-
-        assert "unknown cache action" in capsys.readouterr().err
+        err = capsys.readouterr().err
+        assert "invalid value 'frobnicate' for 'action'" in err
+        assert "choose from dir, verify, clear" in err

--- a/tests/test_cli_conformance.py
+++ b/tests/test_cli_conformance.py
@@ -20,6 +20,7 @@ import pytest
 
 from nab._cli import spec as cli_spec
 from nab._cli.parse import UsageError, parse
+from nab.cli import run
 from nab.config.ladder import build_cli_layer
 from nab.optiondefs import COMMANDS, UNSET, Kind, Opt, Scope, VType
 from nab.optiontable import ALL
@@ -184,39 +185,23 @@ class TestRootRowsAgainstTheirReader:
 
 
 class TestVerbSets:
-    """A verb row's choices are the verbs its command body offers.
+    """A verb row's declared choices are the verbs the parser will accept.
 
-    Neither verb set is annotated with a ``Literal``, because an unknown
-    verb exits 1 from the body rather than raising a type error.  Driving
-    the body with a verb it does not know makes it name the ones it does.
+    The set is written once, as the ``Literal`` the row is annotated with,
+    and the parser refuses anything outside it.  Driving a real command
+    line with a verb no row declares makes the refusal list the set.
     """
 
     @pytest.mark.parametrize("command", ["config", "cache"])
     def test_the_refusal_names_exactly_the_declared_verbs(
-        self,
-        command: str,
-        hermetic_roots: Path,
-        capsys: pytest.CaptureFixture[str],
+        self, command: str, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
         row = next(row for row in _rows(command) if row.kind is Kind.VERB)
-        offered = "expected one of " + ", ".join(repr(verb) for verb in row.choices)
+        offered = "choose from " + ", ".join(row.choices)
 
-        with pytest.raises(SystemExit):
-            self._refuse(command, hermetic_roots)
+        assert run((command, "frobnicate", "--cache-dir", str(tmp_path))) == 2
 
-        assert capsys.readouterr().err.rstrip().endswith(offered)
-
-    @staticmethod
-    def _refuse(command: str, project: Path) -> None:
-        """Call ``command`` with a verb no body knows."""
-        arguments: dict[str, Any] = {"cache_dir": project / "cache"}
-
-        if command == "config":
-            pyproject = project / "pyproject.toml"
-            pyproject.write_text(_MINIMAL_PROJECT, encoding="utf-8")
-            arguments["path"] = pyproject
-
-        _command_function(command)("frobnicate", **arguments)
+        assert offered in capsys.readouterr().err
 
 
 class TestLockfileFlagStability:

--- a/tests/test_cli_docs.py
+++ b/tests/test_cli_docs.py
@@ -914,13 +914,12 @@ class TestCliReferenceMatchesTheseFourBehaviours:
             assert fragment in page, fragment
             assert fragment in body, fragment
 
-    def test_the_exit_one_row_names_an_unknown_action(self, tmp_path: Path) -> None:
-        assert run(("cache", "bogus", "--cache-dir", str(tmp_path))) == 1
+    def test_the_exit_two_row_names_an_unknown_action(self, tmp_path: Path) -> None:
+        assert run(("cache", "bogus", "--cache-dir", str(tmp_path))) == 2
 
-        row = self._rows("## Exit codes")["1"]
-        assert "action" in row
-        for sub in ("cache", "config"):
-            assert f"`{sub}`" in row, sub
+        rows = self._rows("## Exit codes")
+        assert "action" in rows["2"]
+        assert "action" not in rows["1"]
 
     def test_the_environment_table_names_the_config_root(self) -> None:
         assert "XDG_CONFIG_HOME" in self._rows("## Environment variables")

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -609,13 +609,14 @@ def test_only_structured_tables_lack_a_project_flag() -> None:
 
 
 class TestConfigErrors:
-    def test_unknown_action_exits(
-        self, hermetic_roots: Path, capsys: pytest.CaptureFixture[str]
+    def test_an_unknown_action_never_reaches_the_body(
+        self, hermetic_roots: Path
     ) -> None:
+        """The parser refuses it, so the body only asserts it cannot happen."""
         _project(hermetic_roots)
-        with pytest.raises(SystemExit):
+
+        with pytest.raises(AssertionError, match="unreachable config action"):
             config_command("frobnicate", path=hermetic_roots / "pyproject.toml")
-        assert "unknown config action" in capsys.readouterr().err
 
     def test_missing_path_exits(
         self, hermetic_roots: Path, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
`nab cache bogus` answers in a different shape from every other bad word on a line, and with a different status:

    $ nab bogus            nab: unknown command 'bogus'                        exit 2
    $ nab lock --outpt x   nab lock: unrecognized option '--outpt'             exit 2
    $ nab cache bogus      error: unknown cache action 'bogus'                 exit 1

The action is declared as `Verb[Literal["dir", "verify", "clear"]]` and the generated spec carries that set, so the parser already knew it. It skipped the check because `_convert` tested `vtype == "choice"` and a verb row's vtype is `str`. Testing `row.choices` instead covers both, and `cache` and `config` now refuse like anything else:

    nab cache: invalid value 'bogus' for 'action'; choose from dir, verify, clear
    Try 'nab cache --help' for more information.

**An unknown action moves from exit 1 to exit 2**, which is the change worth your call. The exit-code table moves with it.

The two hand-written checks go, since the set is declared once. Each command body keeps an unreachable `AssertionError` rather than an `else` that would silently run `clear`.
