### PR TITLE
Scope the look-ahead blocker line to the range that was scanned

### DIFF
--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -1160,7 +1160,7 @@ class TestHasSatisfyingVersion:
             "foo", SpecifierSet(">=5.0").to_range()
         )
         assert short_reason(provider, "foo") == (
-            "every version needs bar in ==2.0, but the resolve chose bar 1.0"
+            "every version in range needs bar in ==2.0, but the resolve chose bar 1.0"
         )
 
     def test_false_when_every_candidate_hits_the_abort_blocker(self) -> None:
@@ -2251,7 +2251,7 @@ class TestNoVersionsReasons:
         assert result is None
         reason = rendered_reason(provider, "foo")
         assert "bar" in reason
-        assert reason.startswith("every version needs bar in ==2.0")
+        assert reason.startswith("every version in range needs bar in ==2.0")
 
     def test_blocker_reason_outlives_a_later_empty_range(self) -> None:
         """A later ask over an empty range keeps the blocker reason.
@@ -2282,7 +2282,7 @@ class TestNoVersionsReasons:
         assert provider.choose_version("foo", SpecifierSet(">=5.0").to_range()) is None
 
         assert rendered_reason(provider, "foo") == (
-            "every version needs bar in ==2.0, but the resolve chose bar 1.0"
+            "every version in range needs bar in ==2.0, but the resolve chose bar 1.0"
         )
 
     def test_sdist_only_under_dynamic_local_names_build_policy(self) -> None:
@@ -2366,7 +2366,7 @@ class TestNoVersionsReasons:
         )
 
         assert short_reason(provider, "foo") == (
-            "every version needs bar in ==2.0, but the resolve holds bar in <2.0"
+            "every version in range needs bar in ==2.0, but the resolve holds bar in <2.0"
         )
 
     @pytest.mark.parametrize(
@@ -5145,7 +5145,7 @@ class TestDecisionLookAhead:
         )
 
         assert short_reason(provider, "proj") == (
-            "every version needs proj in ==2.0, but the resolve holds proj in >2.0"
+            "every version in range needs proj in ==2.0, but the resolve holds proj in >2.0"
         )
 
     def test_flush_widens_terms_onto_listed_gaps(self) -> None:

--- a/nab-project/tests/test_resolve.py
+++ b/nab-project/tests/test_resolve.py
@@ -4145,9 +4145,55 @@ class TestAugmentResolutionError:
                 _resolved(pyproject, _FAKE_TRANSPORT, python_version="3.12.0")
 
         diagnostics = _diagnostics(info.value)
-        assert "foo: every version needs bar in >=2" in diagnostics
+        assert "foo: every version in range needs bar in >=2" in diagnostics
         assert "bar" in diagnostics
         assert "foo: no version matches the requirement" not in diagnostics
+
+    def test_blocker_line_is_scoped_to_the_range_the_scan_covered(
+        self, tmp_path: Path
+    ) -> None:
+        """The blocker line says "in range" when the ask excluded working versions.
+
+        ``app`` bounds ``lib`` to ``>=3``, so the look-ahead sees only
+        ``lib`` 3.0 and its ``dep==2.2``.  ``lib`` 2.0 and 1.2 declare no
+        ``dep``, so an unqualified "every version" would be false of the
+        package.
+        """
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "proj"\ndependencies = ["app", "web"]\n',
+            encoding="utf-8",
+        )
+
+        coordinator = make_coordinator(
+            listings={
+                "app": _index_wheels("app", "1.0"),
+                "web": _index_wheels("web", "1.1"),
+                "lib": _index_wheels("lib", "3.0", "2.0", "1.2"),
+                "dep": _index_wheels("dep", "2.2", "2.1"),
+            },
+            metadata_by_version={
+                "1.0": _metadata("app", "1.0", "lib>=3"),
+                "1.1": _metadata("web", "1.1", "dep==2.1"),
+                "3.0": _metadata("lib", "3.0", "dep==2.2"),
+                "2.0": _metadata("lib", "2.0"),
+                "1.2": _metadata("lib", "1.2"),
+                "2.2": _metadata("dep", "2.2"),
+                "2.1": _metadata("dep", "2.1"),
+            },
+        )
+
+        with patch("nab_project.resolve.FetchCoordinator") as mock_coord_cls:
+            mock_coord_cls.return_value.__enter__ = lambda _self: coordinator
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            with pytest.raises(ResolutionError) as info:
+                _resolved(pyproject, _FAKE_TRANSPORT, python_version="3.12.0")
+
+        diagnostics = _diagnostics(info.value)
+        assert (
+            "lib: every version in range needs dep in ==2.2, but the resolve"
+            " chose dep 2.1" in diagnostics
+        )
 
     def test_filtered_release_is_not_reported_as_a_missing_version(
         self, tmp_path: Path
@@ -4238,7 +4284,7 @@ class TestAugmentResolutionError:
         diagnostics = _diagnostics(info.value)
         assert "<VersionRange" not in diagnostics
         assert (
-            "foo: every version needs lib in ==5.0, but the resolve chose"
+            "foo: every version in range needs lib in ==5.0, but the resolve chose"
             " lib 9.0" in diagnostics
         )
         assert "requires lib != 9.0" not in diagnostics
@@ -4583,7 +4629,7 @@ class TestAugmentResolutionError:
         assert "<VersionRange" not in diagnostics
         assert "AFTER_LOCALS" not in diagnostics
         assert (
-            "c: every version needs b in ==1.0, but your project requires b >=2"
+            "c: every version in range needs b in ==1.0, but your project requires b >=2"
         ) in diagnostics
 
     def test_blocker_diagnostics_spell_each_declared_range(
@@ -4626,7 +4672,7 @@ class TestAugmentResolutionError:
         assert "<VersionRange" not in diagnostics
         assert "AFTER_LOCALS" not in diagnostics
         assert (
-            "a: every version needs c in ==2.0 or ==1.0, but the resolve chose c 3.0"
+            "a: every version in range needs c in ==2.0 or ==1.0, but the resolve chose c 3.0"
         ) in diagnostics
 
     def test_derivation_renders_readable_ranges(self, tmp_path: Path) -> None:

--- a/nab-provider/src/nab_provider/_provider/listing_diagnosis.py
+++ b/nab-provider/src/nab_provider/_provider/listing_diagnosis.py
@@ -1256,6 +1256,10 @@ def blockers_diagnostic(
 ) -> Diagnostic:
     """Say what the look-ahead found rejecting every candidate in range.
 
