### PR TITLE
Stop reporting a page of unusable files as a package no index carries

### DIFF
--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -35,7 +35,9 @@ from .client import (
     _listing_body,
     _parse_files,
     _verify_metadata_hash,
+    holds_named_files,
     holds_only_yanked,
+    holds_unreachable_link,
     holds_unreadable_format,
     verify_sdist_hash,
     zip_sdist_versions,
@@ -369,6 +371,8 @@ class CachedAsyncSimpleClient:
         self._offline = offline
         self._serialization = serialization
         self._unreadable_only: set[str] = set()
+        self._unreachable_only: set[str] = set()
+        self._no_usable_file: set[str] = set()
         self._all_yanked: set[str] = set()
         self._zip_sdists: dict[str, frozenset[str]] = {}
         self._range_memo = (
@@ -643,28 +647,39 @@ class CachedAsyncSimpleClient:
         entries resolve against.
         """
         files = _parse_files(data, self._index_url, package, page_url=page_url)
-        if not files and holds_unreadable_format(data):
-            self._unreadable_only.add(package)
-        if not files and holds_only_yanked(data):
-            self._all_yanked.add(package)
+        if not files:
+            self._mark_empty_listing(data, package, page_url)
 
         self._zip_sdists[package] = zip_sdist_versions(data, package)
         return files
+
+    def _mark_empty_listing(
+        self, data: object, package: str, page_url: str | None
+    ) -> None:
+        """Record what a body that parsed to no files still said about ``package``.
+
+        One page can meet more than one of these, so each is marked on its own.
+        """
+        if holds_unreadable_format(data):
+            self._unreadable_only.add(package)
+        if holds_unreachable_link(data, self._index_url, package, page_url=page_url):
+            self._unreachable_only.add(package)
+        if holds_only_yanked(data):
+            self._all_yanked.add(package)
+        if holds_named_files(data):
+            self._no_usable_file.add(package)
 
     def served_unreadable_only(self, package: str) -> bool:
         """Whether a listing for ``package`` held only files nab cannot read."""
         return package in self._unreadable_only
 
-    def served_unreachable_only(
-        self,
-        package: str,  # noqa: ARG002 - the IndexClient protocol fixes the signature
-    ) -> bool:
-        """Whether a listing for ``package`` held only links nab cannot reach.
+    def served_unreachable_only(self, package: str) -> bool:
+        """Whether a listing for ``package`` held only links nab cannot reach."""
+        return package in self._unreachable_only
 
-        Always ``False``: the listing parse drops a remote entry whose URL
-        cannot be used, leaving nothing to mark.
-        """
-        return False
+    def served_no_usable_file(self, package: str) -> bool:
+        """Whether a listing for ``package`` named files and nab kept none."""
+        return package in self._no_usable_file
 
     def served_all_yanked(self, package: str) -> bool:
         """Whether a listing for ``package`` held files and yanked every one."""

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -61,6 +61,8 @@ __all__ = [
     "WheelFile",
     "WheelHashMismatchError",
     "extract_sdist_archive",
+    "holds_named_files",
+    "holds_unreachable_link",
     "holds_unreadable_format",
     "is_readable_filename",
     "verify_sdist_hash",
@@ -243,8 +245,8 @@ def zip_sdist_version(filename: str, canonical: str) -> str | None:
     return version if _intern_name(name_part) == canonical else None
 
 
-def _listed_filenames(data: object) -> Iterator[str]:
-    """Yield the unyanked filenames a Simple-API body offers.
+def _listed_entries(data: object) -> Iterator[_FileEntry]:
+    """Yield the unyanked file entries a Simple-API body offers.
 
     A body that is not a list of file entries yields nothing.
     """
@@ -255,11 +257,39 @@ def _listed_filenames(data: object) -> Iterator[str]:
         return
 
     for file_info in raw_files:
-        if not isinstance(file_info, dict) or file_info.get("yanked"):
-            continue
+        if isinstance(file_info, dict) and not file_info.get("yanked"):
+            yield file_info
+
+
+def _listed_filenames(data: object) -> Iterator[str]:
+    """Yield the unyanked filenames a Simple-API body offers."""
+    for file_info in _listed_entries(data):
         filename = file_info.get("filename")
         if isinstance(filename, str):
             yield filename
+
+
+def holds_named_files(data: object) -> bool:
+    """Whether a Simple-API body names at least one unyanked file."""
+    return next(_listed_filenames(data), None) is not None
+
+
+def holds_unreachable_link(
+    data: object, index_url: str, package: str, *, page_url: str | None = None
+) -> bool:
+    """Whether a Simple-API body offers a file behind a URL nab cannot use.
+
+    :func:`_parse_files` drops such an entry, so a page offering only
+    these parses to no files at all.  ``index_url``, ``package`` and
+    ``page_url`` fix the base a relative entry resolves against.
+    """
+    base_url = _listing_base_url(index_url, package, page_url)
+    return any(
+        _resolve_file_url(raw_url, base_url) is None
+        for file_info in _listed_entries(data)
+        if isinstance(file_info.get("filename"), str)
+        and isinstance(raw_url := file_info.get("url"), str)
+    )
 
 
 def holds_unreadable_format(data: object) -> bool:
@@ -518,8 +548,7 @@ def _parse_files(
     lower-priority index and risk pinning a different version.
     """
     expected = canonicalize_name(package)
-    # PEP 691: relative URLs resolve against the package page, not the index root.
-    base_url = page_url if page_url is not None else f"{index_url}{package}/"
+    base_url = _listing_base_url(index_url, package, page_url)
     files: list[WheelFile | SdistFile] = []
     if not isinstance(data, dict):
         msg = (
@@ -549,6 +578,14 @@ def _parse_files(
             files.append(parsed)
 
     return files
+
+
+def _listing_base_url(index_url: str, package: str, page_url: str | None) -> str:
+    """Return the URL a listing's relative entries resolve against.
+
+    PEP 691: that is the package page, not the index root.
+    """
+    return page_url if page_url is not None else f"{index_url}{package}/"
 
 
 def _normalized_url(url: str) -> str:

--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -171,20 +171,23 @@ _FLAT_EXTS = re.compile(r"\.(whl|tar\.gz)$", re.IGNORECASE)
 class _ScanResult(NamedTuple):
     """What one scan of a local index found for a package.
 
-    The four fields beside ``files`` describe what the scan dropped, none of
+    The five fields beside ``files`` describe what the scan dropped, none of
     which leaves a record.  ``unreadable`` says the listing offered a file in
     a format nab does not read, which tells a page of ``.zip`` sdists from an
     empty one; ``unreachable`` says it offered a wheel or ``.tar.gz`` sdist
     behind an href that resolves to no usable URL; ``all_yanked`` says every
     anchor naming a file was yanked, which tells a page of yanked releases
-    from a package this index does not carry; ``zip_sdists`` names the
-    releases it offered as ``.zip`` sdists.
+    from a package this index does not carry; ``named_files`` says an
+    unyanked anchor named a release, whatever the scan then made of it,
+    which tells a page that offered releases from one that offered none;
+    ``zip_sdists`` names the releases it offered as ``.zip`` sdists.
     """
 
     files: list[WheelFile | SdistFile]
     unreadable: bool
     unreachable: bool
     all_yanked: bool
+    named_files: bool
     zip_sdists: frozenset[str]
 
 
@@ -204,6 +207,7 @@ def _scan_pep503_directory(
             unreadable=False,
             unreachable=False,
             all_yanked=False,
+            named_files=False,
             zip_sdists=frozenset(),
         )
 
@@ -259,13 +263,15 @@ def _scan_pep503_directory(
         if record is not None:
             files.append(record)
 
-    # A navigation link is not a release, so the all-yanked test counts only
-    # the anchors that name one.
+    # A navigation link is not a release, so both counts below read the
+    # anchors that name one.
+    named = len(anchors) - yanked - nameless
     return _ScanResult(
         files,
         unreadable=unreadable,
         unreachable=unreachable,
-        all_yanked=yanked > 0 and yanked == len(anchors) - nameless,
+        all_yanked=yanked > 0 and named == 0,
+        named_files=named > 0,
         zip_sdists=frozenset(zip_sdists),
     )
 
@@ -502,7 +508,8 @@ def _scan_flat_wheelhouse(
 
     One directory serves every package, so a file that does not name
     ``package`` says nothing about it: only a ``.zip`` sdist of ``package``
-    makes the scan unreadable.  A flat directory has no yank marks.
+    makes the scan unreadable.  A flat directory has no yank marks and no
+    page that named ``package``'s files.
     """
     canonical = _canonical(package)
     files: list[WheelFile | SdistFile] = []
@@ -532,6 +539,7 @@ def _scan_flat_wheelhouse(
         unreadable=bool(zip_sdists),
         unreachable=False,
         all_yanked=False,
+        named_files=False,
         zip_sdists=frozenset(zip_sdists),
     )
 
@@ -739,6 +747,7 @@ class LocalIndexClient:
         self._root = Path(os.path.abspath(root))  # noqa: PTH100
         self._unreadable_only: set[str] = set()
         self._unreachable_only: set[str] = set()
+        self._no_usable_file: set[str] = set()
         self._all_yanked: set[str] = set()
         self._zip_sdists: dict[str, frozenset[str]] = {}
 
@@ -772,6 +781,7 @@ class LocalIndexClient:
                     unreadable=False,
                     unreachable=False,
                     all_yanked=False,
+                    named_files=False,
                     zip_sdists=frozenset(),
                 )
             else:
@@ -786,6 +796,8 @@ class LocalIndexClient:
             self._unreachable_only.add(package)
         if not scan.files and scan.all_yanked:
             self._all_yanked.add(package)
+        if not scan.files and scan.named_files:
+            self._no_usable_file.add(package)
         self._zip_sdists[package] = scan.zip_sdists
         return scan.files
 
@@ -796,6 +808,10 @@ class LocalIndexClient:
     def served_unreachable_only(self, package: str) -> bool:
         """Whether a listing for ``package`` held only links nab cannot reach."""
         return package in self._unreachable_only
+
+    def served_no_usable_file(self, package: str) -> bool:
+        """Whether a listing for ``package`` named files and nab kept none."""
+        return package in self._no_usable_file
 
     def served_all_yanked(self, package: str) -> bool:
         """Whether a listing for ``package`` held file links and yanked every one."""

--- a/nab-index/src/nab_index/multi_index.py
+++ b/nab-index/src/nab_index/multi_index.py
@@ -66,6 +66,10 @@ class IndexClient(Protocol):
         """Whether a listing for ``package`` held only links nab cannot reach."""
         ...
 
+    def served_no_usable_file(self, package: str) -> bool:
+        """Whether a listing for ``package`` named files and nab kept none."""
+        ...
+
     def served_all_yanked(self, package: str) -> bool:
         """Whether a listing for ``package`` held files and yanked every one."""
         ...
@@ -260,6 +264,17 @@ class MultiIndexClient:
         """
         return any(
             client.served_unreachable_only(package) for client in self._clients.values()
+        )
+
+    def served_no_usable_file(self, package: str) -> bool:
+        """Whether a walked index named files for ``package`` and nab kept none.
+
+        Asked of every client for the same reason
+        :meth:`served_unreadable_only` is: an empty walk routes ``package``
+        to the first index, which need not be the one that served it.
+        """
+        return any(
+            client.served_no_usable_file(package) for client in self._clients.values()
         )
 
     def served_all_yanked(self, package: str) -> bool:

--- a/nab-index/tests/test_index_client.py
+++ b/nab-index/tests/test_index_client.py
@@ -12,7 +12,9 @@ from nab_index.client import (
     _parse_files,
     _parse_sdist_filename,
     _sdist_member_top_level,
+    holds_named_files,
     holds_only_yanked,
+    holds_unreachable_link,
     holds_unreadable_format,
     is_readable_filename,
     zip_sdist_version,
@@ -21,6 +23,8 @@ from nab_index.client import (
 
 # A version digit run past CPython's int-from-string limit.
 OVERSIZED = "1" * (sys.get_int_max_str_digits() + 1)
+
+INDEX_URL = "https://e.example/simple/"
 
 
 @pytest.mark.parametrize(
@@ -179,7 +183,101 @@ def test_holds_only_yanked_false(data: object) -> None:
     assert not holds_only_yanked(data)
 
 
-def test_the_two_empty_listing_flags_are_exclusive() -> None:
+@pytest.mark.parametrize(
+    "data",
+    [
+        pytest.param(
+            {
+                "files": [
+                    {
+                        "filename": "cffi-1.0.2-2.tar.gz",
+                        "url": "https://e.example/cffi-1.0.2-2.tar.gz",
+                    }
+                ]
+            },
+            id="filename-of-another-project",
+        ),
+        pytest.param({"files": [{"filename": "foo-1.0.zip"}]}, id="unreadable-format"),
+        pytest.param(
+            {"files": [{"filename": "foo-1.0-py3-none-any.whl"}]}, id="readable-entry"
+        ),
+    ],
+)
+def test_holds_named_files_true(data: object) -> None:
+    assert holds_named_files(data)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        pytest.param(["files"], id="body-not-an-object"),
+        pytest.param({"files": "nope"}, id="files-not-a-list"),
+        pytest.param({"files": []}, id="no-entries"),
+        pytest.param({"files": ["foo-1.0.whl"]}, id="entry-not-an-object"),
+        pytest.param(
+            {"files": [{"url": "https://e.example/f"}]}, id="entry-with-no-filename"
+        ),
+        pytest.param(
+            {"files": [{"filename": "foo-1.0-py3-none-any.whl", "yanked": True}]},
+            id="yanked-entry",
+        ),
+    ],
+)
+def test_holds_named_files_false(data: object) -> None:
+    assert not holds_named_files(data)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        pytest.param(
+            "https://[::1/foo-1.0-py3-none-any.whl", id="unbalanced-ipv6-bracket"
+        ),
+        pytest.param(
+            "https://exa\u2100mple.com/foo-1.0-py3-none-any.whl",
+            id="netloc-that-changes-under-nfkc",
+        ),
+    ],
+)
+def test_holds_unreachable_link_finds_an_unusable_url(url: str) -> None:
+    """The entry is dropped, so the page it is alone on parses to nothing."""
+    data = {"files": [{"filename": "foo-1.0-py3-none-any.whl", "url": url}]}
+
+    assert _parse_files(data, INDEX_URL, "foo") == []
+    assert holds_unreachable_link(data, INDEX_URL, "foo")
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        pytest.param({"files": []}, id="no-entries"),
+        pytest.param(
+            {
+                "files": [
+                    {
+                        "filename": "foo-1.0-py3-none-any.whl",
+                        "url": "foo-1.0-py3-none-any.whl",
+                    }
+                ]
+            },
+            id="relative-url-the-page-resolves",
+        ),
+        pytest.param(
+            {"files": [{"filename": "foo-1.0-py3-none-any.whl"}]},
+            id="entry-with-no-url",
+        ),
+        pytest.param(
+            {"files": [{"url": "https://[::1/foo-1.0-py3-none-any.whl"}]},
+            id="entry-with-no-filename",
+        ),
+    ],
+)
+def test_holds_unreachable_link_false(data: object) -> None:
+    """A page marks only where an entry naming a file has a URL nothing can use."""
+    assert not holds_unreachable_link(data, INDEX_URL, "foo")
+
+
+def test_a_yanked_zip_sdist_is_yanked_rather_than_unreadable() -> None:
     """A page of yanked .zip sdists is yanked rather than unreadable.
 
     ``holds_unreadable_format`` skips a yanked entry before reading its

--- a/nab-index/tests/test_index_local.py
+++ b/nab-index/tests/test_index_local.py
@@ -74,6 +74,7 @@ def test_scan_directory_without_index_html_returns_empty(tmp_path: Path) -> None
     assert not scan.unreadable
     assert not scan.unreachable
     assert not scan.all_yanked
+    assert not scan.named_files
     assert scan.zip_sdists == frozenset()
 
 
@@ -155,6 +156,30 @@ def test_a_page_of_unreachable_links_is_not_an_absent_package(
     assert run(client.get_files("foo")) == []
     assert client.served_unreachable_only("foo")
     assert not client.served_unreadable_only("foo")
+
+
+def test_a_page_of_files_naming_another_project_is_not_absent(tmp_path: Path) -> None:
+    """A filename that parses to another project still leaves the page naming one.
+
+    ``cffi-1.0.2-2.tar.gz`` parses as project ``cffi-1-0-2`` at version
+    ``2``, so the record is dropped while the anchor still named a release.
+    """
+    package_dir = tmp_path / "cffi"
+    package_dir.mkdir()
+    (package_dir / "index.html").write_text(
+        _anchor("cffi-1.0.2-2.tar.gz"), encoding="utf-8"
+    )
+
+    scan = _scan_pep503_directory(package_dir, "cffi")
+
+    assert scan.files == []
+    assert scan.named_files
+    assert not scan.unreadable
+    assert not scan.unreachable
+
+    client = LocalIndexClient(tmp_path.as_uri())
+    assert run(client.get_files("cffi")) == []
+    assert client.served_no_usable_file("cffi")
 
 
 @pytest.mark.parametrize(

--- a/nab-index/tests/test_index_multi.py
+++ b/nab-index/tests/test_index_multi.py
@@ -49,6 +49,9 @@ class _RecordingClient:
     def served_unreachable_only(self, package: str) -> bool:
         return False
 
+    def served_no_usable_file(self, package: str) -> bool:
+        return False
+
     def served_all_yanked(self, package: str) -> bool:
         return False
 

--- a/nab-project/src/nab_project/fetch.py
+++ b/nab-project/src/nab_project/fetch.py
@@ -1066,6 +1066,7 @@ class FetchCoordinator:
             files,
             unreadable_only=client.served_unreadable_only(req.package),
             unreachable_only=client.served_unreachable_only(req.package),
+            no_usable_file=client.served_no_usable_file(req.package),
             all_yanked=client.served_all_yanked(req.package),
             zip_sdists=client.served_zip_sdists(req.package),
         )

--- a/nab-project/tests/property_python/test_fetch_coordinator.py
+++ b/nab-project/tests/property_python/test_fetch_coordinator.py
@@ -124,6 +124,9 @@ class FakeClient:
     def served_unreachable_only(self, package: str) -> bool:
         return False
 
+    def served_no_usable_file(self, package: str) -> bool:
+        return False
+
     def served_all_yanked(self, package: str) -> bool:
         return False
 

--- a/nab-project/tests/property_python/test_multi_index_contract.py
+++ b/nab-project/tests/property_python/test_multi_index_contract.py
@@ -72,6 +72,9 @@ class Stub:
     def served_unreachable_only(self, package: str) -> bool:
         return False
 
+    def served_no_usable_file(self, package: str) -> bool:
+        return False
+
     def served_all_yanked(self, package: str) -> bool:
         return False
 

--- a/nab-project/tests/property_python/test_multi_index_pep503.py
+++ b/nab-project/tests/property_python/test_multi_index_pep503.py
@@ -78,6 +78,9 @@ class _Stub:
     def served_unreachable_only(self, package: str) -> bool:
         return False
 
+    def served_no_usable_file(self, package: str) -> bool:
+        return False
+
     def served_all_yanked(self, package: str) -> bool:
         return False
 

--- a/nab-project/tests/test_fetch.py
+++ b/nab-project/tests/test_fetch.py
@@ -1672,6 +1672,7 @@ class TestFetchCoordinator:
                 offline_miss: bool = False,
                 unreadable_only: bool = False,
                 unreachable_only: bool = False,
+                no_usable_file: bool = False,
                 all_yanked: bool = False,
                 zip_sdists: frozenset[str] = frozenset(),
             ) -> None:
@@ -1682,6 +1683,7 @@ class TestFetchCoordinator:
                     offline_miss=offline_miss,
                     unreadable_only=unreadable_only,
                     unreachable_only=unreachable_only,
+                    no_usable_file=no_usable_file,
                     all_yanked=all_yanked,
                     zip_sdists=zip_sdists,
                 )

--- a/nab-project/tests/test_multi_index.py
+++ b/nab-project/tests/test_multi_index.py
@@ -45,6 +45,7 @@ class FakeClient:
         self.listing = listing
         self.unreadable: set[str] = set()
         self.unreachable: set[str] = set()
+        self.no_usable_file: set[str] = set()
         self.all_yanked: set[str] = set()
         self.zip_sdists: dict[str, frozenset[str]] = {}
         self.get_files_calls: list[str] = []
@@ -66,6 +67,9 @@ class FakeClient:
 
     def served_unreachable_only(self, package: str) -> bool:
         return package in self.unreachable
+
+    def served_no_usable_file(self, package: str) -> bool:
+        return package in self.no_usable_file
 
     def served_all_yanked(self, package: str) -> bool:
         return package in self.all_yanked

--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -1915,6 +1915,97 @@ class TestNoVersionsReasons:
             "the index lists this package but nab cannot reach any of its links"
         )
 
