### PR TITLE
Share one set event across published fetch keys, 2.5% off langchain's peak

### DIFF
--- a/nab-project/tests/test_fetch.py
+++ b/nab-project/tests/test_fetch.py
@@ -3027,7 +3027,19 @@ def _crashed_range_coord() -> FetchCoordinator:
 
 class TestRangeMetadataCoordinator:
     def test_single_flight_one_enqueue(self) -> None:
-        transport = FakeRangeTransport("well_behaved", _build_range_wheel())
+        """A second request for a read still in flight shares its event."""
+        release = threading.Event()
+
+        class _HeldRangeTransport(FakeRangeTransport):
+            """Hold every range read until the test releases it."""
+
+            async def get(
+                self, url: str, *, headers: dict[str, str] | None = None
+            ) -> _FakeRangeResponse:
+                await asyncio.to_thread(release.wait, 5)
+                return await super().get(url, headers=headers)
+
+        transport = _HeldRangeTransport("well_behaved", _build_range_wheel())
         with FetchCoordinator(transport=transport) as coord:  # type: ignore[arg-type]
             submitted: list[FetchRequest] = []
             orig = coord._submit
@@ -3044,6 +3056,8 @@ class TestRangeMetadataCoordinator:
             e1 = coord.request_range_metadata("widget", "1.0", _RANGE_URL)
             e2 = coord.request_range_metadata("widget", "1.0", _RANGE_URL)
             assert e1 is e2
+
+            release.set()
             assert e1.wait(timeout=5)
             assert len(submitted) == 1
             assert (

--- a/nab-project/tests/test_fetch.py
+++ b/nab-project/tests/test_fetch.py
@@ -357,6 +357,17 @@ class TestInMemoryIndex:
         assert existed2
         assert first is second
 
+    def test_get_or_create_after_the_fetch_landed(self) -> None:
+        """A published key still reports as existing, and its event is set."""
+        idx = InMemoryIndex()
+        idx.get_or_create_pending("listing:foo")
+        idx.store_listing("foo", [])
+
+        event, existed = idx.get_or_create_pending("listing:foo")
+
+        assert existed
+        assert event.is_set()
+
     def test_store_sdist_metadata_fires_sdist_pending(self) -> None:
         idx = InMemoryIndex()
         event, _ = idx.get_or_create_pending("sdist:foo:1.0")

--- a/nab-provider/src/nab_provider/store.py
+++ b/nab-provider/src/nab_provider/store.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import threading
 from contextlib import contextmanager
-from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from nab_provider.metadata import metadata_header_block
@@ -26,9 +25,9 @@ __all__ = [
 ]
 
 
-@dataclass
-class _Pending:
-    event: threading.Event = field(default_factory=threading.Event)
+# Every published key shares this one set event rather than keeping its own.
+_PUBLISHED = threading.Event()
+_PUBLISHED.set()
 
 
 def metadata_pending_key(package: str, version: str, metadata_url: str | None) -> str:
@@ -63,7 +62,7 @@ class InMemoryIndex:
     def __init__(self) -> None:
         """Create an empty index."""
         self._lock = threading.Lock()
-        self._pending: dict[str, _Pending] = {}
+        self._pending: dict[str, threading.Event] = {}
 
         self._listings: dict[str, list[WheelFile | SdistFile]] = {}
         self._listing_errors: dict[str, BaseException] = {}
@@ -125,12 +124,18 @@ class InMemoryIndex:
         """Hold the lock for a store write, then wake ``key``'s waiter.
 
         The wake is outside the lock, and a body that raises skips it.
+
+        A published key stays in the map so it keeps deduplicating, but holds
+        the shared set event rather than one of its own.
         """
         with self._lock:
             yield
             pending = self._pending.get(key)
+            if pending is not None:
+                self._pending[key] = _PUBLISHED
+
         if pending is not None:
-            pending.event.set()
+            pending.set()
 
     def get_listing(self, package: str) -> list[WheelFile | SdistFile] | None:
         """Return the cached listing for ``package``, or ``None``."""
@@ -538,13 +543,17 @@ class InMemoryIndex:
 
         The speculative prefetch, the scan batch and the read can all ask for
         one fetch, so a later caller waits on the request in flight.
+
+        A key whose fetch already landed hands back the shared set event.
         """
         with self._lock:
-            if key in self._pending:
-                return self._pending[key].event, True
-            pending = _Pending()
-            self._pending[key] = pending
-            return pending.event, False
+            event = self._pending.get(key)
+            if event is not None:
+                return event, True
+
+            event = threading.Event()
+            self._pending[key] = event
+            return event, False
 
     def get_parsed_metadata(
         self, package: str, version: str, source_text: str


### PR DESCRIPTION
Peak traced memory on a warm `pip:langchain-ml-course --resolution lowest` resolve drops 5.09 MB of 204.1 MB, 2.5%:

| scenario | peak before | change |
| --- | ---: | ---: |
| `pip:langchain-ml-course --resolution lowest` | 204.1 MB | -5.09 MB (-2.5%) |
| `pip:google-bigquery-soda --resolution lowest` | 63.5 MB | -0.57 MB (-0.90%) |
| `ai-stack:vllm-transformers-floor --resolution highest` | 109.1 MB | -0.57 MB (-0.52%) |

`InMemoryIndex._pending` never released a completed key's `threading.Event`: at the langchain high-water mark 4,096 of its 4,097 entries were fetches that had already landed, each still holding an `Event`, its `Condition`, a lock and a waiter deque.

`_publishing` now swaps a published key's value for one module-level event set at import, and the one-field `_Pending` wrapper goes with it. The key stays in the map, so deduplication is unchanged, and the per-key machinery becomes garbage as soon as the fetch lands.

The instruction count goes down as well, so the memory is not bought with CPU: 3,806,615,017 against 3,809,220,960 on `pip:google-bigquery-soda --resolution lowest`, 0.068% off.

Across the 19-scenario canary set, peak RSS is between about 1% and 4.6% lower locally, with a middle estimate near 3.5%. The clock cannot see a change this small, so the timing runs only rule out a wall regression above about 4.3%.
