### PR TITLE
Defer nab-index's email imports, ~17M instructions off a lock

### DIFF
--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -16,7 +16,6 @@ import re
 import time
 from dataclasses import dataclass, replace
 from datetime import timezone
-from email.utils import parsedate_to_datetime
 from typing import TYPE_CHECKING
 
 from nab_provider.records import select_artifact_hash
@@ -178,6 +177,9 @@ def _http_date_seconds(value: str | None) -> int | None:
     """
     if value is None:
         return None
+
+    # Deferred so importing this module does not load the email package.
+    from email.utils import parsedate_to_datetime  # noqa: PLC0415
 
     try:
         parsed = parsedate_to_datetime(value)

--- a/nab-index/src/nab_index/file_urls.py
+++ b/nab-index/src/nab_index/file_urls.py
@@ -1,9 +1,9 @@
 """File-URL helpers, in a module that imports no index client.
 
 :mod:`nab_index.local_index` reads listings and wheels, so importing it pulls
-in :mod:`zipfile`, :mod:`email.parser` and the HTTP client.  Deciding whether
-a configured index URL is a ``file:`` one needs none of that, and that check
-runs while a command line is still being read, so the two live apart.
+in :mod:`zipfile` and the HTTP client.  Deciding whether a configured index URL
+is a ``file:`` one needs none of that, and that check runs while a command line
+is still being read, so the two live apart.
 """
 
 from __future__ import annotations

--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -25,7 +25,6 @@ import os
 import re
 import stat
 import zipfile
-from email.parser import BytesParser, Parser
 from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple
 from urllib.parse import unquote, urljoin, urlparse, urlsplit
@@ -560,6 +559,9 @@ def _read_sdist_requires_python(sdist_path: Path) -> str | None:
     if pkg_info is None:
         return None
 
+    # Deferred so importing this module does not load the email package.
+    from email.parser import Parser  # noqa: PLC0415
+
     value = Parser().parsestr(pkg_info, headersonly=True).get("Requires-Python")
     return value if isinstance(value, str) else None
 
@@ -581,6 +583,9 @@ def _read_wheel_requires_python(wheel_path: Path, expected: str) -> str | None:
         # Corrupt content raises a different type per compression method, and
         # zstd's does not exist before 3.14, so an explicit list leaves holes.
         return None
+
+    # Deferred so importing this module does not load the email package.
+    from email.parser import BytesParser  # noqa: PLC0415
 
     value = BytesParser().parsebytes(raw, headersonly=True).get("Requires-Python")
     return value if isinstance(value, str) else None

--- a/tests/test_cli_imports.py
+++ b/tests/test_cli_imports.py
@@ -10,8 +10,9 @@ the heavier stdlib modules the rest of nab uses.  ``nab._cli.dispatch``,
 ``nab._cli.render``, ``nab._cli.diagnose`` and ``nab.env`` are the
 sanctioned exemptions, and each is loaded only by a line that asked for it.
 
-The last case bans what a command holds after it has dispatched: a line
-that only reads settings loads nothing a resolve needs.
+The last cases ban what a command holds after it has dispatched: a line
+that only reads settings loads nothing a resolve needs, and a line that
+locks holds no part of ``email``.
 """
 
 from __future__ import annotations
@@ -251,3 +252,16 @@ def test_a_settings_command_loads_no_index_reader(
     (tmp_path / "pyproject.toml").write_text(_PROJECT, encoding="utf-8")
 
     assert _run(_HELD_PROBE, ",".join(_INDEX_READER), *line, cwd=tmp_path) == ""
+
+
+def test_a_lock_command_holds_no_email_module(tmp_path: Path) -> None:
+    """Probe G: locking loads no header parser and no HTTP-date reader.
+
+    :mod:`nab_index.cached_client` and :mod:`nab_index.local_index` are held
+    by the line even under ``--offline``, which keeps the probe off the
+    network. They reach :mod:`email` only from the branch that reads an
+    ``Expires`` header and the two that read a metadata block.
+    """
+    (tmp_path / "pyproject.toml").write_text(_PROJECT, encoding="utf-8")
+
+    assert _run(_HELD_PROBE, "email", "lock", "--offline", cwd=tmp_path) == ""


### PR DESCRIPTION
An offline `nab lock` over a one-local-source project goes from 747,272,338 instructions to 730,678,930, about 2.2% less, and importing `nab._lock` alone from 680,909,000 to 663,982,459, about 2.5%. Both are the same 14 stdlib modules no longer loading (`email` with eleven of its submodules, plus `calendar` and `quopri`), so the saving is a fixed ~17M and its share falls as the command does more work. Peak memory on that lock drops from 13,922,811 bytes to 13,364,337, about 4%.

Three module-scope imports move to their call sites: `parsedate_to_datetime` into `cached_client._http_date_seconds`, `Parser` and `BytesParser` into the two `local_index` readers of `Requires-Python`.

A flat find-links directory is the path that pays. It reads a header out of every wheel and sdist, and the deferred import costs about 1,480 instructions per call once `email` is loaded anyway, so a lock over 400 files pays 589,302 more instructions on a base of 1,000,907,247, 0.06%. A PEP 503 index reaches neither reader, because the page's `data-requires-python` answers instead, and PyPI sends `Cache-Control` rather than `Expires`, so `_http_date_seconds` returns before the import.

The clock cannot see a change this size. The end-to-end runs rule out a wall regression above about 7% and a CPU regression above about 1%.
