### PR TITLE
Freeze the collector once the command module is in, ~4% off `nab cache dir`

### DIFF
--- a/src/nab/_cli/dispatch.py
+++ b/src/nab/_cli/dispatch.py
@@ -17,6 +17,8 @@ from typing import TYPE_CHECKING, cast
 from nab import output
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from nab._cli.parse import Parsed
 
 __all__ = ["dispatch"]
@@ -28,16 +30,25 @@ _USAGE_STATUS = 2
 _FAILED_STATUS = 1
 
 
+def _nothing() -> None:
+    """Stand in for the ``resume`` a caller did not supply."""
+
+
 def dispatch(
     parsed: Parsed,
     table: dict[str, tuple[str, str, str]],
     path_dests: dict[str, tuple[str, ...]],
+    *,
+    resume: Callable[[], None] = _nothing,
 ) -> tuple[int, str]:
     """Start the run's output, then run the command, and report how it ended.
 
     The module named in ``table`` is imported here rather than at the top
     of the CLI, so a command's own imports are paid by the command that
     was asked for and by no other.
+
+    ``resume`` runs between that import and the command, so a caller that
+    paused something for startup has a place to put it back.
     """
     try:
         output.begin(_options(parsed.options))
@@ -46,6 +57,7 @@ def dispatch(
 
     module_name, function_name, _summary = table[parsed.command]
     module = __import__(module_name, fromlist=(function_name,))
+    resume()
     command = getattr(module, function_name)
 
     values = dict(parsed.values)

--- a/src/nab/_entry.py
+++ b/src/nab/_entry.py
@@ -5,23 +5,38 @@ from __future__ import annotations
 import gc
 
 
+def _resume_collector() -> None:
+    """Freeze what startup built, then turn the cyclic collector back on.
+
+    A second call does nothing, so the CLI's call and
+    :func:`console_entry`'s cannot both freeze.
+    """
+    if gc.isenabled():
+        return
+
+    if hasattr(gc, "freeze"):  # PyPy has no gc.freeze
+        gc.freeze()
+    gc.enable()
+
+
 def console_entry() -> None:
-    """Import the CLI with the cyclic collector off, then hand the process to it.
+    """Hand the process to the CLI with the cyclic collector off.
 
-    Both entry paths name this module rather than :mod:`nab.cli` so that no
-    part of the CLI's import graph is built while the collector is on: the
-    import allocates a graph the process keeps, and every pass over it frees
-    almost none of it. Freezing empties the generations the import filled, so
-    re-enabling does not trigger a pass over the whole graph.
+    Both entry paths name this module rather than :mod:`nab.cli`, so neither
+    the CLI's imports nor the command module's are built while the collector
+    is on: they allocate a graph the process keeps, and a pass over it frees
+    almost none of it.
 
-    Importing :mod:`nab.cli` leaves the collector as it found it.
+    The CLI calls back once the command module is in, and freezing there
+    empties the generations those imports filled, so enabling the collector
+    does not start a pass over the whole graph.
+
+    The collector is on again on the way out, whichever way the CLI ended.
     """
     gc.disable()
     try:
         from nab.cli import console_entry as run_cli  # noqa: PLC0415
-    finally:
-        if hasattr(gc, "freeze"):  # PyPy has no gc.freeze
-            gc.freeze()
-        gc.enable()
 
-    run_cli()
+        run_cli(_resume_collector)
+    finally:
+        _resume_collector()

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -24,6 +24,11 @@ from nab._cli import spec
 from nab._cli.parse import Parsed, UsageError, parse
 from nab._version import __version__
 
+# Declared rather than imported from ``typing``, which this path never loads.
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
 __all__ = [
     "console_entry",
     "main",
@@ -49,6 +54,10 @@ _INTERRUPTED = "error: interrupted\n"
 _AUTO = "auto"
 
 
+def _nothing() -> None:
+    """Stand in for the ``resume`` a caller did not supply."""
+
+
 def _load(name: str) -> types.ModuleType:
     """Import one module the entry path defers, and return it.
 
@@ -61,14 +70,17 @@ def _load(name: str) -> types.ModuleType:
     return sys.modules[name]
 
 
-def run(argv: tuple[str, ...]) -> int:
+def run(argv: tuple[str, ...], resume: Callable[[], None] = _nothing) -> int:
     """Run one command line and report the status it ends with.
 
     Both writes a run makes are here, one per stream. A stream that
     refuses one replaces the status with 120, which is what makes a page
     redirected to a full disk an exit code rather than a traceback.
+
+    ``resume`` runs when the line reaches a command module, and not at
+    all on a page or a refusal.
     """
-    status, out, err = _outcome(argv)
+    status, out, err = _outcome(argv, resume)
 
     try:
         if out:
@@ -81,7 +93,7 @@ def run(argv: tuple[str, ...]) -> int:
     return status
 
 
-def _outcome(argv: tuple[str, ...]) -> tuple[int, str, str]:
+def _outcome(argv: tuple[str, ...], resume: Callable[[], None]) -> tuple[int, str, str]:
     """Read the line and act on it: a status, stdout text, and stderr text."""
     try:
         parsed = parse(argv, spec.ROOT, spec.COMMANDS, _PROG)
@@ -106,7 +118,7 @@ def _outcome(argv: tuple[str, ...]) -> tuple[int, str, str]:
         )
         return 0, page, ""
 