+    def test_remote_page_of_unreachable_links_names_the_links(
+        self, tmp_path: Path
+    ) -> None:
+        """A remote page reads like the local one it mirrors, not like absence.
+
+        The wheel sits behind a URL with an unterminated IPv6 bracket, so
+        the entry is dropped and the page parses to nothing.
+        """
+        body = json.dumps(
+            {
+                "files": [
+                    {
+                        "filename": "foo-1.0-py3-none-any.whl",
+                        "url": "https://[::1/foo-1.0-py3-none-any.whl",
+                    }
+                ]
+            }
+        ).encode()
+        OnDiskCache(tmp_path, DEFAULT_INDEX_URL).put_simple(
+            "foo", body, CachePolicy(fetched_at=0, max_age=1, etag=None)
+        )
+
+        with FetchCoordinator(
+            transport=Urllib3AsyncTransport(),
+            cache_dir=tmp_path,
+            offline=True,
+        ) as coordinator:
+            provider = Provider(coordinator)
+            provider.choose_version("foo", SpecifierSet("").to_range())
+
+        assert rendered_reason(provider, "foo") == (
+            "the index lists this package but nab cannot reach any of its links"
+        )
+
+    def test_remote_page_naming_another_project_is_not_absence(
+        self, tmp_path: Path
+    ) -> None:
+        """A filename packaging parses to another project is not a missing package.
+
+        ``cffi-1.0.2-2.tar.gz`` parses as project ``cffi-1-0-2`` at version
+        ``2``, so the file is dropped while the index still lists the
+        project.
+        """
+        body = json.dumps(
+            {
+                "files": [
+                    {
+                        "filename": "cffi-1.0.2-2.tar.gz",
+                        "url": "https://pypi.example/cffi-1.0.2-2.tar.gz",
+                    }
+                ]
+            }
+        ).encode()
+        OnDiskCache(tmp_path, DEFAULT_INDEX_URL).put_simple(
+            "cffi", body, CachePolicy(fetched_at=0, max_age=1, etag=None)
+        )
+
+        with FetchCoordinator(
+            transport=Urllib3AsyncTransport(),
+            cache_dir=tmp_path,
+            offline=True,
+        ) as coordinator:
+            provider = Provider(coordinator)
+            provider.choose_version("cffi", SpecifierSet("").to_range())
+
+        assert rendered_reason(provider, "cffi") == (
+            "the index lists this package but nab can use none of the files it names"
+        )
+
+    def test_local_pep503_page_naming_another_project_is_not_absence(
+        self, tmp_path: Path
+    ) -> None:
+        """The local scanner drops the same filename, so it reports the same line."""
+        package_dir = tmp_path / "cffi"
+        package_dir.mkdir()
+        (package_dir / "index.html").write_text(
+            '<a href="cffi-1.0.2-2.tar.gz">cffi-1.0.2-2.tar.gz</a>', encoding="utf-8"
+        )
+        (package_dir / "cffi-1.0.2-2.tar.gz").write_bytes(b"")
+
+        with FetchCoordinator(
+            transport=Urllib3AsyncTransport(),
+            indexes=[IndexConfig("local", tmp_path.as_uri())],
+        ) as coordinator:
+            provider = Provider(coordinator)
+            provider.choose_version("cffi", SpecifierSet("").to_range())
+
+        assert rendered_reason(provider, "cffi") == (
+            "the index lists this package but nab can use none of the files it names"
+        )
+
     def test_no_match_in_range_records_no_match_reason(self) -> None:
         """A non-empty listing with no in-range version surfaces a no-match reason."""
         coordinator = make_coordinator([make_wheel("1.0")], package="foo")

