### PR TITLE
Stop refusing an offline build env whose requires are all marker-excluded

### DIFF
--- a/nab-project/src/nab_project/_build/env.py
+++ b/nab-project/src/nab_project/_build/env.py
@@ -43,15 +43,22 @@ from installer.utils import get_launcher_kind
 
 from nab_index.client import extract_sdist_archive
 from nab_index.urllib3_async_transport import Urllib3AsyncTransport
+from nab_provider._vendor.packaging.requirements import InvalidRequirement
 from nab_provider._vendor.packaging.utils import (
     canonicalize_name,
     parse_wheel_filename,
 )
 from nab_provider._vendor.packaging.version import Version
 from nab_provider.errors import MissingExtraError
+from nab_provider.marker_holds import (
+    IntractableMarkerError,
+    UnevaluableMarkerError,
+    dependency_marker_holds,
+)
+from nab_provider.pep508 import parse_requirement
 from nab_provider.policy import BuildPolicy, DistPolicy
 from nab_provider.requirements_file import InvalidProjectRequirementError
-from nab_provider.target import ResolveTarget
+from nab_provider.target import ResolveTarget, host_environment
 from nab_provider.vcs_admission import UnsupportedVcsError
 
 from ..download import DownloadError, download_lock
@@ -224,9 +231,10 @@ class NabBuildEnv:
     settings, pruned of declared sources, constraints and group selection
     so the build env resolves against the configured indexes alone.
 
-    ``offline`` refuses to populate the env at all, since every build
-    requirement would have to come off the network.  An empty
-    ``requires`` needs nothing fetched and is still served.
+    ``offline`` refuses to populate the env when a build requirement
+    would have to come off the network.  A ``requires`` that is empty,
+    or whose entries are all excluded by their markers on the host,
+    needs nothing fetched and is still served.
 
     ``chain`` is the :data:`BuildChain` of builds this env is already
     nested inside.  It is empty for the build a resolve asked for, and
@@ -432,6 +440,9 @@ class NabBuildEnv:
         no inherited override may raise it.  A backend invocation to
         learn a build requirement's dependencies would be a second
         recursion, one the depth budget does not count.
