### PR TITLE
Drop the runtime typing_extensions imports, ~1.8% off `nab cache dir`

### DIFF
--- a/nab-index/src/nab_index/_compat.py
+++ b/nab-index/src/nab_index/_compat.py
@@ -1,0 +1,20 @@
+"""Runtime fallback for :func:`typing.override`, so ``typing_extensions`` is not needed.
+
+``override`` runs at class-body time, so unlike the annotation-only helpers it
+cannot hide under ``TYPE_CHECKING``.  Looking it up by name rather than by
+interpreter version keeps this free of a version-gated branch.  Before 3.12 the
+fallback is the identity and so does not set ``__override__``, which nothing
+here reads.
+"""
+
+from __future__ import annotations
+
+import typing
+from typing import TYPE_CHECKING
+
+__all__ = ["override"]
+
+if TYPE_CHECKING:
+    from typing_extensions import override
+else:
+    override = getattr(typing, "override", lambda method: method)

--- a/nab-index/src/nab_index/_html_page.py
+++ b/nab-index/src/nab_index/_html_page.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from html.parser import HTMLParser
 
-from typing_extensions import override
+from ._compat import override
 
 __all__ = [
     "Anchor",

--- a/nab-index/src/nab_index/retry.py
+++ b/nab-index/src/nab_index/retry.py
@@ -13,9 +13,9 @@ from __future__ import annotations
 import random
 
 import urllib3
-from typing_extensions import override
 from urllib3.exceptions import InvalidHeader
 
+from ._compat import override
 from .retry_limits import MAX_REDIRECTS, MAX_RETRIES, RETRY_STATUSES
 
 __all__ = [

--- a/nab-index/src/nab_index/urllib3_async_transport.py
+++ b/nab-index/src/nab_index/urllib3_async_transport.py
@@ -20,8 +20,8 @@ from urllib.parse import urljoin
 import truststore
 import urllib3
 import urllib3.connection
-from typing_extensions import override
 
+from ._compat import override
 from .retry import GET_RETRY, next_delay
 from .retry_limits import MAX_RETRIES
 from .transport import (

--- a/nab-project/src/nab_project/_compat.py
+++ b/nab-project/src/nab_project/_compat.py
@@ -1,0 +1,20 @@
+"""Runtime fallback for :func:`typing.override`, so ``typing_extensions`` is not needed.
+
+``override`` runs at class-body time, so unlike the annotation-only helpers it
+cannot hide under ``TYPE_CHECKING``.  Looking it up by name rather than by
+interpreter version keeps this free of a version-gated branch.  Before 3.12 the
+fallback is the identity and so does not set ``__override__``, which nothing
+here reads.
+"""
+
+from __future__ import annotations
+
+import typing
+from typing import TYPE_CHECKING
+
+__all__ = ["override"]
+
+if TYPE_CHECKING:
+    from typing_extensions import override
+else:
+    override = getattr(typing, "override", lambda method: method)

--- a/nab-project/src/nab_project/conflicts.py
+++ b/nab-project/src/nab_project/conflicts.py
@@ -10,12 +10,11 @@ import enum
 import itertools
 from typing import TYPE_CHECKING
 
-from typing_extensions import override
-
 from nab_provider._vendor.packaging.utils import canonicalize_name
 from nab_provider.conflict_kind import KIND_EXTRA, KIND_GROUP
 from nab_provider.errors import ConfigError
 
+from ._compat import override
 from .value import ValueType
 
 if TYPE_CHECKING:

--- a/nab-project/src/nab_project/value.py
+++ b/nab-project/src/nab_project/value.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from typing import ClassVar
 
-from typing_extensions import override
+from ._compat import override
 
 __all__ = ["ValueType"]
 

--- a/nab-provider/src/nab_provider/_compat.py
+++ b/nab-provider/src/nab_provider/_compat.py
@@ -1,0 +1,20 @@
+"""Runtime fallback for :func:`typing.override`, so ``typing_extensions`` is not needed.
+
+``override`` runs at class-body time, so unlike the annotation-only helpers it
+cannot hide under ``TYPE_CHECKING``.  Looking it up by name rather than by
+interpreter version keeps this free of a version-gated branch.  Before 3.12 the
+fallback is the identity and so does not set ``__override__``, which nothing
+here reads.
+"""
+
+from __future__ import annotations
+
+import typing
+from typing import TYPE_CHECKING
+
+__all__ = ["override"]
+
+if TYPE_CHECKING:
+    from typing_extensions import override
+else:
+    override = getattr(typing, "override", lambda method: method)

--- a/nab-provider/src/nab_provider/_value.py
+++ b/nab-provider/src/nab_provider/_value.py
@@ -8,7 +8,7 @@ share live here; each type declares its own fields and constructor.
 
 from __future__ import annotations
 
-from typing_extensions import override
+from ._compat import override
 
 __all__ = ["SlottedValue"]
 

--- a/src/nab/_compat.py
+++ b/src/nab/_compat.py
@@ -1,0 +1,20 @@
+"""Runtime fallback for :func:`typing.override`, so ``typing_extensions`` is not needed.
+
+``override`` runs at class-body time, so unlike the annotation-only helpers it
+cannot hide under ``TYPE_CHECKING``.  Looking it up by name rather than by
+interpreter version keeps this free of a version-gated branch.  Before 3.12 the
+fallback is the identity and so does not set ``__override__``, which nothing
+here reads.
+"""
+
+from __future__ import annotations
+
+import typing
+from typing import TYPE_CHECKING
+
+__all__ = ["override"]
+
+if TYPE_CHECKING:
+    from typing_extensions import override
+else:
+    override = getattr(typing, "override", lambda method: method)

--- a/src/nab/optiondefs.py
+++ b/src/nab/optiondefs.py
@@ -28,8 +28,7 @@ from __future__ import annotations
 import enum
 from typing import TYPE_CHECKING, Any
 
-from typing_extensions import override
-
+from ._compat import override
 from .optionrows import Scope
 
 if TYPE_CHECKING:

--- a/src/nab/optionrows.py
+++ b/src/nab/optionrows.py
@@ -20,11 +20,11 @@ so a checker reads ``Root.color`` as ``ColorChoice`` while
 for real would hide the rows from the lowering and cost a descriptor call
 per read.
 
-The imports here are ``enum``, ``typing`` and ``typing_extensions``, so the
-module reads a declaration without nab installed.  It is not neutral of nab
-for all that: :class:`Scope` is nab's configuration model and every field of
-:class:`Layer` is a rung of nab's ladder.  :mod:`nab.optionlower` is where
-the rows meet :class:`nab.optiondefs.Opt`.
+The imports here are ``enum``, ``typing`` and :mod:`nab._compat`, so the
+module reads a declaration without the rest of nab loaded.  It is not
+neutral of nab for all that: :class:`Scope` is nab's configuration model
+and every field of :class:`Layer` is a rung of nab's ladder.
+:mod:`nab.optionlower` is where the rows meet :class:`nab.optiondefs.Opt`.
 """
 
 from __future__ import annotations
@@ -32,7 +32,7 @@ from __future__ import annotations
 import enum
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
-from typing_extensions import override
+from ._compat import override
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/src/nab/output.py
+++ b/src/nab/output.py
@@ -21,8 +21,7 @@ import time
 from dataclasses import dataclass
 from typing import IO, TYPE_CHECKING
 
-from typing_extensions import override
-
+from ._compat import override
 from .env import (
     NAB_VERBOSITY,
     color_enabled,

--- a/tests/test_typing_extensions.py
+++ b/tests/test_typing_extensions.py
@@ -1,0 +1,46 @@
+"""No import path into nab loads typing_extensions.
+
+Only ``override`` is needed at class-body time, and each package reads it
+off ``typing`` through its own ``_compat`` shim.  The dependency stays
+declared for ``Self`` and ``Protocol``, which a checker reads and the
+interpreter never loads.
+
+The probe runs in a subprocess: this suite imports most of nab before any
+test runs, so an in-process check would pass whatever the import graph is.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+_PACKAGES = ("nab", "nab_index", "nab_project", "nab_provider")
+
+_PROBE = """
+import importlib
+import pkgutil
+import sys
+
+sys.modules["typing_extensions"] = None
+
+for root in sys.argv[1:]:
+    package = importlib.import_module(root)
+    names = sorted(
+        found.name for found in pkgutil.walk_packages(package.__path__, root + ".")
+    )
+    assert names, f"found no submodules under {root}"
+    for name in names:
+        importlib.import_module(name)
+"""
+
+
+def test_no_module_loads_typing_extensions() -> None:
+    """Every submodule of the four packages imports with typing_extensions blocked."""
+    finished = subprocess.run(  # noqa: S603 - the probe is this file's own source
+        [sys.executable, "-c", _PROBE, *_PACKAGES],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert finished.returncode == 0, finished.stderr


### PR DESCRIPTION
`python -m nab cache dir` runs 5,815,054 fewer instructions, about 1.8% of the process. Nine modules imported `override` from `typing_extensions` at module scope, so every invocation loaded the package for a decorator `typing` has carried since 3.12. They now read it through a per-package `_compat.py`, the shape `nab_resolver` and `nab_markersets` already use.

Callgrind against 8641691b5, `PYTHONHASHSEED=0`:

| workload | instructions | removed |
| --- | --- | --- |
| `python -m nab cache dir` | 327,991,807 -> 322,176,753 | 5,815,054 (1.8%) |
| `import nab._cache_cmd` | 373,897,747 -> 366,148,737 | 7,749,010 (2.1%) |
| `import nab._lock` | 665,068,120 -> 658,415,941 | 6,652,179 (1.0%) |

A second run of the `import nab._lock` pair removed 6,549,553, so read that row as about 1.0% rather than exact. Peak traced bytes for the same import fall by about 259,000 (1.9%), and live blocks by 1,732.

The dependency stays declared: `Self`, `Protocol` and `TypeIs` still come from it under `TYPE_CHECKING`, which the interpreter never loads, and `_compat.py` reads `override` the same way. Below 3.12 the runtime fallback is the identity, and nothing here reads `__override__`.

`tests/test_typing_extensions.py` imports all 143 submodules of `nab`, `nab_index`, `nab_project` and `nab_provider` with `typing_extensions` blocked. The 19-scenario canary run rules out a wall regression above about 4.6% and cannot see a saving this small.
