### PR TITLE
Stop reading a local index page of unreachable links as a missing package

### DIFF
--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -655,6 +655,17 @@ class CachedAsyncSimpleClient:
         """Whether a listing for ``package`` held only files nab cannot read."""
         return package in self._unreadable_only
 
+    def served_unreachable_only(
+        self,
+        package: str,  # noqa: ARG002 - the IndexClient protocol fixes the signature
+    ) -> bool:
+        """Whether a listing for ``package`` held only links nab cannot reach.
+
+        Always ``False``: the listing parse drops a remote entry whose URL
+        cannot be used, leaving nothing to mark.
+        """
+        return False
+
     def served_all_yanked(self, package: str) -> bool:
         """Whether a listing for ``package`` held files and yanked every one."""
         return package in self._all_yanked

--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -171,16 +171,19 @@ _FLAT_EXTS = re.compile(r"\.(whl|tar\.gz)$", re.IGNORECASE)
 class _ScanResult(NamedTuple):
     """What one scan of a local index found for a package.
 
-    The three fields beside ``files`` describe what the scan dropped, none of
+    The four fields beside ``files`` describe what the scan dropped, none of
     which leaves a record.  ``unreadable`` says the listing offered a file in
     a format nab does not read, which tells a page of ``.zip`` sdists from an
-    empty one; ``all_yanked`` says every anchor naming a file was yanked,
-    which tells a page of yanked releases from a package this index does not
-    carry; ``zip_sdists`` names the releases it offered as ``.zip`` sdists.
+    empty one; ``unreachable`` says it offered a wheel or ``.tar.gz`` sdist
+    behind an href that resolves to no usable URL; ``all_yanked`` says every
+    anchor naming a file was yanked, which tells a page of yanked releases
+    from a package this index does not carry; ``zip_sdists`` names the
+    releases it offered as ``.zip`` sdists.
     """
 
     files: list[WheelFile | SdistFile]
     unreadable: bool
+    unreachable: bool
     all_yanked: bool
     zip_sdists: frozenset[str]
 