--- a/nab-provider/src/nab_provider/_provider/listing_diagnosis.py
+++ b/nab-provider/src/nab_provider/_provider/listing_diagnosis.py
@@ -131,6 +131,7 @@ class ReasonKind:
     OFFLINE_MISS: Final = "offline-miss"
     UNREADABLE_ONLY: Final = "unreadable-only"
     UNREACHABLE_ONLY: Final = "unreachable-only"
+    NONE_USABLE: Final = "none-usable"
     YANKED_ONLY: Final = "yanked-only"
     ABSENT: Final = "absent"
     PINNED_ABSENT: Final = "pinned-absent"
@@ -352,6 +353,7 @@ class NoVersionsReason:
 OFFLINE_MISS = NoVersionsReason(ReasonKind.OFFLINE_MISS)
 UNREADABLE_ONLY = NoVersionsReason(ReasonKind.UNREADABLE_ONLY)
 UNREACHABLE_ONLY = NoVersionsReason(ReasonKind.UNREACHABLE_ONLY)
+NONE_USABLE = NoVersionsReason(ReasonKind.NONE_USABLE)
 YANKED_ONLY = NoVersionsReason(ReasonKind.YANKED_ONLY)
 ABSENT = NoVersionsReason(ReasonKind.ABSENT)
 PINNED_ABSENT = NoVersionsReason(ReasonKind.PINNED_ABSENT)
