### PR TITLE
Share one platform-offset table per matrix, 136 KB off a 25-target peak

### DIFF
--- a/nab-provider/src/nab_provider/tags.py
+++ b/nab-provider/src/nab_provider/tags.py
@@ -628,9 +628,7 @@ class TagSet:
                 fixed[ptags.Tag(interpreter, abi, platform_)] = base
                 base += 1
 
-        return _AxisIndex(
-            multiplied, fixed, {p: i for i, p in enumerate(self._platforms)}
-        )
+        return _AxisIndex(multiplied, fixed, _platform_offsets(self._platforms))
 
     @cached_property
     def _placed(self) -> dict[frozenset[Tag], int | None]:
@@ -810,6 +808,16 @@ def _platform_axis(spec: PlatformSpec) -> tuple[str, ...]:
     and the platform axis is the same list each time.
     """
     return tuple(_platform_tags_for_spec(spec))
+
+
+@cache
+def _platform_offsets(platforms: tuple[str, ...]) -> Mapping[str, int]:
+    """Return each platform tag's offset within a block, shared across targets.
+
+    A matrix's targets differ on the interpreter/abi axis and share the
+    platform one, so one table serves every target built from ``platforms``.
+    """
+    return {platform: i for i, platform in enumerate(platforms)}
 
 
 def _python_pair(python_version: str) -> tuple[int, int]:


### PR DESCRIPTION
Peak memory on the `max-25-tuples` universal scenario (5 Pythons by 5 platform specs over `dask`) falls about 0.75%, from 18.28 MB to 18.14 MB. Every target built its own `{platform: offset}` table, though a matrix's targets share one platform axis: the 25 targets retained 25 tables holding 180,536 bytes, and keying the table on the platform tuple leaves 5 holding 41,864.

A 12-target scientific matrix (numpy, scipy, pandas, matplotlib, scikit-learn) turns 12 tables of 45,700 bytes into 3 of 15,436, worth 0.07% of that run's 41.8 MB peak and not worth having on that shape.

The trade is that the cache outlives the resolve, where the per-target tables died with their targets: the 25-target run ends about 37 KB heavier (+0.24%) and holds about 390 more live blocks. What it retains is bounded by the distinct platform axes a process sees, the bound `_platform_axis` beside it already carries.

CPU moves the same way rather than paying for it, 1,483,026 fewer instructions on `max-25-tuples` out of 2.16 billion. Peak RSS agrees, about 0.7% lower locally, between about 0.2% and 1.2%; wall time there sits inside about 1.3% either way. Every scenario in the 19-scenario canary set is single-target, so the change does no work there.
