### PR TITLE
Stop crediting nab-project with the [tool.nab] config ladder

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,8 @@ other tools:
  * `nab-index`: Provides APIs for talking to Python package indexes, abstracts
    HTTP library interface so different HTTP libraries can be plugged in
  * `nab-project`: nab's own host. It implements the fetch interface over
-   nab-index and adds the resolve orchestration, the config ladder, workspace
-   discovery, the build path, the lockfile emitter and the downloader
+   nab-index and adds the resolve orchestration, workspace discovery, the
+   build path, the lockfile emitter and the downloader
 
 All 4 libraries are in experimental mode, I currently recommend pinning them,
 e.g. `nab-resolver==0.0.1`, as APIs may change at any point.

--- a/nab-project/README.md
+++ b/nab-project/README.md
@@ -3,14 +3,14 @@
 nab's own host for [`nab-provider`](https://pypi.org/project/nab-provider/):
 it supplies the provider's I/O over
 [`nab-index`](https://pypi.org/project/nab-index/), and adds the resolve
-orchestration, the `[tool.nab]` config ladder, workspace discovery, the
-PEP 517 build path, the lockfile emitter and the downloader.
+orchestration, workspace discovery, the PEP 517 build path, the lockfile
+emitter and the downloader.
 
 ## When to use it
 
 Use `nab-project` to embed Python package resolution in another tool, with
-nab's own fetching, config and lockfile emitter but without the CLI. If you
-already own your networking, take `nab-provider` instead.
+nab's own fetching and lockfile emitter but without the CLI. If you already
+own your networking, take `nab-provider` instead.
 
 The API is currently under rapid experimentation, if you use it
 pin to an exact version.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ exclude = [
     "tests/test_contributing_docs.py",
     "tests/test_embedding_docs.py",
     "tests/test_env_layer.py",
+    "tests/test_package_descriptions.py",
     "tests/test_release.py",
     "tests/test_type_check_scope.py",
     "tests/test_workspace_shape.py",

--- a/tests/test_package_descriptions.py
+++ b/tests/test_package_descriptions.py
@@ -1,0 +1,166 @@
+"""Check each README's claims against the packages that implement them.
+
+``project.readme`` is the whole of a distribution's page on PyPI.  A capability
+the page credits to a library has to be implemented in that library, and one a
+library's own page promises has to arrive with an install of it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from itertools import takewhile
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import tomli
+
+from nab_provider._vendor.packaging.requirements import Requirement
+from nab_provider._vendor.packaging.utils import canonicalize_name
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+README = REPO_ROOT / "README.md"
+NAB_PROJECT = REPO_ROOT / "nab-project"
+NAB_PROJECT_README = NAB_PROJECT / "README.md"
+
+# The module implementing each capability a README names.  A phrase is listed
+# only when one module implements it, since the lookup answers with a single
+# distribution.
+CAPABILITY_MODULES = {
+    "config ladder": "nab.config.ladder",
+    "resolve orchestration": "nab_project.resolve",
+    "workspace discovery": "nab_project.workspace",
+    "build path": "nab_project.build_backend",
+    "lockfile emitter": "nab_project.lockfile",
+    "downloader": "nab_project.download",
+}
+
+# A Libraries bullet: the library it opens with, then everything it claims.
+_BULLET = re.compile(r"^ \* `([^`\n]+)`:(.*?)(?=^ \*|\Z)", re.MULTILINE | re.DOTALL)
+
+
+def _project(directory: Path) -> dict[str, Any]:
+    """The ``[project]`` table of the check-out rooted at ``directory``."""
+    text = (directory / "pyproject.toml").read_text(encoding="utf-8")
+    return tomli.loads(text)["project"]
+
+
+def _package_distributions() -> dict[str, str]:
+    """Distribution name, keyed by each import package the workspace ships."""
+    checkouts = [REPO_ROOT, *(p.parent for p in REPO_ROOT.glob("*/pyproject.toml"))]
+
+    packages = {}
+    for directory in checkouts:
+        name = canonicalize_name(_project(directory)["name"])
+        for package in (directory / "src").iterdir():
+            if package.is_dir():
+                packages[package.name] = name
+    return packages
+
+
+def _bullet_list(lines: Iterable[str]) -> str:
+    """The bullet list in ``lines``, from its first bullet to its last line.
+
+    A bullet's body runs on over indented lines, so the list ends at the first
+    line that opens neither a bullet nor a continuation.
+    """
+    listed: list[str] = []
+    for line in lines:
+        if line.startswith(" * ") or (listed and line.startswith("   ")):
+            listed.append(line)
+        elif listed:
+            break
+    return "\n".join(listed)
+
+
+def _library_bullets() -> dict[str, str]:
+    """The Libraries section's bullet bodies, keyed by the library each names."""
+    body = README.read_text(encoding="utf-8").partition("\n# Libraries\n")[2]
+    assert body, "README.md has no Libraries section"
+
+    section = takewhile(lambda line: not line.startswith("#"), body.splitlines())
+    return {
+        canonicalize_name(name): claims
+        for name, claims in _BULLET.findall(_bullet_list(section))
+    }
+
+
+def _named_capabilities(text: str) -> dict[str, str]:
+    """The distribution behind each capability ``text`` names."""
+    packages = _package_distributions()
+    return {
+        phrase: packages[module.partition(".")[0]]
+        for phrase, module in CAPABILITY_MODULES.items()
+        if phrase in text
+    }
+
+
+def _install_provides(directory: Path) -> set[str]:
+    """``directory``'s own distribution name, plus the ones it depends on."""
+    project = _project(directory)
+
+    provided = {canonicalize_name(project["name"])}
+    provided.update(
+        canonicalize_name(Requirement(requirement).name)
+        for requirement in project["dependencies"]
+    )
+    return provided
+
+
+def test_every_capability_names_a_module_the_workspace_ships() -> None:
+    """The tests below resolve only the phrases their own text names.
+
+    A mapping no README currently uses would go unchecked, so pin them all here.
+    """
+    packages = _package_distributions()
+    outside = sorted(
+        f"{phrase} -> {module}"
+        for phrase, module in CAPABILITY_MODULES.items()
+        if module.partition(".")[0] not in packages
+    )
+    assert not outside, f"capabilities mapped outside the workspace: {outside}"
+
+    gone = sorted(
+        f"{phrase} -> {module}"
+        for phrase, module in CAPABILITY_MODULES.items()
+        if importlib.util.find_spec(module) is None
+    )
+    assert not gone, f"the READMEs are checked against modules that are gone: {gone}"
+
+
+def test_library_bullets_credit_the_package_that_holds_the_capability() -> None:
+    """A capability the Libraries section gives a library is implemented there."""
+    bullets = _library_bullets()
+    assert bullets, "README.md's Libraries section has no bullets"
+
+    named = {library: _named_capabilities(body) for library, body in bullets.items()}
+    assert any(named.values()), "no Libraries bullet names a known capability"
+
+    misplaced = sorted(
+        f"{library} is credited with the {phrase}, which ships in {owner}"
+        for library, capabilities in named.items()
+        for phrase, owner in capabilities.items()
+        if owner != library
+    )
+    assert not misplaced, f"README.md misattributes: {misplaced}"
+
+
+def test_nab_project_promises_only_what_installing_it_brings_in() -> None:
+    """What its page names has to arrive with nab-project or a dependency."""
+    named = _named_capabilities(NAB_PROJECT_README.read_text(encoding="utf-8"))
+    assert named, "nab-project/README.md names no known capability"
+
+    provided = _install_provides(NAB_PROJECT)
+    missing = sorted(
+        f"the {phrase}, which ships in {owner}"
+        for phrase, owner in named.items()
+        if owner not in provided
+    )
+    assert not missing, (
+        f"nab-project/README.md promises {missing}, and nab-project depends on "
+        f"{sorted(provided - {'nab-project'})}"
+    )


### PR DESCRIPTION
`nab-project`'s PyPI page promises the `[tool.nab]` config ladder, and installing nab-project does not get you one. The ladder moved into `nab.config` on 2026-08-31 (45ba22854), so it ships in the `nab` distribution, which nab-project does not depend on. That commit corrected `docs/explanation/packages.md` and left both READMEs behind, so the root README's Libraries bullet credits nab-project with the ladder too.

Both now name what nab-project ships: the resolve orchestration, workspace discovery, the build path, the lockfile emitter and the downloader. "nab's own fetching, config and lockfile emitter" loses the config for the same reason.

`tests/test_package_descriptions.py` checks the pages against the code. `CAPABILITY_MODULES` maps each phrase a README names to the module behind it: `config ladder` to `nab.config.ladder`, `lockfile emitter` to `nab_project.lockfile`. The tests resolve that module to the distribution shipping it, so a Libraries bullet may credit only what its own library implements, and nab-project's page may promise only what installing nab-project brings in.

A separate test pins every mapping, so a renamed or deleted module fails instead of going unchecked. The file reads the sibling checkouts, so it joins the umbrella sdist's exclude list.