-    return _dispatch(parsed)
+    return _dispatch(parsed, resume)
 
 
 def _color_choice(options: dict[str, object]) -> str:
@@ -135,11 +147,11 @@ def _painting(stream: object, choice: str) -> bool:
     return bool(_load("nab.env").color_enabled(choice, isatty=tty))
 
 
-def _dispatch(parsed: Parsed) -> tuple[int, str, str]:
+def _dispatch(parsed: Parsed, resume: Callable[[], None]) -> tuple[int, str, str]:
     """Run the command the line named, reporting Ctrl-C as an interrupt."""
     try:
         outcome: tuple[int, str] = _load("nab._cli.dispatch").dispatch(
-            parsed, spec.DISPATCH, spec.PATH_DESTS
+            parsed, spec.DISPATCH, spec.PATH_DESTS, resume=resume
         )
     except KeyboardInterrupt:
         return _SIGINT_EXIT_CODE, "", _INTERRUPTED
@@ -148,16 +160,19 @@ def _dispatch(parsed: Parsed) -> tuple[int, str, str]:
     return status, "", f"{message}\n" if message else ""
 
 
-def main(argv: list[str] | None = None) -> None:
+def main(argv: list[str] | None = None, resume: Callable[[], None] = _nothing) -> None:
     """Run the CLI over ``argv``, defaulting to the process's own.
 
     Raises :class:`SystemExit` with the status the run produced, and
     returns normally on success, so a caller that owns the process can
     still do its own teardown.
+
+    ``resume`` runs when the line reaches a command module, and not at
+    all on a page or a refusal.
     """
     _replace_closed_std_streams()
 
-    status = run(tuple(sys.argv[1:] if argv is None else argv))
+    status = run(tuple(sys.argv[1:] if argv is None else argv), resume)
     if _output_was_dropped():
         status = _FLUSH_FAILED_EXIT_CODE
 
@@ -232,19 +247,24 @@ def _flush_std_streams() -> bool:
     return flushed
 
 
-def console_entry() -> None:
+def console_entry(resume: Callable[[], None] = _nothing) -> None:
     """Run the CLI, then end the process without freeing the resolve graph.
 
     Both ``nab`` and ``python -m nab`` end here; :func:`main` returns
     normally for every other caller. No ``atexit`` hook and no finalizer runs
     after this, so a command has to finish any work it cannot lose before
     :func:`main` returns.
+
+    ``resume`` runs when the line reaches a command module and again on
+    the way out, so it has to be safe to call twice.
     """
     status = 0
     try:
-        main()
+        main(resume=resume)
     except SystemExit as exc:
         status = _system_exit_status(exc.code)
+    finally:
+        resume()
 
     if not _flush_std_streams():
         status = _FLUSH_FAILED_EXIT_CODE

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5810,6 +5810,31 @@ class TestMain:
         assert info.value.code == 2
         assert "a command is required" in capsys.readouterr().err
 
