### PR TITLE
Fix nab --help crashing on a COLUMNS value int() refuses

### DIFF
--- a/src/nab/_cli/render.py
+++ b/src/nab/_cli/render.py
@@ -59,9 +59,15 @@ def terminal_width(environ: dict[str, str] | None = None) -> int:
     """
     env = os.environ if environ is None else environ
 
-    declared = env.get("COLUMNS", "")
-    if declared.isdigit() and int(declared) > 0:
-        return int(declared)
+    # str.isdigit() is not enough of a test: int() refuses a superscript
+    # digit, and a digit run past CPython's conversion limit.
+    try:
+        declared = int(env.get("COLUMNS", ""))
+    except ValueError:
+        declared = 0
+
+    if declared > 0:
+        return declared
 
     try:
         return os.get_terminal_size().columns

--- a/tests/test_cli_rules.py
+++ b/tests/test_cli_rules.py
@@ -1240,6 +1240,20 @@ class TestTheWrapper:
 
         assert terminal_width({"COLUMNS": "wide"}) == 99
 
+    def test_a_columns_that_int_refuses_is_ignored(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A superscript digit, and a decimal run past CPython's limit."""
+        monkeypatch.setattr(
+            "nab._cli.render.os.get_terminal_size",
+            lambda: types.SimpleNamespace(columns=99),
+        )
+
+        past_the_limit = "9" * (sys.get_int_max_str_digits() + 1)
+
+        assert terminal_width({"COLUMNS": "\N{SUPERSCRIPT TWO}"}) == 99
+        assert terminal_width({"COLUMNS": past_the_limit}) == 99
+
     def test_no_terminal_falls_back_to_eighty(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
`COLUMNS=² nab --help` prints a traceback instead of a help page:

    File "src/nab/_cli/render.py", line 63, in terminal_width
        if declared.isdigit() and int(declared) > 0:
    ValueError: invalid literal for int() with base 10: '²'

The width guard tests the value with `str.isdigit()` and then converts it with `int()`, and the two do not agree on what a digit is. 128 characters are digits to `isdigit()` that `int()` refuses, among them `¹`, `²`, `³` and the Ethiopic digits. A decimal run over 4300 digits passes `isdigit()` too, and hits CPython's integer conversion limit.

Every help page reads COLUMNS, so `nab --help` and every `nab <command> --help` crash on any of those values.

The guard now converts first and treats a refusal as no value, so those settings fall through the way `COLUMNS=wide` and `COLUMNS=0` already do: the terminal's own width, then 80.
