### PR TITLE
Hand-write lockfile.py's seven value types, ~2% off a `nab lock`

### DIFF
--- a/nab-project/src/nab_project/_build/env.py
+++ b/nab-project/src/nab_project/_build/env.py
@@ -560,7 +560,7 @@ class NabBuildEnv:
             # The sdist goes with the wheels the narrowing drops: nothing
             # installs it, and a bad one would fail the download and take
             # the build with it.
-            return replace(pin, wheels=(preferred,), sdist=None)
+            return pin.replace(wheels=(preferred,), sdist=None)
 
         label = chain_label(pin.name, pin.version)
         chain = self._chain
@@ -588,7 +588,7 @@ class NabBuildEnv:
         to_build.append(
             _PendingBuild(name=pin.name, version=pin.version, sdist=pin.sdist)
         )
-        return replace(pin, wheels=())
+        return pin.replace(wheels=())
 
     def _build_requirement(self, pending: _PendingBuild, wheel_dir: Path) -> Path:
         """Build the downloaded sdist of ``pending`` and return the wheel's path.

--- a/nab-project/src/nab_project/lockfile.py
+++ b/nab-project/src/nab_project/lockfile.py
@@ -50,6 +50,7 @@ from ._lockfile.validate import (
     RootRequirement,
     check_locked,
 )
+from .value import ValueType
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -123,8 +124,7 @@ def _select_primary_digest(
     return None
 
 
-@dataclass(frozen=True, slots=True)
-class WheelArtifact:
+class WheelArtifact(ValueType):
     """A single wheel file to record in the lockfile.
 
     ``hashes`` is the set of (algorithm, digest) pairs the index
@@ -141,12 +141,38 @@ class WheelArtifact:
     for a wheel fetched from a remote index.
     """
 
+    __slots__ = __match_args__ = (
+        "filename",
+        "url",
+        "hashes",
+        "size",
+        "upload_time",
+        "local_path",
+    )
+
     filename: str
     url: str
     hashes: tuple[tuple[str, str], ...]
-    size: int | None = None
-    upload_time: datetime | None = None
-    local_path: Path | None = None
+    size: int | None
+    upload_time: datetime | None
+    local_path: Path | None
+
+    def __init__(
+        self,
+        filename: str,
+        url: str,
+        hashes: tuple[tuple[str, str], ...],
+        size: int | None = None,
+        upload_time: datetime | None = None,
+        local_path: Path | None = None,
+    ) -> None:
+        """Record the wheel ``filename`` and where its bytes come from."""
+        self.filename = filename
+        self.url = url
+        self.hashes = hashes
+        self.size = size
+        self.upload_time = upload_time
+        self.local_path = local_path
 
     @property
     def primary_digest(self) -> tuple[str, str]:
@@ -158,20 +184,45 @@ class WheelArtifact:
         return chosen
 
 
-@dataclass(frozen=True, slots=True)
-class SdistArtifact:
+class SdistArtifact(ValueType):
     """An sdist tarball to record in the lockfile.
 
     See :class:`WheelArtifact` for the meaning of ``hashes``,
     ``upload_time`` and ``local_path``.
     """
 
+    __slots__ = __match_args__ = (
+        "filename",
+        "url",
+        "hashes",
+        "size",
+        "upload_time",
+        "local_path",
+    )
+
     filename: str
     url: str
     hashes: tuple[tuple[str, str], ...]
-    size: int | None = None
-    upload_time: datetime | None = None
-    local_path: Path | None = None
+    size: int | None
+    upload_time: datetime | None
+    local_path: Path | None
+
+    def __init__(
+        self,
+        filename: str,
+        url: str,
+        hashes: tuple[tuple[str, str], ...],
+        size: int | None = None,
+        upload_time: datetime | None = None,
+        local_path: Path | None = None,
+    ) -> None:
+        """Record the sdist ``filename`` and where its bytes come from."""
+        self.filename = filename
+        self.url = url
+        self.hashes = hashes
+        self.size = size
+        self.upload_time = upload_time
+        self.local_path = local_path
 
     @property
     def primary_digest(self) -> tuple[str, str]:
@@ -183,24 +234,53 @@ class SdistArtifact:
         return chosen
 
 
-@dataclass(frozen=True, slots=True)
-class IndexPin:
+class IndexPin(ValueType):
     """A package resolved from a Simple-API index.
 
     ``index`` is the URL of the Simple-API root that served the
     package, matching what PEP 751 expects for ``packages.index``.
     """
 
+    __slots__ = __match_args__ = (
+        "name",
+        "version",
+        "index",
+        "sdist",
+        "wheels",
+        "requires_python",
+    )
+
     name: str
     version: str
     index: str
-    sdist: SdistArtifact | None = None
-    wheels: tuple[WheelArtifact, ...] = ()
-    requires_python: str | None = None
+    sdist: SdistArtifact | None
+    wheels: tuple[WheelArtifact, ...]
+    requires_python: str | None
+
+    def __init__(
+        self,
+        name: str,
+        version: str,
+        index: str,
+        sdist: SdistArtifact | None = None,
+        wheels: tuple[WheelArtifact, ...] = (),
+        requires_python: str | None = None,
+    ) -> None:
+        """Record the ``version`` of ``name`` that ``index`` served."""
+        self.name = name
+        self.version = version
+        self.index = index
+        self.sdist = sdist
+        self.wheels = wheels
+        self.requires_python = requires_python
+
+    def replace(self, **changes: object) -> IndexPin:
+        """Return a copy with ``changes`` applied, as ``dataclasses.replace`` would."""
+        kept = {name: getattr(self, name) for name in self.__match_args__}
+        return IndexPin(**{**kept, **changes})
 
 
-@dataclass(frozen=True, slots=True)
-class LocalPin:
+class LocalPin(ValueType):
     """A package resolved from a local checkout.
 
     ``path`` is the absolute filesystem path the resolver was pointed