+    Blocker lines say "in range" because the scan saw only what the asked
+    range admits: a version outside it may declare none of these
+    dependencies.
+
     One rejection states its ranges on the line, and gets no ``-v`` body:
     the detail would be that same pair of ranges again.  Several name their
     packages and leave the ranges to ``-v``, since two pairs do not fit.
@@ -1265,7 +1269,9 @@ def blockers_diagnostic(
     if len(blockers) + bool(metadata) == 1:
         if not blockers:
             return metadata_diagnostic(provider, normalized, metadata)
-        return Diagnostic(f"every version {_blocker_clause(provider, blockers[0])}")
+        return Diagnostic(
+            f"every version in range {_blocker_clause(provider, blockers[0])}"
+        )
 
     detail = [_blocker_clause(provider, blocker) for blocker in blockers]
     detail.extend(block.message for block in metadata)
@@ -1316,8 +1322,8 @@ def _several_blockers_short(
         list(dict.fromkeys(blocker.package for blocker in blockers)), "packages"
     )
     if not metadata:
-        return f"every version is blocked by {names}"
-    return f"every version is blocked by {names} or rejected on its metadata"
+        return f"every version in range is blocked by {names}"
+    return f"every version in range is blocked by {names} or rejected on its metadata"
 
 
 def metadata_diagnostic(

--- a/nab-provider/tests/test_listing_diagnosis.py
+++ b/nab-provider/tests/test_listing_diagnosis.py
@@ -1652,20 +1652,20 @@ class TestBlockerLines:
         decided = blocker("bar", diagnosis_mod.BlockerKind.DECIDED)
         diagnostic = self._diagnostic([decided])
         assert diagnostic.short == (
-            "every version needs bar in ==2.0, but the resolve chose bar 1.0"
+            "every version in range needs bar in ==2.0, but the resolve chose bar 1.0"
         )
         assert diagnostic.detail == ()
 
     def test_one_held_blocker(self) -> None:
         held = blocker("bar", diagnosis_mod.BlockerKind.HELD)
         assert self._diagnostic([held]).short == (
-            "every version needs bar in ==2.0, but the resolve holds bar in ==1.0"
+            "every version in range needs bar in ==2.0, but the resolve holds bar in ==1.0"
         )
 
     def test_one_root_blocker(self) -> None:
         root = blocker("bar", diagnosis_mod.BlockerKind.ROOT)
         assert self._diagnostic([root]).short == (
-            "every version needs bar in ==2.0, but your project requires bar ==1.0"
+            "every version in range needs bar in ==2.0, but your project requires bar ==1.0"
         )
 
     def test_two_blockers_name_their_packages_and_stop(self) -> None:
@@ -1676,7 +1676,7 @@ class TestBlockerLines:
                 blocker("baz", diagnosis_mod.BlockerKind.ROOT),
             ]
         )
