### PR TITLE
Drop Provider.marker_text_cache, a memo above the memoised Marker.__str__

### DIFF
--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -12354,7 +12354,6 @@ class TestSiblingMetadataDivergence:
         )
         assert provider.consulted_markers == set()
         assert provider.marker_base_cache == {}
-        assert provider.marker_text_cache == {}
         assert provider.marker_extra_cache == {}
 
     def test_sidecar_vs_range_recovered_sibling_crash(self) -> None:

--- a/nab-provider/src/nab_provider/_provider/metadata_resolver.py
+++ b/nab-provider/src/nab_provider/_provider/metadata_resolver.py
@@ -661,7 +661,7 @@ def requirement_gating(provider: Provider, req: Requirement) -> Gating:
     marker_id = id(marker)
     if marker_matches_base(provider, marker, marker_id):
         return "base"
-    if "extra" not in marker_text(provider, marker, marker_id):
+    if "extra" not in str(marker):
         return "excluded"
     return "extra"
 
@@ -704,15 +704,6 @@ def marker_matches_base(provider: Provider, marker: Marker, marker_id: int) -> b
         result = evaluate_prepared(marker, provider.prepared_environment)
         provider.marker_base_cache[marker_id] = result
     return result
-
-
-def marker_text(provider: Provider, marker: Marker, marker_id: int) -> str:
-    """Return ``str(marker)``, cached. Walks the AST on big graphs."""
-    text = provider.marker_text_cache.get(marker_id)
-    if text is None:
-        text = str(marker)
-        provider.marker_text_cache[marker_id] = text
-    return text
 
 
 def marker_matched_extras(

--- a/nab-provider/src/nab_provider/provider.py
+++ b/nab-provider/src/nab_provider/provider.py
@@ -670,8 +670,6 @@ class Provider:
         # alive (see its note above).
         self.marker_base_cache: dict[int, bool] = {}
         self.marker_extra_cache: dict[int, dict[str, bool]] = {}
-        # Memoised str(marker) for the cheap "extra" in marker_text gate.
-        self.marker_text_cache: dict[int, str] = {}
 
         # ``Marker.evaluate`` rebuilds its environment on every call, and this
         # resolve's is fixed, so prepare it up front.  The base environment is


### PR DESCRIPTION
`Provider.marker_text_cache` costs about 255 more instructions per call than the bare `str(marker)` it memoises, counted under callgrind over the 333 distinct markers that reach the `"extra" not in ...` test in `requirement_gating`. An `airflow:airflow-3-0-2-awswrangler --resolution highest` resolve runs that test 1,233 times.

`Marker.__str__` already memoises on the instance, filling `self._serialized` on first call, and `Marker.__hash__` is `hash(str(self))`. Interning a requirement at parse time therefore serialises its marker long before that test runs, so `marker_text` was an `id()` lookup and a dict `get` in front of an attribute read that returns the same string object.

A whole resolve cannot see the difference: repeat instruction counts on `pip:google-bigquery-soda --resolution lowest` disagree with each other by about 0.04%, so those runs rule out only a regression larger than that.

`marker_base_cache` and `marker_extra_cache` stay; those memoise real marker evaluations.