@@ -211,15 +291,32 @@ class LocalPin:
     Both come from the ``[[tool.nab.local-sources]]`` entry.
     """
 
+    __slots__ = __match_args__ = ("name", "version", "path", "editable", "subdirectory")
+
     name: str
     version: str
     path: str
-    editable: bool = False
-    subdirectory: str | None = None
+    editable: bool
+    subdirectory: str | None
+
+    def __init__(
+        self,
+        name: str,
+        version: str,
+        path: str,
+        *,
+        editable: bool = False,
+        subdirectory: str | None = None,
+    ) -> None:
+        """Record the tree at ``path`` as the source of ``name``."""
+        self.name = name
+        self.version = version
+        self.path = path
+        self.editable = editable
+        self.subdirectory = subdirectory
 
 
-@dataclass(frozen=True, slots=True)
-class VcsPin:
+class VcsPin(ValueType):
     """A package resolved from a VCS clone.
 
     ``repo_url`` is the reproducible pip-style installable URL: the
@@ -239,18 +336,49 @@ class VcsPin:
     scheme.
     """
 
+    __slots__ = __match_args__ = (
+        "name",
+        "version",
+        "repo_url",
+        "bare_repo_url",
+        "commit_id",
+        "subdirectory",
+        "requested_revision",
+        "vcs_type",
+    )
+
     name: str
     version: str
     repo_url: str
     bare_repo_url: str
     commit_id: str
-    subdirectory: str | None = None
-    requested_revision: str | None = None
-    vcs_type: str = "git"
+    subdirectory: str | None
+    requested_revision: str | None
+    vcs_type: str
+
+    def __init__(
+        self,
+        name: str,
+        version: str,
+        repo_url: str,
+        bare_repo_url: str,
+        commit_id: str,
+        subdirectory: str | None = None,
+        requested_revision: str | None = None,
+        vcs_type: str = "git",
+    ) -> None:
+        """Record ``name`` as the clone of ``repo_url`` at ``commit_id``."""
+        self.name = name
+        self.version = version
+        self.repo_url = repo_url
+        self.bare_repo_url = bare_repo_url
+        self.commit_id = commit_id
+        self.subdirectory = subdirectory
+        self.requested_revision = requested_revision
+        self.vcs_type = vcs_type
 
 
-@dataclass(frozen=True, slots=True)
-class ArchivePin:
+class ArchivePin(ValueType):
     """A package resolved from a direct-URL archive.
 
     ``url`` is the archive URL with the hash fragment stripped, written