-        assert diagnostic.short == ("every version is blocked by bar and baz")
+        assert diagnostic.short == ("every version in range is blocked by bar and baz")
         assert len(diagnostic.detail) == 2
 
     def test_three_blockers_are_named_on_the_line(self) -> None:
@@ -1688,7 +1688,9 @@ class TestBlockerLines:
                 blocker("qux", diagnosis_mod.BlockerKind.HELD),
             ]
         )
-        assert diagnostic.short == ("every version is blocked by bar, baz and qux")
+        assert diagnostic.short == (
+            "every version in range is blocked by bar, baz and qux"
+        )
         assert len(diagnostic.detail) == 3
 
     def test_four_blockers_are_counted(self) -> None:
@@ -1701,7 +1703,7 @@ class TestBlockerLines:
                 blocker("quux", diagnosis_mod.BlockerKind.DECIDED),
             ]
         )
-        assert diagnostic.short == ("every version is blocked by 4 packages")
+        assert diagnostic.short == ("every version in range is blocked by 4 packages")
         assert len(diagnostic.detail) == 4
 
     def test_two_blockers_on_one_package_name_it_once(self) -> None:
@@ -1712,7 +1714,7 @@ class TestBlockerLines:
                 blocker("bar", diagnosis_mod.BlockerKind.ROOT),
             ]
         )
-        assert diagnostic.short == ("every version is blocked by bar")
+        assert diagnostic.short == ("every version in range is blocked by bar")
 
     def test_a_blocker_beside_unreadable_metadata_says_both(self) -> None:
         diagnostic = self._diagnostic(
@@ -1720,7 +1722,7 @@ class TestBlockerLines:
             (diagnosis_mod.MetadataBlock("No metadata for pkg==2.0"),),
         )
         assert diagnostic.short == (
-            "every version is blocked by bar or rejected on its metadata"
+            "every version in range is blocked by bar or rejected on its metadata"
         )
         assert diagnostic.detail == (
             "needs bar in ==2.0, but the resolve chose bar 1.0",


### PR DESCRIPTION
The blocker line says "every version" of a package the look-ahead only partly scanned:

    Diagnostics:
      - lib: every version needs dep in ==2.2, but the resolve chose dep 2.1

`app` requires `lib>=3`, so the scan saw only `lib` 3.0 and its `dep==2.2`. `lib` 2.0 and 1.2 declare no `dep`, so the chosen `dep` 2.1 does not rule them out. The line calls versions unusable that it never read.

`listing_diagnosis.py` already writes its range-scoped lines with "in range": "every version in range was rejected on its metadata", "no version in range supports Python 3.12". Blocker lines only run on a range-scoped scan, so they say it too:

- `every version in range needs bar in ==2.0, but the resolve chose bar 1.0`
- `every version in range is blocked by bar and baz`