+
+        Offline it returns no wheels rather than refusing when the
+        host's markers exclude every entry.
         """
         # Late import, breaking the cycle ``resolve`` -> ``fetch`` ->
         # ``_sources`` -> ``build_backend`` -> ``_build.runner`` -> this
@@ -443,7 +454,11 @@ class NabBuildEnv:
             requires.extend(extra)
 
         if self._offline:
-            joined = ", ".join(requires)
+            needed = _applicable_requirements(requires)
+            if not needed:
+                return []
+
+            joined = ", ".join(needed)
             msg = f"build requirements unavailable in offline mode: {joined}"
             raise BuildEnvError(msg)
 
@@ -864,6 +879,40 @@ def _dist_scheme_paths(
 def _supports_symlinks() -> bool:
     """``venv.EnvBuilder(symlinks=...)`` heuristic; avoids Windows traps."""
     return sys.platform != "win32"
+
+
+def _applicable_requirements(requires: list[str]) -> list[str]:
+    """Return the entries of ``requires`` the host has to install.
+
+    The venv is created from the host interpreter, so a requirement
+    whose PEP 508 marker excludes the host is never installed.
+    """
+    environment = host_environment()
+    return [
+        requirement
+        for requirement in requires
+        if _requirement_applies(requirement, environment)
+    ]
+
+
+def _requirement_applies(requirement: str, environment: Mapping[str, str]) -> bool:
+    """Whether ``requirement`` applies under the ``environment`` marker values.
+
+    An unparseable string and a marker nothing decides both count as
+    applying, since neither shows the host to be excluded.
+    """
+    try:
+        parsed = parse_requirement(requirement)
+    except InvalidRequirement:
+        return True
+
+    if parsed.marker is None:
+        return True
+
+    try:
+        return dependency_marker_holds(parsed.marker, environment)
+    except (UnevaluableMarkerError, IntractableMarkerError):
+        return True
 
 
 def _render_synthetic_pyproject(requires: list[str]) -> str:

--- a/nab-project/tests/test_build_runner.py
+++ b/nab-project/tests/test_build_runner.py
@@ -2318,15 +2318,23 @@ class TestBuildEnvOffline:
         monkeypatch.setattr("nab_project.resolve.resolve_for_targets", _no_network)
         monkeypatch.setattr("nab_project._build.env.download_lock", _no_network)
 
-    def test_refuses_before_the_inner_resolve(self, tmp_path: Path) -> None:
+    def _offline_env(
+        self, tmp_path: Path, requires: list[str]
+    ) -> tuple[NabBuildEnv, Path]:
+        """An offline env over ``requires``, and the wheel dir to fill."""
         env = NabBuildEnv(
-            requires=["foo"],
+            requires=requires,
             config=ResolveInputs(),
             offline=True,
             transport_factory=_no_network,  # type: ignore[arg-type]
         )
         wheel_dir = tmp_path / "wheels"
         wheel_dir.mkdir()
+        return env, wheel_dir
+
+    def test_refuses_before_the_inner_resolve(self, tmp_path: Path) -> None:
+        env, wheel_dir = self._offline_env(tmp_path, ["foo"])
+
         with pytest.raises(BuildEnvError, match=r"unavailable in offline mode: foo"):
             env._resolve_and_download(wheel_dir)
 
@@ -2365,6 +2373,60 @@ class TestBuildEnvOffline:
         source = _write_fake_backend_project(tmp_path)
         metadata = run_build_backend(source, config=config, offline=True)
         assert metadata.name == "fake-pkg"
+
+    def test_backend_whose_requirements_are_all_excluded_still_builds(
+        self, tmp_path: Path, config: ResolveInputs
+    ) -> None:
+        """The one build requirement is marker-excluded, so nothing is fetched."""
+        source = _write_fake_backend_project(tmp_path)
+        (source / "pyproject.toml").write_text(
+            "[build-system]\n"
+            "requires = ['tomli; python_version < \"3.0\"']\n"
+            'build-backend = "nab_test_backend"\n'
+            'backend-path = ["."]\n',
+            encoding="utf-8",
+        )
+
+        metadata = run_build_backend(source, config=config, offline=True)
+
+        assert metadata.name == "fake-pkg"
+
+    def test_marker_excluded_requirements_need_no_fetch(self, tmp_path: Path) -> None:
+        """The host's markers exclude every entry, so nothing has to be fetched."""
+        env, wheel_dir = self._offline_env(tmp_path, ['tomli; python_version < "3.0"'])
+
+        assert env._resolve_and_download(wheel_dir) == []
+
+    def test_refusal_names_only_the_requirements_that_apply(
+        self, tmp_path: Path
+    ) -> None:
+        """A partly excluded list still refuses, naming what has to be fetched."""
+        env, wheel_dir = self._offline_env(
+            tmp_path, ['tomli; python_version < "3.0"', "hatchling"]
+        )
+
+        with pytest.raises(
+            BuildEnvError, match=r"unavailable in offline mode: hatchling$"
+        ):
+            env._resolve_and_download(wheel_dir)
+
+    def test_unparseable_requirement_is_refused(self, tmp_path: Path) -> None:
+        """A string that is not PEP 508 is not an exclusion."""
+        env, wheel_dir = self._offline_env(tmp_path, ["not a requirement!!"])
+
+        with pytest.raises(
+            BuildEnvError, match=r"unavailable in offline mode: not a requirement!!$"
+        ):
+            env._resolve_and_download(wheel_dir)
+
+    def test_undecidable_marker_is_refused(self, tmp_path: Path) -> None:
+        """A marker nothing decides is not an exclusion."""
+        env, wheel_dir = self._offline_env(
+            tmp_path, ['foo; python_full_version ~= "3"']
+        )
+
+        with pytest.raises(BuildEnvError, match=r"unavailable in offline mode: foo;"):
+            env._resolve_and_download(wheel_dir)
 
     def test_hook_extras_named_in_a_stable_order(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
Offline, an sdist whose `[build-system].requires` are all excluded by their markers is refused, though nothing would be fetched. With `requires = ['tomli; python_version < "3.0"']`:

    build requirements unavailable in offline mode: tomli; python_version < "3.0"

That reaches the resolve as an `UnsupportedSdistError`, which skips a PyPI sdist version and ends the resolve for a declared source.

The offline check listed every string in `requires` without reading its marker. The venv is created from the host interpreter, so a requirement the host's markers exclude is never installed anyway.

The check now filters `requires` against the host marker environment, and the env is built with nothing installed when nothing is left. A partly excluded list still refuses, naming only the entries that have to come off the network. A string that is not valid PEP 508, and a marker nothing decides, both count as applying.