@@ -263,11 +391,28 @@ class ArchivePin:
     records it (see :func:`_pin_to_package`).
     """
 
+    __slots__ = __match_args__ = ("name", "version", "url", "hashes", "subdirectory")
+
     name: str
     version: str
     url: str
     hashes: tuple[tuple[str, str], ...]
-    subdirectory: str | None = None
+    subdirectory: str | None
+
+    def __init__(
+        self,
+        name: str,
+        version: str,
+        url: str,
+        hashes: tuple[tuple[str, str], ...],
+        subdirectory: str | None = None,
+    ) -> None:
+        """Record the archive at ``url`` as the source of ``name``."""
+        self.name = name
+        self.version = version
+        self.url = url
+        self.hashes = hashes
+        self.subdirectory = subdirectory
 
     @property
     def primary_digest(self) -> tuple[str, str]:
@@ -282,8 +427,7 @@ class ArchivePin:
 PinShape = IndexPin | LocalPin | VcsPin | ArchivePin
 
 
-@dataclass(frozen=True, slots=True)
-class Provenance:
+class Provenance(ValueType):
     """Optional ``[tool.nab]`` provenance block written into the lock.
 
     PEP 751 lets tools record any additional metadata under
@@ -295,20 +439,58 @@ class Provenance:
     feed any of it into the install path.
     """
 
+    __slots__ = __match_args__ = (
+        "nab_version",
+        "created_at",
+        "command_line",
+        "input_path",
+        "mode",
+        "python_specifier",
+        "platforms",
+        "cli_project_overrides",
+        "package_metadata_overrides",
+    )
+
     nab_version: str
     created_at: datetime
     command_line: tuple[str, ...]
     input_path: str
     mode: str
-    python_specifier: str | None = None
-    platforms: tuple[str, ...] = ()
-    # The --project-* CLI overrides that shaped this lock, as
-    # ``(flag, rendered value)`` pairs.  Recorded so a reader can see the
-    # lock did not derive from the committed files alone.
-    cli_project_overrides: tuple[tuple[str, str], ...] = ()
-    # The configured ``[tool.nab]`` per-package metadata overrides as
-    # ``(requirement, (field, ...))`` pairs; input provenance, audit-only.
-    package_metadata_overrides: tuple[tuple[str, tuple[str, ...]], ...] = ()
+    python_specifier: str | None
+    platforms: tuple[str, ...]
+
+    cli_project_overrides: tuple[tuple[str, str], ...]
+    """The ``--project-*`` CLI overrides that shaped this lock, as
+    ``(flag, rendered value)`` pairs.  Recorded so a reader can see the
+    lock did not derive from the committed files alone."""
+
+    package_metadata_overrides: tuple[tuple[str, tuple[str, ...]], ...]
+    """The configured ``[tool.nab]`` per-package metadata overrides, as
+    ``(requirement, (field, ...))`` pairs."""
+
+    def __init__(  # noqa: PLR0913 - one keyword per input the lock records
+        self,
+        nab_version: str,
+        created_at: datetime,
+        command_line: tuple[str, ...],
+        input_path: str,
+        mode: str,
+        *,
+        python_specifier: str | None = None,
+        platforms: tuple[str, ...] = (),
+        cli_project_overrides: tuple[tuple[str, str], ...] = (),
+        package_metadata_overrides: tuple[tuple[str, tuple[str, ...]], ...] = (),
+    ) -> None:
+        """Record the inputs that produced the lock."""
+        self.nab_version = nab_version
+        self.created_at = created_at
+        self.command_line = command_line
+        self.input_path = input_path
+        self.mode = mode
+        self.python_specifier = python_specifier
+        self.platforms = platforms
+        self.cli_project_overrides = cli_project_overrides
+        self.package_metadata_overrides = package_metadata_overrides
 
     def to_block(self) -> dict[str, Any]:
         """Render to the dict the TOML writer drops under ``[tool.nab]``.

--- a/nab-project/tests/test_project_value_types.py
+++ b/nab-project/tests/test_project_value_types.py
@@ -1,9 +1,10 @@
-"""The value types nab-project declares.
+"""The conflict and input value types nab-project declares.
 
 ``ConflictSet``, ``ConflictMember``, ``ConflictFork`` and ``ResolveInputs``
 are written against :class:`nab_project.value.ValueType` rather than
 ``@dataclass``, so the base's equality and each type's own rendering are
