### PR TITLE
Send nab config explain dist-policy to the page that documents the key

### DIFF
--- a/docs/explanation/universal.md
+++ b/docs/explanation/universal.md
@@ -74,6 +74,11 @@ platforms = ["linux_x86_64", "macos_arm64"]
 python-order = "asc"
 ```
 
+`mode` selects the resolve. It defaults to `"specific"`, one version
+per package for a single environment. `"universal"` resolves every
+target the matrix declares, and a project file setting one without the
+other is a config error.
+
 `python` is a PEP 440 specifier expanded into one target per
 minor version. `platforms` is a list of platform ids
 (`linux_x86_64`, `linux_aarch64`, `linux_i686`, `linux_armv7l`,

--- a/src/nab/optiontable.py
+++ b/src/nab/optiontable.py
@@ -248,7 +248,6 @@ class ProjectKeys(
             render=hooks.render_dist_policy,
         ),
         help="which distribution kinds the resolve may pin",
-        docs="reference/build-policy.md",
     )
 
     build_policy = Value[BuildPolicyFlag | None](

--- a/tests/test_cli_docs.py
+++ b/tests/test_cli_docs.py
@@ -133,6 +133,11 @@ def _names_flag(text: str, flag: str) -> bool:
     )
 
 
+def _names_value(text: str, value: str) -> bool:
+    """Whether ``text`` writes ``value`` as a literal: a code span or a quoted token."""
+    return re.search(rf"""[`"']{re.escape(value)}(?![\w-])""", text) is not None
+
+
 def _unwrapped(text: str) -> str:
     """``text`` with its line wrapping removed, so a claim matches on one line."""
     return " ".join(text.split())
@@ -255,6 +260,25 @@ class TestEveryRowNamesAPage:
         missing = sorted({row.docs for row in ALL if not (_DOCS / row.docs).is_file()})
 
         assert missing == []
+
+    def test_a_key_links_to_a_page_that_writes_out_its_values(self) -> None:
+        """The page a key names writes out every value that key takes.
+
+        A value counts only where the page writes it as a literal, so the
+        word in ordinary prose does not stand in for the documented value.
+        The key count is asserted because an empty list would pass the loop.
+        """
+        enumerated = [row for row in OPTIONS if row.choices]
+        assert len(enumerated) == 6, [row.name for row in enumerated]
+
+        unlisted: dict[str, list[str]] = {}
+        for row in enumerated:
+            page = _page(_DOCS / row.docs)
+            missing = [value for value in row.choices if not _names_value(page, value)]
+            if missing:
+                unlisted[row.name] = missing
+
+        assert unlisted == {}
 
 
 class TestCliReferenceFlagCoverage:

--- a/tests/test_cli_table.py
+++ b/tests/test_cli_table.py
@@ -54,7 +54,7 @@ _PAGES = (
     ("build-group", "reference/selection.md"),
     ("requires-python", "reference/configuration.md"),
     ("uploaded-prior-to", "reference/configuration.md"),
-    ("dist-policy", "reference/build-policy.md"),
+    ("dist-policy", "reference/configuration.md"),
     ("build-policy", "reference/build-policy.md"),
     ("build-requires-depth", "reference/build-policy.md"),
     ("environment", "reference/configuration.md"),


### PR DESCRIPTION
`nab config explain dist-policy` points at a page that never documents the key:

```
dist-policy (project, enum(wheel-only|prefer-wheel|wheel-or-sdist|sdist-only|sdist-install))
  which distribution kinds the resolve may pin
  see https://nab.readthedocs.io/en/stable/reference/build-policy.html
```

`reference/build-policy.md` is about `build-policy`. It names three of the five dist policies in passing and never `prefer-wheel` or `wheel-or-sdist`. All five have a table under "Dist policy" in `reference/configuration.md`, the page `ProjectKeys` already defaults to, so the row's `docs=` override comes out.

A test now asserts that for each of the six keys with a fixed value set, the page it names writes out every value as a literal. That caught `mode` too: `explanation/universal.md` shows `mode = "universal"` in an example and never writes `"specific"`, so the page now documents both values and the matrix table `"universal"` requires.
