### PR TITLE
Reject a source or workspace member name that is not a valid package name

### DIFF
--- a/nab-project/src/nab_project/workspace.py
+++ b/nab-project/src/nab_project/workspace.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING, Any
 
 import tomli
 
-from nab_provider._vendor.packaging.utils import canonicalize_name
+from nab_provider._vendor.packaging.utils import InvalidName, canonicalize_name
 from nab_provider.policy import LocalSource
 
 from . import toml_io
@@ -143,8 +143,8 @@ def workspace_local_sources(
     or ``[`` raises :class:`WorkspaceDiscoveryError` with a message
     naming the offending entry.  For every member directory the function
     opens ``<member>/pyproject.toml`` and requires ``[project].name``; a
-    pyproject that is missing or not a regular file, and a missing name,
-    are hard errors.
+    pyproject that is missing or not a regular file, and a name that is
+    missing or not a valid package name, are hard errors.
 
     Two members declaring the same canonical name raises
     :class:`WorkspaceDiscoveryError`.  The returned tuple preserves
@@ -208,7 +208,15 @@ def workspace_local_sources(
             )
             raise WorkspaceDiscoveryError(msg)
 
-        canonical = canonicalize_name(name)
+        try:
+            canonical = canonicalize_name(name, validate=True)
+        except InvalidName as exc:
+            msg = (
+                f"{member_pyproject}: workspace member [project].name"
+                f" {name!r} is not a valid package name"
+            )
+            raise WorkspaceDiscoveryError(msg) from exc
+
         if canonical in seen:
             msg = (
                 f"{declared_in}: workspace members declare duplicate"

--- a/nab-project/tests/test_workspace.py
+++ b/nab-project/tests/test_workspace.py
@@ -528,6 +528,23 @@ class TestReadWorkspaceMembers:
         ):
             read_workspace_members(root)
 
+    def test_member_with_invalid_name_raises(self, tmp_path: Path) -> None:
+        root = _write(
+            tmp_path / "pyproject.toml",
+            '[project]\nname = "ws"\nversion = "0"\n'
+            "[tool.nab.workspace]\n"
+            'members = ["pkg"]\n',
+        )
+        member = _write(
+            tmp_path / "pkg" / "pyproject.toml",
+            '[project]\nname = "my pkg"\nversion = "0"\n',
+        )
+        with pytest.raises(
+            WorkspaceDiscoveryError,
+            match=rf"{re.escape(str(member))}.*is not a valid package name",
+        ):
+            read_workspace_members(root)
+
     def test_duplicate_canonical_name_raises(self, tmp_path: Path) -> None:
         # ``A`` and ``a`` canonicalise to the same name.
         root = _write(

--- a/src/nab/config/values.py
+++ b/src/nab/config/values.py
@@ -1416,6 +1416,19 @@ def _validate_allowed_repo(repo: str) -> None:
         raise SourceConfigError(msg) from exc
 
 
+def _validate_source_name(where: str, index: int, name: str) -> None:
+    """Reject a declared source ``name`` that is not a valid package name.
+
+    A source is matched to a requirement by canonical name, so a name
+    that is not a package name can never match one.
+    """
+    try:
+        canonicalize_name(name, validate=True)
+    except InvalidName as exc:
+        msg = f"{where}[{index}] name {name!r} is not a valid package name"
+        raise SourceConfigError(msg) from exc
+
+
 _LOCAL_SOURCE_KEYS = frozenset({"name", "path", "editable", "subdirectory"})
 
 
@@ -1443,6 +1456,8 @@ def _parse_local_source(
     if not isinstance(name, str) or not isinstance(path_value, str):
         msg = f"{where}[{i}] name and path must be strings"
         raise SourceConfigError(msg)
+
+    _validate_source_name(where, i, name)
 
     editable = entry.get("editable", False)
     if not isinstance(editable, bool):
@@ -1485,16 +1500,18 @@ def parse_local_sources(
 
 def parse_vcs_sources(value: object, where: str) -> tuple[VcsSource, ...]:
     """Read ``vcs-sources``, one name and url per table."""
-    return tuple(
-        VcsSource(name=entry.name, url=entry.url)
-        for entry in _iter_name_url_tables(where, value)
-    )
+    out: list[VcsSource] = []
+    for entry in _iter_name_url_tables(where, value):
+        _validate_source_name(where, entry.position, entry.name)
+        out.append(VcsSource(name=entry.name, url=entry.url))
+    return tuple(out)
 
 
 def parse_archive_sources(value: object, where: str) -> tuple[ArchiveSource, ...]:
     """Read ``archive-sources``, one name and url per table, each url validated."""
     out: list[ArchiveSource] = []
     for entry in _iter_name_url_tables(where, value):
+        _validate_source_name(where, entry.position, entry.name)
         _validate_archive_url(where, entry.position, entry.url)
         out.append(ArchiveSource(name=entry.name, url=entry.url))
     return tuple(out)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2629,6 +2629,14 @@ class TestIndexes:
         with pytest.raises(ConfigError, match="duplicate index name"):
             read_pyproject_config(path)
 
+    def test_name_is_a_label_not_a_package_name(self, tmp_path: Path) -> None:
+        # Index names label repositories, so the package-name rule does not apply.
+        path = write(
+            tmp_path,
+            '[[tool.nab.indexes]]\nname = "my index"\nurl = "https://a/"\n',
+        )
+        assert [i.name for i in read_pyproject_config(path).indexes] == ["my index"]
+
     def test_unknown_key_rejected(self, tmp_path: Path) -> None:
         path = write(
             tmp_path,
@@ -2984,6 +2992,25 @@ class TestLocalSources:
         with pytest.raises(ConfigError, match="duplicate canonical name"):
             read_pyproject_config(path)
 
+    @pytest.mark.parametrize(
+        "name", ["", "my pkg", "mypkg ", " mypkg", "my!pkg", "my/pkg"]
+    )
+    def test_invalid_name_rejected(self, tmp_path: Path, name: str) -> None:
+        path = write(
+            tmp_path,
+            f'[[tool.nab.local-sources]]\nname = "{name}"\npath = "../a"\n',
+        )
+        with pytest.raises(ConfigError, match="is not a valid package name"):
+            read_pyproject_config(path)
+
+    def test_name_needing_canonicalisation_accepted(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[[tool.nab.local-sources]]\nname = "My_Fork"\npath = "../a"\n',
+        )
+        (source,) = read_pyproject_config(path).local_sources
+        assert source.name == "My_Fork"
+
 
 class TestVcsSources:
     def test_round_trip(self, tmp_path: Path) -> None:
@@ -3047,6 +3074,16 @@ class TestVcsSources:
         with pytest.raises(ConfigError, match="duplicate canonical name"):
             read_pyproject_config(path)
 
+    def test_invalid_name_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab.vcs]\npolicy = "allow"\n'
+            '[[tool.nab.vcs-sources]]\nname = "my pkg"\n'
+            'url = "git+https://github.com/me/x.git@abc"\n',
+        )
+        with pytest.raises(ConfigError, match="is not a valid package name"):
+            read_pyproject_config(path)
+
     def test_canonical_name_collides_with_local_source(self, tmp_path: Path) -> None:
         path = write(
             tmp_path,
@@ -3069,6 +3106,14 @@ class TestArchiveSources:
         (source,) = read_pyproject_config(path).archive_sources
         assert source.name == "foo"
         assert source.url == self._URL
+
+    def test_invalid_name_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            f'[[tool.nab.archive-sources]]\nname = "my pkg"\nurl = "{self._URL}"\n',
+        )
+        with pytest.raises(ConfigError, match="is not a valid package name"):
+            read_pyproject_config(path)
 
     def test_must_be_array(self, tmp_path: Path) -> None:
         path = write(tmp_path, '[tool.nab]\narchive-sources = "x"\n')


### PR DESCRIPTION
A `name` in `[[tool.nab.local-sources]]`, `[[tool.nab.vcs-sources]]` or `[[tool.nab.archive-sources]]` that is not a valid package name is accepted and then matches nothing, so the pin is ignored and the package comes from the index instead.

```toml
[[tool.nab.local-sources]]
name = "my fork"
path = "../my-fork"
```

On main a `my-fork` dependency resolves from PyPI: sources are keyed by canonical name, and `my fork` canonicalises to itself rather than to `my-fork`.

All three now reject the name:

```
<project>/pyproject.toml: local-sources[0] name 'my fork' is not a valid package name
```

A workspace member's `[project].name` gets the same check and raises `WorkspaceDiscoveryError` naming the member's pyproject.toml.

`My_Fork` is still accepted, since it canonicalises. Index names are untouched: they label repositories, not packages.