+    def test_a_resume_reaches_the_command_module_import(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """``main`` forwards the callback the whole way down to the dispatch."""
+        resumed: list[int] = []
+
+        main(
+            ["cache", "dir", "--cache-dir", str(tmp_path)],
+            resume=lambda: resumed.append(1),
+        )
+
+        assert resumed == [1]
+        assert capsys.readouterr().out == f"{tmp_path}\n"
+
+    def test_a_line_that_short_circuits_leaves_the_resume_to_its_caller(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """``--version`` imports no command module, so nothing resumes here."""
+        resumed: list[int] = []
+
+        main(["--version"], resume=lambda: resumed.append(1))
+
+        assert resumed == []
+        assert capsys.readouterr().out.startswith("nab ")
+
     def test_version_flag_prints_and_returns(
         self, capsys: pytest.CaptureFixture[str]
     ) -> None:
@@ -6043,6 +6068,52 @@ class TestConsoleEntry:
         ):
             console_entry()
         mock_exit.assert_called_once_with(120)
+
+    def test_a_dispatching_line_resumes_at_the_import_and_again_on_the_way_out(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A line that reaches a command runs ``resume`` at both call sites."""
+        resumed: list[int] = []
+        monkeypatch.setattr(
+            sys, "argv", ["nab", "cache", "dir", "--cache-dir", str(tmp_path)]
+        )
+
+        with patch("nab.cli.os._exit") as mock_exit:
+            console_entry(lambda: resumed.append(1))
+
+        assert resumed == [1, 1]
+        assert capsys.readouterr().out == f"{tmp_path}\n"
+        mock_exit.assert_called_once_with(0)
+
+    def test_a_line_that_never_dispatched_still_resumes_the_caller(self) -> None:
+        """A page or a refusal ends before dispatch, so the resume runs here.
+
+        ``os._exit`` follows, so this is the last chance to put back what
+        the process entry paused.
+        """
+        resumed: list[int] = []
+        with (
+            patch("nab.cli.main"),
+            patch("nab.cli.os._exit"),
+        ):
+            console_entry(lambda: resumed.append(1))
+
+        assert resumed == [1]
+
+    def test_a_crash_resumes_the_caller_before_it_propagates(self) -> None:
+        """An exception on its way to the interpreter leaves nothing paused."""
+        resumed: list[int] = []
+        with (
+            patch("nab.cli.main", side_effect=ValueError("boom")),
+            patch("nab.cli.os._exit"),
+            pytest.raises(ValueError, match="boom"),
+        ):
+            console_entry(lambda: resumed.append(1))
+
+        assert resumed == [1]
 
     def test_a_crash_is_left_to_the_interpreter(self) -> None:
         """Only ``SystemExit`` takes the fast exit; anything else propagates."""

--- a/tests/test_cli_rules.py
+++ b/tests/test_cli_rules.py
@@ -19,6 +19,7 @@ say so.
 
 from __future__ import annotations
 
+import builtins
 import errno
 import io
 import subprocess
@@ -1353,6 +1354,44 @@ class TestDispatch:
         command.run = run  # type: ignore[attr-defined]
 
         assert dispatch(self._parsed({}), self._TABLE, {}) == (0, "")
+
+    def test_the_resume_runs_between_the_import_and_the_command(
+        self, command: types.ModuleType, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``resume`` marks the end of startup: the module is in, nothing has run."""
+        events: list[str] = []
+        real_import = builtins.__import__
+
+        def record_import(name: str, *args: Any, **kwargs: Any) -> Any:
+            if name == "nab_probe_command":
+                events.append("import")
+            return real_import(name, *args, **kwargs)
+
+        def run(**_values: object) -> None:
+            events.append("command")
+
+        command.run = run  # type: ignore[attr-defined]
+        monkeypatch.setattr(builtins, "__import__", record_import)
+
+        dispatch(
+            self._parsed({}), self._TABLE, {}, resume=lambda: events.append("resume")
+        )
+
+        assert events == ["import", "resume", "command"]
+
+    def test_a_line_the_printer_refuses_never_resumes(
+        self, command: types.ModuleType, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Nothing was imported, so the caller is left as it was."""
+        monkeypatch.setenv("NAB_VERBOSITY", "loud")
+        resumed: list[int] = []
+
+        status, _message = dispatch(
+            self._parsed({}), self._TABLE, {}, resume=lambda: resumed.append(1)
+        )
+
+        assert status == 2
+        assert resumed == []
 
     def test_a_malformed_verbosity_is_a_usage_error_and_no_command_runs(
         self, command: types.ModuleType, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -8,6 +8,7 @@ import importlib
 import os
 import subprocess
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -45,7 +46,7 @@ def test_imports_the_cli_while_the_collector_is_off(
             enabled_at_import.append(gc.isenabled())
         return real_import(name, *args, **kwargs)
 
-    monkeypatch.setattr("nab.cli.console_entry", lambda: None)
+    monkeypatch.setattr("nab.cli.console_entry", lambda _resume: None)
     monkeypatch.setattr(builtins, "__import__", record_import)
 
     console_entry()
@@ -54,19 +55,56 @@ def test_imports_the_cli_while_the_collector_is_off(
 
 
 @pytest.mark.usefixtures("restored_gc_state")
-def test_freezes_the_import_graph_before_enabling(
+def test_the_cli_runs_with_the_collector_off_until_it_resumes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The freeze runs while the collector is still off, the CLI once it is on."""
+    """The collector stays off until the CLI calls back.
+
+    Everything the CLI imports before that call is inside the freeze.
+    """
     events: list[tuple[str, bool]] = []
     monkeypatch.setattr(gc, "freeze", lambda: events.append(("freeze", gc.isenabled())))
-    monkeypatch.setattr(
-        "nab.cli.console_entry", lambda: events.append(("cli", gc.isenabled()))
-    )
+
+    def run_cli(resume: Callable[[], None]) -> None:
+        events.append(("cli", gc.isenabled()))
+        resume()
+        events.append(("resumed", gc.isenabled()))
+
+    monkeypatch.setattr("nab.cli.console_entry", run_cli)
 
     console_entry()
 
-    assert events == [("freeze", False), ("cli", True)]
+    assert events == [("cli", False), ("freeze", False), ("resumed", True)]
+
+
+@pytest.mark.usefixtures("restored_gc_state", "stubbed_gc_freeze")
+def test_a_cli_that_never_resumes_still_leaves_the_collector_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The module that switches the collector off is the one that guarantees it back."""
+    monkeypatch.setattr("nab.cli.console_entry", lambda _resume: None)
+
+    console_entry()
+
+    assert gc.isenabled()
+
+
+@pytest.mark.usefixtures("restored_gc_state")
+def test_a_second_resume_does_not_freeze_again(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One freeze between the CLI's call and this module's own.
+
+    A freeze on the second would take the command's own graph into the
+    permanent generation.
+    """
+    freezes: list[int] = []
+    monkeypatch.setattr(gc, "freeze", lambda: freezes.append(1))
+    monkeypatch.setattr("nab.cli.console_entry", lambda resume: resume())
+
+    console_entry()
+
+    assert freezes == [1]
 
 
 @pytest.mark.usefixtures("restored_gc_state")
@@ -74,15 +112,38 @@ def test_without_gc_freeze_still_reenables_the_collector(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The collector comes back on an interpreter without ``gc.freeze``."""
-    enabled_during: list[bool] = []
+    enabled_after: list[bool] = []
     monkeypatch.delattr(gc, "freeze")
-    monkeypatch.setattr(
-        "nab.cli.console_entry", lambda: enabled_during.append(gc.isenabled())
-    )
+
+    def run_cli(resume: Callable[[], None]) -> None:
+        resume()
+        enabled_after.append(gc.isenabled())
+
+    monkeypatch.setattr("nab.cli.console_entry", run_cli)
 
     console_entry()
 
-    assert enabled_during == [True]
+    assert enabled_after == [True]
+
+
+@pytest.mark.usefixtures("restored_gc_state", "stubbed_gc_freeze")
+def test_a_cli_that_cannot_be_imported_leaves_the_collector_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A broken install raises out of here rather than out of a paused process."""
+    real_import = builtins.__import__
+
+    def refuse_cli(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "nab.cli":
+            raise ImportError(name)
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", refuse_cli)
+
+    with pytest.raises(ImportError):
+        console_entry()
+
+    assert gc.isenabled()
 
 
 def test_console_script_runs_the_collector_off_entry() -> None:


### PR DESCRIPTION
`nab cache dir` goes from 338,692,266 instructions to 324,845,706, 4.1% off, and an offline five-package `nab lock` from 886,885,415 to 858,474,057, 3.2% off, by freezing the cyclic collector once the command module is imported rather than straight after `nab.cli`. Locally the clock follows: about 4.4% off cache dir and about 3.6% off the lock.

`nab._entry` disabled the collector, imported `nab.cli`, and froze there. The process holds 46 modules at that point and a `nab cache dir` run ends with 204, so most of the import graph was built with the collector on. The CLI now calls back once the command module is in, and the freeze happens there.

The cost is memory: peak RSS on the lock is up between about 0.3% and 0.9% locally, on a 38 MB process, because the collector no longer runs during those imports. On `nab cache dir` peak RSS sits inside about 0.4% either way.

A page or a refusal never reaches dispatch, so `console_entry` runs the callback on the way out too; only the first call freezes. It defaults to a no-op, so `nab.cli` as a library still sets no collector policy. `cli.py` declares `TYPE_CHECKING = False` instead of importing it: this path does not load `typing`.
