### PR TITLE
Import the on-disk cache in the verbs that open one, 7.4% off cache dir

### DIFF
--- a/src/nab/_cache_cmd.py
+++ b/src/nab/_cache_cmd.py
@@ -8,14 +8,15 @@ bucket nab owns, including the cloned and extracted source trees.
 ``verify`` and ``clear`` descend only into the buckets nab owns, never
 follow a symlink out of the root, and refuse a root that holds foreign
 files.
+
+Only those two verbs need :mod:`nab_index.cache`, so they import it
+themselves and ``dir`` never loads it.
 """
 
 from __future__ import annotations
 
 import sys
 from pathlib import Path
-
-from nab_index.cache import OnDiskCache, is_recognized_bucket
 
 from ._run import _default_cache_dir, _fail_config, effective_config
 from .config.values import SourceConfigError
@@ -74,6 +75,8 @@ def _verify(root: Path) -> None:
     nothing, so the status is what a script reads to learn the cache is
     not clean.
     """
+    from nab_index.cache import OnDiskCache  # noqa: PLC0415
+
     _refuse_foreign_root(root)
     cache = OnDiskCache(root, "")
     corrupt = 0
@@ -88,6 +91,8 @@ def _verify(root: Path) -> None:
 
 
 def _clear(root: Path) -> None:
+    from nab_index.cache import OnDiskCache  # noqa: PLC0415
+
     _refuse_foreign_root(root)
     cache = OnDiskCache(root, "")
     removed = cache.clear_cache()
@@ -101,6 +106,8 @@ def _refuse_foreign_root(root: Path) -> None:
     cache, so a maintenance verb refuses it. A recognized name on a plain
     file does not make the root a cache. A missing or empty root passes.
     """
+    from nab_index.cache import is_recognized_bucket  # noqa: PLC0415
+
     if root.exists() and not root.is_dir():
         printer().error(f"{root} is not a directory")
         sys.exit(1)

--- a/tests/test_cli_imports.py
+++ b/tests/test_cli_imports.py
@@ -138,6 +138,18 @@ _INDEX_READER = (
     "zipfile",
 )
 
+# The on-disk cache and the stdlib modules its import pulls in.  Only
+# ``verify`` and ``clear`` open a cache.
+_CACHE_STORE = (
+    "nab_index.cache",
+    "hashlib",
+    "json",
+    "shutil",
+    "tempfile",
+    "bz2",
+    "lzma",
+)
+
 _PROJECT = '[project]\nname = "probe"\nversion = "0.1"\ndependencies = []\n'
 
 
@@ -251,3 +263,13 @@ def test_a_settings_command_loads_no_index_reader(
     (tmp_path / "pyproject.toml").write_text(_PROJECT, encoding="utf-8")
 
     assert _run(_HELD_PROBE, ",".join(_INDEX_READER), *line, cwd=tmp_path) == ""
+
+
+@pytest.mark.parametrize("line", [("cache", "dir"), ("config", "list")])
+def test_a_settings_command_loads_no_cache_store(
+    line: tuple[str, ...], tmp_path: Path
+) -> None:
+    """Probe G: neither command loads the cache store or the decoders behind it."""
+    (tmp_path / "pyproject.toml").write_text(_PROJECT, encoding="utf-8")
+
+    assert _run(_HELD_PROBE, ",".join(_CACHE_STORE), *line, cwd=tmp_path) == ""


### PR DESCRIPTION
`nab cache dir` prints a path and nothing else, but it loaded the whole on-disk cache module to do it. One invocation goes from 325,064,420 instructions to 301,138,866, 23,925,554 fewer, or 7.4% of the whole command.

`src/nab/_cache_cmd.py` imported `nab_index.cache` at module scope, and only `verify` and `clear` open a cache. Importing it inside those two helpers drops 25 modules from a `cache dir` run, `sys.modules` 204 to 179 with none added: the cache module and the `hashlib`, `json`, `shutil` and `tempfile` trees it pulls in. Peak allocation for the same command falls from 6,185,047 to 5,772,445 bytes, 6.7% less.

`cache clear` pays the import at call time instead, about 640,000 instructions or 0.2%. Two runs put it at +642,214 and +637,569, since that command touches the filesystem and does not repeat exactly.

Locally `nab cache dir` runs between about 7% and 10% faster. No resolve path imports `nab._cache_cmd`. A test in `tests/test_cli_imports.py` asserts none of those modules load once `cache dir` has dispatched.