-pinned here.
+pinned here.  A new subclass also needs a case in the umbrella suite's
+``tests/test_value_types.py``.
 """
 
 from __future__ import annotations

--- a/tests/test_value_types.py
+++ b/tests/test_value_types.py
@@ -1,4 +1,4 @@
-"""The hand-written value types of the ``[tool.nab]`` surface.
+"""The hand-written value types of the ``[tool.nab]`` surface and the lockfile.
 
 They subclass :class:`nab_project.value.ValueType` rather than applying
 ``@dataclass(slots=True)``, so field order, equality, hashing, repr and the
@@ -26,7 +26,7 @@ from nab.config.ladder import (
 )
 from nab.config.values import MatrixConfig
 from nab.optiondefs import Kind, Opt, Scope, VType
-from nab_project import conflicts, inputs
+from nab_project import conflicts, inputs, lockfile
 from nab_project.conflicts import (
     ConflictFork,
     ConflictKind,
@@ -35,6 +35,15 @@ from nab_project.conflicts import (
     ConflictSet,
 )
 from nab_project.inputs import ResolveInputs
+from nab_project.lockfile import (
+    ArchivePin,
+    IndexPin,
+    LocalPin,
+    Provenance,
+    SdistArtifact,
+    VcsPin,
+    WheelArtifact,
+)
 from nab_project.value import ValueType
 from nab_provider._vendor.packaging.requirements import Requirement
 from nab_provider.overrides import IndexOverride, PackageOverride
@@ -94,6 +103,18 @@ PACKAGE_OVERRIDE = PackageOverride(
 ORIGIN = Origin(SourceKind.PYPROJECT, "/p/pyproject.toml")
 OTHER_ORIGIN = Origin(SourceKind.USER_TOML, "/u/nab.toml")
 SPEC = _option("mode")
+
+LOCKED_AT = datetime(2026, 1, 1, tzinfo=timezone.utc)
+LATER = datetime(2026, 2, 1, tzinfo=timezone.utc)
+
+WHEEL = WheelArtifact(
+    "acme-1.0-py3-none-any.whl",
+    "https://acme.test/acme-1.0-py3-none-any.whl",
+    (("sha256", "a" * 64),),
+)
+SDIST = SdistArtifact(
+    "acme-1.0.tar.gz", "https://acme.test/acme-1.0.tar.gz", (("sha256", "b" * 64),)
+)
 
 
 class Case(NamedTuple):
@@ -271,6 +292,147 @@ CASES = [
             "pyproject": None,
         },
     ),
+    Case(
+        WheelArtifact,
+        {
+            "filename": "acme-1.0-py3-none-any.whl",
+            "url": "https://acme.test/acme-1.0-py3-none-any.whl",
+            "hashes": (("sha256", "a" * 64),),
+            "size": 1024,
+            "upload_time": LOCKED_AT,
+            "local_path": Path("/w/acme-1.0-py3-none-any.whl"),
+        },
+        {
+            "filename": "acme-2.0-py3-none-any.whl",
+            "url": "https://acme.test/acme-2.0-py3-none-any.whl",
+            "hashes": (("sha256", "b" * 64),),
+            "size": 2048,
+            "upload_time": LATER,
+            "local_path": None,
+        },
+    ),
+    Case(
+        SdistArtifact,
+        {
+            "filename": "acme-1.0.tar.gz",
+            "url": "https://acme.test/acme-1.0.tar.gz",
+            "hashes": (("sha256", "b" * 64),),
+            "size": 4096,
+            "upload_time": LOCKED_AT,
+            "local_path": Path("/w/acme-1.0.tar.gz"),
+        },
+        {
+            "filename": "acme-2.0.tar.gz",
+            "url": "https://acme.test/acme-2.0.tar.gz",
+            "hashes": (("sha256", "c" * 64),),
+            "size": 8192,
+            "upload_time": LATER,
+            "local_path": None,
+        },
+    ),
+    Case(
+        IndexPin,
+        {
+            "name": "acme",
+            "version": "1.0",
+            "index": "https://acme.test/simple/",
+            "sdist": SDIST,
+            "wheels": (WHEEL,),
+            "requires_python": ">=3.10",
+        },
+        {
+            "name": "beta",
+            "version": "2.0",
+            "index": "https://beta.test/simple/",
+            "sdist": None,
+            "wheels": (),
+            "requires_python": ">=3.11",
+        },
+    ),
+    Case(
+        LocalPin,
+        {
+            "name": "alpha",
+            "version": "1.0",
+            "path": "/p/alpha",
+            "editable": True,
+            "subdirectory": "packages/alpha",
+        },
+        {
+            "name": "beta",
+            "version": "2.0",
+            "path": "/p/beta",
+            "editable": False,
+            "subdirectory": None,
+        },
+        positional=False,
+    ),
+    Case(
+        VcsPin,
+        {
+            "name": "gamma",
+            "version": "1.0",
+            "repo_url": "git+https://g.test/gamma@" + "c" * 40,
+            "bare_repo_url": "https://g.test/gamma",
+            "commit_id": "c" * 40,
+            "subdirectory": "packages/gamma",
+            "requested_revision": "main",
+            "vcs_type": "git",
+        },
+        {
+            "name": "delta",
+            "version": "2.0",
+            "repo_url": "git+https://d.test/delta@" + "d" * 40,
+            "bare_repo_url": "https://d.test/delta",
+            "commit_id": "d" * 40,
+            "subdirectory": None,
+            "requested_revision": "release",
+            "vcs_type": "hg",
+        },
+    ),
+    Case(
+        ArchivePin,
+        {
+            "name": "epsilon",
+            "version": "1.0",
+            "url": "https://e.test/epsilon-1.0.zip",
+            "hashes": (("sha256", "e" * 64),),
+            "subdirectory": "packages/epsilon",
+        },
+        {
+            "name": "zeta",
+            "version": "2.0",
+            "url": "https://e.test/zeta-2.0.zip",
+            "hashes": (("sha256", "f" * 64),),
+            "subdirectory": None,
+        },
+    ),
+    Case(
+        Provenance,
+        {
+            "nab_version": "0.0.7",
+            "created_at": LOCKED_AT,
+            "command_line": ("nab", "lock"),
+            "input_path": "/p/pyproject.toml",
+            "mode": "specific",
+            "python_specifier": ">=3.10",
+            "platforms": ("linux_x86_64",),
+            "cli_project_overrides": (("--project-resolution", "lowest"),),
+            "package_metadata_overrides": (("foo>=1", ("requires-dist",)),),
+        },
+        {
+            "nab_version": "0.0.8",
+            "created_at": LATER,
+            "command_line": ("nab", "lock", "--upgrade"),
+            "input_path": "/q/pyproject.toml",
+            "mode": "universal",
+            "python_specifier": ">=3.11",
+            "platforms": ("macos_arm64",),
+            "cli_project_overrides": (),
+            "package_metadata_overrides": (),
+        },
+        positional=False,
+    ),
 ]
 
 BY_ID = pytest.mark.parametrize("case", CASES, ids=[c.id for c in CASES])
@@ -313,7 +475,7 @@ def test_the_cases_cover_every_value_type() -> None:
     """A subclass these modules name and ``CASES`` omits would go unchecked."""
     declared = {
         obj
-        for module in (hooks, ladder, model, values, conflicts, inputs)
+        for module in (hooks, ladder, model, values, conflicts, inputs, lockfile)
         for obj in vars(module).values()
         if isinstance(obj, type) and issubclass(obj, ValueType) and obj is not ValueType
     }
@@ -355,7 +517,7 @@ def test_repr_names_every_field_in_order(case: Case) -> None:
 
 
 def test_repr_leads_with_the_qualified_name() -> None:
-    """All eleven are module-level, so only a nested class separates the two names."""
+    """Every case is module-level, so only a nested class separates the two names."""
 
     class Nested(ValueType):
         __slots__ = __match_args__ = ("value",)


### PR DESCRIPTION
Locally a `nab lock` runs about 2.3% faster, between about 1.8% and 2.7% over 40 runs of each version: roughly 3 ms off a 143 ms offline lock of a 9-package project (requests, rich, urllib3).

`@dataclass` builds `__init__`, `__eq__` and `__repr__` with `exec` at every import, and `nab_project/lockfile.py` applies it nine times. Hand-writing seven of those on the package's own `nab_project.value.ValueType` takes `import nab._lock` from 708,113,085 instructions to 679,154,289, a drop of 28,958,796 (4.09%). `import nab._download` drops the same 4%.

The saving is fixed at 28.5 to 29.2 million instructions whatever the command goes on to do, so its share falls as the work grows: 3.99% of an offline lock of one local source, about 2.8% of the 9-package lock. Peak memory on that lock falls 91,502 bytes of 20,023,888.

`TargetLock` and `LockInput` keep the decorator, because `dataclasses.replace()` reaches them from `lockfile.py`, `_lockfile/pylock.py`, `_build/env.py` and `nab._lock`. `IndexPin` grew its own `replace()` for the two call sites in `_build/env.py`. `LocalPin.editable` and `Provenance`'s optional fields are keyword-only now; no caller passed them positionally.
