### PR TITLE
Hold a lone sha256 table as its digest, 7.6% off langchain peak memory

### DIFF
--- a/nab-provider/src/nab_provider/records.py
+++ b/nab-provider/src/nab_provider/records.py
@@ -106,12 +106,15 @@ def sidecar_hash(value: object) -> tuple[str, str] | None:
 def _compact_table(table: dict[object, object]) -> object:
     """Return the form of ``table`` a record holds until something reads it.
 
-    An index almost always publishes one algorithm, and holding that as an
-    interned ``(algo, digest)`` pair retains less than the dict it was served
-    as.  Anything else is held as it stands.
+    An index almost always publishes one sha256 digest, and that is held as the
+    digest alone.  Any other one-entry table with a string name is held as an
+    interned ``(algo, digest)`` pair, and anything else as the dict it was
+    served as.
     """
     if len(table) == 1:
         ((algo, digest),) = table.items()
+        if algo == "sha256" and type(digest) is str:
+            return digest
         if type(algo) is str:
             return (sys.intern(algo), digest)
     return table
@@ -127,6 +130,8 @@ def _compact_shared_table(table: dict[object, object]) -> object:
     """
     if len(table) == 1:
         ((algo, digest),) = table.items()
+        if algo == "sha256" and type(digest) is str:
+            return digest
         if type(algo) is str:
             return (algo, digest)
     return table
@@ -134,6 +139,8 @@ def _compact_shared_table(table: dict[object, object]) -> object:
 
 def _expand_table(held: object) -> object:
     """Return ``held`` as the index served it, undoing :func:`_compact_table`."""
+    if type(held) is str:
+        return {"sha256": held}
     if isinstance(held, tuple):
         algo, digest = held
         return {algo: digest}

--- a/nab-provider/tests/test_record_deferral.py
+++ b/nab-provider/tests/test_record_deferral.py
@@ -16,7 +16,9 @@ from nab_provider.records import (
 )
 
 DIGEST = "a" * 64
+SHA512_DIGEST = "b" * 128
 SHA256 = "sha256"
+SHA512 = "sha512"
 _TIMEOUT = 10.0
 
 
@@ -79,12 +81,33 @@ def test_a_second_read_returns_the_value_the_first_stored() -> None:
     assert wheel.metadata_hash is metadata_hash
 
 
-def test_a_one_algorithm_table_is_held_as_a_pair() -> None:
+def test_a_lone_sha256_table_is_held_as_the_digest_alone() -> None:
     """The compact form is why a deferred record costs less than the served dict."""
     wheel = _deferred_wheel({"sha256": DIGEST}, sidecar={"sha256": DIGEST})
 
-    assert wheel._raw_hashes == (SHA256, DIGEST)
-    assert wheel._raw_metadata == (SHA256, DIGEST)
+    assert wheel._raw_hashes == DIGEST
+    assert wheel._raw_metadata == DIGEST
+
+
+def test_a_lone_other_algorithm_table_is_held_as_a_pair() -> None:
+    """Only sha256 can be held as the digest alone; another name is kept beside it."""
+    wheel = _deferred_wheel(
+        {"sha512": SHA512_DIGEST}, sidecar={"sha512": SHA512_DIGEST}
+    )
+
+    assert wheel._raw_hashes == (SHA512, SHA512_DIGEST)
+    assert wheel._raw_metadata == (SHA512, SHA512_DIGEST)
+
+
+def test_a_lone_sha256_whose_digest_is_not_a_string_keeps_its_name() -> None:
+    """Only a string digest can stand for the table, so a non-string keeps its name."""
+    wheel = _deferred_wheel({"sha256": 7}, sidecar={"sha256": 7})
+
+    assert wheel._raw_hashes == (SHA256, 7)
+    assert wheel._raw_metadata == (SHA256, 7)
+
+    assert wheel.raw_hashes() == {"sha256": 7}
+    assert wheel.raw_sidecar() == {"sha256": 7}
 
 
 def test_a_many_algorithm_table_is_held_as_it_stands() -> None:
@@ -96,23 +119,35 @@ def test_a_many_algorithm_table_is_held_as_it_stands() -> None:
     assert wheel._raw_metadata == table
 
 
+def test_a_rehydrated_lone_sha256_table_is_held_as_the_digest_alone() -> None:
+    """A row rebuilt from a cached listing takes the same compact form."""
+    wheel = _rehydrated_wheel({"sha256": DIGEST})
+
+    assert wheel._raw_hashes == DIGEST
+    assert wheel._raw_metadata == DIGEST
+
+    assert wheel.hashes == ((SHA256, DIGEST),)
+    assert wheel.metadata_hash == (SHA256, DIGEST)
+    assert wheel.raw_hashes() == {"sha256": DIGEST}
+
+
 def test_a_rehydrated_one_algorithm_table_keeps_the_name_the_row_carried() -> None:
     """One blob decodes to one name object, so re-interning it per row buys nothing."""
-    algo = b"sha256".decode()
-    assert algo is not SHA256
+    algo = b"sha512".decode()
+    assert algo is not SHA512
 
-    wheel = _rehydrated_wheel({algo: DIGEST})
+    wheel = _rehydrated_wheel({algo: SHA512_DIGEST})
     hashes, metadata = wheel._raw_hashes, wheel._raw_metadata
     assert isinstance(hashes, tuple)
     assert isinstance(metadata, tuple)
 
-    assert hashes == (algo, DIGEST)
+    assert hashes == (algo, SHA512_DIGEST)
     assert hashes[0] is algo
     assert metadata[0] is algo
 
     # Reading the field parses and interns, so the pair a caller sees is unchanged.
-    assert wheel.hashes == ((SHA256, DIGEST),)
-    assert wheel.hashes[0][0] is SHA256
+    assert wheel.hashes == ((SHA512, SHA512_DIGEST),)
+    assert wheel.hashes[0][0] is SHA512
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Peak memory on a warm `pip:langchain-ml-course --resolution lowest` resolve falls about 7.6%, 16.9 MB off a 221 MB peak, and about 5.6% on `pip:google-bigquery-soda --resolution lowest`. Both sides drew the same decisions.

An index row almost always publishes exactly one sha256 digest, and a wheel carries a second for its PEP 714 sidecar. Each was held as a fresh 56-byte `(algo, digest)` tuple; `_compact_table` and `_compact_shared_table` now keep the digest alone, and `_expand_table` puts the name back when something reads the table. The held form never leaves memory, so no cache format moves.

The memory is not bought back in CPU. Instructions fall the same way, 2.2% on soda and 2.6% on langchain.

Locally the clock sees more than that. Of the 19-scenario canary set, 17 report a wall time and 15 of those got faster, by about 2% to 21%; resampling scenarios puts the median between about 7% and 17% faster. On soda the working set shrinks too: first-level data misses fall about 7%, last-level about 11%. That does not account for all of it.

Live bytes at the end of the resolve do not follow: langchain sits inside its own run-to-run spread, soda about 26 kB (0.1%) higher.