@@ -197,7 +200,11 @@ def _scan_pep503_directory(
     index_html = package_dir / "index.html"
     if not _is_file(index_html):
         return _ScanResult(
-            [], unreadable=False, all_yanked=False, zip_sdists=frozenset()
+            [],
+            unreadable=False,
+            unreachable=False,
+            all_yanked=False,
+            zip_sdists=frozenset(),
         )
 
     try:
@@ -212,6 +219,7 @@ def _scan_pep503_directory(
 
     files: list[WheelFile | SdistFile] = []
     unreadable = False
+    unreachable = False
     yanked = 0
     nameless = 0
     zip_sdists: set[str] = set()
@@ -222,12 +230,17 @@ def _scan_pep503_directory(
             yanked += 1
             continue
 
-        filename, file_url, local_path, hashes = _resolve_local_link(
-            anchor.href, base_url, bases
-        )
+        link = _resolve_local_link(anchor.href, base_url, bases)
+        filename = link.filename
         if filename is None:
-            nameless += 1
+            # An unreachable href still names a release, so it does not join
+            # the navigation links the all-yanked test discounts.
+            if link.unreachable:
+                unreachable = True
+            else:
+                nameless += 1
             continue
+
         if not is_readable_filename(filename):
             unreadable = True
             if (version := zip_sdist_version(filename, canonical)) is not None:
@@ -236,10 +249,10 @@ def _scan_pep503_directory(
 
         record = _make_record(
             filename,
-            file_url,
-            local_path,
+            link.url,
+            link.local_path,
             anchor.requires_python,
-            hashes,
+            link.hashes,
             canonical,
             has_metadata=metadata_declaration(anchor.metadata) is not None,
         )
@@ -247,10 +260,11 @@ def _scan_pep503_directory(
             files.append(record)
 
     # A navigation link is not a release, so the all-yanked test counts only
-    # the anchors that name a file.
+    # the anchors that name one.
     return _ScanResult(
         files,
         unreadable=unreadable,
+        unreachable=unreachable,
         all_yanked=yanked > 0 and yanked == len(anchors) - nameless,
         zip_sdists=frozenset(zip_sdists),
     )
@@ -276,14 +290,28 @@ def _page_base_url(index_html: Path, base_href: str | None) -> str:
         raise MalformedLocalListingError(msg) from exc
 
 
+class _Link(NamedTuple):
+    """One anchor of a listing, resolved against the page it sits on.
+
+    ``filename`` is ``None`` when no artefact came out of the href.
+    ``unreachable`` then tells the two reasons apart: set when the href's
+    last segment is a wheel or ``.tar.gz`` sdist name, so the page offered a
+    release; clear for a navigation or ``mailto:`` link that names nothing.
+    """
+
+    filename: str | None
+    url: str
+    local_path: Path | None
+    hashes: tuple[tuple[str, str], ...]
+    unreachable: bool = False
+
+
 def _resolve_local_link(
     href: str,
     base_url: str,
     bases: list[str] | None,
-) -> tuple[str | None, str, Path | None, tuple[tuple[str, str], ...]]:
-    """Resolve an anchor href to ``(filename, url, local_path, hashes)``.
-
-    ``filename`` is ``None`` when the href names no file.
+) -> _Link:
+    """Resolve an anchor href to the artefact it names, if any.
 
     ``base_url`` is the page's ``<base href>`` when it carries one, else the
     ``index.html`` URL, and ``bases`` is :func:`_merging_bases` over the page.
@@ -314,7 +342,14 @@ def _resolve_local_link(
         parsed = urlparse(url)
         page = urlparse(base_url)
     except ValueError:
-        return (None, href_no_frag, None, hashes)
+        segment = href_no_frag.rsplit("/", 1)[-1]
+        return _Link(
+            None,
+            href_no_frag,
+            None,
+            hashes,
+            unreachable=is_readable_filename(unquote(segment)),
+        )
 
     # An autoindex's navigation links name no file: "../" leaves no last
     # segment, and a sort link is a bare query ("?C=N;O=D") resolving back to
@@ -327,18 +362,24 @@ def _resolve_local_link(
     )
 
     if not last_segment or points_at_page:
-        return (None, url, None, hashes)
+        return _Link(None, url, None, hashes)
 
     if parsed.scheme in {"http", "https"}:
-        return (unquote(last_segment), url, None, hashes)
+        return _Link(unquote(last_segment), url, None, hashes)
 
     # Drop an anchor naming no local file rather than fail the whole listing.
     try:
         path = _parsed_file_url_path(parsed, url)
     except ValueError:
-        return (None, url, None, hashes)
+        return _Link(
+            None,
+            url,
+            None,
+            hashes,
+            unreachable=is_readable_filename(unquote(last_segment)),
+        )
 
-    return (path.name, url, path, hashes)
+    return _Link(path.name, url, path, hashes)
 
 
 # A mirror href climbs out of the package directory to the shared packages
@@ -489,6 +530,7 @@ def _scan_flat_wheelhouse(
     return _ScanResult(
         files,
         unreadable=bool(zip_sdists),
+        unreachable=False,
         all_yanked=False,
         zip_sdists=frozenset(zip_sdists),
     )
@@ -696,6 +738,7 @@ class LocalIndexClient:
         root = parse_file_url(index_url)
         self._root = Path(os.path.abspath(root))  # noqa: PTH100
         self._unreadable_only: set[str] = set()
+        self._unreachable_only: set[str] = set()
         self._all_yanked: set[str] = set()
         self._zip_sdists: dict[str, frozenset[str]] = {}
 
@@ -725,7 +768,11 @@ class LocalIndexClient:
                 scan = _scan_pep503_directory(package_dir, canonical)
             elif not _is_dir(self._root):
                 scan = _ScanResult(
-                    [], unreadable=False, all_yanked=False, zip_sdists=frozenset()
+                    [],
+                    unreadable=False,
+                    unreachable=False,
+                    all_yanked=False,
+                    zip_sdists=frozenset(),
                 )
             else:
                 scan = _scan_flat_wheelhouse(self._root, package)
@@ -735,6 +782,8 @@ class LocalIndexClient:
 
         if not scan.files and scan.unreadable:
             self._unreadable_only.add(package)
+        if not scan.files and scan.unreachable:
+            self._unreachable_only.add(package)
         if not scan.files and scan.all_yanked:
             self._all_yanked.add(package)
         self._zip_sdists[package] = scan.zip_sdists
@@ -743,6 +792,10 @@ class LocalIndexClient:
     def served_unreadable_only(self, package: str) -> bool:
         """Whether a listing for ``package`` held only files nab cannot read."""
         return package in self._unreadable_only
+
+    def served_unreachable_only(self, package: str) -> bool:
+        """Whether a listing for ``package`` held only links nab cannot reach."""
+        return package in self._unreachable_only
 
     def served_all_yanked(self, package: str) -> bool:
         """Whether a listing for ``package`` held file links and yanked every one."""

--- a/nab-index/src/nab_index/multi_index.py
+++ b/nab-index/src/nab_index/multi_index.py
@@ -62,6 +62,10 @@ class IndexClient(Protocol):
         """Whether a listing for ``package`` held only files nab cannot read."""
         ...
 
+    def served_unreachable_only(self, package: str) -> bool:
+        """Whether a listing for ``package`` held only links nab cannot reach."""
+        ...
+
     def served_all_yanked(self, package: str) -> bool:
         """Whether a listing for ``package`` held files and yanked every one."""
         ...
@@ -245,6 +249,17 @@ class MultiIndexClient:
         """
         return any(
             client.served_unreadable_only(package) for client in self._clients.values()
+        )
+
+    def served_unreachable_only(self, package: str) -> bool:
+        """Whether any walked index served ``package`` only links nab cannot reach.
+
+        Asked of every client for the same reason
+        :meth:`served_unreadable_only` is: an empty walk routes ``package``
+        to the first index, which need not be the one that served it.
+        """
+        return any(
+            client.served_unreachable_only(package) for client in self._clients.values()
         )
 
     def served_all_yanked(self, package: str) -> bool:

--- a/nab-index/tests/test_index_local.py
+++ b/nab-index/tests/test_index_local.py
@@ -68,7 +68,13 @@ def test_scan_directory_without_index_html_returns_empty(tmp_path: Path) -> None
     # exercised directly here.
     package_dir = tmp_path / "foo"
     package_dir.mkdir()
-    assert _scan_pep503_directory(package_dir, "foo") == ([], False, False, frozenset())
+    scan = _scan_pep503_directory(package_dir, "foo")
+
+    assert scan.files == []
+    assert not scan.unreadable
+    assert not scan.unreachable
+    assert not scan.all_yanked
+    assert scan.zip_sdists == frozenset()
 
 
 def _anchor(filename: str, *, yanked: bool = False) -> str:
@@ -81,6 +87,7 @@ _YANKED_WHEEL = _anchor("foo-1.0-py3-none-any.whl", yanked=True)
 _YANKED_SDIST = _anchor("foo-2.0.tar.gz", yanked=True)
 _MISNAMED = _anchor("foo-1.0.zip")
 _READABLE = _anchor("foo-3.0-py3-none-any.whl")
+_UNREACHABLE = _anchor("ftp://mirror.example/foo-4.0-py3-none-any.whl")
 
 
 @pytest.mark.parametrize(
@@ -92,6 +99,7 @@ _READABLE = _anchor("foo-3.0-py3-none-any.whl")
         pytest.param(_MISNAMED, False, id="misnamed-link-alone"),
         pytest.param(_YANKED_WHEEL + _MISNAMED, False, id="one-link-stands"),
         pytest.param(_YANKED_WHEEL + _READABLE, False, id="one-link-admitted"),
+        pytest.param(_YANKED_WHEEL + _UNREACHABLE, False, id="one-link-unreachable"),
     ],
 )
 def test_the_all_yanked_flag_counts_the_yanked_links(
@@ -124,6 +132,68 @@ def test_a_page_of_yanked_misnamed_links_reads_as_yanked(tmp_path: Path) -> None
     assert scan.files == []
     assert not scan.unreadable
     assert scan.all_yanked
+
+
+def test_a_page_of_unreachable_links_is_not_an_absent_package(
+    tmp_path: Path,
+) -> None:
+    """An href naming a file nab cannot reach still says the page listed one.
+
+    Dropping it silently makes the listing identical to one for a package
+    the index does not carry.  The filename parses, so only the href fails
+    and the format flag stays clear.
+    """
+    package_dir = _make_index(tmp_path, _UNREACHABLE)
+
+    scan = _scan_pep503_directory(package_dir, "foo")
+
+    assert scan.files == []
+    assert scan.unreachable
+    assert not scan.unreadable
+
+    client = LocalIndexClient(tmp_path.as_uri())
+    assert run(client.get_files("foo")) == []
+    assert client.served_unreachable_only("foo")
+    assert not client.served_unreadable_only("foo")
+
+
+@pytest.mark.parametrize(
+    ("href", "expected"),
+    [
+        pytest.param(
+            "http://[bad/foo-1.0-py3-none-any.whl", True, id="wheel-behind-a-bad-host"
+        ),
+        pytest.param("http://[bad", False, id="bad-host-alone"),
+        pytest.param("mailto:admin@example.com", False, id="mailto"),
+    ],
+)
+def test_an_href_marks_the_page_only_when_it_names_a_release(
+    tmp_path: Path, href: str, expected: bool
+) -> None:
+    """All three hrefs are dropped; only the one naming a wheel loses a release.
+
+    An unterminated bracket and a ``mailto:`` offer nothing, so marking them
+    would report a package the index does not carry as one whose links nab
+    could not reach.
+    """
+    package_dir = _make_index(tmp_path, _anchor(href))
+
+    scan = _scan_pep503_directory(package_dir, "foo")
+
+    assert scan.files == []
+    assert scan.unreachable is expected
+
+
+def test_a_page_of_navigation_links_reads_as_an_empty_page(tmp_path: Path) -> None:
+    """An autoindex's own links name no file, so they mark nothing."""
+    body = '<a href="../">parent</a><a href="?C=N;O=D">sort</a>'
+    package_dir = _make_index(tmp_path, body)
+
+    scan = _scan_pep503_directory(package_dir, "foo")
+
+    assert scan.files == []
+    assert not scan.unreachable
+    assert not scan.unreadable
 
 
 def test_get_sdist_archive_returns_file_bytes(tmp_path: Path) -> None:

--- a/nab-index/tests/test_index_multi.py
+++ b/nab-index/tests/test_index_multi.py
@@ -46,6 +46,9 @@ class _RecordingClient:
     def served_unreadable_only(self, package: str) -> bool:
         return False
 
+    def served_unreachable_only(self, package: str) -> bool:
+        return False
+
     def served_all_yanked(self, package: str) -> bool:
         return False
 

--- a/nab-project/src/nab_project/fetch.py
+++ b/nab-project/src/nab_project/fetch.py
@@ -1065,6 +1065,7 @@ class FetchCoordinator:
             req.package,
             files,
             unreadable_only=client.served_unreadable_only(req.package),
+            unreachable_only=client.served_unreachable_only(req.package),
             all_yanked=client.served_all_yanked(req.package),
             zip_sdists=client.served_zip_sdists(req.package),
         )

--- a/nab-project/tests/property_python/test_fetch_coordinator.py
+++ b/nab-project/tests/property_python/test_fetch_coordinator.py
@@ -121,6 +121,9 @@ class FakeClient:
     def served_unreadable_only(self, package: str) -> bool:
         return False
 
+    def served_unreachable_only(self, package: str) -> bool:
+        return False
+
     def served_all_yanked(self, package: str) -> bool:
         return False
 

--- a/nab-project/tests/property_python/test_multi_index_contract.py
+++ b/nab-project/tests/property_python/test_multi_index_contract.py
@@ -69,6 +69,9 @@ class Stub:
     def served_unreadable_only(self, package: str) -> bool:
         return False
 
+    def served_unreachable_only(self, package: str) -> bool:
+        return False
+
     def served_all_yanked(self, package: str) -> bool:
         return False
 

--- a/nab-project/tests/property_python/test_multi_index_pep503.py
+++ b/nab-project/tests/property_python/test_multi_index_pep503.py
@@ -75,6 +75,9 @@ class _Stub:
     def served_unreadable_only(self, package: str) -> bool:
         return False
 
+    def served_unreachable_only(self, package: str) -> bool:
+        return False
+
     def served_all_yanked(self, package: str) -> bool:
         return False
 

--- a/nab-project/tests/test_fetch.py
+++ b/nab-project/tests/test_fetch.py
@@ -1671,6 +1671,7 @@ class TestFetchCoordinator:
                 *,
                 offline_miss: bool = False,
                 unreadable_only: bool = False,
+                unreachable_only: bool = False,
                 all_yanked: bool = False,
                 zip_sdists: frozenset[str] = frozenset(),
             ) -> None:
@@ -1680,6 +1681,7 @@ class TestFetchCoordinator:
                     data,
                     offline_miss=offline_miss,
                     unreadable_only=unreadable_only,
+                    unreachable_only=unreachable_only,
                     all_yanked=all_yanked,
                     zip_sdists=zip_sdists,
                 )

--- a/nab-project/tests/test_multi_index.py
+++ b/nab-project/tests/test_multi_index.py
@@ -44,6 +44,7 @@ class FakeClient:
     def __init__(self, listing: dict[str, list[WheelFile | SdistFile]]) -> None:
         self.listing = listing
         self.unreadable: set[str] = set()
+        self.unreachable: set[str] = set()
         self.all_yanked: set[str] = set()
         self.zip_sdists: dict[str, frozenset[str]] = {}
         self.get_files_calls: list[str] = []
@@ -62,6 +63,9 @@ class FakeClient:
 
     def served_unreadable_only(self, package: str) -> bool:
         return package in self.unreadable
+
+    def served_unreachable_only(self, package: str) -> bool:
+        return package in self.unreachable
 
     def served_all_yanked(self, package: str) -> bool:
         return package in self.all_yanked

--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -1891,6 +1891,30 @@ class TestNoVersionsReasons:
             "no file the index served is one nab can read"
         )
 
+    def test_local_pep503_page_of_unreachable_links_names_the_links(
+        self, tmp_path: Path
+    ) -> None:
+        """The line names the links, not a missing package or a bad filename.
+
+        The index carries a page for ``foo`` naming a wheel, so sending the
+        reader to check the package name would be wrong.
+        """
+        package_dir = tmp_path / "foo"
+        package_dir.mkdir()
+        (package_dir / "index.html").write_text(
+            '<a href="ftp://mirror.example/foo-1.0-py3-none-any.whl">foo-1.0</a>',
+            encoding="utf-8",
+        )
+        with FetchCoordinator(
+            transport=Urllib3AsyncTransport(),
+            indexes=[IndexConfig("local", tmp_path.as_uri())],
+        ) as coordinator:
+            provider = Provider(coordinator)
+            provider.choose_version("foo", SpecifierSet("").to_range())
+        assert rendered_reason(provider, "foo") == (
+            "the index lists this package but nab cannot reach any of its links"
+        )
+
     def test_no_match_in_range_records_no_match_reason(self) -> None:
         """A non-empty listing with no in-range version surfaces a no-match reason."""
         coordinator = make_coordinator([make_wheel("1.0")], package="foo")

--- a/nab-provider/src/nab_provider/_provider/listing_diagnosis.py
+++ b/nab-provider/src/nab_provider/_provider/listing_diagnosis.py
@@ -57,6 +57,7 @@ if TYPE_CHECKING:
     Kind: TypeAlias = Literal[
         "offline-miss",
         "unreadable-only",
+        "unreachable-only",
         "yanked-only",
         "absent",
         "pinned-absent",
@@ -129,6 +130,7 @@ class ReasonKind:
 
     OFFLINE_MISS: Final = "offline-miss"
     UNREADABLE_ONLY: Final = "unreadable-only"
+    UNREACHABLE_ONLY: Final = "unreachable-only"
     YANKED_ONLY: Final = "yanked-only"
     ABSENT: Final = "absent"
     PINNED_ABSENT: Final = "pinned-absent"
@@ -349,6 +351,7 @@ class NoVersionsReason:
 # record path allocates nothing for them.
 OFFLINE_MISS = NoVersionsReason(ReasonKind.OFFLINE_MISS)
 UNREADABLE_ONLY = NoVersionsReason(ReasonKind.UNREADABLE_ONLY)
+UNREACHABLE_ONLY = NoVersionsReason(ReasonKind.UNREACHABLE_ONLY)
 YANKED_ONLY = NoVersionsReason(ReasonKind.YANKED_ONLY)
 ABSENT = NoVersionsReason(ReasonKind.ABSENT)
 PINNED_ABSENT = NoVersionsReason(ReasonKind.PINNED_ABSENT)
@@ -358,9 +361,9 @@ EXTRA_BASE_EMPTY = NoVersionsReason(ReasonKind.EXTRA_BASE_EMPTY)
 
 NO_MATCH = Diagnostic("no version matches the requirement")
 
-# The four situations the index client answers on its own with a fixed line.
+# The five situations the index client answers on its own with a fixed line.
 # None of them is a walk, so only the two with something to add carry a ``-v``
-# body: for the other two, saying the same fact at more length is not detail.
+# body: for the others, saying the same fact at more length is not detail.
 FIXED_DIAGNOSTICS: dict[Kind, Diagnostic] = {
     ReasonKind.OFFLINE_MISS: Diagnostic(
         "offline mode skipped an index with no cached listing",
@@ -376,6 +379,9 @@ FIXED_DIAGNOSTICS: dict[Kind, Diagnostic] = {
     ReasonKind.UNREADABLE_ONLY: Diagnostic(
         "no file the index served is one nab can read",
         ("nab reads wheels and .tar.gz sdists whose name and version parse",),
+    ),
+    ReasonKind.UNREACHABLE_ONLY: Diagnostic(
+        "the index lists this package but nab cannot reach any of its links"
     ),
     ReasonKind.YANKED_ONLY: Diagnostic(
         "the index lists this package but every file is yanked"

--- a/nab-provider/src/nab_provider/provider.py
+++ b/nab-provider/src/nab_provider/provider.py
@@ -1778,13 +1778,24 @@ class Provider:
             return _diagnosis.FILTERED_EMPTY
         if index.is_offline_listing_miss(normalized):
             return _diagnosis.OFFLINE_MISS
-        # Nothing sets both: the unreadable flag needs a file that stands,
-        # and the yank flag needs every one withdrawn.
+
+        # A page can set both of these marks; the unreadable line wins.
         if index.is_unreadable_only_listing(normalized):
             return _diagnosis.UNREADABLE_ONLY
+        if index.is_unreachable_only_listing(normalized):
+            return _diagnosis.UNREACHABLE_ONLY
+
         if index.is_all_yanked_listing(normalized):
             return _diagnosis.YANKED_ONLY
-        if index.is_pinned_listing(normalized):
+        return self._absent_listing_marker(normalized)
+
+    def _absent_listing_marker(self, normalized: str) -> _diagnosis.NoVersionsReason:
+        """Classify a package no index served a page for.
+
+        A pin routes the ask to one index, so missing there is not missing
+        from the configured set.
+        """
+        if self.coordinator.index.is_pinned_listing(normalized):
             return _diagnosis.PINNED_ABSENT
         return _diagnosis.ABSENT
 

--- a/nab-provider/src/nab_provider/store.py
+++ b/nab-provider/src/nab_provider/store.py
@@ -75,6 +75,8 @@ class InMemoryIndex:
         self._offline_listing_misses: set[str] = set()
         # Packages whose empty listing stands for a page of formats nab cannot read.
         self._unreadable_only_listings: set[str] = set()
+        # Packages whose empty listing stands for a page of links nab cannot reach.
+        self._unreachable_only_listings: set[str] = set()
         # Packages whose empty listing stands for a page of yanked files.
         self._all_yanked_listings: set[str] = set()
         # Versions an index served as a ``.zip`` sdist, which the listing parse
@@ -141,6 +143,7 @@ class InMemoryIndex:
         *,
         offline_miss: bool = False,
         unreadable_only: bool = False,
+        unreachable_only: bool = False,
         all_yanked: bool = False,
         zip_sdists: frozenset[str] = frozenset(),
     ) -> None:
@@ -150,8 +153,9 @@ class InMemoryIndex:
 
         ``offline_miss`` marks an empty listing as an index skipped offline
         rather than one that served no files; ``unreadable_only`` marks it as
-        a page of formats nab does not read; ``all_yanked`` marks it as a page
-        whose every file is yanked.
+        a page of formats nab does not read; ``unreachable_only`` marks it as
+        a page whose every link nab cannot reach; ``all_yanked`` marks it as
+        a page whose every file is yanked.
 
         ``zip_sdists`` names the releases served as a ``.zip`` sdist, which
         nothing in ``data`` records.  It replaces whatever a prior store left,
@@ -165,6 +169,8 @@ class InMemoryIndex:
                 self._offline_listing_misses.add(package)
             if unreadable_only:
                 self._unreadable_only_listings.add(package)
+            if unreachable_only:
+                self._unreachable_only_listings.add(package)
             if all_yanked:
                 self._all_yanked_listings.add(package)
             if zip_sdists:
@@ -181,6 +187,10 @@ class InMemoryIndex:
     def is_unreadable_only_listing(self, package: str) -> bool:
         """Whether ``package``'s empty listing held only unreadable formats."""
         return package in self._unreadable_only_listings
+
+    def is_unreachable_only_listing(self, package: str) -> bool:
+        """Whether ``package``'s empty listing held only links nab cannot reach."""
+        return package in self._unreachable_only_listings
 
     def is_all_yanked_listing(self, package: str) -> bool:
         """Whether ``package``'s empty listing held files and yanked every one."""


### PR DESCRIPTION
A `file://` index page whose anchors all point at URLs nab cannot use reports `package not found on any configured index`. The page is there and names a wheel; the scan dropped every anchor silently, so the empty listing read as a package no index carries.

An href is dropped that way when its scheme is one nab does not fetch (an `ftp://` mirror link), when a `file://` href does not decode to a usable path, or when the URL itself does not parse.

Against a local index whose only anchor for `foo` is `ftp://mirror.example/foo-1.0-py3-none-any.whl`, `nab lock` now ends with:

    Diagnostics:
      - foo: the index lists this package but nab cannot reach any of its links

Only an href whose last segment parses as a wheel or `.tar.gz` sdist name marks the page, so an autoindex's `../` and sort links still read as an empty one. A page carrying both an unreadable format and an unreachable link keeps the unreadable line.