@@ -361,7 +363,7 @@ EXTRA_BASE_EMPTY = NoVersionsReason(ReasonKind.EXTRA_BASE_EMPTY)
 
 NO_MATCH = Diagnostic("no version matches the requirement")
 
-# The five situations the index client answers on its own with a fixed line.
+# The six situations the index client answers on its own with a fixed line.
 # None of them is a walk, so only the two with something to add carry a ``-v``
 # body: for the others, saying the same fact at more length is not detail.
 FIXED_DIAGNOSTICS: dict[Kind, Diagnostic] = {
@@ -382,6 +384,9 @@ FIXED_DIAGNOSTICS: dict[Kind, Diagnostic] = {
     ),
     ReasonKind.UNREACHABLE_ONLY: Diagnostic(
         "the index lists this package but nab cannot reach any of its links"
+    ),
+    ReasonKind.NONE_USABLE: Diagnostic(
+        "the index lists this package but nab can use none of the files it names"
     ),
     ReasonKind.YANKED_ONLY: Diagnostic(
         "the index lists this package but every file is yanked"

--- a/nab-provider/src/nab_provider/provider.py
+++ b/nab-provider/src/nab_provider/provider.py
@@ -1700,10 +1700,9 @@ class Provider:
         index served no files or every file it served was dropped by one of
         the listing filter's rungs.  The stored listing tells absence from
         incompatibility apart, except that it is also empty for an index
-        skipped offline, for a page of formats nab does not read (``.zip``
-        sdists, ``.exe`` installers), and for one whose every file is
-        yanked.  All three are marked when stored, so the reason names what
-        happened instead of absence.
+        skipped offline and for a page that named files nab could not use.
+        Both are marked when stored, so the reason names what happened
+        instead of absence.
 
         A look-ahead rejection emits a clause that removes the rejected
         versions from the range, so the resolver asks again over a range
@@ -1777,15 +1776,31 @@ class Provider:
         if index.is_offline_listing_miss(normalized):
             return _diagnosis.OFFLINE_MISS
 
-        # A page can set both of these marks; the unreadable line wins.
+        served = self._served_page_marker(normalized)
+        if served is not None:
+            return served
+        return self._absent_listing_marker(normalized)
+
+    def _served_page_marker(
+        self, normalized: str
+    ) -> _diagnosis.NoVersionsReason | None:
+        """Classify an empty listing by the marks its page was stored with.
+
+        One page can carry several, so the order is the one the report
+        prefers: the most specific reason nothing came off the page first,
+        the bare fact that it named files last.  ``None`` when no index
+        marked a page for ``normalized``.
+        """
+        index = self.coordinator.index
         if index.is_unreadable_only_listing(normalized):
             return _diagnosis.UNREADABLE_ONLY
         if index.is_unreachable_only_listing(normalized):
             return _diagnosis.UNREACHABLE_ONLY
-
         if index.is_all_yanked_listing(normalized):
             return _diagnosis.YANKED_ONLY
-        return self._absent_listing_marker(normalized)
+        if index.is_no_usable_file_listing(normalized):
+            return _diagnosis.NONE_USABLE
+        return None
 
     def _absent_listing_marker(self, normalized: str) -> _diagnosis.NoVersionsReason:
         """Classify a package no index served a page for.

--- a/nab-provider/src/nab_provider/store.py
+++ b/nab-provider/src/nab_provider/store.py
@@ -77,6 +77,8 @@ class InMemoryIndex:
         self._unreadable_only_listings: set[str] = set()
         # Packages whose empty listing stands for a page of links nab cannot reach.
         self._unreachable_only_listings: set[str] = set()
+        # Packages whose empty listing stands for a page nab kept no file off.
+        self._no_usable_file_listings: set[str] = set()
         # Packages whose empty listing stands for a page of yanked files.
         self._all_yanked_listings: set[str] = set()
         # Versions an index served as a ``.zip`` sdist, which the listing parse
@@ -144,6 +146,7 @@ class InMemoryIndex:
         offline_miss: bool = False,
         unreadable_only: bool = False,
         unreachable_only: bool = False,
+        no_usable_file: bool = False,
         all_yanked: bool = False,
         zip_sdists: frozenset[str] = frozenset(),
     ) -> None:
@@ -154,8 +157,9 @@ class InMemoryIndex:
         ``offline_miss`` marks an empty listing as an index skipped offline
         rather than one that served no files; ``unreadable_only`` marks it as
         a page of formats nab does not read; ``unreachable_only`` marks it as
-        a page whose every link nab cannot reach; ``all_yanked`` marks it as
-        a page whose every file is yanked.
+        a page whose every link nab cannot reach; ``no_usable_file`` marks it
+        as a page that named files nab kept none of; ``all_yanked`` marks it
+        as a page whose every file is yanked.
 
         ``zip_sdists`` names the releases served as a ``.zip`` sdist, which
         nothing in ``data`` records.  It replaces whatever a prior store left,
@@ -171,6 +175,8 @@ class InMemoryIndex:
                 self._unreadable_only_listings.add(package)
             if unreachable_only:
                 self._unreachable_only_listings.add(package)
+            if no_usable_file:
+                self._no_usable_file_listings.add(package)
             if all_yanked:
                 self._all_yanked_listings.add(package)
             if zip_sdists:
@@ -191,6 +197,10 @@ class InMemoryIndex:
     def is_unreachable_only_listing(self, package: str) -> bool:
         """Whether ``package``'s empty listing held only links nab cannot reach."""
         return package in self._unreachable_only_listings
+
+    def is_no_usable_file_listing(self, package: str) -> bool:
+        """Whether ``package``'s empty listing named files nab kept none of."""
+        return package in self._no_usable_file_listings
 
     def is_all_yanked_listing(self, package: str) -> bool:
         """Whether ``package``'s empty listing held files and yanked every one."""


### PR DESCRIPTION
A page the index served, whose file entries nab drops one by one, reports absence:

    cffi: package not found on any configured index

The index carries cffi and served the page. Two cases reach that line.

- An entry's URL cannot be used: an unbalanced IPv6 bracket, or a netloc that changes under NFKC. The local scanner already reports those as unreachable links, but `CachedAsyncSimpleClient.served_unreachable_only` returned `False` for every package, so a remote page fell through to absence.
- The filename parses to another project, or packaging does not recognise it. `cffi-1.0.2-2.tar.gz` parses as project `cffi-1-0-2` at version `2`, so `_parse_files` drops it and nothing marked the page.

The remote client now marks the first the way the local one does. The second gets its own line, on both paths:

    cffi: the index lists this package but nab can use none of the files it names

Unreadable format, unreachable links and yanked-only are checked ahead of it, so a page meeting several keeps the most specific. `IndexClient` gains `served_no_usable_file`.
