### PR TITLE
CI overhaul: every package type-checked, each suite run once, fresh locks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,3 +35,8 @@ updates:
         patterns: ["*"]
     cooldown:
       default-days: 7
+    ignore:
+      # typos also tags its sub-crates (varcon-core-v5.0.7 sits on the v1.44.0
+      # release), and the higher number reads as an upgrade.
+      - dependency-name: "https://github.com/crate-ci/typos"
+        versions: [">=2"]

--- a/.github/requirements/pylock.build.toml
+++ b/.github/requirements/pylock.build.toml
@@ -31,34 +31,35 @@ created-by = "nab"
 
 [[packages]]
 name = "hatchling"
-version = "1.31.0"
+version = "1.32.0"
 requires-python = ">=3.10"
 dependencies = [
     { name = "packaging" },
     { name = "pathspec" },
     { name = "pluggy" },
     { name = "tomli" },
+    { name = "tomlkit" },
     { name = "trove-classifiers" },
 ]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "hatchling-1.31.0.tar.gz"
-upload-time = 2026-07-08 01:48:32.237659+00:00
-url = "https://files.pythonhosted.org/packages/25/e2/dfa73fe78f773018dcaebc6d09b819bc10d328ff5a6b4a66efa1e3d71f52/hatchling-1.31.0.tar.gz"
-size = 57208
+name = "hatchling-1.32.0.tar.gz"
+upload-time = 2026-08-11 05:03:44.114701+00:00
+url = "https://files.pythonhosted.org/packages/69/08/33331757185504aae48b8d9bd78cec03a76e3aecfb52e549d05a2347c0dd/hatchling-1.32.0.tar.gz"
+size = 57783
 
 [packages.sdist.hashes]
-sha256 = "6b48ad4068a482ed7239b3a8215bc55b47aad3345d58dfc94e553c5d2d46211b"
+sha256 = "0bdbde4a52b06c37e3eca395f85a762bf0ef06fe374fd8ae429dc6be10230f5f"
 
 [[packages.wheels]]
-name = "hatchling-1.31.0-py3-none-any.whl"
-upload-time = 2026-07-08 01:48:31.024633+00:00
-url = "https://files.pythonhosted.org/packages/64/e2/2c0af0a52d16be74a4f194564fcdc417521ed863e9b65e4bc9052dacba6f/hatchling-1.31.0-py3-none-any.whl"
-size = 77747
+name = "hatchling-1.32.0-py3-none-any.whl"
+upload-time = 2026-08-11 05:03:42.644966+00:00
+url = "https://files.pythonhosted.org/packages/a9/84/1798b6d85ecde0e31546004efd25c5de1b1f49250644a60cce460e12593a/hatchling-1.32.0-py3-none-any.whl"
+size = 78435
 
 [packages.wheels.hashes]
-sha256 = "aac80bec8b6fe35e8480f1c335be8910fa210a0e6f735a139be205dadcacb544"
+sha256 = "0e17c9c3b9aa7c625acc8d0f5b622f107d5049af9ecf5ada4de1aada5be7cdbc"
 
 [[packages]]
 name = "packaging"
@@ -158,6 +159,30 @@ size = 14583
 sha256 = "0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe"
 
 [[packages]]
+name = "tomlkit"
+version = "0.15.1"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "tomlkit-0.15.1.tar.gz"
+upload-time = 2026-07-17 01:48:04.562015+00:00
+url = "https://files.pythonhosted.org/packages/94/96/e07752635b98536177fa1f37671c8f3cdde2e724c6bcf6034b2cfb571565/tomlkit-0.15.1.tar.gz"
+size = 180129
+
+[packages.sdist.hashes]
+sha256 = "e25bbf38843005246210a12982776f27f99cb9be67160e14434d0c0d21ee1e97"
+
+[[packages.wheels]]
+name = "tomlkit-0.15.1-py3-none-any.whl"
+upload-time = 2026-07-17 01:48:05.728578+00:00
+url = "https://files.pythonhosted.org/packages/13/bc/8c13eb66537dce1d2bd3a57132902f38d0e7f5bb46fa9f4daed9fe9d76ee/tomlkit-0.15.1-py3-none-any.whl"
+size = 49449
+
+[packages.wheels.hashes]
+sha256 = "177a05aece5a8ca5266fd3c448abb47b8d352f09d477d3ca8332db4d89b24304"
+
+[[packages]]
 name = "trove-classifiers"
 version = "2026.6.1.19"
 index = "https://pypi.org/simple/"
@@ -182,7 +207,7 @@ sha256 = "ab4c4ec93cc4a4e7815fa759906e05e6bb3f2fbd92ea0f897288c6a43efd15b3"
 
 [tool.nab]
 nab-version = "0.0.16.dev0"
-created-at = 2026-08-12 13:49:39.688262+00:00
+created-at = 2026-09-02 00:02:58.518404+00:00
 command-line = [
     "nab",
     "lock",
@@ -190,6 +215,7 @@ command-line = [
     "--no-emit-workspace",
     "--output",
     ".github/requirements/pylock.build.toml",
+    "--upgrade",
 ]
 input-path = "pyproject.toml"
 mode = "universal"

--- a/.github/requirements/pylock.crosshair.toml
+++ b/.github/requirements/pylock.crosshair.toml
@@ -208,7 +208,7 @@ sha256 = "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
 
 [[packages]]
 name = "coverage"
-version = "7.15.3"
+version = "7.15.4"
 marker = "\"crosshair\" in dependency_groups"
 requires-python = ">=3.10"
 dependencies = [
@@ -217,251 +217,251 @@ dependencies = [
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "coverage-7.15.3.tar.gz"
-upload-time = 2026-08-02 18:50:17.006034+00:00
-url = "https://files.pythonhosted.org/packages/f4/45/78dbf9604ee5b3db24efbf26bed1cb58862fb40480cba821963c69348751/coverage-7.15.3.tar.gz"
-size = 935592
+name = "coverage-7.15.4.tar.gz"
+upload-time = 2026-08-06 13:50:24.442007+00:00
+url = "https://files.pythonhosted.org/packages/be/c3/4f2195f512fb172aa425a8803a874b2baa9ba7f80ff7b6080998761fc701/coverage-7.15.4.tar.gz"
+size = 936952
 
 [packages.sdist.hashes]
-sha256 = "ae7ea5a4614acf399ef0483c4cb34f8f8f01df848d8fcbe7d3ce0865733f1c4d"
+sha256 = "0548198fff07ccf4faf469520bce1c2eceb1ce3e62891921138dec10907f9d00"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp310-cp310-macosx_10_9_x86_64.whl"
-upload-time = 2026-08-02 18:47:25.951302+00:00
-url = "https://files.pythonhosted.org/packages/90/d9/01d8e19b2c0e55903bfb540c9f6bd32326f1d5b2fcb5a7dd8648ae2dd9c5/coverage-7.15.3-cp310-cp310-macosx_10_9_x86_64.whl"
-size = 222202
+name = "coverage-7.15.4-cp310-cp310-macosx_10_9_x86_64.whl"
+upload-time = 2026-08-06 13:46:55.253092+00:00
+url = "https://files.pythonhosted.org/packages/30/70/b052a519a584663a7bd052841a2debe11c8309ec49a7786340003f9c0a02/coverage-7.15.4-cp310-cp310-macosx_10_9_x86_64.whl"
+size = 222245
 
 [packages.wheels.hashes]
-sha256 = "3a82b2ceee91ba353e59fe2436d8a9eae799ff9825e5385423ea205d693e2949"
+sha256 = "d0be6daac4cce6b8c8dc65886bae1b082ddbca4da8e5cbb5e15166acf253e264"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp310-cp310-macosx_11_0_arm64.whl"
-upload-time = 2026-08-02 18:47:28.359879+00:00
-url = "https://files.pythonhosted.org/packages/1e/92/1c23aeb83c7239af07061abc6e96f00f9b62deec8fae022cab1b353e6d46/coverage-7.15.3-cp310-cp310-macosx_11_0_arm64.whl"
-size = 222723
+name = "coverage-7.15.4-cp310-cp310-macosx_11_0_arm64.whl"
+upload-time = 2026-08-06 13:46:57.848800+00:00
+url = "https://files.pythonhosted.org/packages/67/39/892fa511aba3d1c3c8f49509a0ff5c71eab9f9f88d08e1a38da395821660/coverage-7.15.4-cp310-cp310-macosx_11_0_arm64.whl"
+size = 222762
 
 [packages.wheels.hashes]
-sha256 = "3088cce65e54c2eefc08e7e1ca0b0acec1e95e8cf084ac848599103ed0367f74"
+sha256 = "b24e078eabcd6a9caa8b0713f9bc1eeb310bcc960a29d45a3b4fcd4b16d5b11d"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-08-02 18:47:31.445458+00:00
-url = "https://files.pythonhosted.org/packages/88/70/53e010accfea3340905c5bb9207a2e461bba9b372621f1b88c1bd0e1392a/coverage-7.15.3-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 251290
+name = "coverage-7.15.4-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-08-06 13:47:00.764674+00:00
+url = "https://files.pythonhosted.org/packages/0b/4f/b1973f67a1382af65b572a31ed692f8e490a6ad707191eab59148376832a/coverage-7.15.4-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 251328
 
 [packages.wheels.hashes]
-sha256 = "b51f279a2477b0e1f288b98f141fd227acfdd1d3f0370400e473788879b47871"
+sha256 = "83cf06cdd687677742caff1a9134833b7a8b75f111519d2cb0e0ba1b9a851e15"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-08-02 18:47:33.033060+00:00
-url = "https://files.pythonhosted.org/packages/5b/13/d916056137fb6969e9d9f58ee11d1ef56778673843828315030733a3a0b6/coverage-7.15.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 253156
+name = "coverage-7.15.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-08-06 13:47:01.976545+00:00
+url = "https://files.pythonhosted.org/packages/a2/09/03efa6722a132abcac91b32a60b64b240dd707c189c64eee697e48992c96/coverage-7.15.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 253194
 
 [packages.wheels.hashes]
-sha256 = "7835176988cbcf1f014db683bc33aa15e0558e412bf08deaa99757335b88df15"
+sha256 = "8fa4de68e2a752468ff14b4e15db7def689a71be759e826a31ccecbef69c5fd0"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp310-cp310-win_amd64.whl"
-upload-time = 2026-08-02 18:47:47.668157+00:00
-url = "https://files.pythonhosted.org/packages/53/8a/f1032fb2714c28fedf00d73562c4bb9f713fa8a90593ed577bbb708a7de1/coverage-7.15.3-cp310-cp310-win_amd64.whl"
-size = 224886
+name = "coverage-7.15.4-cp310-cp310-win_amd64.whl"
+upload-time = 2026-08-06 13:47:14.170514+00:00
+url = "https://files.pythonhosted.org/packages/7b/06/9a318fc3ae040d4d6cb2d86101c6aa963fab20899a5c58666adf52cde0ca/coverage-7.15.4-cp310-cp310-win_amd64.whl"
+size = 224919
 
 [packages.wheels.hashes]
-sha256 = "179fbf847e6c3d90ea71bfd570fe57f1ddb1c51474754894871c1e11099efaa0"
+sha256 = "3fc2130bf37df31852a8384f12601563a45a0024bccc6624f38355cba7a8d360"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp311-cp311-macosx_10_9_x86_64.whl"
-upload-time = 2026-08-02 18:47:49.228115+00:00
-url = "https://files.pythonhosted.org/packages/b3/9c/c8a3a923c24f631695cea2d5e2f02e776bc0af6e03800626e13a6c05a615/coverage-7.15.3-cp311-cp311-macosx_10_9_x86_64.whl"
-size = 222328
+name = "coverage-7.15.4-cp311-cp311-macosx_10_9_x86_64.whl"
+upload-time = 2026-08-06 13:47:15.578595+00:00
+url = "https://files.pythonhosted.org/packages/2a/66/edcec7d7a0b524aa8923e22925fde6fe50ce005a113dca13ae1581455c4c/coverage-7.15.4-cp311-cp311-macosx_10_9_x86_64.whl"
+size = 222367
 
 [packages.wheels.hashes]
-sha256 = "5f3f854ab4599d98f7799ac9b91e34e8ec9ebc9a6372ee8c1f3413a68cc8b5e9"
+sha256 = "bbac5abad70df71019988f83f26ac7092ff2642975def4429e98dc7585ef3490"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp311-cp311-macosx_11_0_arm64.whl"
-upload-time = 2026-08-02 18:47:51.219614+00:00
-url = "https://files.pythonhosted.org/packages/92/51/dda77f34cbd2513d6ffb898c901d19e9ca55f48c0cbc4a1eb173a97d157a/coverage-7.15.3-cp311-cp311-macosx_11_0_arm64.whl"
-size = 222832
+name = "coverage-7.15.4-cp311-cp311-macosx_11_0_arm64.whl"
+upload-time = 2026-08-06 13:47:16.961506+00:00
+url = "https://files.pythonhosted.org/packages/e6/c6/ab8de429e2e8548faf58ec7e1674a4ce00414b4113942d3fe87109cf0f68/coverage-7.15.4-cp311-cp311-macosx_11_0_arm64.whl"
+size = 222874
 
 [packages.wheels.hashes]
-sha256 = "75268348fee1f199653b8a846262aec5581c6bb008c4f58824959fb708cc688f"
+sha256 = "357a173465c7ce028d07a95cc2b63b5bf59f50ecdd5ad75c5cbb78ada984048e"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-08-02 18:47:54.404019+00:00
-url = "https://files.pythonhosted.org/packages/14/e2/4b1e0eeb727ffb471e411c1bd3402184b5dd54a77a762b0e55e87cdf9ae3/coverage-7.15.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 255160
+name = "coverage-7.15.4-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-08-06 13:47:19.765915+00:00
+url = "https://files.pythonhosted.org/packages/fb/65/ec03b743a2a229c72cc1eff3e57be9d3564e9c6b4d5aba2d70744a3fc0d8/coverage-7.15.4-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 255199
 
 [packages.wheels.hashes]
-sha256 = "718d366251b060c10731c7dd359de6caea72250036eb94576aa56dacbf830a11"
+sha256 = "7a2b580774a4786c1053157c0165e04476e03ff293993d7c148eee784a94bae6"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-08-02 18:47:56.157542+00:00
-url = "https://files.pythonhosted.org/packages/e9/9e/a602d2d48f9db9f795e578a86aa914f7b20008e9330902defcfb73d17b3a/coverage-7.15.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 257269
+name = "coverage-7.15.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-08-06 13:47:21.206658+00:00
+url = "https://files.pythonhosted.org/packages/41/4b/5163729e4b6582d61975cfd3ccab45b4ec53e21cf156d9941cb025188468/coverage-7.15.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 257308
 
 [packages.wheels.hashes]
-sha256 = "fa1bbaa502a6e877f3ee67cbac3eba2bb637f623e454e6c37b81b38896dbd48f"
+sha256 = "a9464451c4efffe8d47ace5a540b10b0dc10e879066290f8600872b7f54a419d"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp311-cp311-win_amd64.whl"
-upload-time = 2026-08-02 18:48:11.611051+00:00
-url = "https://files.pythonhosted.org/packages/b4/98/0050c692d120988f1973a15196f52dee4ae221848b760281461a2005b613/coverage-7.15.3-cp311-cp311-win_amd64.whl"
-size = 224906
+name = "coverage-7.15.4-cp311-cp311-win_amd64.whl"
+upload-time = 2026-08-06 13:47:34.205864+00:00
+url = "https://files.pythonhosted.org/packages/e2/6d/81fa4161dfb3ed9d74e40d58647eff83a56b7612e78352581280fce2f477/coverage-7.15.4-cp311-cp311-win_amd64.whl"
+size = 224937
 
 [packages.wheels.hashes]
-sha256 = "28743dad31622e8c474b17446118037361f5b1f4f2ecdf72d4f6fde246d64446"
+sha256 = "63fd6fcd1dd6e158f7eb78606e72933b3f6d01e7b747f99c6c12d764307a0fdc"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp312-cp312-macosx_10_13_x86_64.whl"
-upload-time = 2026-08-02 18:48:15.018777+00:00
-url = "https://files.pythonhosted.org/packages/d1/6c/bac99d9d4c6abe856e93bf3f5212982ac0bfac126dd4a042753bd53bc5af/coverage-7.15.3-cp312-cp312-macosx_10_13_x86_64.whl"
-size = 222499
+name = "coverage-7.15.4-cp312-cp312-macosx_10_13_x86_64.whl"
+upload-time = 2026-08-06 13:47:37.562250+00:00
+url = "https://files.pythonhosted.org/packages/1d/48/bc8d4ba7b37551a767bd863f15b3f80182b271c2f55975356f5f7dbe94c2/coverage-7.15.4-cp312-cp312-macosx_10_13_x86_64.whl"
+size = 222543
 
 [packages.wheels.hashes]
-sha256 = "79a3e32e83227d83d9684459ed579769b56c369ac2d7313099b2d9e031d2e10f"
+sha256 = "d4fedd1f7f428f9fe83b1ead5e7cc87a43427be31aadafbac3ac0636dc7abb22"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp312-cp312-macosx_11_0_arm64.whl"
-upload-time = 2026-08-02 18:48:16.884964+00:00
-url = "https://files.pythonhosted.org/packages/aa/bc/cb9a39b083bc1aa70586482dab25c9be20bab0ec6c155340e50d9066bb1e/coverage-7.15.3-cp312-cp312-macosx_11_0_arm64.whl"
-size = 222866
+name = "coverage-7.15.4-cp312-cp312-macosx_11_0_arm64.whl"
+upload-time = 2026-08-06 13:47:38.927299+00:00
+url = "https://files.pythonhosted.org/packages/20/dd/88d6f83f1fffc974a3691a34a97951c5b12df7512a6782c5963883cbc058/coverage-7.15.4-cp312-cp312-macosx_11_0_arm64.whl"
+size = 222905
 
 [packages.wheels.hashes]
-sha256 = "767feb87c5886d781d0a69fafd450a20826ddab7b79bce1665deb64d21441b60"
+sha256 = "37e2f0cdf58e2e1fed4e4d5a8f8786ae2f7eb80b478016876667dc4a01d60a97"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-08-02 18:48:20.172593+00:00
-url = "https://files.pythonhosted.org/packages/66/64/43e72500ed6815cef189f9193f29d7af4b078830337c95ea976cd0c0d427/coverage-7.15.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 257103
+name = "coverage-7.15.4-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-08-06 13:47:41.931828+00:00
+url = "https://files.pythonhosted.org/packages/8c/3f/f0642a372f494bd0d7dad3b497083b910194a5f1c88be2c94fef707c3b59/coverage-7.15.4-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 257145
 
 [packages.wheels.hashes]
-sha256 = "63a4ff67364afb2cac826b8bbd78a5c50ce656a7b7137436b44d7b96a9271088"
+sha256 = "899b9da30f3c6c336566e3707495bb23e8302d39d862f01fa78c48b99b9437e2"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-08-02 18:48:21.963498+00:00
-url = "https://files.pythonhosted.org/packages/66/3a/2893e2937adfe02f45fd38e4a8a0a0d8b7a02ff9e012ac3d009bee3c4f16/coverage-7.15.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 258220
+name = "coverage-7.15.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-08-06 13:47:43.527105+00:00
+url = "https://files.pythonhosted.org/packages/71/17/8b46d0ed68251016002ec972c8fc0119961a765d0984cafb8bf317c43758/coverage-7.15.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 258257
 
 [packages.wheels.hashes]
-sha256 = "6e95e42856509675fe26560310313a6117640e96f9a1e19bb3d220116a27c94c"
+sha256 = "d15715e8c46552827e5e4f30a35575a2dbcad14454cf3284c54483946bd16931"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp312-cp312-win_amd64.whl"
-upload-time = 2026-08-02 18:48:38.941989+00:00
-url = "https://files.pythonhosted.org/packages/b1/0f/df90cc1e8d095ce263968a93e04829821b2afb31ac2752c06a2e0a8e3c13/coverage-7.15.3-cp312-cp312-win_amd64.whl"
-size = 225098
+name = "coverage-7.15.4-cp312-cp312-win_amd64.whl"
+upload-time = 2026-08-06 13:47:57.520954+00:00
+url = "https://files.pythonhosted.org/packages/49/b9/5c5f80cc55f5acaaca6dee677626bfcec8c87204a7809b438b08e84f4571/coverage-7.15.4-cp312-cp312-win_amd64.whl"
+size = 225135
 
 [packages.wheels.hashes]
-sha256 = "fa7b17902c3c1dd8a7adb52679b7f6340bba08443d710c8838e04db8cf62be2a"
+sha256 = "6befeab5fb2b51c958ca4ac6c5d141a1e8240f4f76e46350f1911963deda49cd"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp313-cp313-macosx_10_13_x86_64.whl"
-upload-time = 2026-08-02 18:48:42.476817+00:00
-url = "https://files.pythonhosted.org/packages/68/6e/62ae61e1fc434956bec38ed1d5b1c494f58cf579dbd998e77abffe7b3e6b/coverage-7.15.3-cp313-cp313-macosx_10_13_x86_64.whl"
-size = 222522
+name = "coverage-7.15.4-cp313-cp313-macosx_10_13_x86_64.whl"
+upload-time = 2026-08-06 13:48:00.796792+00:00
+url = "https://files.pythonhosted.org/packages/f1/84/651a9310859673aaa3b3203f1aa1641ca60fcf2494683e1c9474c7172780/coverage-7.15.4-cp313-cp313-macosx_10_13_x86_64.whl"
+size = 222565
 
 [packages.wheels.hashes]
-sha256 = "1182eed05674c63d40951fae27c43e822749f04d25f75df64c2e4fa3168678de"
+sha256 = "c705b28feb2775dc82a25f1d473a370bc37ff93f5177f4e29ce2425f560f6921"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp313-cp313-macosx_11_0_arm64.whl"
-upload-time = 2026-08-02 18:48:44.274728+00:00
-url = "https://files.pythonhosted.org/packages/13/ff/c74c673d81e0e77b6608c3d21331e3db42e30daeb3c8a0a8860d4c9e2e14/coverage-7.15.3-cp313-cp313-macosx_11_0_arm64.whl"
-size = 222894
+name = "coverage-7.15.4-cp313-cp313-macosx_11_0_arm64.whl"
+upload-time = 2026-08-06 13:48:02.391936+00:00
+url = "https://files.pythonhosted.org/packages/82/f9/4dcf700137e8af550670f4d74d1b63828ce93e1e2b05e5f10710eb2ea987/coverage-7.15.4-cp313-cp313-macosx_11_0_arm64.whl"
+size = 222936
 
 [packages.wheels.hashes]
-sha256 = "c0c4b0d7c4cd56e470d0c9d8441f42e8a96cdfd95050fec027f1d4dd9f11006c"
+sha256 = "3ff205ab5e3ecc670f6a4dd19d9cbf12ede53dd41cfc1e15716ec961ea6d314e"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-08-02 18:48:47.846801+00:00
-url = "https://files.pythonhosted.org/packages/29/c6/e92a66cda49a2751b09826d51258f199b92aa0cb005bc5f34e9729a52a9c/coverage-7.15.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 256484
+name = "coverage-7.15.4-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-08-06 13:48:05.996722+00:00
+url = "https://files.pythonhosted.org/packages/b0/04/d1cff1c2ead4708a6a79c01d3736b6a25bd38a36678398f72a8dd33dfad9/coverage-7.15.4-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 256523
 
 [packages.wheels.hashes]
-sha256 = "7a47e2a0a0ace9241e70ee00e44520f88b843094603dd54303f1bafecd929c30"
+sha256 = "12b59c90084e3234fb11184886bf4a40f4f16a8c8f867be2e087b81f8e8868d4"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-08-02 18:48:49.664817+00:00
-url = "https://files.pythonhosted.org/packages/96/7a/730929164b457cf25cf76c23898b90f9039a104a647890801b6586797b14/coverage-7.15.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 257723
+name = "coverage-7.15.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-08-06 13:48:08.036066+00:00
+url = "https://files.pythonhosted.org/packages/b9/80/d34e13fb4b293cbdb9665838cf5522077b8ad14ef947550631a4bced36a5/coverage-7.15.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 257759
 
 [packages.wheels.hashes]
-sha256 = "95bad94f83807ae60ed76f3ac012f69b2605ac9ea81bee959a5a483f7fa09c10"
+sha256 = "349062d66f00b40fa2c1c222438bad25fabf755631b5d82937fe985c8008615c"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp313-cp313-win_amd64.whl"
-upload-time = 2026-08-02 18:49:06.894452+00:00
-url = "https://files.pythonhosted.org/packages/1c/64/88f762ea80de2070207246faef514513be874486b2773528f2cc2b4b515c/coverage-7.15.3-cp313-cp313-win_amd64.whl"
-size = 225116
+name = "coverage-7.15.4-cp313-cp313-win_amd64.whl"
+upload-time = 2026-08-06 13:48:23.376105+00:00
+url = "https://files.pythonhosted.org/packages/e0/e2/2946c7f0b42b152ecb21ff1bdad72e3d301e790c0c487e4a86e8c9f69347/coverage-7.15.4-cp313-cp313-win_amd64.whl"
+size = 225148
 
 [packages.wheels.hashes]
-sha256 = "835528518a1d823cf336740324b2f335f7c01e609e74abcb5d5163b3e66661e3"
+sha256 = "2ff8f5e9b8f7a94f0c11c45631eee103dbcb7d63274edd12c56efe1be690b3b4"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp314-cp314-macosx_10_15_x86_64.whl"
-upload-time = 2026-08-02 18:49:11.242670+00:00
-url = "https://files.pythonhosted.org/packages/35/6f/8c2dc014357618b3226c90f731b8282766c3685786f422558991dc49fbf2/coverage-7.15.3-cp314-cp314-macosx_10_15_x86_64.whl"
-size = 222571
+name = "coverage-7.15.4-cp314-cp314-macosx_10_15_x86_64.whl"
+upload-time = 2026-08-06 13:48:26.806172+00:00
+url = "https://files.pythonhosted.org/packages/ea/ac/748cf29eeb2d6be34a3176ce26a4f49e38085ee08e8935f05f6f26ed7e0f/coverage-7.15.4-cp314-cp314-macosx_10_15_x86_64.whl"
+size = 222608
 
 [packages.wheels.hashes]
-sha256 = "1e3bb08ad574bd9fb6a991f645728f70d333c1c1958dd5fcde65e24cb862813d"
+sha256 = "770e9325ab5ea6d56f77e59b29ecfe0ac20b57a82a601876f90494a4dda0386f"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp314-cp314-macosx_11_0_arm64.whl"
-upload-time = 2026-08-02 18:49:13.448301+00:00
-url = "https://files.pythonhosted.org/packages/07/50/d867c7ceae9d56b7e74ee61ea834f1aa4f9a1e1c7f0ce39393ba573b1c12/coverage-7.15.3-cp314-cp314-macosx_11_0_arm64.whl"
-size = 222902
+name = "coverage-7.15.4-cp314-cp314-macosx_11_0_arm64.whl"
+upload-time = 2026-08-06 13:48:28.432135+00:00
+url = "https://files.pythonhosted.org/packages/0b/02/1abbf5c984677b0aa439cdacaccbf38d248939d8ef8fe1cc7a50d73edb77/coverage-7.15.4-cp314-cp314-macosx_11_0_arm64.whl"
+size = 222940
 
 [packages.wheels.hashes]
-sha256 = "9e5860eaff02a0b7f1b73304bdf846596ee62ab3a78d25c68044ebf684cb1fef"
+sha256 = "d12b33a3a50a1676b7784dc8d00a0c6d66a9f2add4b85a041c19b6a7e53ef23c"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-08-02 18:49:17.801831+00:00
-url = "https://files.pythonhosted.org/packages/16/8a/6777f192af264165103e2a3d3768dbadb9894a0a2359a16877141d9ae8f5/coverage-7.15.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 256452
+name = "coverage-7.15.4-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-08-06 13:48:31.634898+00:00
+url = "https://files.pythonhosted.org/packages/a1/26/595759762e514e81be1d7d01ed03444303bcd152226a6529998d253f9201/coverage-7.15.4-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 256492
 
 [packages.wheels.hashes]
-sha256 = "f9147be876e9d83765e0b82176674dc248a6b9283e25e01e7462611b97e9b731"
+sha256 = "ff97a14362eef486483ed44042ca2027ea257df6ff768e62358ee0c9776925ac"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-08-02 18:49:19.878255+00:00
-url = "https://files.pythonhosted.org/packages/7d/7b/3d7ac46a0234bc684f41ee42be95e29b2b6525695adb04083609d5ac2149/coverage-7.15.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 257798
+name = "coverage-7.15.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-08-06 13:48:33.186086+00:00
+url = "https://files.pythonhosted.org/packages/24/68/b79aabac54d482be23b5fcdd4f4662bff24a78edc4ee29201726929936d5/coverage-7.15.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 257837
 
 [packages.wheels.hashes]
-sha256 = "61a01f8c3804760fcc5a3d31c4f3cab792d660d44e17bf7adeaf0ea51e07821e"
+sha256 = "5a325e815318638aed1655d9c06e6d7c2d3d46c09231ce988070428a8762d734"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp314-cp314-win_amd64.whl"
-upload-time = 2026-08-02 18:49:38.366697+00:00
-url = "https://files.pythonhosted.org/packages/b3/78/5c93ec43784fd3e404ca23cd0584ae24bc1732de4a3fc194b68c3be88db0/coverage-7.15.3-cp314-cp314-win_amd64.whl"
-size = 225246
+name = "coverage-7.15.4-cp314-cp314-win_amd64.whl"
+upload-time = 2026-08-06 13:48:49.513627+00:00
+url = "https://files.pythonhosted.org/packages/ee/90/219484e476d6e101ba0a444852579e05f5b75c37c611a42ed1190f73ef62/coverage-7.15.4-cp314-cp314-win_amd64.whl"
+size = 225259
 
 [packages.wheels.hashes]
-sha256 = "64d0845f9c3ed47302bed265c15ab4dbb64aa4ec1490839b8e328f4e7fa914d2"
+sha256 = "f0204ed122758782970526057093f448051a39db9d810d4e344bb87a3546f425"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-py3-none-any.whl"
-upload-time = 2026-08-02 18:50:14.709301+00:00
-url = "https://files.pythonhosted.org/packages/37/e7/7069b3d6c018917f49ba2e1c5fb910e498c7fefa3a1b78cb1b79e61ff45d/coverage-7.15.3-py3-none-any.whl"
-size = 214297
+name = "coverage-7.15.4-py3-none-any.whl"
+upload-time = 2026-08-06 13:50:22.192922+00:00
+url = "https://files.pythonhosted.org/packages/b4/d9/e70c286c979378f061d8266e279b686ab0b0b688e1fe0af864684f23a77d/coverage-7.15.4-py3-none-any.whl"
+size = 214332
 
 [packages.wheels.hashes]
-sha256 = "da78fa6fc7dafe4212839173133ee85afcf42c5cd5f3e47fa7c1c210453b445e"
+sha256 = "964730a1e9de9c0cf11be6a1a3c79ce419c34882842abd256086ba4698705e84"
 
 [[packages]]
 name = "crosshair-tool"
-version = "0.0.109"
+version = "0.0.110"
 marker = "\"crosshair\" in dependency_groups"
 requires-python = ">=3.8"
 dependencies = [
@@ -476,238 +476,238 @@ dependencies = [
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "crosshair_tool-0.0.109.tar.gz"
-upload-time = 2026-07-21 14:29:05.171552+00:00
-url = "https://files.pythonhosted.org/packages/64/77/53ce9bb66a3930d1641fa934a11c83a7182b0318087bf9e6fd43cc9968a2/crosshair_tool-0.0.109.tar.gz"
-size = 613845
+name = "crosshair_tool-0.0.110.tar.gz"
+upload-time = 2026-08-16 23:53:29.851036+00:00
+url = "https://files.pythonhosted.org/packages/fb/04/dbe1e3769eec8ec46bbb8e1ccf7540369ef74a40e9121440bef6dec815e5/crosshair_tool-0.0.110.tar.gz"
+size = 628630
 
 [packages.sdist.hashes]
-sha256 = "486e3b1772c6d530a614e870fc4709ccebe5e04fd8af16bc160cba5d6c21cee4"
+sha256 = "fc0dd25117309728bf6fe304ed6ffce906a6b6aefc6c275b5bbb6cc7186367b3"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.109-cp310-cp310-macosx_10_9_universal2.whl"
-upload-time = 2026-07-21 14:28:05.720415+00:00
-url = "https://files.pythonhosted.org/packages/80/45/dd97fb1b37a22a23bfbe40a968178a3d801cda5b52811db7b6a3bd3d5db3/crosshair_tool-0.0.109-cp310-cp310-macosx_10_9_universal2.whl"
-size = 701437
+name = "crosshair_tool-0.0.110-cp310-cp310-macosx_10_9_universal2.whl"
+upload-time = 2026-08-16 23:52:22.722218+00:00
+url = "https://files.pythonhosted.org/packages/6c/25/d0397accf0ae8d1d85634bf2057ab3f6673564338690bf410cde629cebb6/crosshair_tool-0.0.110-cp310-cp310-macosx_10_9_universal2.whl"
+size = 718469
 
 [packages.wheels.hashes]
-sha256 = "8b0f38bdb8945b1a6f5ec83dbe95df283d04f24d64fd6b49ea0e9c207c2e94b2"
+sha256 = "13607b69688f2a31e2ac26daee6941d42b98af04e0f426e378eaaadaf3de984e"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.109-cp310-cp310-macosx_10_9_x86_64.whl"
-upload-time = 2026-07-21 14:28:07.041490+00:00
-url = "https://files.pythonhosted.org/packages/9a/9b/dec139479c1113ea8fc177d9b861587d1b19029d5d9972be6ea55a490832/crosshair_tool-0.0.109-cp310-cp310-macosx_10_9_x86_64.whl"
-size = 690215
+name = "crosshair_tool-0.0.110-cp310-cp310-macosx_10_9_x86_64.whl"
+upload-time = 2026-08-16 23:52:24.646936+00:00
+url = "https://files.pythonhosted.org/packages/16/cc/3f39165e915761fba20a89ad922bfdcb866c23b2143dc102be282f4aecca/crosshair_tool-0.0.110-cp310-cp310-macosx_10_9_x86_64.whl"
+size = 707253
 
 [packages.wheels.hashes]
-sha256 = "f497953f101ea891771a4b119b4d74fdb844fbee9f8f4902d1f6b3bc8cc468cf"
+sha256 = "812c101ac95c730926077556588ccaaeda2bb58d4b4250a76f9946cdee55256c"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.109-cp310-cp310-macosx_11_0_arm64.whl"
-upload-time = 2026-07-21 14:28:08.116513+00:00
-url = "https://files.pythonhosted.org/packages/62/87/51a300767492b73943043ebb89b88e2713eb69a5655f70b777f115dc34dd/crosshair_tool-0.0.109-cp310-cp310-macosx_11_0_arm64.whl"
-size = 690932
+name = "crosshair_tool-0.0.110-cp310-cp310-macosx_11_0_arm64.whl"
+upload-time = 2026-08-16 23:52:26.250617+00:00
+url = "https://files.pythonhosted.org/packages/85/42/43a81e8cf307810171452093bb822784b6677dc0b3c34627d97aeb64e77d/crosshair_tool-0.0.110-cp310-cp310-macosx_11_0_arm64.whl"
+size = 707962
 
 [packages.wheels.hashes]
-sha256 = "266c46ca6f3a455deaeda6206cdca8c1992def4c2e8a29cf919070dffc358c0a"
+sha256 = "e45572e4fefe4b270096e7d6221fef7ddb13edc40adc2a3b9720cd50b00f5190"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.109-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-07-21 14:28:09.163108+00:00
-url = "https://files.pythonhosted.org/packages/e4/35/df0fbbac111d45d1758b91fb3509c729bceb72eeb717e8fb7877a6ee87c6/crosshair_tool-0.0.109-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 733560
+name = "crosshair_tool-0.0.110-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-08-16 23:52:27.462818+00:00
+url = "https://files.pythonhosted.org/packages/c0/9e/eb035f0d0ab6d39112aac4ec426b8498d52c8631cf709fe28308feeb6ff7/crosshair_tool-0.0.110-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 750585
 
 [packages.wheels.hashes]
-sha256 = "5cb01f8a2ceaf6eea7b29fc7269d3933ff850581b5741e750ecb9a5c98896dd6"
+sha256 = "c3df600af72ba4aabdce93a8ce45fb16f207e4fb6f60d83ac7984de131bdf275"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.109-cp310-cp310-win_amd64.whl"
-upload-time = 2026-07-21 14:28:12.845750+00:00
-url = "https://files.pythonhosted.org/packages/e2/db/0842b8c2ecfa01d2c22fcb0863408564b2b90acc10b446c0057da0104cc1/crosshair_tool-0.0.109-cp310-cp310-win_amd64.whl"
-size = 689770
+name = "crosshair_tool-0.0.110-cp310-cp310-win_amd64.whl"
+upload-time = 2026-08-16 23:52:31.599934+00:00
+url = "https://files.pythonhosted.org/packages/21/29/055eeedb4579f0ef00c46ef6e5d305635647594f8bcc442b6f465c3707ec/crosshair_tool-0.0.110-cp310-cp310-win_amd64.whl"
+size = 706799
 
 [packages.wheels.hashes]
-sha256 = "1e2f71ec1e3421accfa43e1e5a94194dcf61ab75d5a6655ec55d37ca807a302a"
+sha256 = "18f72ee1fa7994fc01bd11a9358dd31c7e406d1358fa5517d80ee560efe50841"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.109-cp311-cp311-macosx_10_9_universal2.whl"
-upload-time = 2026-07-21 14:28:14.089125+00:00
-url = "https://files.pythonhosted.org/packages/11/c5/aa65b943cbb3ee940f584a2b5f6a5cf9f47f332c20e5b56d024b91f068f5/crosshair_tool-0.0.109-cp311-cp311-macosx_10_9_universal2.whl"
-size = 701376
+name = "crosshair_tool-0.0.110-cp311-cp311-macosx_10_9_universal2.whl"
+upload-time = 2026-08-16 23:52:32.777567+00:00
+url = "https://files.pythonhosted.org/packages/20/14/fa608234eb37424e078ab8b6240195711ba6f75730e2af335e215aea8719/crosshair_tool-0.0.110-cp311-cp311-macosx_10_9_universal2.whl"
+size = 718408
 
 [packages.wheels.hashes]
-sha256 = "98885474287148091d592f7c646535f5c01dc15feeecac0a30181e8d339d8086"
+sha256 = "2bd0b8837404b0ff1b35f7a02ba8e3cc33fc0bbb0fe77c87f614b173e058ab0f"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.109-cp311-cp311-macosx_10_9_x86_64.whl"
-upload-time = 2026-07-21 14:28:15.391988+00:00
-url = "https://files.pythonhosted.org/packages/b0/f5/128b08f01ef580b33ec2d3b73fe57e62a89960d05eac4388a9fecb243a87/crosshair_tool-0.0.109-cp311-cp311-macosx_10_9_x86_64.whl"
-size = 690183
+name = "crosshair_tool-0.0.110-cp311-cp311-macosx_10_9_x86_64.whl"
+upload-time = 2026-08-16 23:52:34.038576+00:00
+url = "https://files.pythonhosted.org/packages/85/4d/bb62191cb81acbf7a37cd8604ab75e864d84c207d56733bcb068c91a1038/crosshair_tool-0.0.110-cp311-cp311-macosx_10_9_x86_64.whl"
+size = 707215
 
 [packages.wheels.hashes]
-sha256 = "3bec5ad32d7079553167ef6db720c0023948b62b62497940e72bffd803034a13"
+sha256 = "56a8f098361d887812998c553a69379d3659633ef2467ebcdc4227c7ab13e437"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.109-cp311-cp311-macosx_11_0_arm64.whl"
-upload-time = 2026-07-21 14:28:16.570501+00:00
-url = "https://files.pythonhosted.org/packages/2b/e1/014487b74aabcea18bc40961d50c245f851e3a3d929cae31d1536f5ed03f/crosshair_tool-0.0.109-cp311-cp311-macosx_11_0_arm64.whl"
-size = 690909
+name = "crosshair_tool-0.0.110-cp311-cp311-macosx_11_0_arm64.whl"
+upload-time = 2026-08-16 23:52:35.352234+00:00
+url = "https://files.pythonhosted.org/packages/43/3f/691f3c9ca43d0dc848e08b26736b3e85cf513bebdd1b00fe01ef40ddcc46/crosshair_tool-0.0.110-cp311-cp311-macosx_11_0_arm64.whl"
+size = 707941
 
 [packages.wheels.hashes]
-sha256 = "61fd3346d82813959d92d4b50f4ae64c016fcbee7928b4c66d1812760a7fc70d"
+sha256 = "0bed85e08ef9180fd9567fa387851bfb43a02c8f35030d5f8f01e61fde95934f"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.109-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-07-21 14:28:17.518547+00:00
-url = "https://files.pythonhosted.org/packages/12/6c/3ddf8ecd09cf7dec469c1e5f524cd3bd4bc7c6d31be18feea5e91c669854/crosshair_tool-0.0.109-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 731487
+name = "crosshair_tool-0.0.110-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-08-16 23:52:36.723279+00:00
+url = "https://files.pythonhosted.org/packages/d0/79/e6309447cd69d68c7a5a2d7dcad6ec4fee0b016543663640ff41ba6ef14a/crosshair_tool-0.0.110-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 748514
 
 [packages.wheels.hashes]
-sha256 = "565ff9ebf99c282770f7e946ca8b3dc9b3022e38906e34b90fa10f538f342d92"
+sha256 = "5f5a93ef928e61fc5178f2f221e7b06908a949461161e20a738210ecb063d85d"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.109-cp311-cp311-win_amd64.whl"
-upload-time = 2026-07-21 14:28:21.039442+00:00
-url = "https://files.pythonhosted.org/packages/d8/a8/52e7c935ec81cef6c2b81be21492fbdcadee859013b372a50e2f643316c5/crosshair_tool-0.0.109-cp311-cp311-win_amd64.whl"
-size = 689706
+name = "crosshair_tool-0.0.110-cp311-cp311-win_amd64.whl"
+upload-time = 2026-08-16 23:52:41.463785+00:00
+url = "https://files.pythonhosted.org/packages/99/41/1b63abfcf235e6b62ae431a4af5838fc5e8cf3fbc14e9066d348425980f4/crosshair_tool-0.0.110-cp311-cp311-win_amd64.whl"
+size = 706734
 
 [packages.wheels.hashes]
-sha256 = "9ca9f552a62dd73bd76a2c5c1bb4708a23c8a780cbfcd7766c571793d1ba3c2a"
+sha256 = "8e638cfbb3b83044d905c093285a874b52f47e53d33504d786dd1165be492a3c"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.109-cp312-cp312-macosx_10_13_universal2.whl"
-upload-time = 2026-07-21 14:28:22.359981+00:00
-url = "https://files.pythonhosted.org/packages/9c/7f/411e9308cf67ee1ddd910ec4cda6b99672e4f066fc863a4912fb611e3919/crosshair_tool-0.0.109-cp312-cp312-macosx_10_13_universal2.whl"
-size = 706022
+name = "crosshair_tool-0.0.110-cp312-cp312-macosx_10_13_universal2.whl"
+upload-time = 2026-08-16 23:52:42.736176+00:00
+url = "https://files.pythonhosted.org/packages/fb/37/dbd9d05fc298269fb475ab7973ecd48acb711058101f17e01f4594b617f8/crosshair_tool-0.0.110-cp312-cp312-macosx_10_13_universal2.whl"
+size = 723059
 
 [packages.wheels.hashes]
-sha256 = "8f4fb847773f8331ec879a34ee80952a9f57606271820c5dcc2b27f557929103"
+sha256 = "ef608793a590899e2dc627b5fe9f180a417bf7075380dff697aa6773cbe263d7"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.109-cp312-cp312-macosx_10_13_x86_64.whl"
-upload-time = 2026-07-21 14:28:23.472845+00:00
-url = "https://files.pythonhosted.org/packages/6d/de/81bcb44ec4599d376fc0ee3d48a93911a2f06b503045db2f7d2de3b1d166/crosshair_tool-0.0.109-cp312-cp312-macosx_10_13_x86_64.whl"
-size = 692609
+name = "crosshair_tool-0.0.110-cp312-cp312-macosx_10_13_x86_64.whl"
+upload-time = 2026-08-16 23:52:43.967230+00:00
+url = "https://files.pythonhosted.org/packages/84/24/0d1a30a9d06ae4943780a62799dd0eb660e7959f5a6c5478c790d2729149/crosshair_tool-0.0.110-cp312-cp312-macosx_10_13_x86_64.whl"
+size = 709641
 
 [packages.wheels.hashes]
-sha256 = "f6287999c63e61becceac70d9748d6092252f8062794598d620ee95169878072"
+sha256 = "bdda9eb1cb3132bb44ed16a83631a43af595f8a14e5979744519d650f5eae192"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.109-cp312-cp312-macosx_11_0_arm64.whl"
-upload-time = 2026-07-21 14:28:24.601864+00:00
-url = "https://files.pythonhosted.org/packages/fa/7b/8599063cb8850796165227e52ff0633a53165529faed0b1182dbb275b9a9/crosshair_tool-0.0.109-cp312-cp312-macosx_11_0_arm64.whl"
-size = 693061
+name = "crosshair_tool-0.0.110-cp312-cp312-macosx_11_0_arm64.whl"
+upload-time = 2026-08-16 23:52:45.278054+00:00
+url = "https://files.pythonhosted.org/packages/32/10/63367081764838bf5cccdfe97014e3bc09bf45a2e1f32b7ac2126a540d85/crosshair_tool-0.0.110-cp312-cp312-macosx_11_0_arm64.whl"
+size = 710096
 
 [packages.wheels.hashes]
-sha256 = "3eeb6e6a2b6a687340593b0f67a4e17fe4ffefa24990eb574212e6bf33bca43c"
+sha256 = "15e21c550e2e8afa392f6140e0630aebdc26491bc6a7fe2926f58a4025c09884"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.109-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-07-21 14:28:25.641962+00:00
-url = "https://files.pythonhosted.org/packages/49/93/8bebcf8783aaac5d731ef8427e86165f87c4e3cda518f2011e388c6d6116/crosshair_tool-0.0.109-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 740699
+name = "crosshair_tool-0.0.110-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-08-16 23:52:46.470356+00:00
+url = "https://files.pythonhosted.org/packages/f8/e5/f56a7ab7b8919502c73bc5b6c7e00cd680c5af874f77d42314ab56f3b8ac/crosshair_tool-0.0.110-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 757726
 
 [packages.wheels.hashes]
-sha256 = "b750895da5892a5079b5c50981129ccec116ab59cb0ca3446c2405822d8de7b0"
+sha256 = "dad308590784f8747303463a054ee621137de84b24486cd458739eba11bcefe8"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.109-cp312-cp312-win_amd64.whl"
-upload-time = 2026-07-21 14:28:29.400161+00:00
-url = "https://files.pythonhosted.org/packages/3b/08/483b993c4e86b6f2d79cc2bad9e089114bf0646736ddf07aa0fdc2a49291/crosshair_tool-0.0.109-cp312-cp312-win_amd64.whl"
-size = 691649
+name = "crosshair_tool-0.0.110-cp312-cp312-win_amd64.whl"
+upload-time = 2026-08-16 23:52:50.401948+00:00
+url = "https://files.pythonhosted.org/packages/5a/d1/3c0ea57a93dc1acf52193ebc1e1cb6fcefe1bcfb664c0aae3da9bb2842f2/crosshair_tool-0.0.110-cp312-cp312-win_amd64.whl"
+size = 708678
 
 [packages.wheels.hashes]
-sha256 = "1f3008c976b7606a946546ca2eac4d8e7232a3457707092613571952cc91c11b"
+sha256 = "22c414999188d6e60a9010a6c049aa036dd5b78d668cf4a3740af9c6687ea1e4"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.109-cp313-cp313-macosx_10_13_universal2.whl"
-upload-time = 2026-07-21 14:28:30.619313+00:00
-url = "https://files.pythonhosted.org/packages/b8/9c/6f9db50e5e92e1045396eae0e0c55e5095dcb9da1986d642a73d15bc7070/crosshair_tool-0.0.109-cp313-cp313-macosx_10_13_universal2.whl"
-size = 713640
+name = "crosshair_tool-0.0.110-cp313-cp313-macosx_10_13_universal2.whl"
+upload-time = 2026-08-16 23:52:51.612070+00:00
+url = "https://files.pythonhosted.org/packages/b2/93/37a408058aef3d8b132b14ebb2154ebfd8d61a89908248a8f2ecacf97bb9/crosshair_tool-0.0.110-cp313-cp313-macosx_10_13_universal2.whl"
+size = 730667
 
 [packages.wheels.hashes]
-sha256 = "67d693610ddf564e2a74eefb51efb5ebc3e91b786cc8a4fd0b9e6ac09d216fce"
+sha256 = "91bdc4a4606fe9678f3819ccbf05ad8793eaf7d9601b6fa741ebcc062740ac29"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.109-cp313-cp313-macosx_10_13_x86_64.whl"
-upload-time = 2026-07-21 14:28:31.766503+00:00
-url = "https://files.pythonhosted.org/packages/12/bf/8cd0f844f3967dadceea2095a0aa1a14b0d11f60a533a87b22937df72451/crosshair_tool-0.0.109-cp313-cp313-macosx_10_13_x86_64.whl"
-size = 696359
+name = "crosshair_tool-0.0.110-cp313-cp313-macosx_10_13_x86_64.whl"
+upload-time = 2026-08-16 23:52:52.681818+00:00
+url = "https://files.pythonhosted.org/packages/c6/cd/72a0db018a119a5d65e0b264ac74c1b5c9ea44939aaf3047f86f63ba1615/crosshair_tool-0.0.110-cp313-cp313-macosx_10_13_x86_64.whl"
+size = 713390
 
 [packages.wheels.hashes]
-sha256 = "4e838645c09212d81eee3c77df721454be031861cbd633439a3596e9bc941846"
+sha256 = "e5b2ebb495b9be9a99f1f49f47d6b232c635809c6e5e53ec6d65908859f0b58d"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.109-cp313-cp313-macosx_11_0_arm64.whl"
-upload-time = 2026-07-21 14:28:33.276705+00:00
-url = "https://files.pythonhosted.org/packages/a1/ca/d53541e8c758659d23022dc3d2aedbba3c4b7baf1cd364237145d64c2d2e/crosshair_tool-0.0.109-cp313-cp313-macosx_11_0_arm64.whl"
-size = 696953
+name = "crosshair_tool-0.0.110-cp313-cp313-macosx_11_0_arm64.whl"
+upload-time = 2026-08-16 23:52:54.109754+00:00
+url = "https://files.pythonhosted.org/packages/45/e0/10173b1421ff4c632e427933454fda32379bcd8a857edfd9ff4fbac36e4f/crosshair_tool-0.0.110-cp313-cp313-macosx_11_0_arm64.whl"
+size = 713988
 
 [packages.wheels.hashes]
-sha256 = "0f60d46a07c74a0ffbbdcfc7dfd75c1c2fea38cceb6ea1e8e6c478a2984d41f9"
+sha256 = "a502d2e836600ff612d809768759760f3d1338edb2b0994e3369ec5925d3c57b"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.109-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-07-21 14:28:34.345077+00:00
-url = "https://files.pythonhosted.org/packages/5c/ac/8e156c5254f36943d1c570a9836e7ebae53e12c9c7aab8e05145c8431102/crosshair_tool-0.0.109-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 747168
+name = "crosshair_tool-0.0.110-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-08-16 23:52:55.277844+00:00
+url = "https://files.pythonhosted.org/packages/22/22/5766a4aa20767d59f6e05506363830c8b923673f40d28409cf421d414f10/crosshair_tool-0.0.110-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 764193
 
 [packages.wheels.hashes]
-sha256 = "197d6d43faae9c6597cdbb22d181392f60a24dd3732fdca984126cf9ef6e31ee"
+sha256 = "e095460bc61974967f36205f90dd1d65b99c0be649ebcd9d48b6c7664fb7e207"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.109-cp313-cp313-win_amd64.whl"
-upload-time = 2026-07-21 14:28:37.685621+00:00
-url = "https://files.pythonhosted.org/packages/6d/9c/4e47a7f1f6eadc32c31397aac38ea0256cd4b117c8d6926e562e57b64bc5/crosshair_tool-0.0.109-cp313-cp313-win_amd64.whl"
-size = 691648
+name = "crosshair_tool-0.0.110-cp313-cp313-win_amd64.whl"
+upload-time = 2026-08-16 23:52:59.146328+00:00
+url = "https://files.pythonhosted.org/packages/94/39/bdc85d4c2cad692c6d1147450018dfd30116c35d0ff43335878ab16764f0/crosshair_tool-0.0.110-cp313-cp313-win_amd64.whl"
+size = 708675
 
 [packages.wheels.hashes]
-sha256 = "112eb6b0f36dab49e1218835fc77037f5040e7e97ac0d59a5d6a7e314d578308"
+sha256 = "15e7210121e4471ff56b67bfcfaeedf5b4265625928418752c91db89e23cfe67"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.109-cp314-cp314-macosx_10_13_universal2.whl"
-upload-time = 2026-07-21 14:28:38.941411+00:00
-url = "https://files.pythonhosted.org/packages/8e/e9/c83388ac1815ecba3755ba0e4d813992f524df2e3033cc2e393a63dba905/crosshair_tool-0.0.109-cp314-cp314-macosx_10_13_universal2.whl"
-size = 711425
+name = "crosshair_tool-0.0.110-cp314-cp314-macosx_10_13_universal2.whl"
+upload-time = 2026-08-16 23:53:00.456214+00:00
+url = "https://files.pythonhosted.org/packages/37/76/1188b519ede0c1ba42fdce400a2ba9052744bbb393afb1c503edc1682ee1/crosshair_tool-0.0.110-cp314-cp314-macosx_10_13_universal2.whl"
+size = 728452
 
 [packages.wheels.hashes]
-sha256 = "9b271f1bc35068181cc5ea912d4e5cde2154c9794af12537f25a409a5505bda1"
+sha256 = "d30ef73b792f6e0c9202db82cdb9a45005b66396c9c2e0a745bc65a8608c80d8"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.109-cp314-cp314-macosx_10_13_x86_64.whl"
-upload-time = 2026-07-21 14:28:40.149931+00:00
-url = "https://files.pythonhosted.org/packages/bc/fd/64d2ddafa0dc736f80b4d76b82c803db1acf4978d19490d022e18d95ab30/crosshair_tool-0.0.109-cp314-cp314-macosx_10_13_x86_64.whl"
-size = 695269
+name = "crosshair_tool-0.0.110-cp314-cp314-macosx_10_13_x86_64.whl"
+upload-time = 2026-08-16 23:53:01.740945+00:00
+url = "https://files.pythonhosted.org/packages/2f/38/8182a8878c3d57c1a7c73a5c289b411e0ac4e97d1e2f2a3f13c5ce8a36ab/crosshair_tool-0.0.110-cp314-cp314-macosx_10_13_x86_64.whl"
+size = 712301
 
 [packages.wheels.hashes]
-sha256 = "35c52feeb9d011e0f30482dda88423f03060f15814c3db0093b44d53279d820b"
+sha256 = "2a787b8aaf8790f519bfe5cbc53cbc7690811b6d6259fe122735c76e7d390140"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.109-cp314-cp314-macosx_11_0_arm64.whl"
-upload-time = 2026-07-21 14:28:41.415326+00:00
-url = "https://files.pythonhosted.org/packages/83/9b/8596ea2c1aa8880ef8568b82836f2949bb0cc22f6188670b30814db7b4d1/crosshair_tool-0.0.109-cp314-cp314-macosx_11_0_arm64.whl"
-size = 695882
+name = "crosshair_tool-0.0.110-cp314-cp314-macosx_11_0_arm64.whl"
+upload-time = 2026-08-16 23:53:02.892840+00:00
+url = "https://files.pythonhosted.org/packages/0c/4d/228eaa2873efbe1bc3b2b8da9c7c014c0ced2046ca703ba6c358ba5ec2cf/crosshair_tool-0.0.110-cp314-cp314-macosx_11_0_arm64.whl"
+size = 712916
 
 [packages.wheels.hashes]
-sha256 = "ed7cb3b139de22aea15e5db97551a847110195d57429f64663df028f9de01f5b"
+sha256 = "e78e2f74ebcee7ffb36251f83e6534bd1bee6c6edeb2ccedfed9826609a23252"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.109-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-07-21 14:28:42.669134+00:00
-url = "https://files.pythonhosted.org/packages/4b/b8/6adfae5d2520fafb9a53f323a1de9fbade347b0e95dd18a4fe364c1624a0/crosshair_tool-0.0.109-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 785790
+name = "crosshair_tool-0.0.110-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-08-16 23:53:04.717346+00:00
+url = "https://files.pythonhosted.org/packages/4f/95/4d76ae5652a8c1d1cf7e44f6742f018da545df5c968e1ad923ce858f03dc/crosshair_tool-0.0.110-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 802818
 
 [packages.wheels.hashes]
-sha256 = "6b465ec291d4867f27736a622ac220c7dabe55650af3f8a8cadf414cdc543f01"
+sha256 = "72135403a82d4467ca4d53b844cfcd67aa370fd9249944b9fa3dcab1927726b3"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.109-cp314-cp314-win_amd64.whl"
-upload-time = 2026-07-21 14:28:46.215512+00:00
-url = "https://files.pythonhosted.org/packages/bd/37/4aaf72d0b30539efd167b87a6fe18aafb0143e57267d8586be8dfbf59b67/crosshair_tool-0.0.109-cp314-cp314-win_amd64.whl"
-size = 690632
+name = "crosshair_tool-0.0.110-cp314-cp314-win_amd64.whl"
+upload-time = 2026-08-16 23:53:09.105397+00:00
+url = "https://files.pythonhosted.org/packages/56/83/b602c6da62cef07495ca1a4e5565205c2289a79a634ebb34cfd5000bde27/crosshair_tool-0.0.110-cp314-cp314-win_amd64.whl"
+size = 707699
 
 [packages.wheels.hashes]
-sha256 = "e2ced2f4dc500465537ba4f43ed760775a1b4b2080c498b4f7c2722bb0ff2f3b"
+sha256 = "a73a9ab75b1a1899b01ad74e9de382ee1f9b9e54e93b4ef39438b9b6bf64f29a"
 
 [[packages]]
 name = "exceptiongroup"
@@ -929,7 +929,7 @@ sha256 = "b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5"
 
 [[packages]]
 name = "hypothesis"
-version = "6.165.1"
+version = "6.165.10"
 marker = "\"crosshair\" in dependency_groups"
 requires-python = ">=3.10"
 dependencies = [
@@ -939,283 +939,283 @@ dependencies = [
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "hypothesis-6.165.1.tar.gz"
-upload-time = 2026-08-04 21:02:05.394980+00:00
-url = "https://files.pythonhosted.org/packages/29/ba/6a79ef3edd4d32f011267ba709393ba0bb018751fe019032f9b63a3a29fc/hypothesis-6.165.1.tar.gz"
-size = 496225
+name = "hypothesis-6.165.10.tar.gz"
+upload-time = 2026-08-16 22:56:15.404426+00:00
+url = "https://files.pythonhosted.org/packages/5c/e2/0fad246d2b6330e1f78479bfc566b5c22be82aee8a865cde9a08f648487d/hypothesis-6.165.10.tar.gz"
+size = 503703
 
 [packages.sdist.hashes]
-sha256 = "0fe3ae25bd0b0938d8681eacaa8ebc981761f1387db7bef609b22cfdec848dc2"
+sha256 = "68b45e09834cd80523cb1eb274463073c7a9af4e4ef7cff34d9615f355572d32"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp310-abi3-macosx_10_12_x86_64.whl"
-upload-time = 2026-08-04 21:00:47.014918+00:00
-url = "https://files.pythonhosted.org/packages/c0/24/ad0c5136b1d82b6955f79edbc39f7092dced8c09e9b08aec5a3ec02c02b5/hypothesis-6.165.1-cp310-abi3-macosx_10_12_x86_64.whl"
-size = 775946
+name = "hypothesis-6.165.10-cp310-abi3-macosx_10_12_x86_64.whl"
+upload-time = 2026-08-16 22:55:44.058264+00:00
+url = "https://files.pythonhosted.org/packages/05/c1/9a9538e6d185baf5cc7f15bc3b76e08efbb3de4b3c782f234356449c0dd7/hypothesis-6.165.10-cp310-abi3-macosx_10_12_x86_64.whl"
+size = 783243
 
 [packages.wheels.hashes]
-sha256 = "1a5640b5e52211e6a876a53af28ec292b984bb02a57be1e39fac38f2f28c6921"
+sha256 = "f839d29d0cc12048cf073d88ca4fdf94d420bc2b8afd69641ff6d496422ccd4f"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp310-abi3-macosx_11_0_arm64.whl"
-upload-time = 2026-08-04 21:00:35.334223+00:00
-url = "https://files.pythonhosted.org/packages/67/4f/c6dc9b300c2da163cc20d857f87e5d7f21240d99f071d1da3c27ac3d6269/hypothesis-6.165.1-cp310-abi3-macosx_11_0_arm64.whl"
-size = 771443
+name = "hypothesis-6.165.10-cp310-abi3-macosx_11_0_arm64.whl"
+upload-time = 2026-08-16 22:55:46.948220+00:00
+url = "https://files.pythonhosted.org/packages/a1/30/b70d9d79e871a75cbdeccd9067f20ecdb9eb2a1dfa03c630be3ad13b8b30/hypothesis-6.165.10-cp310-abi3-macosx_11_0_arm64.whl"
+size = 778815
 
 [packages.wheels.hashes]
-sha256 = "49c385fefc6d43c1f94792718d0f6bdb3dec894239d1118cfcceb48a4eaa495c"
+sha256 = "e10858f57ed0e74baa04393845f469fe8ad502c16ece4499bef7700c575611bd"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-upload-time = 2026-08-04 21:01:07.771642+00:00
-url = "https://files.pythonhosted.org/packages/b7/9a/8e9ecb2d0d1608e64cadca9297654c07fecbef8d66a9dce5d26db02bdf19/hypothesis-6.165.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-size = 1100733
+name = "hypothesis-6.165.10-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+upload-time = 2026-08-16 22:54:53.082995+00:00
+url = "https://files.pythonhosted.org/packages/db/52/6f0a9b7aab24b0635e2238f3fbddea5b54b17879ac813df42a3cc3384c5c/hypothesis-6.165.10-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+size = 1108009
 
 [packages.wheels.hashes]
-sha256 = "559f37d914f2a7c5d2b28b3ef7282814992082c1492343fed644244d984208ce"
+sha256 = "76a7be86d986223b9f1bdb7e7cbcdb048649901fdb956c598ef73bdab1786cd5"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-upload-time = 2026-08-04 21:00:42.104256+00:00
-url = "https://files.pythonhosted.org/packages/a0/d4/97fcc4d2fc69c71856cc4b7ff8f85d00d0cdc9218e8272630e52a83e8cae/hypothesis-6.165.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-size = 1150180
+name = "hypothesis-6.165.10-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+upload-time = 2026-08-16 22:56:02.159775+00:00
+url = "https://files.pythonhosted.org/packages/7d/18/8a26c24d3d9db20265f39df341ab265858c094e209571e3179cf237935f4/hypothesis-6.165.10-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+size = 1157528
 
 [packages.wheels.hashes]
-sha256 = "829a45c5459f7070277ac0fb0e7b052a7d9bdc2f54a546bfc34279213b6fa858"
+sha256 = "2abb50cf1cf77d721de0a24c3f99d9c4ffdeb2cbd1e12aebb5a7a93e2b6b6d1f"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp310-abi3-win_amd64.whl"
-upload-time = 2026-08-04 21:01:11.382705+00:00
-url = "https://files.pythonhosted.org/packages/b6/15/b6e98c68799f381123c872ca3493f1eb400b0e28550be938d1d3d63743c2/hypothesis-6.165.1-cp310-abi3-win_amd64.whl"
-size = 667859
+name = "hypothesis-6.165.10-cp310-abi3-win_amd64.whl"
+upload-time = 2026-08-16 22:55:01.697546+00:00
+url = "https://files.pythonhosted.org/packages/2c/fc/ff2988b72b5705ad9ca500444bf3f43e3c2f41edfa034bbfeb23b215791a/hypothesis-6.165.10-cp310-abi3-win_amd64.whl"
+size = 675213
 
 [packages.wheels.hashes]
-sha256 = "d30337baadfdaccf0ad6d70fe135201722f67f7522584b2a7494cfd7e03798a6"
+sha256 = "e9f924aa610c0618445e1e8738c822c3190ce2a2699a0cb48ec3a351a96761f2"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp310-cp310-macosx_10_12_x86_64.whl"
-upload-time = 2026-08-04 21:01:20.695173+00:00
-url = "https://files.pythonhosted.org/packages/2f/49/afc3102bb18ed2f5cbfa4ca2dfb2927e6af5ddc992a366494b946ae8021f/hypothesis-6.165.1-cp310-cp310-macosx_10_12_x86_64.whl"
-size = 776629
+name = "hypothesis-6.165.10-cp310-cp310-macosx_10_12_x86_64.whl"
+upload-time = 2026-08-16 22:55:29.078640+00:00
+url = "https://files.pythonhosted.org/packages/26/61/5e89268ce03317fb9f82449a1b3efd9e599dee090288fd0cf7586c532fb1/hypothesis-6.165.10-cp310-cp310-macosx_10_12_x86_64.whl"
+size = 783959
 
 [packages.wheels.hashes]
-sha256 = "7d71de7bab66af3152de2d03e615055fda7000c1f2325588bca9bba1ec0e8534"
+sha256 = "73e6df02a6a62f8045b511c272f894d08e56d174504c793c9effcbc6778051a8"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp310-cp310-macosx_11_0_arm64.whl"
-upload-time = 2026-08-04 21:01:26.716510+00:00
-url = "https://files.pythonhosted.org/packages/de/db/c4450c471fa77c70fe4f296d0ad87c984dcd2fd138a10fb475b7f74fe005/hypothesis-6.165.1-cp310-cp310-macosx_11_0_arm64.whl"
-size = 772365
+name = "hypothesis-6.165.10-cp310-cp310-macosx_11_0_arm64.whl"
+upload-time = 2026-08-16 22:54:57.698906+00:00
+url = "https://files.pythonhosted.org/packages/e1/e9/f4e0832e81bb53b70cf1712e28c867db64245b32595b594217452e7dbd8d/hypothesis-6.165.10-cp310-cp310-macosx_11_0_arm64.whl"
+size = 779684
 
 [packages.wheels.hashes]
-sha256 = "be98424c7501b3f2946d2fb96678688afdb127429be1a101befbae8e3312b6aa"
+sha256 = "8b20f44773a9ab84400465e318712d8c2ca16418d35b9f80aa27fdf2d690ad10"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-upload-time = 2026-08-04 21:00:51.784748+00:00
-url = "https://files.pythonhosted.org/packages/6f/92/1e0dd48e68e456045ebb04c50f95147b3484226e97a96e3aa9b0f58aaf4a/hypothesis-6.165.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-size = 1101229
+name = "hypothesis-6.165.10-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+upload-time = 2026-08-16 22:55:03.282605+00:00
+url = "https://files.pythonhosted.org/packages/77/de/ea072d3359d5678771bed407f80439e8ac7ca905d1031b0372f61bf5746e/hypothesis-6.165.10-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+size = 1108540
 
 [packages.wheels.hashes]
-sha256 = "4d1d91ef9f2a9618a80a34211f6269fabd79338f8cd9e258a2e379a4093b04a1"
+sha256 = "bb8c7d05ea27a093a92b250904095d71d924b6b44e5795a415c1b20c265f0c65"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-upload-time = 2026-08-04 21:01:02.114422+00:00
-url = "https://files.pythonhosted.org/packages/3a/a7/9f32f6dcfa18c5c6662942b6b264faa5b441951e4af347270f161722c23d/hypothesis-6.165.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-size = 1150647
+name = "hypothesis-6.165.10-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+upload-time = 2026-08-16 22:54:36.205289+00:00
+url = "https://files.pythonhosted.org/packages/28/56/e7c395cdaa3d6c28b944c1c3c516dee50d2b7b3aeafa31874b57009ca51f/hypothesis-6.165.10-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+size = 1158089
 
 [packages.wheels.hashes]
-sha256 = "dfcdf827ec449c59429eac5230c45d6bc297fb3da127621b7360df7c29ba6a6d"
+sha256 = "f4dafd6d6ababfa3b14dd6e5f0378cb7c7d291895a31a40abcbb7cc74f396131"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp310-cp310-win_amd64.whl"
-upload-time = 2026-08-04 21:00:16.200901+00:00
-url = "https://files.pythonhosted.org/packages/59/a7/0bdd0561abd5901044ecdb533077693f5bb8ed37ed0d2a29794cb270381b/hypothesis-6.165.1-cp310-cp310-win_amd64.whl"
-size = 667742
+name = "hypothesis-6.165.10-cp310-cp310-win_amd64.whl"
+upload-time = 2026-08-16 22:54:29.872104+00:00
+url = "https://files.pythonhosted.org/packages/70/99/9d844330f570d6a4f127a683eab1e78c8263e6e72b16189f3534fa6bf6de/hypothesis-6.165.10-cp310-cp310-win_amd64.whl"
+size = 675082
 
 [packages.wheels.hashes]
-sha256 = "44d701a2d1078aacec9d473ece2f63b12e7b1bb1afef058408d83eefdcd6a0fd"
+sha256 = "56cb8c9055e50545fe6e3e5a560ec25a724673b2e4051f3c24d44e3ebc35dd72"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp311-cp311-macosx_10_12_x86_64.whl"
-upload-time = 2026-08-04 21:00:55.428416+00:00
-url = "https://files.pythonhosted.org/packages/50/34/6cc747835aebec9d481b908c762bf552beec2ae7b95d1db3de40a66ef120/hypothesis-6.165.1-cp311-cp311-macosx_10_12_x86_64.whl"
-size = 776390
+name = "hypothesis-6.165.10-cp311-cp311-macosx_10_12_x86_64.whl"
+upload-time = 2026-08-16 22:55:36.624360+00:00
+url = "https://files.pythonhosted.org/packages/ed/c2/b9546ace11f241c9c02d389f258cb80c14447a8c885771c9f1f0bc1d85ca/hypothesis-6.165.10-cp311-cp311-macosx_10_12_x86_64.whl"
+size = 783716
 
 [packages.wheels.hashes]
-sha256 = "2dac5c816124efec59dcb8117a4a521e0647faad1041c5280d0009304145ad79"
+sha256 = "592107a0faf6c9c3a63a8dbf13dfb1cbda1cf599b0bc11c953221b00204b9ce1"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp311-cp311-macosx_11_0_arm64.whl"
-upload-time = 2026-08-04 21:00:20.007100+00:00
-url = "https://files.pythonhosted.org/packages/65/da/98025b789cc9ed7e1136176b3528029ee0c758733cfedc8963f6671e4c7b/hypothesis-6.165.1-cp311-cp311-macosx_11_0_arm64.whl"
-size = 772175
+name = "hypothesis-6.165.10-cp311-cp311-macosx_11_0_arm64.whl"
+upload-time = 2026-08-16 22:55:07.633139+00:00
+url = "https://files.pythonhosted.org/packages/37/10/27c2fdd574fd798caf5e91eb51f7834b098f5d840ce733efb3fba79ef86e/hypothesis-6.165.10-cp311-cp311-macosx_11_0_arm64.whl"
+size = 779507
 
 [packages.wheels.hashes]
-sha256 = "f2d3bf3b4035271024f215ae592b4adeaf5c95569b8a64362f358e6c2fa1fe83"
+sha256 = "f9180c362bde06fd05380298ded4e234fbc0d6ede0a864835bfd91c1e24283d5"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-upload-time = 2026-08-04 21:00:32.251930+00:00
-url = "https://files.pythonhosted.org/packages/df/47/4689ddf832a43bcb2fff4045aa37ba3eb5387ede2648488d010d61fc0cdc/hypothesis-6.165.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-size = 1101069
+name = "hypothesis-6.165.10-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+upload-time = 2026-08-16 22:55:39.653728+00:00
+url = "https://files.pythonhosted.org/packages/5e/b6/70bc23695f3783c4b0486b6cad47b08a20f791db4a3c1b25250add9659fa/hypothesis-6.165.10-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+size = 1108406
 
 [packages.wheels.hashes]
-sha256 = "52a23badd21024ea3e4767121ed47309a349171e0614ce0069037d891e68a0f9"
+sha256 = "d623801ae3dcd97b77b983400ef3d48bf976648e4efff19929175322eaae074d"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-upload-time = 2026-08-04 21:01:52.536928+00:00
-url = "https://files.pythonhosted.org/packages/ee/25/b71cac1cc16d633c4b8da876a078d55e1e6b2702acbbc701492390c01cfc/hypothesis-6.165.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-size = 1150514
+name = "hypothesis-6.165.10-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+upload-time = 2026-08-16 22:55:24.394291+00:00
+url = "https://files.pythonhosted.org/packages/71/4c/32e200bd7a352af4b7f4e3729aaa4cd002cb5fe8c4c6aef5599d0019f152/hypothesis-6.165.10-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+size = 1157850
 
 [packages.wheels.hashes]
-sha256 = "f57a7340e2cfbb0143b9d1cbe982d663560f0eef39e6aa99c6a711f29c072c27"
+sha256 = "20f6236cfb90b7817bb1a6a087589ca4aa46d73170f0dd62963952ed5dadc589"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp311-cp311-win_amd64.whl"
-upload-time = 2026-08-04 21:01:34.042968+00:00
-url = "https://files.pythonhosted.org/packages/f2/8d/4d226b095da3e1b99d7e5d3621f3f964f2a7b5bfbbb82126992a8f6e799b/hypothesis-6.165.1-cp311-cp311-win_amd64.whl"
-size = 667598
+name = "hypothesis-6.165.10-cp311-cp311-win_amd64.whl"
+upload-time = 2026-08-16 22:55:42.613036+00:00
+url = "https://files.pythonhosted.org/packages/82/ac/bc16faba4b42883e3d290bfaceff51e258b63fbbdf789bf9fe88df1ce537/hypothesis-6.165.10-cp311-cp311-win_amd64.whl"
+size = 674920
 
 [packages.wheels.hashes]
-sha256 = "9763c1cb9dd6b9a1ab395481d4067b2e8a3b148a97e599b419788e8775106b54"
+sha256 = "5671d2b2bf83bd4b6f02e55b32d432506eff5358c82f39b460a849ce19a2666e"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp312-cp312-macosx_10_12_x86_64.whl"
-upload-time = 2026-08-04 21:01:14.907426+00:00
-url = "https://files.pythonhosted.org/packages/30/48/7a8de755d9b9cab7caa9ef9051ffa2a5a21f7b20f813c902b0123952ed33/hypothesis-6.165.1-cp312-cp312-macosx_10_12_x86_64.whl"
-size = 777509
+name = "hypothesis-6.165.10-cp312-cp312-macosx_10_12_x86_64.whl"
+upload-time = 2026-08-16 22:54:45.429027+00:00
+url = "https://files.pythonhosted.org/packages/e9/45/cde4f78afe2b9e29caecf38319eedc1deb76aebcacbdd128e03cbb2511c3/hypothesis-6.165.10-cp312-cp312-macosx_10_12_x86_64.whl"
+size = 784835
 
 [packages.wheels.hashes]
-sha256 = "53b3d1e8ed9140994955f7bf27c185d45a475dc9d4bc95c69e7bd48b5c3c426f"
+sha256 = "637445c1593a2a9d1024fda50082f07bb56baedda78d90a25f64b8111727ef94"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp312-cp312-macosx_11_0_arm64.whl"
-upload-time = 2026-08-04 21:00:48.553670+00:00
-url = "https://files.pythonhosted.org/packages/54/2b/97224357923b13c3dd84ebbcd39bd414368543306e60b72b72deb0743f4a/hypothesis-6.165.1-cp312-cp312-macosx_11_0_arm64.whl"
-size = 769074
+name = "hypothesis-6.165.10-cp312-cp312-macosx_11_0_arm64.whl"
+upload-time = 2026-08-16 22:55:33.633066+00:00
+url = "https://files.pythonhosted.org/packages/7f/81/847f30b81cbfd07607296b3ce43067cf4f80799bd9244167f587de9c8081/hypothesis-6.165.10-cp312-cp312-macosx_11_0_arm64.whl"
+size = 776419
 
 [packages.wheels.hashes]
-sha256 = "8f4b0e0664e058fdf1637d1ca9d984e5286372ad58b70222195dc535a771c4bd"
+sha256 = "713f4ce4e82c26b53031f139de959bc9e8b54d3995aa824b89bbdf8229df2a45"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-upload-time = 2026-08-04 21:00:38.915552+00:00
-url = "https://files.pythonhosted.org/packages/e4/f4/e00e850e4e3b1d25b2b7b6528b8fc0dd3ce5c5989cdb4863b6b9cd814b06/hypothesis-6.165.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-size = 1099519
+name = "hypothesis-6.165.10-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+upload-time = 2026-08-16 22:55:10.389496+00:00
+url = "https://files.pythonhosted.org/packages/04/66/4c71c5be7a49d84b8c3a9278c1807c4c81181ab5474beb27df9d4c40dc0e/hypothesis-6.165.10-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+size = 1106830
 
 [packages.wheels.hashes]
-sha256 = "616df752e3b2f8db6e463a86ad42942024094050adf4406bda4543b6b91333c3"
+sha256 = "f9ff356e97e3ab09db07c8b675efa67340103874a0bae7465acb83dad7a35f7f"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-upload-time = 2026-08-04 21:00:45.151152+00:00
-url = "https://files.pythonhosted.org/packages/59/cb/24498d5b5a0d73c780a31d9b2269ff032cdacb772a986f8fb52444aa3dae/hypothesis-6.165.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-size = 1149568
+name = "hypothesis-6.165.10-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+upload-time = 2026-08-16 22:55:53.350534+00:00
+url = "https://files.pythonhosted.org/packages/e3/c4/e2cbd2810e79f7a452a8ea9f6c6438ee718ce938d8cc12252cf0b36a81d3/hypothesis-6.165.10-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+size = 1156952
 
 [packages.wheels.hashes]
-sha256 = "38a67b9f6807dade978d293be183c7487968a9c3c9a656c33effd75ddc8405f8"
+sha256 = "1a380bc99aa3b035e6a95a2201bf792d4082a04ca75babcc21849c2d0914bb28"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp312-cp312-win_amd64.whl"
-upload-time = 2026-08-04 21:01:50.588633+00:00
-url = "https://files.pythonhosted.org/packages/08/85/ee8ea059d01971fd7c0d9498911eac5b94ef6678a39575eebe37fdf2d49b/hypothesis-6.165.1-cp312-cp312-win_amd64.whl"
-size = 665024
+name = "hypothesis-6.165.10-cp312-cp312-win_amd64.whl"
+upload-time = 2026-08-16 22:54:49.110755+00:00
+url = "https://files.pythonhosted.org/packages/74/59/6caf69dd5fe03499ada94c9cec016bffcc164511c6b93fe680f01209b9ff/hypothesis-6.165.10-cp312-cp312-win_amd64.whl"
+size = 672337
 
 [packages.wheels.hashes]
-sha256 = "16b63ec033a0dceb6e00da6cc5d49bb38803c6825ca68f52604e424a2e3682ed"
+sha256 = "3376f2594763aef14faa519b0fb27cae7ce9eeaab4c69efa07777499110306c9"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp313-cp313-macosx_10_12_x86_64.whl"
-upload-time = 2026-08-04 21:01:48.265736+00:00
-url = "https://files.pythonhosted.org/packages/58/ae/6154945a7603e305273f98fc10bc3364a6e67d347ff810e02f864a7b7843/hypothesis-6.165.1-cp313-cp313-macosx_10_12_x86_64.whl"
-size = 777400
+name = "hypothesis-6.165.10-cp313-cp313-macosx_10_12_x86_64.whl"
+upload-time = 2026-08-16 22:54:32.371117+00:00
+url = "https://files.pythonhosted.org/packages/b1/fb/c82c5bd92864ffcf319772fedc8c9bf2dbe4ca14baa0fee6e49e67b5ba1c/hypothesis-6.165.10-cp313-cp313-macosx_10_12_x86_64.whl"
+size = 784726
 
 [packages.wheels.hashes]
-sha256 = "57c235a348b544455e13300e6cf11e0bf3eea4b692331beb42854edc8e661045"
+sha256 = "9d77c3be7b429875036ad0f0597c6e5cc6bb17894a4da005e3807de64d2673ad"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp313-cp313-macosx_11_0_arm64.whl"
-upload-time = 2026-08-04 21:00:50.295697+00:00
-url = "https://files.pythonhosted.org/packages/b7/75/3817a4878664895e2f9c5518aa4918366db5bc2521a6498e480a6ada1b1c/hypothesis-6.165.1-cp313-cp313-macosx_11_0_arm64.whl"
-size = 769040
+name = "hypothesis-6.165.10-cp313-cp313-macosx_11_0_arm64.whl"
+upload-time = 2026-08-16 22:55:13.303522+00:00
+url = "https://files.pythonhosted.org/packages/0e/b9/3d7acd08506da85557e65147b7f3fca8c47684e33be90bee0acb523920db/hypothesis-6.165.10-cp313-cp313-macosx_11_0_arm64.whl"
+size = 776375
 
 [packages.wheels.hashes]
-sha256 = "28b1aae4f2cf6cb99d34b1979d06d21f36ef771afb42418c9243da145e36e09a"
+sha256 = "490c56b830772b0eca3b4b2cecb3741a1ed26b1d7206a279e1525dbf0aa95ee4"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-upload-time = 2026-08-04 21:00:37.215988+00:00
-url = "https://files.pythonhosted.org/packages/e3/12/34d55b84b761448f76a493e1d71ce1ceb0529a92db013635e74dbbd64030/hypothesis-6.165.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-size = 1099438
+name = "hypothesis-6.165.10-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+upload-time = 2026-08-16 22:55:06.129333+00:00
+url = "https://files.pythonhosted.org/packages/38/6b/922e8b3f9a706dd89d440b9545d2c6231c65e74da1c1fee3ff36c251b9c4/hypothesis-6.165.10-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+size = 1106763
 
 [packages.wheels.hashes]
-sha256 = "33fb3293d3b7a56749b34ac64012540bec5c4d2ca701fa47a88cbc88846d1228"
+sha256 = "ed68e27b8a61e57a3ccdc7c5a14499e00b54dfe223087204d5d40b3b5ef58b6d"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-upload-time = 2026-08-04 21:01:22.695223+00:00
-url = "https://files.pythonhosted.org/packages/1c/23/cf88d3ec0521089258000ff17d3a6bd13c78c2efcfaaece9af06e5b0f2d5/hypothesis-6.165.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-size = 1149379
+name = "hypothesis-6.165.10-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+upload-time = 2026-08-16 22:54:33.824194+00:00
+url = "https://files.pythonhosted.org/packages/01/39/f5b9a5d390d4edd1ad472334493ac442963ebeb4daaa74ff4bdac6ef292f/hypothesis-6.165.10-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+size = 1156778
 
 [packages.wheels.hashes]
-sha256 = "9ca1f560b9b0a9b000619d199748994eb8703915bbaf60a5377feaf296f7514f"
+sha256 = "6caadcd1afb62630ff5c5ff353626eaa616553a5971295ad6dc2b19ca8a39620"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp313-cp313-win_amd64.whl"
-upload-time = 2026-08-04 21:00:24.428403+00:00
-url = "https://files.pythonhosted.org/packages/54/d5/eda5cc31ac6c56a238ae5b341737c812fbc1fb84e93ad47088da96f4a953/hypothesis-6.165.1-cp313-cp313-win_amd64.whl"
-size = 665035
+name = "hypothesis-6.165.10-cp313-cp313-win_amd64.whl"
+upload-time = 2026-08-16 22:56:03.792099+00:00
+url = "https://files.pythonhosted.org/packages/cc/cc/662b94880f260b0a88de1fdcf60fc9984f6e2a796da549542adc10a7bc83/hypothesis-6.165.10-cp313-cp313-win_amd64.whl"
+size = 672346
 
 [packages.wheels.hashes]
-sha256 = "55ed0599c5e5fdf7ada0b48ee1de05f314bcf6f01e49ad92a786da3d169c9d1c"
+sha256 = "c01dd04044c472e47193b54f68e84e08d6ebf4f29551885aa959b015f7cd9747"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp314-cp314-macosx_10_12_x86_64.whl"
-upload-time = 2026-08-04 21:01:46.361154+00:00
-url = "https://files.pythonhosted.org/packages/c7/c5/d7c53d4e6a76f2d27a2179e9ea80ebcc76dcc151e17fa4df07efb943c7ae/hypothesis-6.165.1-cp314-cp314-macosx_10_12_x86_64.whl"
-size = 777613
+name = "hypothesis-6.165.10-cp314-cp314-macosx_10_12_x86_64.whl"
+upload-time = 2026-08-16 22:55:21.255200+00:00
+url = "https://files.pythonhosted.org/packages/3f/77/55e020c9c576532ff7d20bf8b1dfa052ecbd5ada1949b02f76c44c966f7e/hypothesis-6.165.10-cp314-cp314-macosx_10_12_x86_64.whl"
+size = 784833
 
 [packages.wheels.hashes]
-sha256 = "99c0b348dd0090418ecac8e3f072e7db8f3d4d745b80ed29cb7e6413eba578d5"
+sha256 = "9ccac776b2ca93b324806facd526ccb45da0fd035001c899a35b02c44431e209"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp314-cp314-macosx_11_0_arm64.whl"
-upload-time = 2026-08-04 21:01:18.729973+00:00
-url = "https://files.pythonhosted.org/packages/7f/ad/d1854bb869e840c0406a271a5f9e82377900317aad38c51a05d31f783df6/hypothesis-6.165.1-cp314-cp314-macosx_11_0_arm64.whl"
-size = 769175
+name = "hypothesis-6.165.10-cp314-cp314-macosx_11_0_arm64.whl"
+upload-time = 2026-08-16 22:56:10.159054+00:00
+url = "https://files.pythonhosted.org/packages/4f/f2/01da2adf829cf549eaddcabb8e8072077fb3d26da4275f4c1e89b2c0af74/hypothesis-6.165.10-cp314-cp314-macosx_11_0_arm64.whl"
+size = 776545
 
 [packages.wheels.hashes]
-sha256 = "d37ca9b20de6413e931280fce4428cf49ed769dc421d80b4ecce2b2e47266eae"
+sha256 = "e5f95f7b622e4171096d92175dda0a560f0955ade9b8a3a07bdcf151f7359611"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-upload-time = 2026-08-04 21:00:27.566914+00:00
-url = "https://files.pythonhosted.org/packages/fd/5b/eecf6b1ad0d41007f88a3347be19e83fb04d53dffcc7c372e20b509bc366/hypothesis-6.165.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-size = 1099937
+name = "hypothesis-6.165.10-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+upload-time = 2026-08-16 22:54:50.266066+00:00
+url = "https://files.pythonhosted.org/packages/cf/8e/58d4f842895220b793c53fc94a6489705b3665bb4d0ae4d338ce03fdf9fb/hypothesis-6.165.10-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+size = 1107271
 
 [packages.wheels.hashes]
-sha256 = "c2dbf82a127e4a598745e6708535dab8e5dafbe498664b6dfaf451f305a8b3fc"
+sha256 = "f76d1562643693b8a40066f1f96af795b93fd9bcfc9690a1af2ff4c5867ee29e"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-upload-time = 2026-08-04 21:00:12.050571+00:00
-url = "https://files.pythonhosted.org/packages/55/9b/c58c4910cf6766857a7dd31da294f32b26d03e94d05b225c0dcc83fb41b9/hypothesis-6.165.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-size = 1149618
+name = "hypothesis-6.165.10-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+upload-time = 2026-08-16 22:54:25.890564+00:00
+url = "https://files.pythonhosted.org/packages/8f/b8/206468912d2153306bb8a41afdfc59e45b7a73a0495bbe4b9cb4f0e79c1d/hypothesis-6.165.10-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+size = 1156915
 
 [packages.wheels.hashes]
-sha256 = "6b60824e0a15dd712d0ac93940029cdc79f5a10f1e9289ec0a82bddd8d43a3c4"
+sha256 = "60cab3ab4ea468d31a33739ffd7e94ec3e37dea891d65a6582ecc8a477175191"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp314-cp314-win_amd64.whl"
-upload-time = 2026-08-04 21:00:43.606865+00:00
-url = "https://files.pythonhosted.org/packages/ce/4f/98603203f2e7838c180bd2b3bd32c07aecc02d62ce46d040cba4d1b892e9/hypothesis-6.165.1-cp314-cp314-win_amd64.whl"
-size = 664903
+name = "hypothesis-6.165.10-cp314-cp314-win_amd64.whl"
+upload-time = 2026-08-16 22:54:24.831851+00:00
+url = "https://files.pythonhosted.org/packages/48/86/9b4fb75f520a028edec50ffc904a94d724180395d71feb6d7a0ce7bb6f00/hypothesis-6.165.10-cp314-cp314-win_amd64.whl"
+size = 672145
 
 [packages.wheels.hashes]
-sha256 = "6bb8b5899151b35b4453face837536430c3835aabb71431b60ef26f4281a386e"
+sha256 = "d1ea02fa8ab3d33eb1125eade81f7136341eb429152c6dbe2ae6f8bc33b3fbdd"
 
 [[packages]]
 name = "hypothesis-crosshair"
@@ -1248,28 +1248,28 @@ sha256 = "094b9d48056b4e5bb8f208a99b0887e689fb4c6794550715cd65d6c2ae67d1f4"
 
 [[packages]]
 name = "idna"
-version = "3.18"
+version = "3.19"
 marker = "\"crosshair\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "idna-3.18.tar.gz"
-upload-time = 2026-06-02 14:34:07.794523+00:00
-url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz"
-size = 196711
+name = "idna-3.19.tar.gz"
+upload-time = 2026-08-18 05:14:24.270231+00:00
+url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz"
+size = 215237
 
 [packages.sdist.hashes]
-sha256 = "ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"
+sha256 = "5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15"
 
 [[packages.wheels]]
-name = "idna-3.18-py3-none-any.whl"
-upload-time = 2026-06-02 14:34:06.319954+00:00
-url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl"
-size = 65455
+name = "idna-3.19-py3-none-any.whl"
+upload-time = 2026-08-18 05:14:22.343598+00:00
+url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl"
+size = 68550
 
 [packages.wheels.hashes]
-sha256 = "7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"
+sha256 = "815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4"
 
 [[packages]]
 name = "importlib-metadata"
@@ -1483,28 +1483,28 @@ sha256 = "510a6dea2476177230c7d851125e5948efdf3fdb9ebfd8543fc434972f8faed4"
 
 [[packages]]
 name = "pygments"
-version = "2.20.0"
+version = "2.21.0"
 marker = "\"crosshair\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "pygments-2.20.0.tar.gz"
-upload-time = 2026-03-29 13:29:33.898791+00:00
-url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz"
-size = 4955991
+name = "pygments-2.21.0.tar.gz"
+upload-time = 2026-08-17 08:02:48.824391+00:00
+url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz"
+size = 5005329
 
 [packages.sdist.hashes]
-sha256 = "6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"
+sha256 = "610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c"
 
 [[packages.wheels]]
-name = "pygments-2.20.0-py3-none-any.whl"
-upload-time = 2026-03-29 13:29:30.038266+00:00
-url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl"
-size = 1231151
+name = "pygments-2.21.0-py3-none-any.whl"
+upload-time = 2026-08-17 08:02:44.912148+00:00
+url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl"
+size = 1250147
 
 [packages.wheels.hashes]
-sha256 = "81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"
+sha256 = "2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9"
 
 [[packages]]
 name = "pyproject-hooks"
@@ -2086,63 +2086,63 @@ sha256 = "9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
 
 [[packages]]
 name = "z3-solver"
-version = "5.0.0.0"
+version = "5.1.0.0"
 marker = "\"crosshair\" in dependency_groups"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "z3_solver-5.0.0.0.tar.gz"
-upload-time = 2026-07-17 01:54:16.286027+00:00
-url = "https://files.pythonhosted.org/packages/d8/00/4ffb6fb197af2e6645165433d65bbfc7c914e4176573da954685f09e51a2/z3_solver-5.0.0.0.tar.gz"
-size = 5388479
+name = "z3_solver-5.1.0.0.tar.gz"
+upload-time = 2026-08-16 04:29:28.806459+00:00
+url = "https://files.pythonhosted.org/packages/ee/f0/493c2b3acdb65f452a5b22cbec5241f81a8f5c12ef012f3baff1ad82b738/z3_solver-5.1.0.0.tar.gz"
+size = 5468088
 
 [packages.sdist.hashes]
-sha256 = "24d4b524c21f48c86c7058a36e83091c1fc08be28b68bf5a0f3cce5305ed8464"
+sha256 = "269a0bf62949d227a16ab42afee6750f18477e173a14de6aeaf8789f33f813b5"
 
 [[packages.wheels]]
-name = "z3_solver-5.0.0.0-py3-none-macosx_13_0_arm64.whl"
-upload-time = 2026-07-17 01:53:49.290984+00:00
-url = "https://files.pythonhosted.org/packages/6a/a4/8a8e4a630b6a55fc7eeb5549d2235ecb7273dc08df59f4ad1bc27aa33e3b/z3_solver-5.0.0.0-py3-none-macosx_13_0_arm64.whl"
-size = 38511191
+name = "z3_solver-5.1.0.0-py3-none-macosx_13_0_arm64.whl"
+upload-time = 2026-08-16 04:29:02.621753+00:00
+url = "https://files.pythonhosted.org/packages/01/9a/cdb6db09d6aff6a803a94505aa24666db5e47df7aad0f2b1b0ddcb52ed12/z3_solver-5.1.0.0-py3-none-macosx_13_0_arm64.whl"
+size = 38759094
 
 [packages.wheels.hashes]
-sha256 = "37d44cf3c90c4c4629d8a074b432bbf06c30ed937b76c79088df9d6534aba50a"
+sha256 = "399a38a85d784105e5df5a05c04a581481bfdb80af7424779cf76fa843b4e66c"
 
 [[packages.wheels]]
-name = "z3_solver-5.0.0.0-py3-none-macosx_13_0_x86_64.whl"
-upload-time = 2026-07-17 01:53:53.335468+00:00
-url = "https://files.pythonhosted.org/packages/40/67/70cc067a3922bcaa680669cc4cfa427dcd90885f03a01d41dd244c2320bb/z3_solver-5.0.0.0-py3-none-macosx_13_0_x86_64.whl"
-size = 41135979
+name = "z3_solver-5.1.0.0-py3-none-macosx_13_0_x86_64.whl"
+upload-time = 2026-08-16 04:29:06.761622+00:00
+url = "https://files.pythonhosted.org/packages/29/1a/33544c70e014d9d6d8743201eecd3afdc260639b2711c9c0172ddf1fa93b/z3_solver-5.1.0.0-py3-none-macosx_13_0_x86_64.whl"
+size = 41418780
 
 [packages.wheels.hashes]
-sha256 = "c907c3bce4be50112460502f8adefe60112dcf8bc0838f113fdeba3bc4350bab"
+sha256 = "069feb3ecfa0cbf40524b6a06bf0a02d604e1710bd42012ac197e2e343e39cc0"
 
 [[packages.wheels]]
-name = "z3_solver-5.0.0.0-py3-none-manylinux_2_27_x86_64.whl"
-upload-time = 2026-07-17 01:53:57.236365+00:00
-url = "https://files.pythonhosted.org/packages/d7/7d/a7c5c76e943cff57a0cec4662b7e576ae72db17520276acd931dcea72939/z3_solver-5.0.0.0-py3-none-manylinux_2_27_x86_64.whl"
-size = 32985664
+name = "z3_solver-5.1.0.0-py3-none-manylinux_2_27_x86_64.whl"
+upload-time = 2026-08-16 04:29:10.350592+00:00
+url = "https://files.pythonhosted.org/packages/34/de/30329041d9a2dda11308576a80b5db17060e4b03a7ba7f550437fb38dd6b/z3_solver-5.1.0.0-py3-none-manylinux_2_27_x86_64.whl"
+size = 33098276
 
 [packages.wheels.hashes]
-sha256 = "5571949b47abee67935aeb05db9e48af14ed96ceda18f6ff8b75eb3901bb9c54"
+sha256 = "dfad9e309d7010b1ff6bdb33f21570a1603ef4727373221c7117a74448f0cfef"
 
 [[packages.wheels]]
-name = "z3_solver-5.0.0.0-py3-none-manylinux_2_38_aarch64.whl"
-upload-time = 2026-07-17 01:54:00.721345+00:00
-url = "https://files.pythonhosted.org/packages/c5/fe/829778607d4cd2571a16a128ea9099cacf4139c641b87473d5c8f2c17603/z3_solver-5.0.0.0-py3-none-manylinux_2_38_aarch64.whl"
-size = 28307680
+name = "z3_solver-5.1.0.0-py3-none-manylinux_2_38_aarch64.whl"
+upload-time = 2026-08-16 04:29:14.149471+00:00
+url = "https://files.pythonhosted.org/packages/ec/49/7db70c39fefde52eb5571ae709fa370260536439082d36b9ed1ab36bd1a0/z3_solver-5.1.0.0-py3-none-manylinux_2_38_aarch64.whl"
+size = 28571775
 
 [packages.wheels.hashes]
-sha256 = "8d5a400edd32a7492b73ffed575677b8f0ae04401c6860b7d8b3c79c5ff609e7"
+sha256 = "1dcfcccb4b027951d7adf267b5b236e7a67b8433cc358d802dcb0280151587bf"
 
 [[packages.wheels]]
-name = "z3_solver-5.0.0.0-py3-none-win_amd64.whl"
-upload-time = 2026-07-17 01:54:10.269464+00:00
-url = "https://files.pythonhosted.org/packages/b3/3c/bc1d7d55e5493e4637ef48c7a3680ce5e00082352f680baa22f491bfee20/z3_solver-5.0.0.0-py3-none-win_amd64.whl"
-size = 16918299
+name = "z3_solver-5.1.0.0-py3-none-win_amd64.whl"
+upload-time = 2026-08-16 04:29:23.430597+00:00
+url = "https://files.pythonhosted.org/packages/3f/5a/e3651dc6c976bc44861f4ba0167366a1ce0b11b3bcbad7377f0d28f9f513/z3_solver-5.1.0.0-py3-none-win_amd64.whl"
+size = 17040097
 
 [packages.wheels.hashes]
-sha256 = "9b0aca98598353ea7eb59a51f909a399f6d0e687a1de3671b60a734cea4bb6bd"
+sha256 = "1561efd36e06f4cb7cbf11b63a2fba8fc8fdeb9c5754df90c84f9bd7a4864552"
 
 [[packages]]
 name = "zipp"
@@ -2171,7 +2171,7 @@ sha256 = "25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f"
 
 [tool.nab]
 nab-version = "0.0.16.dev0"
-created-at = 2026-08-12 13:49:27.987742+00:00
+created-at = 2026-09-02 00:02:45.923999+00:00
 command-line = [
     "nab",
     "lock",
@@ -2182,6 +2182,7 @@ command-line = [
     "--no-emit-workspace",
     "--output",
     ".github/requirements/pylock.crosshair.toml",
+    "--upgrade",
 ]
 input-path = "pyproject.toml"
 mode = "universal"

--- a/.github/requirements/pylock.dists.toml
+++ b/.github/requirements/pylock.dists.toml
@@ -523,7 +523,7 @@ sha256 = "25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f"
 
 [tool.nab]
 nab-version = "0.0.16.dev0"
-created-at = 2026-08-12 13:49:38.756512+00:00
+created-at = 2026-09-02 00:02:58.160460+00:00
 command-line = [
     "nab",
     "lock",
@@ -534,6 +534,7 @@ command-line = [
     "--no-emit-workspace",
     "--output",
     ".github/requirements/pylock.dists.toml",
+    "--upgrade",
 ]
 input-path = "pyproject.toml"
 mode = "universal"

--- a/.github/requirements/pylock.docs.toml
+++ b/.github/requirements/pylock.docs.toml
@@ -173,37 +173,46 @@ sha256 = "62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775"
 
 [[packages]]
 name = "charset-normalizer"
-version = "3.4.9"
+version = "3.5.1"
 marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.7"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "charset_normalizer-3.4.9.tar.gz"
-upload-time = 2026-07-07 14:34:58.454748+00:00
-url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz"
-size = 152439
+name = "charset_normalizer-3.5.1.tar.gz"
+upload-time = 2026-08-15 08:20:44.807628+00:00
+url = "https://files.pythonhosted.org/packages/e5/3f/143b048436775b0f76ac3eec145c019e8173ccc2885c8f20319b996d5e83/charset_normalizer-3.5.1.tar.gz"
+size = 171764
 
 [packages.sdist.hashes]
-sha256 = "673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b"
+sha256 = "6117b84ea48435e5356dc737f5121485c30920ba43375fa7b434fd753df0eac3"
 
 [[packages.wheels]]
-name = "charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-07-07 14:33:41.631371+00:00
-url = "https://files.pythonhosted.org/packages/ea/f8/72eb13dcabe7257035cea8aefd922caad2f110d252bf9f67c4c2ca763aee/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 223149
+name = "charset_normalizer-3.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-08-15 08:17:46.496792+00:00
+url = "https://files.pythonhosted.org/packages/fb/af/63240b0c0248c075c2535a1f1bd992821d8251b9f173abc13329661d09e4/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 250638
 
 [packages.wheels.hashes]
-sha256 = "84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33"
+sha256 = "62b55f6722735a6c472f88361cde6640608773d9443cebdbb51abf436a1fcdd3"
 
 [[packages.wheels]]
-name = "charset_normalizer-3.4.9-py3-none-any.whl"
-upload-time = 2026-07-07 14:34:56.993397+00:00
-url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl"
-size = 64538
+name = "charset_normalizer-3.5.1-cp37-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-08-15 08:19:52.654163+00:00
+url = "https://files.pythonhosted.org/packages/9f/2f/fe3f187327aac18e2d54e9d2b08e15d27bf9b642d9e51c219f130fc34d1a/charset_normalizer-3.5.1-cp37-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 253057
 
 [packages.wheels.hashes]
-sha256 = "68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5"
+sha256 = "a6dac12ff6b846103483683f60c5f8fee205121adc58ffd87e90a90a3af69e99"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.5.1-py3-none-any.whl"
+upload-time = 2026-08-15 08:20:43.306209+00:00
+url = "https://files.pythonhosted.org/packages/cc/61/d01fc49b8dea277640b55a9e15960dbca9fdc8c9fde18e572d39c59f4019/charset_normalizer-3.5.1-py3-none-any.whl"
+size = 68658
+
+[packages.wheels.hashes]
+sha256 = "6df0ec430f9a831772c23ca5a224cba36517a58a84bb32c32bb59a9fa67c47f6"
 
 [[packages]]
 name = "docutils"
@@ -264,53 +273,53 @@ sha256 = "bb0ead5309f9500130665a26bee87693c41ce4dbdff864dbfb6b0dae4673d24f"
 
 [[packages]]
 name = "idna"
-version = "3.18"
+version = "3.19"
 marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "idna-3.18.tar.gz"
-upload-time = 2026-06-02 14:34:07.794523+00:00
-url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz"
-size = 196711
+name = "idna-3.19.tar.gz"
+upload-time = 2026-08-18 05:14:24.270231+00:00
+url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz"
+size = 215237
 
 [packages.sdist.hashes]
-sha256 = "ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"
+sha256 = "5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15"
 
 [[packages.wheels]]
-name = "idna-3.18-py3-none-any.whl"
-upload-time = 2026-06-02 14:34:06.319954+00:00
-url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl"
-size = 65455
+name = "idna-3.19-py3-none-any.whl"
+upload-time = 2026-08-18 05:14:22.343598+00:00
+url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl"
+size = 68550
 
 [packages.wheels.hashes]
-sha256 = "7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"
+sha256 = "815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4"
 
 [[packages]]
 name = "imagesize"
-version = "2.0.0"
+version = "2.0.1"
 marker = "\"docs\" in dependency_groups"
-requires-python = "<3.15,>=3.10"
+requires-python = ">=3.10"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "imagesize-2.0.0.tar.gz"
-upload-time = 2026-03-03 14:18:29.941652+00:00
-url = "https://files.pythonhosted.org/packages/6c/e6/7bf14eeb8f8b7251141944835abd42eb20a658d89084b7e1f3e5fe394090/imagesize-2.0.0.tar.gz"
-size = 1773045
+name = "imagesize-2.0.1.tar.gz"
+upload-time = 2026-08-24 12:35:19.130667+00:00
+url = "https://files.pythonhosted.org/packages/fb/5e/513ff06670c84e7b9887c1fdf61b2d42b4f574a831f2f1d2222023049d8a/imagesize-2.0.1.tar.gz"
+size = 1883774
 
 [packages.sdist.hashes]
-sha256 = "8e8358c4a05c304f1fccf7ff96f036e7243a189e9e42e90851993c558cfe9ee3"
+sha256 = "b2ba6a4dea487a7ebcd53248d3476aca449d30db12a2dde5e0c5ca9624fd77e5"
 
 [[packages.wheels]]
-name = "imagesize-2.0.0-py2.py3-none-any.whl"
-upload-time = 2026-03-03 14:18:27.892459+00:00
-url = "https://files.pythonhosted.org/packages/5f/53/fb7122b71361a0d121b669dcf3d31244ef75badbbb724af388948de543e2/imagesize-2.0.0-py2.py3-none-any.whl"
-size = 9441
+name = "imagesize-2.0.1-py3-none-any.whl"
+upload-time = 2026-08-24 12:35:12.548956+00:00
+url = "https://files.pythonhosted.org/packages/01/f9/575c8d760eae1fc99651b7cc5efd96ad5379ca4d6b53750b0fb4fe983f34/imagesize-2.0.1-py3-none-any.whl"
+size = 14794
 
 [packages.wheels.hashes]
-sha256 = "5667c5bbb57ab3f1fa4bc366f4fbc971db3d5ed011fd2715fd8001f782718d96"
+sha256 = "ea0c9a0384df69ed86a943a15cde37d0360b82491b3910dc2215e202e62b5b02"
 
 [[packages]]
 name = "installer"
@@ -366,7 +375,7 @@ sha256 = "85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"
 
 [[packages]]
 name = "linkify-it-py"
-version = "2.1.0"
+version = "2.1.1"
 marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.10"
 dependencies = [
@@ -375,22 +384,22 @@ dependencies = [
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "linkify_it_py-2.1.0.tar.gz"
-upload-time = 2026-03-01 07:48:47.683141+00:00
-url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz"
-size = 29158
+name = "linkify_it_py-2.1.1.tar.gz"
+upload-time = 2026-08-24 17:16:57.028452+00:00
+url = "https://files.pythonhosted.org/packages/53/3e/79f35b8c31a1881893b7e62be80b2573f06e38db47c33065749293ee1b97/linkify_it_py-2.1.1.tar.gz"
+size = 30889
 
 [packages.sdist.hashes]
-sha256 = "43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b"
+sha256 = "a78f40fee177eb912e9d2375074108378523c38d3fde5d3ee804f465b6cfbfee"
 
 [[packages.wheels]]
-name = "linkify_it_py-2.1.0-py3-none-any.whl"
-upload-time = 2026-03-01 07:48:46.098014+00:00
-url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl"
-size = 19878
+name = "linkify_it_py-2.1.1-py3-none-any.whl"
+upload-time = 2026-08-24 17:16:55.965173+00:00
+url = "https://files.pythonhosted.org/packages/eb/3d/e34b19cd144071c583317268c4feb2c59c03ac57eef69753410c7abb11c0/linkify_it_py-2.1.1-py3-none-any.whl"
+size = 20532
 
 [packages.wheels.hashes]
-sha256 = "0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e"
+sha256 = "8539a6b470efce90ba9b69e39b848e5b15b7ad89f7f98ca17d3532c243f987dc"
 
 [[packages]]
 name = "markdown-it-py"
@@ -557,28 +566,28 @@ sha256 = "d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c"
 
 [[packages]]
 name = "pygments"
-version = "2.20.0"
+version = "2.21.0"
 marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "pygments-2.20.0.tar.gz"
-upload-time = 2026-03-29 13:29:33.898791+00:00
-url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz"
-size = 4955991
+name = "pygments-2.21.0.tar.gz"
+upload-time = 2026-08-17 08:02:48.824391+00:00
+url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz"
+size = 5005329
 
 [packages.sdist.hashes]
-sha256 = "6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"
+sha256 = "610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c"
 
 [[packages.wheels]]
-name = "pygments-2.20.0-py3-none-any.whl"
-upload-time = 2026-03-29 13:29:30.038266+00:00
-url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl"
-size = 1231151
+name = "pygments-2.21.0-py3-none-any.whl"
+upload-time = 2026-08-17 08:02:44.912148+00:00
+url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl"
+size = 1250147
 
 [packages.wheels.hashes]
-sha256 = "81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"
+sha256 = "2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9"
 
 [[packages]]
 name = "pyproject-hooks"
@@ -712,28 +721,28 @@ sha256 = "7e207fa178741da09cdee59d3ecec3827ad5f92b1fc5c9ff3755b639f71f5752"
 
 [[packages]]
 name = "soupsieve"
-version = "2.9.1"
+version = "2.9.2"
 marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.10"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "soupsieve-2.9.1.tar.gz"
-upload-time = 2026-07-21 16:57:17.452293+00:00
-url = "https://files.pythonhosted.org/packages/d9/38/e12680bbe6b4f8f3d17adcaf38d26850aa756c85cf4a80e79fc12a018fe8/soupsieve-2.9.1.tar.gz"
-size = 122261
+name = "soupsieve-2.9.2.tar.gz"
+upload-time = 2026-08-07 00:57:24.801188+00:00
+url = "https://files.pythonhosted.org/packages/69/99/a6ca3beb3ccacb41fb3321d8a60e5566f9e6467601ef8eba6a17e1b89778/soupsieve-2.9.2.tar.gz"
+size = 122445
 
 [packages.sdist.hashes]
-sha256 = "c33e6605bbc71dd628b00c632d58ae607c22bade247e52553928f83bbb75b4ba"
+sha256 = "4a55d8cf158a9c2e587fa4922f1bbb91d68ac829e2d6f25403a85747c71daf74"
 
 [[packages.wheels]]
-name = "soupsieve-2.9.1-py3-none-any.whl"
-upload-time = 2026-07-21 16:57:16.421373+00:00
-url = "https://files.pythonhosted.org/packages/0f/2c/437fe806897c2d6cfdc3ee43a18da8bf8e568530a4ae9bac781541ca9896/soupsieve-2.9.1-py3-none-any.whl"
-size = 37404
+name = "soupsieve-2.9.2-py3-none-any.whl"
+upload-time = 2026-08-07 00:57:23.524076+00:00
+url = "https://files.pythonhosted.org/packages/eb/dc/ad025c1ee131eba60c69f4dd5779b18fcf1e6b21a343e2162a84d5d133c7/soupsieve-2.9.2-py3-none-any.whl"
+size = 37370
 
 [packages.wheels.hashes]
-sha256 = "4f4477399246b7a0c720a88ca2454b11cd6bb9ae4c9d170140786e916776c14c"
+sha256 = "8089a26fd974ca7a1f30276d3d8492ab266ab15af581642dfe8aa162e0c1c823"
 
 [[packages]]
 name = "sphinx"
@@ -1168,7 +1177,7 @@ sha256 = "9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
 
 [tool.nab]
 nab-version = "0.0.16.dev0"
-created-at = 2026-08-12 13:49:36.513520+00:00
+created-at = 2026-09-02 00:02:56.540498+00:00
 command-line = [
     "nab",
     "lock",
@@ -1183,6 +1192,7 @@ command-line = [
     "specific",
     "--python",
     "3.13",
+    "--upgrade",
 ]
 input-path = "pyproject.toml"
 mode = "specific"

--- a/.github/requirements/pylock.nox.toml
+++ b/.github/requirements/pylock.nox.toml
@@ -42,28 +42,28 @@ created-by = "nab"
 
 [[packages]]
 name = "argcomplete"
-version = "3.7.0"
+version = "3.7.2"
 marker = "\"nox\" in dependency_groups"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "argcomplete-3.7.0.tar.gz"
-upload-time = 2026-06-30 22:28:22.249666+00:00
-url = "https://files.pythonhosted.org/packages/95/c0/c8e94135e66fabf89a120d9b4b123fe6993506beca6c1938a74c24cfa5fd/argcomplete-3.7.0.tar.gz"
-size = 73284
+name = "argcomplete-3.7.2.tar.gz"
+upload-time = 2026-08-06 04:53:21.662042+00:00
+url = "https://files.pythonhosted.org/packages/87/6f/5a73f04007ca950701765949209f068da628bd11f9c2da287278ce91e0ee/argcomplete-3.7.2.tar.gz"
+size = 74473
 
 [packages.sdist.hashes]
-sha256 = "afde224f753f874807b1dc1414e883ab8fe0cda9c04807b6047dcb8e1ac23913"
+sha256 = "aad8b69a0b9969edb62db0d1752354c0d50717b10e0cbb00e2a958381b9fc6b9"
 
 [[packages.wheels]]
-name = "argcomplete-3.7.0-py3-none-any.whl"
-upload-time = 2026-06-30 22:28:20.547827+00:00
-url = "https://files.pythonhosted.org/packages/12/f6/5b8ec087cd9cfa9449491ec83f76fb6b7006b4dff57d2ba8aaab330fe8e4/argcomplete-3.7.0-py3-none-any.whl"
-size = 42575
+name = "argcomplete-3.7.2-py3-none-any.whl"
+upload-time = 2026-08-06 04:53:20.246664+00:00
+url = "https://files.pythonhosted.org/packages/46/bd/551ee6af426af84ca33e02622be722925c196608e9127d731ef17c47f06e/argcomplete-3.7.2-py3-none-any.whl"
+size = 43294
 
 [packages.wheels.hashes]
-sha256 = "d8f0f22d2a8a7caa383be1e22b6caf1ecaf0ebd10d8f83cc125e36540c95830c"
+sha256 = "6029205678bdd9c1c728a155f5f9ecf5812393f969eef58807641a2bc2aa5b19"
 
 [[packages]]
 name = "attrs"
@@ -176,9 +176,9 @@ sha256 = "30d392604e9110045a2c2aeefc27d7a017abbab63f3a8aee594eac0801df784e"
 
 [[packages]]
 name = "dependency-groups"
-version = "1.3.1"
+version = "1.3.2"
 marker = "\"nox\" in dependency_groups"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     { name = "packaging" },
     { name = "tomli" },
@@ -186,22 +186,22 @@ dependencies = [
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "dependency_groups-1.3.1.tar.gz"
-upload-time = 2025-05-02 00:34:29.452155+00:00
-url = "https://files.pythonhosted.org/packages/62/55/f054de99871e7beb81935dea8a10b90cd5ce42122b1c3081d5282fdb3621/dependency_groups-1.3.1.tar.gz"
-size = 10093
+name = "dependency_groups-1.3.2.tar.gz"
+upload-time = 2026-08-22 02:43:30.137764+00:00
+url = "https://files.pythonhosted.org/packages/b5/16/65e61d8e837e0d70a99a0d4dd76e2af53357c3a03ed1db8ad9b5786d7f25/dependency_groups-1.3.2.tar.gz"
+size = 13309
 
 [packages.sdist.hashes]
-sha256 = "78078301090517fd938c19f64a53ce98c32834dfe0dee6b88004a569a6adfefd"
+sha256 = "c81831f43828dbc3987ee247eb198241a0152b8e7ceab10977cc3808eb388ac7"
 
 [[packages.wheels]]
-name = "dependency_groups-1.3.1-py3-none-any.whl"
-upload-time = 2025-05-02 00:34:27.085036+00:00
-url = "https://files.pythonhosted.org/packages/99/c7/d1ec24fb280caa5a79b6b950db565dab30210a66259d17d5bb2b3a9f878d/dependency_groups-1.3.1-py3-none-any.whl"
-size = 8664
+name = "dependency_groups-1.3.2-py3-none-any.whl"
+upload-time = 2026-08-22 02:43:28.853754+00:00
+url = "https://files.pythonhosted.org/packages/a1/e4/da5f2f176050efcfb9222a76a3e81c41f69f775be8e563b76ca4292a134f/dependency_groups-1.3.2-py3-none-any.whl"
+size = 9802
 
 [packages.wheels.hashes]
-sha256 = "51aeaa0dfad72430fcfb7bcdbefbd75f3792e5919563077f30bc0d73f4493030"
+sha256 = "8c337f7b92445823b0d0ea507f611390c58dcd2112be00aebcd738a2ca7a1c64"
 
 [[packages]]
 name = "distlib"
@@ -229,28 +229,28 @@ sha256 = "4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b"
 
 [[packages]]
 name = "filelock"
-version = "3.32.2"
+version = "3.32.4"
 marker = "\"nox\" in dependency_groups"
 requires-python = ">=3.10"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "filelock-3.32.2.tar.gz"
-upload-time = 2026-07-29 22:46:04.895806+00:00
-url = "https://files.pythonhosted.org/packages/f6/57/3ba6e6cb097f85b855b00163d169f35365f44277df044dcf96d55b8f62a3/filelock-3.32.2.tar.gz"
-size = 217172
+name = "filelock-3.32.4.tar.gz"
+upload-time = 2026-08-23 17:37:55.363520+00:00
+url = "https://files.pythonhosted.org/packages/6d/30/03b03951873a1a0ffc7e8ca0e10c15597b59e8d0e39260704cd2ea087bc4/filelock-3.32.4.tar.gz"
+size = 222126
 
 [packages.sdist.hashes]
-sha256 = "c33351e1f49cae33414acbc6d56784e6ecee82514ec90795da1161fc4836b5b8"
+sha256 = "2bde2e4cf732e0153406d8a7bc80620ecf5e621fe0d25e41143c4e3b4733ff30"
 
 [[packages.wheels]]
-name = "filelock-3.32.2-py3-none-any.whl"
-upload-time = 2026-07-29 22:46:03.520503+00:00
-url = "https://files.pythonhosted.org/packages/c1/e8/72f8cef9fdfeffe06213fe8508039396ee48daa0e3259457ed766173bfd6/filelock-3.32.2-py3-none-any.whl"
-size = 98830
+name = "filelock-3.32.4-py3-none-any.whl"
+upload-time = 2026-08-23 17:37:53.913430+00:00
+url = "https://files.pythonhosted.org/packages/01/a4/9b63d595d748e3aff8812b65eacc1a2c4bd90b7c2012e08e72373b4835eb/filelock-3.32.4-py3-none-any.whl"
+size = 99864
 
 [packages.wheels.hashes]
-sha256 = "87dd94cf281e586d135fa51132b8e3d9a598b316e90377a288663c9321036c82"
+sha256 = "22e58ca3b1ae3b98993b762d7338367ae64fe50252bf78d59da3bfebcdf1cedd"
 
 [[packages]]
 name = "humanize"
@@ -331,7 +331,7 @@ sha256 = "011d045df8b954ced7dde3a7e42ae4418da40ecda7990f2d11d5ed7c146fd98b"
 
 [[packages]]
 name = "nox"
-version = "2026.7.11"
+version = "2026.8.17"
 marker = "\"nox\" in dependency_groups"
 requires-python = ">=3.10"
 dependencies = [
@@ -341,28 +341,30 @@ dependencies = [
     { name = "dependency-groups" },
     { name = "humanize" },
     { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
     { name = "tomli" },
     { name = "virtualenv" },
 ]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "nox-2026.7.11.tar.gz"
-upload-time = 2026-07-12 00:32:19.859182+00:00
-url = "https://files.pythonhosted.org/packages/75/bf/aafe066019cb1bcd3e1c22957412d6eb560bd6553c1afd28502168a51418/nox-2026.7.11.tar.gz"
-size = 4042267
+name = "nox-2026.8.17.tar.gz"
+upload-time = 2026-08-18 03:09:57.078816+00:00
+url = "https://files.pythonhosted.org/packages/be/65/4cef8ae8f6dbcb5753b202e46791277f1ea0b4a0650d1a6cb940c468b143/nox-2026.8.17.tar.gz"
+size = 4076047
 
 [packages.sdist.hashes]
-sha256 = "dec9bd2c854540a2d5c0b841eaaf1d23a7c26cd90af36d9f1f1668b34524bfd9"
+sha256 = "8d9c69c9b996a59db1eb2c6968deaebc2edbc55317d205981bbc4a37351d3f2e"
 
 [[packages.wheels]]
-name = "nox-2026.7.11-py3-none-any.whl"
-upload-time = 2026-07-12 00:32:18.070783+00:00
-url = "https://files.pythonhosted.org/packages/a0/70/4b459b66bbd7c9be3c9b15f2cf1605bbe10f58c6395fd99a59a21f3c0777/nox-2026.7.11-py3-none-any.whl"
-size = 77265
+name = "nox-2026.8.17-py3-none-any.whl"
+upload-time = 2026-08-18 03:09:55.684784+00:00
+url = "https://files.pythonhosted.org/packages/81/71/e0829a0500646070e98bc4442afa2917bfe5b6f1289511d8de853ae86497/nox-2026.8.17-py3-none-any.whl"
+size = 94839
 
 [packages.wheels.hashes]
-sha256 = "f5e811693ee8374d269396204eb39990d2084da67ed968239f94301805c9a169"
+sha256 = "a96a5286007cbc0d1eb1930e85738668f6722adba1ffaa48287296a96963086e"
 
 [[packages]]
 name = "packaging"
@@ -390,28 +392,28 @@ sha256 = "d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c"
 
 [[packages]]
 name = "platformdirs"
-version = "4.11.0"
+version = "4.11.4"
 marker = "\"nox\" in dependency_groups"
 requires-python = ">=3.10"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "platformdirs-4.11.0.tar.gz"
-upload-time = 2026-07-21 13:09:36.565916+00:00
-url = "https://files.pythonhosted.org/packages/78/9b/560e4be8e26f6fd133a03630a8df0c663b9e8d61b4ade152b72005aec83b/platformdirs-4.11.0.tar.gz"
-size = 31953
+name = "platformdirs-4.11.4.tar.gz"
+upload-time = 2026-08-24 14:53:49.676697+00:00
+url = "https://files.pythonhosted.org/packages/50/bb/ebc6636e1ae41314f796ebb7215fd28febb45f9aac72f2b04cb74b5071dc/platformdirs-4.11.4.tar.gz"
+size = 34079
 
 [packages.sdist.hashes]
-sha256 = "0555d18370482847566ffabcaa53ad7c6c1c29f195989ae1ed634a05f76ea1e0"
+sha256 = "f3373be828247211d0febabea97e238c3dfde8a60b3c90c32756fb52cb21556d"
 
 [[packages.wheels]]
-name = "platformdirs-4.11.0-py3-none-any.whl"
-upload-time = 2026-07-21 13:09:35.422952+00:00
-url = "https://files.pythonhosted.org/packages/7d/68/d8d58938dfb1370b266a1a729e6d77a985be23689a0496498ee17b2cbf90/platformdirs-4.11.0-py3-none-any.whl"
-size = 23247
+name = "platformdirs-4.11.4-py3-none-any.whl"
+upload-time = 2026-08-24 14:53:48.406471+00:00
+url = "https://files.pythonhosted.org/packages/28/be/0ff05fcd2938fb58ad9219bd54135968342d214737e012d62d43f06a2dd6/platformdirs-4.11.4-py3-none-any.whl"
+size = 23741
 
 [packages.wheels.hashes]
-sha256 = "360ccded2b7fce0af0ff80cc8f5942a1c5d99b0e856033acb030bfc634709e74"
+sha256 = "e34ff91a24bcddc6d939b878bdf3f5c437c9c46fe9e212b1bf455fdf1ee57586"
 
 [[packages]]
 name = "pyproject-hooks"
@@ -439,7 +441,7 @@ sha256 = "9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913"
 
 [[packages]]
 name = "python-discovery"
-version = "1.5.1"
+version = "1.5.3"
 marker = "\"nox\" in dependency_groups"
 requires-python = ">=3.8"
 dependencies = [
@@ -448,22 +450,22 @@ dependencies = [
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "python_discovery-1.5.1.tar.gz"
-upload-time = 2026-07-31 22:06:02.480231+00:00
-url = "https://files.pythonhosted.org/packages/04/b7/1581a8103855c43567776aa34135e5ec3c597346c23bfd10c7eb5e0b10a4/python_discovery-1.5.1.tar.gz"
-size = 77200
+name = "python_discovery-1.5.3.tar.gz"
+upload-time = 2026-08-24 14:48:46.396050+00:00
+url = "https://files.pythonhosted.org/packages/b2/8f/3c92c45737f654f2488ab3662b7604a55d3d35146d37c9ce80f5c95b95a6/python_discovery-1.5.3.tar.gz"
+size = 82477
 
 [packages.sdist.hashes]
-sha256 = "e2ea8b884cd1701f386eda8cf327b87743f1dc21b7f784470799537d95635384"
+sha256 = "e500eb24025fb7c4876c1fdcfbafd9028a10c71b661aee38cb6fb0de594518c1"
 
 [[packages.wheels]]
-name = "python_discovery-1.5.1-py3-none-any.whl"
-upload-time = 2026-07-31 22:06:01.116925+00:00
-url = "https://files.pythonhosted.org/packages/6a/07/a89b539750a159d5101c4eb9fc84e2961f65cefbd5e0b7440b284471c0b0/python_discovery-1.5.1-py3-none-any.whl"
-size = 35752
+name = "python_discovery-1.5.3-py3-none-any.whl"
+upload-time = 2026-08-24 14:48:45.305622+00:00
+url = "https://files.pythonhosted.org/packages/30/12/823d9a321904ccfd2969a24b84fdfd1e6614c707ec569c62879bf1dbc6c5/python_discovery-1.5.3-py3-none-any.whl"
+size = 38290
 
 [packages.wheels.hashes]
-sha256 = "ac07f44cade589d954e9d6a1e1468539fdddd2cf676beb51da73e0f156b7c932"
+sha256 = "8305296358f1aa2ed302a25b84be7df84fef8ca47c7dce2da63cb7325333044e"
 
 [[packages]]
 name = "tomli"
@@ -767,7 +769,7 @@ sha256 = "9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
 
 [[packages]]
 name = "virtualenv"
-version = "21.7.1"
+version = "21.7.5"
 marker = "\"nox\" in dependency_groups"
 requires-python = ">=3.9"
 dependencies = [
@@ -780,22 +782,22 @@ dependencies = [
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "virtualenv-21.7.1.tar.gz"
-upload-time = 2026-07-30 15:40:36.360035+00:00
-url = "https://files.pythonhosted.org/packages/ea/fa/18004e5cb15541ad2a68ff219c755233b012b12d4ec8663d06a258082bec/virtualenv-21.7.1.tar.gz"
-size = 5525237
+name = "virtualenv-21.7.5.tar.gz"
+upload-time = 2026-08-25 05:39:16.140053+00:00
+url = "https://files.pythonhosted.org/packages/1d/60/fc54e876e34f94dd0cf0185aaecfd4bfa906653f003d9b2fb21428642fca/virtualenv-21.7.5.tar.gz"
+size = 5346743
 
 [packages.sdist.hashes]
-sha256 = "d0dbfaa5483487baea28d7210ef8d24c9d1bd0f10f449eeb215568825a9b334e"
+sha256 = "a73c4246fba3c8901ff9717399f466e00eeca5a3834981f1a6ebb4f1e94de2f8"
 
 [[packages.wheels]]
-name = "virtualenv-21.7.1-py3-none-any.whl"
-upload-time = 2026-07-30 15:40:34.512679+00:00
-url = "https://files.pythonhosted.org/packages/4b/a7/ded126c19495158a05c7202b3389139839d4cf78d622d453867778e0f7a8/virtualenv-21.7.1-py3-none-any.whl"
-size = 5504576
+name = "virtualenv-21.7.5-py3-none-any.whl"
+upload-time = 2026-08-25 05:39:14.229247+00:00
+url = "https://files.pythonhosted.org/packages/ca/d8/401141bf45637be916c86d325bd821c5838c7eff83294b934cd94e774e4f/virtualenv-21.7.5-py3-none-any.whl"
+size = 5324697
 
 [packages.wheels.hashes]
-sha256 = "6394973f990536e34c05157179146c020284c42fe01da1dfeb0ba16c345280d9"
+sha256 = "e36ca889510ab6cb0b1dca93c59e5431dd4422a3c88f487358d470c90af8c07a"
 
 [[packages]]
 name = "zipp"
@@ -824,7 +826,7 @@ sha256 = "25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f"
 
 [tool.nab]
 nab-version = "0.0.16.dev0"
-created-at = 2026-08-12 13:49:37.438752+00:00
+created-at = 2026-09-02 00:02:57.358225+00:00
 command-line = [
     "nab",
     "lock",
@@ -835,6 +837,7 @@ command-line = [
     "--no-emit-workspace",
     "--output",
     ".github/requirements/pylock.nox.toml",
+    "--upgrade",
 ]
 input-path = "pyproject.toml"
 mode = "universal"

--- a/.github/requirements/pylock.pre-commit.toml
+++ b/.github/requirements/pylock.pre-commit.toml
@@ -147,28 +147,28 @@ sha256 = "4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b"
 
 [[packages]]
 name = "filelock"
-version = "3.32.2"
+version = "3.32.4"
 marker = "\"pre-commit\" in dependency_groups"
 requires-python = ">=3.10"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "filelock-3.32.2.tar.gz"
-upload-time = 2026-07-29 22:46:04.895806+00:00
-url = "https://files.pythonhosted.org/packages/f6/57/3ba6e6cb097f85b855b00163d169f35365f44277df044dcf96d55b8f62a3/filelock-3.32.2.tar.gz"
-size = 217172
+name = "filelock-3.32.4.tar.gz"
+upload-time = 2026-08-23 17:37:55.363520+00:00
+url = "https://files.pythonhosted.org/packages/6d/30/03b03951873a1a0ffc7e8ca0e10c15597b59e8d0e39260704cd2ea087bc4/filelock-3.32.4.tar.gz"
+size = 222126
 
 [packages.sdist.hashes]
-sha256 = "c33351e1f49cae33414acbc6d56784e6ecee82514ec90795da1161fc4836b5b8"
+sha256 = "2bde2e4cf732e0153406d8a7bc80620ecf5e621fe0d25e41143c4e3b4733ff30"
 
 [[packages.wheels]]
-name = "filelock-3.32.2-py3-none-any.whl"
-upload-time = 2026-07-29 22:46:03.520503+00:00
-url = "https://files.pythonhosted.org/packages/c1/e8/72f8cef9fdfeffe06213fe8508039396ee48daa0e3259457ed766173bfd6/filelock-3.32.2-py3-none-any.whl"
-size = 98830
+name = "filelock-3.32.4-py3-none-any.whl"
+upload-time = 2026-08-23 17:37:53.913430+00:00
+url = "https://files.pythonhosted.org/packages/01/a4/9b63d595d748e3aff8812b65eacc1a2c4bd90b7c2012e08e72373b4835eb/filelock-3.32.4-py3-none-any.whl"
+size = 99864
 
 [packages.wheels.hashes]
-sha256 = "87dd94cf281e586d135fa51132b8e3d9a598b316e90377a288663c9321036c82"
+sha256 = "22e58ca3b1ae3b98993b762d7338367ae64fe50252bf78d59da3bfebcdf1cedd"
 
 [[packages]]
 name = "identify"
@@ -298,32 +298,32 @@ sha256 = "d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c"
 
 [[packages]]
 name = "platformdirs"
-version = "4.11.0"
+version = "4.11.4"
 marker = "\"pre-commit\" in dependency_groups"
 requires-python = ">=3.10"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "platformdirs-4.11.0.tar.gz"
-upload-time = 2026-07-21 13:09:36.565916+00:00
-url = "https://files.pythonhosted.org/packages/78/9b/560e4be8e26f6fd133a03630a8df0c663b9e8d61b4ade152b72005aec83b/platformdirs-4.11.0.tar.gz"
-size = 31953
+name = "platformdirs-4.11.4.tar.gz"
+upload-time = 2026-08-24 14:53:49.676697+00:00
+url = "https://files.pythonhosted.org/packages/50/bb/ebc6636e1ae41314f796ebb7215fd28febb45f9aac72f2b04cb74b5071dc/platformdirs-4.11.4.tar.gz"
+size = 34079
 
 [packages.sdist.hashes]
-sha256 = "0555d18370482847566ffabcaa53ad7c6c1c29f195989ae1ed634a05f76ea1e0"
+sha256 = "f3373be828247211d0febabea97e238c3dfde8a60b3c90c32756fb52cb21556d"
 
 [[packages.wheels]]
-name = "platformdirs-4.11.0-py3-none-any.whl"
-upload-time = 2026-07-21 13:09:35.422952+00:00
-url = "https://files.pythonhosted.org/packages/7d/68/d8d58938dfb1370b266a1a729e6d77a985be23689a0496498ee17b2cbf90/platformdirs-4.11.0-py3-none-any.whl"
-size = 23247
+name = "platformdirs-4.11.4-py3-none-any.whl"
+upload-time = 2026-08-24 14:53:48.406471+00:00
+url = "https://files.pythonhosted.org/packages/28/be/0ff05fcd2938fb58ad9219bd54135968342d214737e012d62d43f06a2dd6/platformdirs-4.11.4-py3-none-any.whl"
+size = 23741
 
 [packages.wheels.hashes]
-sha256 = "360ccded2b7fce0af0ff80cc8f5942a1c5d99b0e856033acb030bfc634709e74"
+sha256 = "e34ff91a24bcddc6d939b878bdf3f5c437c9c46fe9e212b1bf455fdf1ee57586"
 
 [[packages]]
 name = "pre-commit"
-version = "4.6.1"
+version = "4.6.2"
 marker = "\"pre-commit\" in dependency_groups"
 requires-python = ">=3.10"
 dependencies = [
@@ -336,22 +336,22 @@ dependencies = [
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "pre_commit-4.6.1.tar.gz"
-upload-time = 2026-07-21 20:56:58.225199+00:00
-url = "https://files.pythonhosted.org/packages/25/3a/ddb78f32a0814e66b18a099377a106a2dcdce92d86a034d69d65df9b256e/pre_commit-4.6.1.tar.gz"
-size = 198646
+name = "pre_commit-4.6.2.tar.gz"
+upload-time = 2026-08-10 22:07:18.421719+00:00
+url = "https://files.pythonhosted.org/packages/74/89/1f3e8e1fc3e97de0fa963495832f581f025f29471602a309e48808244292/pre_commit-4.6.2.tar.gz"
+size = 198670
 
 [packages.sdist.hashes]
-sha256 = "03e809865c7d178b9979d06c761fcbfe6808fdaded8581a745bb110e52050421"
+sha256 = "8f5d7bfb021ecdbcd9d49d89847082dd24172ccde534390081a679ad046e2441"
 
 [[packages.wheels]]
-name = "pre_commit-4.6.1-py2.py3-none-any.whl"
-upload-time = 2026-07-21 20:56:57.064358+00:00
-url = "https://files.pythonhosted.org/packages/fb/49/bc925106abcdac498074f2cbe6137e94e09f418dd2b7775df5b577dc0313/pre_commit-4.6.1-py2.py3-none-any.whl"
-size = 226186
+name = "pre_commit-4.6.2-py2.py3-none-any.whl"
+upload-time = 2026-08-10 22:07:16.942290+00:00
+url = "https://files.pythonhosted.org/packages/45/e2/bbb7129c9e7999a6b8ee9cca3b66486c25c423ab5a75f34071798b74ce94/pre_commit-4.6.2-py2.py3-none-any.whl"
+size = 226202
 
 [packages.wheels.hashes]
-sha256 = "0e3b2942510d1fb34eec167a3ec57331bf8442122f1153a9fb8b58f5c49b2717"
+sha256 = "e2dde9a75d3bce11bd3831c26d134df00a2803c1d818be6a0383c3dcda25dc4e"
 
 [[packages]]
 name = "pyproject-hooks"
@@ -379,7 +379,7 @@ sha256 = "9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913"
 
 [[packages]]
 name = "python-discovery"
-version = "1.5.1"
+version = "1.5.3"
 marker = "\"pre-commit\" in dependency_groups"
 requires-python = ">=3.8"
 dependencies = [
@@ -388,22 +388,22 @@ dependencies = [
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "python_discovery-1.5.1.tar.gz"
-upload-time = 2026-07-31 22:06:02.480231+00:00
-url = "https://files.pythonhosted.org/packages/04/b7/1581a8103855c43567776aa34135e5ec3c597346c23bfd10c7eb5e0b10a4/python_discovery-1.5.1.tar.gz"
-size = 77200
+name = "python_discovery-1.5.3.tar.gz"
+upload-time = 2026-08-24 14:48:46.396050+00:00
+url = "https://files.pythonhosted.org/packages/b2/8f/3c92c45737f654f2488ab3662b7604a55d3d35146d37c9ce80f5c95b95a6/python_discovery-1.5.3.tar.gz"
+size = 82477
 
 [packages.sdist.hashes]
-sha256 = "e2ea8b884cd1701f386eda8cf327b87743f1dc21b7f784470799537d95635384"
+sha256 = "e500eb24025fb7c4876c1fdcfbafd9028a10c71b661aee38cb6fb0de594518c1"
 
 [[packages.wheels]]
-name = "python_discovery-1.5.1-py3-none-any.whl"
-upload-time = 2026-07-31 22:06:01.116925+00:00
-url = "https://files.pythonhosted.org/packages/6a/07/a89b539750a159d5101c4eb9fc84e2961f65cefbd5e0b7440b284471c0b0/python_discovery-1.5.1-py3-none-any.whl"
-size = 35752
+name = "python_discovery-1.5.3-py3-none-any.whl"
+upload-time = 2026-08-24 14:48:45.305622+00:00
+url = "https://files.pythonhosted.org/packages/30/12/823d9a321904ccfd2969a24b84fdfd1e6614c707ec569c62879bf1dbc6c5/python_discovery-1.5.3-py3-none-any.whl"
+size = 38290
 
 [packages.wheels.hashes]
-sha256 = "ac07f44cade589d954e9d6a1e1468539fdddd2cf676beb51da73e0f156b7c932"
+sha256 = "8305296358f1aa2ed302a25b84be7df84fef8ca47c7dce2da63cb7325333044e"
 
 [[packages]]
 name = "pyyaml"
@@ -948,7 +948,7 @@ sha256 = "9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
 
 [[packages]]
 name = "virtualenv"
-version = "21.7.1"
+version = "21.7.5"
 marker = "\"pre-commit\" in dependency_groups"
 requires-python = ">=3.9"
 dependencies = [
@@ -961,22 +961,22 @@ dependencies = [
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "virtualenv-21.7.1.tar.gz"
-upload-time = 2026-07-30 15:40:36.360035+00:00
-url = "https://files.pythonhosted.org/packages/ea/fa/18004e5cb15541ad2a68ff219c755233b012b12d4ec8663d06a258082bec/virtualenv-21.7.1.tar.gz"
-size = 5525237
+name = "virtualenv-21.7.5.tar.gz"
+upload-time = 2026-08-25 05:39:16.140053+00:00
+url = "https://files.pythonhosted.org/packages/1d/60/fc54e876e34f94dd0cf0185aaecfd4bfa906653f003d9b2fb21428642fca/virtualenv-21.7.5.tar.gz"
+size = 5346743
 
 [packages.sdist.hashes]
-sha256 = "d0dbfaa5483487baea28d7210ef8d24c9d1bd0f10f449eeb215568825a9b334e"
+sha256 = "a73c4246fba3c8901ff9717399f466e00eeca5a3834981f1a6ebb4f1e94de2f8"
 
 [[packages.wheels]]
-name = "virtualenv-21.7.1-py3-none-any.whl"
-upload-time = 2026-07-30 15:40:34.512679+00:00
-url = "https://files.pythonhosted.org/packages/4b/a7/ded126c19495158a05c7202b3389139839d4cf78d622d453867778e0f7a8/virtualenv-21.7.1-py3-none-any.whl"
-size = 5504576
+name = "virtualenv-21.7.5-py3-none-any.whl"
+upload-time = 2026-08-25 05:39:14.229247+00:00
+url = "https://files.pythonhosted.org/packages/ca/d8/401141bf45637be916c86d325bd821c5838c7eff83294b934cd94e774e4f/virtualenv-21.7.5-py3-none-any.whl"
+size = 5324697
 
 [packages.wheels.hashes]
-sha256 = "6394973f990536e34c05157179146c020284c42fe01da1dfeb0ba16c345280d9"
+sha256 = "e36ca889510ab6cb0b1dca93c59e5431dd4422a3c88f487358d470c90af8c07a"
 
 [[packages]]
 name = "zipp"
@@ -1005,7 +1005,7 @@ sha256 = "25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f"
 
 [tool.nab]
 nab-version = "0.0.16.dev0"
-created-at = 2026-08-12 13:49:26.545473+00:00
+created-at = 2026-09-02 00:02:44.308932+00:00
 command-line = [
     "nab",
     "lock",
@@ -1016,6 +1016,7 @@ command-line = [
     "--no-emit-workspace",
     "--output",
     ".github/requirements/pylock.pre-commit.toml",
+    "--upgrade",
 ]
 input-path = "pyproject.toml"
 mode = "universal"

--- a/.github/requirements/pylock.release.toml
+++ b/.github/requirements/pylock.release.toml
@@ -392,208 +392,244 @@ sha256 = "3222ba5d678f80a030e6afbcc33dc1ae5cb45facabb61cee2c7016b8432fde48"
 
 [[packages]]
 name = "charset-normalizer"
-version = "3.4.9"
+version = "3.5.1"
 marker = "\"release\" in dependency_groups"
 requires-python = ">=3.7"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "charset_normalizer-3.4.9.tar.gz"
-upload-time = 2026-07-07 14:34:58.454748+00:00
-url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz"
-size = 152439
+name = "charset_normalizer-3.5.1.tar.gz"
+upload-time = 2026-08-15 08:20:44.807628+00:00
+url = "https://files.pythonhosted.org/packages/e5/3f/143b048436775b0f76ac3eec145c019e8173ccc2885c8f20319b996d5e83/charset_normalizer-3.5.1.tar.gz"
+size = 171764
 
 [packages.sdist.hashes]
-sha256 = "673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b"
+sha256 = "6117b84ea48435e5356dc737f5121485c30920ba43375fa7b434fd753df0eac3"
 
 [[packages.wheels]]
-name = "charset_normalizer-3.4.9-cp310-cp310-macosx_10_9_universal2.whl"
-upload-time = 2026-07-07 14:32:36.236156+00:00
-url = "https://files.pythonhosted.org/packages/ad/81/8e983840c6e5b93b33c2ba81aa3d52c2e42f0e9a690ce7607a2e61da4a5c/charset_normalizer-3.4.9-cp310-cp310-macosx_10_9_universal2.whl"
-size = 322240
+name = "charset_normalizer-3.5.1-cp310-cp310-macosx_10_9_universal2.whl"
+upload-time = 2026-08-15 08:16:22.964547+00:00
+url = "https://files.pythonhosted.org/packages/71/aa/554e2614f38fc34c58ff1d0911ae8535ad2516440d5482d76fe59f1088b0/charset_normalizer-3.5.1-cp310-cp310-macosx_10_9_universal2.whl"
+size = 369072
 
 [packages.wheels.hashes]
-sha256 = "cd6280cf040f233bd7d3407b743b4b4c74f70e8e1c4199cb112a62c941c0772a"
+sha256 = "d1ee1e296209fdce05b81b663250eefa02213a2da7b41bf26f7829b8ba3545aa"
 
 [[packages.wheels]]
-name = "charset_normalizer-3.4.9-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-07-07 14:32:38.142295+00:00
-url = "https://files.pythonhosted.org/packages/de/d1/b4319dc3229d8272fba305e206fc0a148e2de8d4087917ce62ae6382f359/charset_normalizer-3.4.9-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 216475
+name = "charset_normalizer-3.5.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-08-15 08:16:24.810803+00:00
+url = "https://files.pythonhosted.org/packages/03/6d/439231dfc3ccfa6f8c06477b7da2219cbd41a2de3d49084df8ec7b5100f2/charset_normalizer-3.5.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 251142
 
 [packages.wheels.hashes]
-sha256 = "aa99adc8f081b475a12843953db36831eaf83ec33eb46a90629ca6a5de45a616"
+sha256 = "e9fbdce1e47394b09bc9f26ab117dfc8d6491977a11d86f592bb42c779db2fda"
 
 [[packages.wheels]]
-name = "charset_normalizer-3.4.9-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-07-07 14:32:42.592821+00:00
-url = "https://files.pythonhosted.org/packages/e8/5f/b98b8da398637b551e427e7be922bdec19177dc54d6811dcdaa503f23aac/charset_normalizer-3.4.9-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 223817
+name = "charset_normalizer-3.5.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-08-15 08:16:30.722857+00:00
+url = "https://files.pythonhosted.org/packages/32/cd/4f564b8f132de25db594efc706897069f016790cea63a5669c9df2675f64/charset_normalizer-3.5.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 261644
 
 [packages.wheels.hashes]
-sha256 = "9bb41182d93ea91f60b4bc8fbf4c820c69ef8a12ab2d917f3f1834f1acad07e8"
+sha256 = "96eefc178f8636b9c760c5829345307fd81cfae9ab1e80997dbddeb0f54ee9a3"
 
 [[packages.wheels]]
-name = "charset_normalizer-3.4.9-cp310-cp310-win_amd64.whl"
-upload-time = 2026-07-07 14:32:53.193825+00:00
-url = "https://files.pythonhosted.org/packages/37/8d/ca39a7559a4797505530d084fd3a49a2c959efbbbff146302fb7be4e3b35/charset_normalizer-3.4.9-cp310-cp310-win_amd64.whl"
-size = 162314
+name = "charset_normalizer-3.5.1-cp310-cp310-win_amd64.whl"
+upload-time = 2026-08-15 08:16:43.787022+00:00
+url = "https://files.pythonhosted.org/packages/d2/21/83fffb77864408b8bf0fe1ca603926401d6f8775a8e150b39aacc9958f8a/charset_normalizer-3.5.1-cp310-cp310-win_amd64.whl"
+size = 206030
 
 [packages.wheels.hashes]
-sha256 = "8c041122946b7ba21bb32c45b1aa57b1be35527690aeb3c5c234521085632eee"
+sha256 = "be47f99644b208bff7766314013f9acf57b056b04191d570d68ad14022cf5b1d"
 
 [[packages.wheels]]
-name = "charset_normalizer-3.4.9-cp311-cp311-macosx_10_9_universal2.whl"
-upload-time = 2026-07-07 14:32:56.021195+00:00
-url = "https://files.pythonhosted.org/packages/0b/e3/85ec501f206fb049259288c1f3506e53876937fb00edb47009348e66756b/charset_normalizer-3.4.9-cp311-cp311-macosx_10_9_universal2.whl"
-size = 317075
+name = "charset_normalizer-3.5.1-cp311-cp311-macosx_10_9_universal2.whl"
+upload-time = 2026-08-15 08:16:46.646179+00:00
+url = "https://files.pythonhosted.org/packages/6a/b6/034f6802e9c3f6418966cfabb7db8c9252cc2429c5098f41cc43af804149/charset_normalizer-3.5.1-cp311-cp311-macosx_10_9_universal2.whl"
+size = 363585
 
 [packages.wheels.hashes]
-sha256 = "0e94703ec9684807f20cfb5eed95c70f67f2a8f21ad620146d7b5a13677b93e5"
+sha256 = "eda059b6bc8bc0812d626fd91a7ce01bf583df0a61296eff390fd94141a34e30"
 
 [[packages.wheels]]
-name = "charset_normalizer-3.4.9-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-07-07 14:32:57.780289+00:00
-url = "https://files.pythonhosted.org/packages/c3/69/2a5385192e67175f7d8bd5ce4f57c24bc956439adeae5c13a99aa28a53d1/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 213837
+name = "charset_normalizer-3.5.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-08-15 08:16:48.287671+00:00
+url = "https://files.pythonhosted.org/packages/d5/fa/6a7e2a7c4b5451912b8c417732df79574354443592a88d616de03da66ae5/charset_normalizer-3.5.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 251189
 
 [packages.wheels.hashes]
-sha256 = "2a441ea71902098ffe78c5abe6c494f44160b4af614ed16c3d9a3b1d17fd8ee2"
+sha256 = "aa2bb0b37202dca27175591f761108b5d34096ade1191ffe4808bdf6b1571488"
 
 [[packages.wheels]]
-name = "charset_normalizer-3.4.9-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-07-07 14:33:02.199800+00:00
-url = "https://files.pythonhosted.org/packages/a5/34/49b9060e8418b14fb5cba9cf6bfb383111e2538a03a1fb18e66a95aeb3d5/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 221276
+name = "charset_normalizer-3.5.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-08-15 08:16:54.085182+00:00
+url = "https://files.pythonhosted.org/packages/0d/35/731ac04aa0a097fc1c97f0994c375bdb230c6c96619db794208fe664e9ce/charset_normalizer-3.5.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 262325
 
 [packages.wheels.hashes]
-sha256 = "04ce310cb89c15df659582aee80a0603788732a5e017d5bd5c81158106ce249c"
+sha256 = "c7b742bf31c88566b4bb6335a7f393bb322e580b6bb98df7bd0c25e6e3519ce8"
 
 [[packages.wheels]]
-name = "charset_normalizer-3.4.9-cp311-cp311-win_amd64.whl"
-upload-time = 2026-07-07 14:33:12.743786+00:00
-url = "https://files.pythonhosted.org/packages/ed/a1/e29995109e455dc8eff8d0fac6ae509be39561318a7cfeac5d33ad029213/charset_normalizer-3.4.9-cp311-cp311-win_amd64.whl"
-size = 161410
+name = "charset_normalizer-3.5.1-cp311-cp311-win_amd64.whl"
+upload-time = 2026-08-15 08:17:07.075426+00:00
+url = "https://files.pythonhosted.org/packages/e3/57/32f0ccea59e8612057c61d6fd22ef2cb63cca93c9fe594094919696ac170/charset_normalizer-3.5.1-cp311-cp311-win_amd64.whl"
+size = 206653
 
 [packages.wheels.hashes]
-sha256 = "6366a16e1a25018694d6a5d784d09b046edc9eac40ea2b54065c3052672516a1"
+sha256 = "f9b1e28d0e8dbfa858abdba91d6b547beaf2df1a59bec6da6faae7b96a4991a9"
 
 [[packages.wheels]]
-name = "charset_normalizer-3.4.9-cp312-cp312-macosx_10_13_universal2.whl"
-upload-time = 2026-07-07 14:33:15.666307+00:00
-url = "https://files.pythonhosted.org/packages/70/4a/ecbd131485c07fcdfad54e28946d513e3da22ef3b4bd854dcafae54ec739/charset_normalizer-3.4.9-cp312-cp312-macosx_10_13_universal2.whl"
-size = 319300
+name = "charset_normalizer-3.5.1-cp312-cp312-macosx_10_13_universal2.whl"
+upload-time = 2026-08-15 08:17:10.072179+00:00
+url = "https://files.pythonhosted.org/packages/30/27/78873dc8b6a56357517b74b6bb9568b80450e7bb4f6ef7e3fa9d22aa0bd7/charset_normalizer-3.5.1-cp312-cp312-macosx_10_13_universal2.whl"
+size = 344456
 
 [packages.wheels.hashes]
-sha256 = "45b0cc4e3556cd875e09102988d1ab8356c998b596c9fced84547c8138b487a0"
+sha256 = "5b6d1386bf0096d26d3a863dc0a487a5b4eb9aa93cf5ba69683d29dde6b9d60f"
 
 [[packages.wheels]]
-name = "charset_normalizer-3.4.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-07-07 14:33:17.031769+00:00
-url = "https://files.pythonhosted.org/packages/ec/96/5d9364e3342d69f3a045e1777bc47c85c383e6e9466d561b33fdb419d1f9/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 215802
+name = "charset_normalizer-3.5.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-08-15 08:17:11.563784+00:00
+url = "https://files.pythonhosted.org/packages/9a/4c/be49ada26b1f0232d57aa89bbebf997a5cc2332a5616b6eca26ff680044d/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 238530
 
 [packages.wheels.hashes]
-sha256 = "9b2aff1c7b3884512b9512c3eaadd9bab39fb45042ffaaa1dd08ff2b9f8109d9"
+sha256 = "4582c27e8c889d64811987b5967fbd3ae0c823fe1fd933b543d55ac20bb475fa"
 
 [[packages.wheels]]
-name = "charset_normalizer-3.4.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-07-07 14:33:21.747000+00:00
-url = "https://files.pythonhosted.org/packages/01/c4/4fa4c8b3097a11f3c5f09a35b72ed6855fb1d332469504962ab7bafcc702/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 224256
+name = "charset_normalizer-3.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-08-15 08:17:17.683623+00:00
+url = "https://files.pythonhosted.org/packages/6f/89/bb5108dc6c3651dca963f2b0a3ba19bbcb370c94e1b6d3e0e844a58e6dca/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 248801
 
 [packages.wheels.hashes]
-sha256 = "5e226f6218febc71f6c1fc2fafb91c226f75bdc1d8fb12d66823716e891608fd"
+sha256 = "b9af956078716df40d985fb0dfeb2c2120c5ca92ba4ff4b388acfd01cdc14d08"
 
 [[packages.wheels]]
-name = "charset_normalizer-3.4.9-cp312-cp312-win_amd64.whl"
-upload-time = 2026-07-07 14:33:32.176413+00:00
-url = "https://files.pythonhosted.org/packages/80/cc/f920afd1a23c58ccd53c1d36085a71893a4737ff5e66e0371efab6809850/charset_normalizer-3.4.9-cp312-cp312-win_amd64.whl"
-size = 162557
+name = "charset_normalizer-3.5.1-cp312-cp312-win_amd64.whl"
+upload-time = 2026-08-15 08:17:30.668865+00:00
+url = "https://files.pythonhosted.org/packages/9d/7a/4c6c298171e6b3e745633180ff59350fc0ca0db1ffd28df1e369e0579f71/charset_normalizer-3.5.1-cp312-cp312-win_amd64.whl"
+size = 200551
 
 [packages.wheels.hashes]
-sha256 = "4b3dac63058cc36820b0dd072f89898604e2d39686fe05321729d00d8ac185a0"
+sha256 = "3617ac3cfd8b9888f145ad89dd6e692285834b0201c6074a5eeaad3fd4d668c2"
 
 [[packages.wheels]]
-name = "charset_normalizer-3.4.9-cp313-cp313-macosx_10_13_universal2.whl"
-upload-time = 2026-07-07 14:33:35.408555+00:00
-url = "https://files.pythonhosted.org/packages/b2/06/97ec2aeae780b31d742b6352218b43841a6871e2564578ca522dce4a45c3/charset_normalizer-3.4.9-cp313-cp313-macosx_10_13_universal2.whl"
-size = 317688
+name = "charset_normalizer-3.5.1-cp313-cp313-macosx_10_13_universal2.whl"
+upload-time = 2026-08-15 08:17:39.303564+00:00
+url = "https://files.pythonhosted.org/packages/a4/a0/562247944386f7d4ef94467e84876600cc1e0f1b93239aaa9213d2bc3cbd/charset_normalizer-3.5.1-cp313-cp313-macosx_10_13_universal2.whl"
+size = 340473
 
 [packages.wheels.hashes]
-sha256 = "440eede837960000d74978f0eba527be106b5b9aee0daf779d395276ed0b0614"
+sha256 = "e90251c0c7bdd54a100a0dce3c07b7e637278c93af29dbf78ebb89a58c4bac7d"
 
 [[packages.wheels]]
-name = "charset_normalizer-3.4.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-07-07 14:33:36.996418+00:00
-url = "https://files.pythonhosted.org/packages/d0/39/8ff066c672434225f8d25f8b739f992af250944392173dcc88362681c9bf/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 214982
+name = "charset_normalizer-3.5.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-08-15 08:17:40.660836+00:00
+url = "https://files.pythonhosted.org/packages/31/e7/1d994be1b93d41e9502b8b0460eaa88a1dd8df335df415db87d6c3e91ab2/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 240156
 
 [packages.wheels.hashes]
-sha256 = "21e764fd1e70b6a3e205a0e46f3051701f98a8cb3fad66eeb80e48bb502f8698"
+sha256 = "94d78ecec2605a8d0398b0f365d5f12a63248438516f5dac536a5eff7337df4a"
 
 [[packages.wheels]]
-name = "charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-07-07 14:33:41.631371+00:00
-url = "https://files.pythonhosted.org/packages/ea/f8/72eb13dcabe7257035cea8aefd922caad2f110d252bf9f67c4c2ca763aee/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 223149
+name = "charset_normalizer-3.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-08-15 08:17:46.496792+00:00
+url = "https://files.pythonhosted.org/packages/fb/af/63240b0c0248c075c2535a1f1bd992821d8251b9f173abc13329661d09e4/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 250638
 
 [packages.wheels.hashes]
-sha256 = "84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33"
+sha256 = "62b55f6722735a6c472f88361cde6640608773d9443cebdbb51abf436a1fcdd3"
 
 [[packages.wheels]]
-name = "charset_normalizer-3.4.9-cp313-cp313-win_amd64.whl"
-upload-time = 2026-07-07 14:33:52.197409+00:00
-url = "https://files.pythonhosted.org/packages/e8/ef/6953a77c7cf2c2ff9998e6f575ab3e380119f100223381565a4f94c1f836/charset_normalizer-3.4.9-cp313-cp313-win_amd64.whl"
-size = 161947
+name = "charset_normalizer-3.5.1-cp313-cp313-win_amd64.whl"
+upload-time = 2026-08-15 08:18:01.506167+00:00
+url = "https://files.pythonhosted.org/packages/8a/33/56d97ade41c8db611e727168c52ae46c9224c362ec28d4b65d7e9869e8da/charset_normalizer-3.5.1-cp313-cp313-win_amd64.whl"
+size = 199295
 
 [packages.wheels.hashes]
-sha256 = "fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115"
+sha256 = "aea996a6aba25260827c9ea511d1addfde2da9eb686ac961838509086188b7e6"
 
 [[packages.wheels]]
-name = "charset_normalizer-3.4.9-cp314-cp314-macosx_10_15_universal2.whl"
-upload-time = 2026-07-07 14:33:54.994032+00:00
-url = "https://files.pythonhosted.org/packages/7e/8d/496817fa0944239ecae662dd57ea765cfeaec6a735f9f025d4b7b72e7143/charset_normalizer-3.4.9-cp314-cp314-macosx_10_15_universal2.whl"
-size = 317253
+name = "charset_normalizer-3.5.1-cp314-cp314-macosx_10_15_universal2.whl"
+upload-time = 2026-08-15 08:18:10.458682+00:00
+url = "https://files.pythonhosted.org/packages/e9/40/095ce62fa078483cccc1fa2b36e6bc9580b85422a20ee9f925341c50e44f/charset_normalizer-3.5.1-cp314-cp314-macosx_10_15_universal2.whl"
+size = 341823
 
 [packages.wheels.hashes]
-sha256 = "0327fcd59a935777d83410750c50600ee9571af2846f71ce40f25b13da1ef380"
+sha256 = "c428c6c31eb5f4277d7f8eccaf767fbd548ddd5ce3c8b4f4cbbfab3d96b5904c"
 
 [[packages.wheels]]
-name = "charset_normalizer-3.4.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-07-07 14:33:56.334257+00:00
-url = "https://files.pythonhosted.org/packages/2b/f9/ef4a69ea338ad3c0deceea0f5f7d2380ae8b52132b06d652cb0d2cd86706/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 215898
+name = "charset_normalizer-3.5.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-08-15 08:18:11.989609+00:00
+url = "https://files.pythonhosted.org/packages/f1/5a/0e58b1c04a1596e0256f407274a92d5fb2ee21324409d1fab1da48a65b5b/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 242458
 
 [packages.wheels.hashes]
-sha256 = "8a79d9f4d8001473a30c163556b3c3bfebec837495a412dde78b51672f6134f9"
+sha256 = "2f06b7eae9dbe77fe1d644ca244dad508de8d302870a43f3c559b521270938a0"
 
 [[packages.wheels]]
-name = "charset_normalizer-3.4.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-07-07 14:34:01.517411+00:00
-url = "https://files.pythonhosted.org/packages/f4/c4/b3e049d2aa3766180c78507110543d9d50894cc97f57de543f1be521dcdc/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 223143
+name = "charset_normalizer-3.5.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-08-15 08:18:18.127304+00:00
+url = "https://files.pythonhosted.org/packages/e0/91/39c3af510b0aa32bbda03374259200f28430febfd1bf5e511fe765282ce5/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 251240
 
 [packages.wheels.hashes]
-sha256 = "c25fe15c70c59eb7c5ce8c06a1f3fa1da0ecc5ea1e7a5922c40fd2fa9b0d5046"
+sha256 = "15f024313246a4ed976c60f440bb8d257815513a681d212ff74fd46f7d715a90"
 
 [[packages.wheels]]
-name = "charset_normalizer-3.4.9-cp314-cp314-win_amd64.whl"
-upload-time = 2026-07-07 14:34:12.470500+00:00
-url = "https://files.pythonhosted.org/packages/49/fd/a1d26144398c67486422a72bf5812cda22cb4ccfcd95a290fb41ceb4b8e2/charset_normalizer-3.4.9-cp314-cp314-win_amd64.whl"
-size = 162796
+name = "charset_normalizer-3.5.1-cp314-cp314-win_amd64.whl"
+upload-time = 2026-08-15 08:18:33.466489+00:00
+url = "https://files.pythonhosted.org/packages/7a/7c/4938c329b6a9d446f6a59aa2092ff7118f274209b5ed0e26893d1d30a63c/charset_normalizer-3.5.1-cp314-cp314-win_amd64.whl"
+size = 204175
 
 [packages.wheels.hashes]
-sha256 = "16b65ea0f2465b6fb52aa22de5eca612aa964ddfec00a912e26f4656cbef890b"
+sha256 = "c658c50ac0c98cd755a2dd50b7977d3bca7df401dcc47fbdfa87db53ef7d4e8b"
 
 [[packages.wheels]]
-name = "charset_normalizer-3.4.9-py3-none-any.whl"
-upload-time = 2026-07-07 14:34:56.993397+00:00
-url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl"
-size = 64538
+name = "charset_normalizer-3.5.1-cp37-abi3-macosx_10_9_universal2.whl"
+upload-time = 2026-08-15 08:19:50.959613+00:00
+url = "https://files.pythonhosted.org/packages/5b/97/fb4e82231aba271ffd775a1b4993b0defc4e3059f286ae41d9433409fe85/charset_normalizer-3.5.1-cp37-abi3-macosx_10_9_universal2.whl"
+size = 331467
 
 [packages.wheels.hashes]
-sha256 = "68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5"
+sha256 = "41876ee62a3dddf48ff1121ad8f0798032aa03f2fd35f21f34a4cab14f18d8d2"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.5.1-cp37-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-08-15 08:19:52.654163+00:00
+url = "https://files.pythonhosted.org/packages/9f/2f/fe3f187327aac18e2d54e9d2b08e15d27bf9b642d9e51c219f130fc34d1a/charset_normalizer-3.5.1-cp37-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 253057
+
+[packages.wheels.hashes]
+sha256 = "a6dac12ff6b846103483683f60c5f8fee205121adc58ffd87e90a90a3af69e99"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.5.1-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-08-15 08:19:54.163294+00:00
+url = "https://files.pythonhosted.org/packages/d7/c7/9e48cee5c161fe24da823b61bf381921d77cb994a0a4de148e95018c1984/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 240930
+
+[packages.wheels.hashes]
+sha256 = "cee5dd7c6fb5dd52a0fe2a740f9bc6e3593f5f8b1788bde49de02086f30182b2"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.5.1-cp37-abi3-win_amd64.whl"
+upload-time = 2026-08-15 08:20:13.908867+00:00
+url = "https://files.pythonhosted.org/packages/35/4f/b911ed898b26a09789eba9c9200c999aff6c61b4bafaf4838e56d1a1e1a3/charset_normalizer-3.5.1-cp37-abi3-win_amd64.whl"
+size = 199764
+
+[packages.wheels.hashes]
+sha256 = "70055ff39b97c99e7ae40ea3e393fb62aa2e44dbd9b29f8d14f42fb0025c3959"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.5.1-py3-none-any.whl"
+upload-time = 2026-08-15 08:20:43.306209+00:00
+url = "https://files.pythonhosted.org/packages/cc/61/d01fc49b8dea277640b55a9e15960dbca9fdc8c9fde18e572d39c59f4019/charset_normalizer-3.5.1-py3-none-any.whl"
+size = 68658
+
+[packages.wheels.hashes]
+sha256 = "6df0ec430f9a831772c23ca5a224cba36517a58a84bb32c32bb59a9fa67c47f6"
 
 [[packages]]
 name = "colorama"
@@ -622,7 +658,7 @@ sha256 = "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
 
 [[packages]]
 name = "cryptography"
-version = "50.0.0"
+version = "50.0.1"
 marker = "\"release\" in dependency_groups"
 requires-python = "!=3.9.0,!=3.9.1,>=3.9"
 dependencies = [
@@ -632,157 +668,157 @@ dependencies = [
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "cryptography-50.0.0.tar.gz"
-upload-time = 2026-07-31 14:25:10.110218+00:00
-url = "https://files.pythonhosted.org/packages/de/41/6cbdcf9142d00fe82836fbb51e503e58088575cf7a0fe1dbff6695bf0840/cryptography-50.0.0.tar.gz"
-size = 880201
+name = "cryptography-50.0.1.tar.gz"
+upload-time = 2026-08-25 19:45:45.499357+00:00
+url = "https://files.pythonhosted.org/packages/bb/ad/5d6702db60b1e40b41ef513b6967ff5848f307d50f8449baf1634f5908f1/cryptography-50.0.1.tar.gz"
+size = 880381
 
 [packages.sdist.hashes]
-sha256 = "eeac2acb5a20ed25e0ad6d1df9891a520b78b404266b6d11778f25d5d691a6c9"
+sha256 = "5dd9bda1c12b4162f6ff568eeb5e0ff956c28d14406e875cfe8a63a2d414ff20"
 
 [[packages.wheels]]
-name = "cryptography-50.0.0-cp311-abi3-macosx_11_0_arm64.whl"
-upload-time = 2026-07-31 14:23:33.331759+00:00
-url = "https://files.pythonhosted.org/packages/c5/5c/59086b4aac5e879d38ddbcf74e4be7ade89cebc3eb199a55da998c3bb46a/cryptography-50.0.0-cp311-abi3-macosx_11_0_arm64.whl"
-size = 4001252
+name = "cryptography-50.0.1-cp311-abi3-macosx_11_0_arm64.whl"
+upload-time = 2026-08-25 19:44:03.155112+00:00
+url = "https://files.pythonhosted.org/packages/ba/19/797e2aaac9df6a66f1550f49979dc1b1e39ecd2077501c30efa81e8d5d67/cryptography-50.0.1-cp311-abi3-macosx_11_0_arm64.whl"
+size = 4010153
 
 [packages.wheels.hashes]
-sha256 = "031e2d5dd4bb9caa3ca9c82e5a197fd8ae680232cee62603d1a813f3f07e3d03"
+sha256 = "b8f852c65863251b9e3a1b8c150ce21e59b522dbb6a7d4bc80e680d38388e986"
 
 [[packages.wheels]]
-name = "cryptography-50.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
-upload-time = 2026-07-31 14:23:35.611972+00:00
-url = "https://files.pythonhosted.org/packages/57/ef/8f2df13c7216bcad3e1c74e07f6e193d93e998e114f524a53877c9af27ad/cryptography-50.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
-size = 4719554
+name = "cryptography-50.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
+upload-time = 2026-08-25 19:44:05.461494+00:00
+url = "https://files.pythonhosted.org/packages/90/34/9ce9a62ed9dc82ca9fd6a34445b6904af56e5f38b3eae2ed32e49c36053d/cryptography-50.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
+size = 4723133
 
 [packages.wheels.hashes]
-sha256 = "fd9192b7b70c573d7f214eb1ae35e00d359f6f5e4b27c7e21e30de1fc6204645"
+sha256 = "53e279950892dc102c6b4e52af03ae5ea92fac572a1ddab78ca73a997f62b69f"
 
 [[packages.wheels]]
-name = "cryptography-50.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
-upload-time = 2026-07-31 14:23:37.635896+00:00
-url = "https://files.pythonhosted.org/packages/d9/41/029086c34d91052fc3b88bcc8056f709a7c915c7a23b235a54eb800b1c97/cryptography-50.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
-size = 4702130
+name = "cryptography-50.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+upload-time = 2026-08-25 19:44:07.375092+00:00
+url = "https://files.pythonhosted.org/packages/57/26/e6d4fc8512a51a5f9ee7bfdbfb853bce1197087df40c9ad993ad370b846f/cryptography-50.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+size = 4712478
 
 [packages.wheels.hashes]
-sha256 = "06a32a980526a6ab9a4b9bf8f7385800791e2bb960903cb6b530e4817509a3b7"
+sha256 = "ff838d62ec1bfce4f9ba7fa16f4a7b554cd8d0c299e6be37502161a660c84eef"
 
 [[packages.wheels]]
-name = "cryptography-50.0.0-cp311-abi3-manylinux_2_28_aarch64.whl"
-upload-time = 2026-07-31 14:23:39.471725+00:00
-url = "https://files.pythonhosted.org/packages/7d/ff/b6ce0954962e7f7b969f850a883744197bb3910bdfd7b6da162eab7d9f68/cryptography-50.0.0-cp311-abi3-manylinux_2_28_aarch64.whl"
-size = 4725244
+name = "cryptography-50.0.1-cp311-abi3-manylinux_2_28_aarch64.whl"
+upload-time = 2026-08-25 19:44:09.294395+00:00
+url = "https://files.pythonhosted.org/packages/e6/de/d3cdc2815697aae84126cbd6a030ca7b6b452e28a88b501b836bd3aa7a86/cryptography-50.0.1-cp311-abi3-manylinux_2_28_aarch64.whl"
+size = 4730726
 
 [packages.wheels.hashes]
-sha256 = "a1b30560f2acc95aa8b2e06e716a13dbfc97314747b80d9707e307f77b40d6b3"
+sha256 = "e74591e283fe6eb956416c929eb58262a719fe0311fd9054c62c3350ed8760d8"
 
 [[packages.wheels]]
-name = "cryptography-50.0.0-cp311-abi3-manylinux_2_28_x86_64.whl"
-upload-time = 2026-07-31 14:23:43.139500+00:00
-url = "https://files.pythonhosted.org/packages/6b/72/a1116d683a6d7ece94590013882515de087edf9ef0e6292aae615a44df73/cryptography-50.0.0-cp311-abi3-manylinux_2_28_x86_64.whl"
-size = 4734609
+name = "cryptography-50.0.1-cp311-abi3-manylinux_2_28_x86_64.whl"
+upload-time = 2026-08-25 19:44:14.051778+00:00
+url = "https://files.pythonhosted.org/packages/e1/1b/82f0f0d8858d4432be1af790477edf62aef90324041aa07c57e57bef1af7/cryptography-50.0.1-cp311-abi3-manylinux_2_28_x86_64.whl"
+size = 4746720
 
 [packages.wheels.hashes]
-sha256 = "b42a28c1844fd9de8f3f7d540e36b66f3a9c83fceac7170ebc7a6a19edd9dcae"
+sha256 = "51593d180cf6d179bde5c5d065bed81386b1f381656ae7d042b7ffc87a9895ad"
 
 [[packages.wheels]]
-name = "cryptography-50.0.0-cp311-abi3-manylinux_2_34_aarch64.whl"
-upload-time = 2026-07-31 14:23:46.930757+00:00
-url = "https://files.pythonhosted.org/packages/32/98/8a151d64367204cbc63ec65d37502f1d9c53cf4bfc6ec3c532614dbec60d/cryptography-50.0.0-cp311-abi3-manylinux_2_34_aarch64.whl"
-size = 4724529
+name = "cryptography-50.0.1-cp311-abi3-manylinux_2_34_aarch64.whl"
+upload-time = 2026-08-25 19:44:18.085228+00:00
+url = "https://files.pythonhosted.org/packages/39/3b/e96c1ef71edef71057c7e3c3d982ce8fda554e0c52d0cc19c18845cde3eb/cryptography-50.0.1-cp311-abi3-manylinux_2_34_aarch64.whl"
+size = 4730028
 
 [packages.wheels.hashes]
-sha256 = "07949c449a1abcf60d1ee6e88956d89404c7df3c8258f46589e912988e551987"
+sha256 = "e2ca8fd1b6b4b82a1c4cb02841d0837e3c12336c2e24b520ab8ab3b969733d8f"
 
 [[packages.wheels]]
-name = "cryptography-50.0.0-cp311-abi3-manylinux_2_34_x86_64.whl"
-upload-time = 2026-07-31 14:23:50.861885+00:00
-url = "https://files.pythonhosted.org/packages/da/3a/f05e32c99d440c9bb891ea0e36c9091891e36be5a9a87ab2ee6ea20729f6/cryptography-50.0.0-cp311-abi3-manylinux_2_34_x86_64.whl"
-size = 4734462
+name = "cryptography-50.0.1-cp311-abi3-manylinux_2_34_x86_64.whl"
+upload-time = 2026-08-25 19:44:22.376412+00:00
+url = "https://files.pythonhosted.org/packages/85/66/6ccca4722987ddedaa7fc9c3f4708af7431f5535666c174350830888c6b7/cryptography-50.0.1-cp311-abi3-manylinux_2_34_x86_64.whl"
+size = 4746230
 
 [packages.wheels.hashes]
-sha256 = "82148ec5bddac30b51a5b3c1945075f896fa022cb93f8e4a01e9f6ee95292c5f"
+sha256 = "51afcfceb15597cf2635068e4ac9a56b2abde622edde17f37d85fd7b5306497a"
 
 [[packages.wheels]]
-name = "cryptography-50.0.0-cp311-abi3-win_amd64.whl"
-upload-time = 2026-07-31 14:23:56.677223+00:00
-url = "https://files.pythonhosted.org/packages/32/2e/c9db68a0c4bfa28e310707527c0ee3a2bd254104d2e02e68f368e197aa4c/cryptography-50.0.0-cp311-abi3-win_amd64.whl"
-size = 3840395
+name = "cryptography-50.0.1-cp311-abi3-win_amd64.whl"
+upload-time = 2026-08-25 19:44:28.784623+00:00
+url = "https://files.pythonhosted.org/packages/42/8b/cb12b1b60c91b074ca6bf0fdd59aa8f10d8bc5f73af8faece86ef0421b37/cryptography-50.0.1-cp311-abi3-win_amd64.whl"
+size = 3842826
 
 [packages.wheels.hashes]
-sha256 = "bd1c592e4d5974f0d08d4888e432157adba757c66da0246918e43677fafa2d30"
+sha256 = "aed8db4f6d71c51efb89530e12d9464e7bf2923d46c3205dc794a2a93f8c0648"
 
 [[packages.wheels]]
-name = "cryptography-50.0.0-cp39-abi3-macosx_11_0_arm64.whl"
-upload-time = 2026-07-31 14:24:24.122286+00:00
-url = "https://files.pythonhosted.org/packages/03/37/73d005be173aff344af30e9fd2a576575cb2391a7101d9cd3842e1fa8cce/cryptography-50.0.0-cp39-abi3-macosx_11_0_arm64.whl"
-size = 4036009
+name = "cryptography-50.0.1-cp39-abi3-macosx_11_0_arm64.whl"
+upload-time = 2026-08-25 19:44:58.305212+00:00
+url = "https://files.pythonhosted.org/packages/84/a9/ee16a903f13755e914d1eecc482fe64d1f10761c3960e5d8fa6837377aff/cryptography-50.0.1-cp39-abi3-macosx_11_0_arm64.whl"
+size = 4035307
 
 [packages.wheels.hashes]
-sha256 = "ccdc4a71a4dabae05de219404f9f4abc38e3b58422177ff93d0da05967dafa07"
+sha256 = "ca83d00d9e69cd5eb63f2e69c3a5a59e0cecae5ae14c6ae0b35830fe3b37bad0"
 
 [[packages.wheels]]
-name = "cryptography-50.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
-upload-time = 2026-07-31 14:24:26.118933+00:00
-url = "https://files.pythonhosted.org/packages/ff/c6/7a6202a534e32103a285b7834a120869557fe198d51d7cfe59754c8bda9c/cryptography-50.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
-size = 4745252
+name = "cryptography-50.0.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
+upload-time = 2026-08-25 19:45:00.401738+00:00
+url = "https://files.pythonhosted.org/packages/5e/a5/9ec7e81e8526c0d7a387d73386b2daed3f39e10d81a85930bd1b6bfba65c/cryptography-50.0.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
+size = 4751900
 
 [packages.wheels.hashes]
-sha256 = "910e1d2668e7de9648f2bcee30e180db2a6b15c30f887d7c4c93ddf96e3992e3"
+sha256 = "05ba322c4da95b262a212c345af888ef2c37c88c0509756ea00a0e6d68850f23"
 
 [[packages.wheels]]
-name = "cryptography-50.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
-upload-time = 2026-07-31 14:24:27.994487+00:00
-url = "https://files.pythonhosted.org/packages/85/4f/0fa8c2f4428198f15d9ff8d63400e27afbf94ce833f6108da1eb3753f945/cryptography-50.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
-size = 4728939
+name = "cryptography-50.0.1-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+upload-time = 2026-08-25 19:45:02.786244+00:00
+url = "https://files.pythonhosted.org/packages/7e/3c/0e77bd5ffcf078e9dd27d3074aad6c030d9b10d0bf69329d573c927a188c/cryptography-50.0.1-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+size = 4738357
 
 [packages.wheels.hashes]
-sha256 = "a91296cb61e8df6f86d0c19cc4068228da256bf59bf86049fbd821084565327f"
+sha256 = "e22dfed744bd4002e909464cb23d2f0b05c6f3113a79ef2e9864a53db737c733"
 
 [[packages.wheels]]
-name = "cryptography-50.0.0-cp39-abi3-manylinux_2_28_aarch64.whl"
-upload-time = 2026-07-31 14:24:30.254986+00:00
-url = "https://files.pythonhosted.org/packages/d1/63/54dd723490ba2dc09b299682c10b38db38f159728bcaae8c591b8af2f22d/cryptography-50.0.0-cp39-abi3-manylinux_2_28_aarch64.whl"
-size = 4748483
+name = "cryptography-50.0.1-cp39-abi3-manylinux_2_28_aarch64.whl"
+upload-time = 2026-08-25 19:45:04.889297+00:00
+url = "https://files.pythonhosted.org/packages/27/3a/3c5f80daa4dcd47323c7af8a2fcb90de27a33564d4fcac69846c0972691a/cryptography-50.0.1-cp39-abi3-manylinux_2_28_aarch64.whl"
+size = 4758474
 
 [packages.wheels.hashes]
-sha256 = "e722f16708d854fe924790e051061f6704a472c3bac347b6fd88033ea8dd0dc5"
+sha256 = "4c4188f7c0cf655be5c06342b817ed0f9595b69ffa2b12026e5353eed29dea88"
 
 [[packages.wheels]]
-name = "cryptography-50.0.0-cp39-abi3-manylinux_2_28_x86_64.whl"
-upload-time = 2026-07-31 14:24:34.599603+00:00
-url = "https://files.pythonhosted.org/packages/46/c9/f60aed34c013f317f92817b6c171c2d22a78270fa41109bd4b08af26b194/cryptography-50.0.0-cp39-abi3-manylinux_2_28_x86_64.whl"
-size = 4762647
+name = "cryptography-50.0.1-cp39-abi3-manylinux_2_28_x86_64.whl"
+upload-time = 2026-08-25 19:45:09.396053+00:00
+url = "https://files.pythonhosted.org/packages/d6/51/3f9701867a46b6c1740c9b52fc4d3bed6cbdcfedcc9b6e64305c07f39cff/cryptography-50.0.1-cp39-abi3-manylinux_2_28_x86_64.whl"
+size = 4772942
 
 [packages.wheels.hashes]
-sha256 = "105110f43a471dbd0060b9c9516cb8a6a79233631a04cc2ba16f28323ac6e025"
+sha256 = "407fe2b6db00939c05c0e945e9914238f2f0a430974839429dafc82b1ee6bee5"
 
 [[packages.wheels]]
-name = "cryptography-50.0.0-cp39-abi3-manylinux_2_34_aarch64.whl"
-upload-time = 2026-07-31 14:24:39.493901+00:00
-url = "https://files.pythonhosted.org/packages/d8/36/83bb81f6e569bc38e1e4a7bc80f29b46bb9601920bc455fc8e888f5d5742/cryptography-50.0.0-cp39-abi3-manylinux_2_34_aarch64.whl"
-size = 4748095
+name = "cryptography-50.0.1-cp39-abi3-manylinux_2_34_aarch64.whl"
+upload-time = 2026-08-25 19:45:13.745632+00:00
+url = "https://files.pythonhosted.org/packages/84/d5/7d1fe1cb93f91c428093ff234e128c89ba8ea61a6f26aab406081f9b996e/cryptography-50.0.1-cp39-abi3-manylinux_2_34_aarch64.whl"
+size = 4758050
 
 [packages.wheels.hashes]
-sha256 = "2a8183b489dc1f7f80f135780fadc1108f14b31b8a40411c7a5b17425f65f28b"
+sha256 = "01f41478cf33fc605a6a089cd56d28b45c6c0b45a1928b61797f2621a04bac71"
 
 [[packages.wheels]]
-name = "cryptography-50.0.0-cp39-abi3-manylinux_2_34_x86_64.whl"
-upload-time = 2026-07-31 14:24:43.636215+00:00
-url = "https://files.pythonhosted.org/packages/9c/f8/d97f9603efda3888187bfdb893f26c41be4735c10631d05d284ee6b047c4/cryptography-50.0.0-cp39-abi3-manylinux_2_34_x86_64.whl"
-size = 4762400
+name = "cryptography-50.0.1-cp39-abi3-manylinux_2_34_x86_64.whl"
+upload-time = 2026-08-25 19:45:18.315527+00:00
+url = "https://files.pythonhosted.org/packages/8c/eb/5d7124083e8d8cda8f5b348f544b71ad6f707ad63193758ef4d8e569da02/cryptography-50.0.1-cp39-abi3-manylinux_2_34_x86_64.whl"
+size = 4772694
 
 [packages.wheels.hashes]
-sha256 = "37fdb0d0111f1e2ff07139dfb79f1b49531f8e213c46f1163dd7642979b58c47"
+sha256 = "9dde0a357190eb3b1da1bb9ab750e9c85cba82ca5977aa0836cbb94e92611239"
 
 [[packages.wheels]]
-name = "cryptography-50.0.0-cp39-abi3-win_amd64.whl"
-upload-time = 2026-07-31 14:24:50.085583+00:00
-url = "https://files.pythonhosted.org/packages/57/30/4a22984d4f1bdfb8c054f07a92bc176b97a3134cc1d6c4b3bffb1f3688b4/cryptography-50.0.0-cp39-abi3-win_amd64.whl"
-size = 3874135
+name = "cryptography-50.0.1-cp39-abi3-win_amd64.whl"
+upload-time = 2026-08-25 19:45:24.418333+00:00
+url = "https://files.pythonhosted.org/packages/99/89/87ef49ffe383ef4e147d27b7bf2088fb0b54ea409dd87b5a89442e5828a5/cryptography-50.0.1-cp39-abi3-win_amd64.whl"
+size = 3875429
 
 [packages.wheels.hashes]
-sha256 = "d24fead1d4d076e1bfb006dcec392074a3cd8d7b4fc8a595aa64073b2b7a96ba"
+sha256 = "55d16b1ef3ee0958d893a977b19777887e546c9954ea81b200c3301a864013f2"
 
 [[packages]]
 name = "dnspython"
@@ -893,28 +929,28 @@ sha256 = "f5ec41ed2629a508f5d0988eda142e190c9c6da971100612c4de9ad9f9b237ca"
 
 [[packages]]
 name = "idna"
-version = "3.18"
+version = "3.19"
 marker = "\"release\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "idna-3.18.tar.gz"
-upload-time = 2026-06-02 14:34:07.794523+00:00
-url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz"
-size = 196711
+name = "idna-3.19.tar.gz"
+upload-time = 2026-08-18 05:14:24.270231+00:00
+url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz"
+size = 215237
 
 [packages.sdist.hashes]
-sha256 = "ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"
+sha256 = "5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15"
 
 [[packages.wheels]]
-name = "idna-3.18-py3-none-any.whl"
-upload-time = 2026-06-02 14:34:06.319954+00:00
-url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl"
-size = 65455
+name = "idna-3.19-py3-none-any.whl"
+upload-time = 2026-08-18 05:14:22.343598+00:00
+url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl"
+size = 68550
 
 [packages.wheels.hashes]
-sha256 = "7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"
+sha256 = "815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4"
 
 [[packages]]
 name = "importlib-metadata"
@@ -1216,55 +1252,55 @@ sha256 = "4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192"
 
 [[packages]]
 name = "nh3"
-version = "0.3.6"
+version = "0.3.7"
 marker = "\"release\" in dependency_groups"
 requires-python = ">=3.8"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "nh3-0.3.6.tar.gz"
-upload-time = 2026-06-22 00:47:02.008115+00:00
-url = "https://files.pythonhosted.org/packages/5e/1b/ef84624f14954d270f74060a19fc550dd4f06656399447569afb584d8c06/nh3-0.3.6.tar.gz"
-size = 24684
+name = "nh3-0.3.7.tar.gz"
+upload-time = 2026-08-23 14:26:30.728660+00:00
+url = "https://files.pythonhosted.org/packages/18/2f/022b27146d52d24b1b353b003359134788ecbcd6fcdf6283adbd57c0fbc8/nh3-0.3.7.tar.gz"
+size = 25662
 
 [packages.sdist.hashes]
-sha256 = "f3736c9dd3d1856f80cd031715b84ca75cda2bbb1ac802c3da26bfce590838d7"
+sha256 = "71860d01c16f4d8c72e334e0674beb2b0899dbd0bf760de18932ef4390303848"
 
 [[packages.wheels]]
-name = "nh3-0.3.6-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl"
-upload-time = 2026-06-22 00:46:36.660608+00:00
-url = "https://files.pythonhosted.org/packages/f3/ab/a7653bce9a3b204be6a6931767a9e23595807bb84790ce6685e4d7e5bd08/nh3-0.3.6-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl"
-size = 1443564
+name = "nh3-0.3.7-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl"
+upload-time = 2026-08-23 14:26:09.025294+00:00
+url = "https://files.pythonhosted.org/packages/94/0d/c257754bf57f829f307aa226bbe136d3a1356b5a0d08324c7b6bd2a8aacd/nh3-0.3.7-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl"
+size = 1493959
 
 [packages.wheels.hashes]
-sha256 = "a43ebd7543555c3ac1bc353023d0794e75cb76f6f18f19c32e95441496c0cc25"
+sha256 = "6c3aa50eb26e9228238271db9f983cbc3b006dfbfeca2d4dc34c33ddc6ac5ea5"
 
 [[packages.wheels]]
-name = "nh3-0.3.6-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-upload-time = 2026-06-22 00:46:38.101500+00:00
-url = "https://files.pythonhosted.org/packages/41/21/e1084ab18eb589506335c7c7576f2d4643e9a0c0e33983ef0e549a256b96/nh3-0.3.6-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-size = 838002
+name = "nh3-0.3.7-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+upload-time = 2026-08-23 14:26:10.606442+00:00
+url = "https://files.pythonhosted.org/packages/07/42/a687e7091928806e514f89fa2666f25ec9bfe0a902fc4402b25e51ce408b/nh3-0.3.7-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+size = 859615
 
 [packages.wheels.hashes]
-sha256 = "e1b160831c9cdb06a6c79c2f9cdb11386602938f9af260d1c457a85add4f6f69"
+sha256 = "f266d3f1b3647449923a8e406524632220dd5d8b647078dfe45b885d33d10479"
 
 [[packages.wheels]]
-name = "nh3-0.3.6-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-upload-time = 2026-06-22 00:46:45.990736+00:00
-url = "https://files.pythonhosted.org/packages/5b/67/314f6151bad77a93d751978a344033e1fc890822f05f0416079338e34231/nh3-0.3.6-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-size = 806699
+name = "nh3-0.3.7-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+upload-time = 2026-08-23 14:26:17.272038+00:00
+url = "https://files.pythonhosted.org/packages/a6/ed/c5510c615dce55b6fcc364aa1838142f938beed64f5e4927490dfcaf4405/nh3-0.3.7-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+size = 832161
 
 [packages.wheels.hashes]
-sha256 = "905f877dc66dd7aea4a76e54bcb26acb5ff8216f720c0017ccf63e0e6035698e"
+sha256 = "70f5ac8626e899a4bab0ef74ca2f5bd602f49c7b739e6e5026b4afc6d63dac42"
 
 [[packages.wheels]]
-name = "nh3-0.3.6-cp38-abi3-win_amd64.whl"
-upload-time = 2026-06-22 00:46:59.163532+00:00
-url = "https://files.pythonhosted.org/packages/82/fa/2b5d684e3edf1e81bfd02d298c78c3e3da77ca1d8a2be3183a79544a7548/nh3-0.3.6-cp38-abi3-win_amd64.whl"
-size = 624461
+name = "nh3-0.3.7-cp38-abi3-win_amd64.whl"
+upload-time = 2026-08-23 14:26:28.294566+00:00
+url = "https://files.pythonhosted.org/packages/b4/b9/34433ccb1f0fe6968dabbb7d4bf5721c6221878ef07832748c06655a6a80/nh3-0.3.7-cp38-abi3-win_amd64.whl"
+size = 644462
 
 [packages.wheels.hashes]
-sha256 = "f338ac7d594c067679f1e99b4f5ec3906842979560f9d8f15d6bdfa39a353b10"
+sha256 = "618e3059caf41ccdf5dcccb3fa9df4cf6e4efe23d1382a8bbfca272a8a4f8bfc"
 
 [[packages]]
 name = "packaging"
@@ -1292,28 +1328,28 @@ sha256 = "d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c"
 
 [[packages]]
 name = "platformdirs"
-version = "4.11.0"
+version = "4.11.4"
 marker = "\"release\" in dependency_groups"
 requires-python = ">=3.10"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "platformdirs-4.11.0.tar.gz"
-upload-time = 2026-07-21 13:09:36.565916+00:00
-url = "https://files.pythonhosted.org/packages/78/9b/560e4be8e26f6fd133a03630a8df0c663b9e8d61b4ade152b72005aec83b/platformdirs-4.11.0.tar.gz"
-size = 31953
+name = "platformdirs-4.11.4.tar.gz"
+upload-time = 2026-08-24 14:53:49.676697+00:00
+url = "https://files.pythonhosted.org/packages/50/bb/ebc6636e1ae41314f796ebb7215fd28febb45f9aac72f2b04cb74b5071dc/platformdirs-4.11.4.tar.gz"
+size = 34079
 
 [packages.sdist.hashes]
-sha256 = "0555d18370482847566ffabcaa53ad7c6c1c29f195989ae1ed634a05f76ea1e0"
+sha256 = "f3373be828247211d0febabea97e238c3dfde8a60b3c90c32756fb52cb21556d"
 
 [[packages.wheels]]
-name = "platformdirs-4.11.0-py3-none-any.whl"
-upload-time = 2026-07-21 13:09:35.422952+00:00
-url = "https://files.pythonhosted.org/packages/7d/68/d8d58938dfb1370b266a1a729e6d77a985be23689a0496498ee17b2cbf90/platformdirs-4.11.0-py3-none-any.whl"
-size = 23247
+name = "platformdirs-4.11.4-py3-none-any.whl"
+upload-time = 2026-08-24 14:53:48.406471+00:00
+url = "https://files.pythonhosted.org/packages/28/be/0ff05fcd2938fb58ad9219bd54135968342d214737e012d62d43f06a2dd6/platformdirs-4.11.4-py3-none-any.whl"
+size = 23741
 
 [packages.wheels.hashes]
-sha256 = "360ccded2b7fce0af0ff80cc8f5942a1c5d99b0e856033acb030bfc634709e74"
+sha256 = "e34ff91a24bcddc6d939b878bdf3f5c437c9c46fe9e212b1bf455fdf1ee57586"
 
 [[packages]]
 name = "pyasn1"
@@ -1643,28 +1679,28 @@ sha256 = "811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac"
 
 [[packages]]
 name = "pygments"
-version = "2.20.0"
+version = "2.21.0"
 marker = "\"release\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "pygments-2.20.0.tar.gz"
-upload-time = 2026-03-29 13:29:33.898791+00:00
-url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz"
-size = 4955991
+name = "pygments-2.21.0.tar.gz"
+upload-time = 2026-08-17 08:02:48.824391+00:00
+url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz"
+size = 5005329
 
 [packages.sdist.hashes]
-sha256 = "6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"
+sha256 = "610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c"
 
 [[packages.wheels]]
-name = "pygments-2.20.0-py3-none-any.whl"
-upload-time = 2026-03-29 13:29:30.038266+00:00
-url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl"
-size = 1231151
+name = "pygments-2.21.0-py3-none-any.whl"
+upload-time = 2026-08-17 08:02:44.912148+00:00
+url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl"
+size = 1250147
 
 [packages.wheels.hashes]
-sha256 = "81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"
+sha256 = "2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9"
 
 [[packages]]
 name = "pyjwt"
@@ -2070,28 +2106,28 @@ sha256 = "0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137"
 
 [[packages]]
 name = "securesystemslib"
-version = "1.4.0"
+version = "1.5.0"
 marker = "\"release\" in dependency_groups"
 requires-python = "~=3.10"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "securesystemslib-1.4.0.tar.gz"
-upload-time = 2026-05-27 08:01:53.210331+00:00
-url = "https://files.pythonhosted.org/packages/b8/11/9623c61604f9b8955248d43fc6a75658bb687c0d3ab65b032b2e43613bd5/securesystemslib-1.4.0.tar.gz"
-size = 934332
+name = "securesystemslib-1.5.0.tar.gz"
+upload-time = 2026-08-24 08:22:40.311192+00:00
+url = "https://files.pythonhosted.org/packages/82/9c/6a7bac8eef1012d100f601beecb0ffa676efe52e5785e6f71b9842075275/securesystemslib-1.5.0.tar.gz"
+size = 945978
 
 [packages.sdist.hashes]
-sha256 = "faea87be0f9c4b4277a5fa1b54bf9bfd807be9a94ab11be6c557dc8b75c43285"
+sha256 = "3701219c8149a0b1b45f4298d672efc78cd15c0d7d83d5a18bf585e1fce1320d"
 
 [[packages.wheels]]
-name = "securesystemslib-1.4.0-py3-none-any.whl"
-upload-time = 2026-05-27 08:01:51.093395+00:00
-url = "https://files.pythonhosted.org/packages/f9/29/3ff76b9d90ce4482dc8e8d216dc3a6b6d0c934c52f68b0738e2c99ca685f/securesystemslib-1.4.0-py3-none-any.whl"
-size = 871457
+name = "securesystemslib-1.5.0-py3-none-any.whl"
+upload-time = 2026-08-24 08:22:38.813795+00:00
+url = "https://files.pythonhosted.org/packages/47/01/f0636f9d14bd86974ca242d24005edb81f52092d20a03da9ad7a54de804f/securesystemslib-1.5.0-py3-none-any.whl"
+size = 876061
 
 [packages.wheels.hashes]
-sha256 = "a0743a3d978cf26e98a70a57e3fbd5a18e0a74c20cabe615f6a55b02ef0272b3"
+sha256 = "66d2ea40ae150fb938767935a67252f5cfe37ec7cc2ec6e1d28c2509377014f6"
 
 [[packages]]
 name = "sigstore"
@@ -2560,31 +2596,31 @@ sha256 = "481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8"
 
 [[packages]]
 name = "typing-inspection"
-version = "0.4.2"
+version = "0.4.4"
 marker = "\"release\" in dependency_groups"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     { name = "typing-extensions" },
 ]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "typing_inspection-0.4.2.tar.gz"
-upload-time = 2025-10-01 02:14:41.687923+00:00
-url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz"
-size = 75949
+name = "typing_inspection-0.4.4.tar.gz"
+upload-time = 2026-08-12 12:37:25.997329+00:00
+url = "https://files.pythonhosted.org/packages/a3/26/b09b8010994eccc3c09092e6b34058f36a460eea2d4c3e8b910c695975a0/typing_inspection-0.4.4.tar.gz"
+size = 76928
 
 [packages.sdist.hashes]
-sha256 = "ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464"
+sha256 = "547274fa6b0a561ccf549cc9524b999a578e737d015d8709d021f9d0d13bea47"
 
 [[packages.wheels]]
-name = "typing_inspection-0.4.2-py3-none-any.whl"
-upload-time = 2025-10-01 02:14:40.154613+00:00
-url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl"
-size = 14611
+name = "typing_inspection-0.4.4-py3-none-any.whl"
+upload-time = 2026-08-12 12:37:24.648475+00:00
+url = "https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl"
+size = 14750
 
 [packages.wheels.hashes]
-sha256 = "4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7"
+sha256 = "65b8397ba37ccbce054456aaccddfc91e6e3083c92824df348d96ca832f3f147"
 
 [[packages]]
 name = "urllib3"
@@ -2637,7 +2673,7 @@ sha256 = "25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f"
 
 [tool.nab]
 nab-version = "0.0.16.dev0"
-created-at = 2026-08-12 13:49:31.025096+00:00
+created-at = 2026-09-02 00:02:50.879756+00:00
 command-line = [
     "nab",
     "lock",
@@ -2648,6 +2684,7 @@ command-line = [
     "--no-emit-workspace",
     "--output",
     ".github/requirements/pylock.release.toml",
+    "--upgrade",
 ]
 input-path = "pyproject.toml"
 mode = "universal"

--- a/.github/requirements/pylock.tests.toml
+++ b/.github/requirements/pylock.tests.toml
@@ -153,7 +153,7 @@ sha256 = "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
 
 [[packages]]
 name = "coverage"
-version = "7.15.3"
+version = "7.15.4"
 marker = "\"tests\" in dependency_groups"
 requires-python = ">=3.10"
 dependencies = [
@@ -162,247 +162,247 @@ dependencies = [
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "coverage-7.15.3.tar.gz"
-upload-time = 2026-08-02 18:50:17.006034+00:00
-url = "https://files.pythonhosted.org/packages/f4/45/78dbf9604ee5b3db24efbf26bed1cb58862fb40480cba821963c69348751/coverage-7.15.3.tar.gz"
-size = 935592
+name = "coverage-7.15.4.tar.gz"
+upload-time = 2026-08-06 13:50:24.442007+00:00
+url = "https://files.pythonhosted.org/packages/be/c3/4f2195f512fb172aa425a8803a874b2baa9ba7f80ff7b6080998761fc701/coverage-7.15.4.tar.gz"
+size = 936952
 
 [packages.sdist.hashes]
-sha256 = "ae7ea5a4614acf399ef0483c4cb34f8f8f01df848d8fcbe7d3ce0865733f1c4d"
+sha256 = "0548198fff07ccf4faf469520bce1c2eceb1ce3e62891921138dec10907f9d00"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp310-cp310-macosx_10_9_x86_64.whl"
-upload-time = 2026-08-02 18:47:25.951302+00:00
-url = "https://files.pythonhosted.org/packages/90/d9/01d8e19b2c0e55903bfb540c9f6bd32326f1d5b2fcb5a7dd8648ae2dd9c5/coverage-7.15.3-cp310-cp310-macosx_10_9_x86_64.whl"
-size = 222202
+name = "coverage-7.15.4-cp310-cp310-macosx_10_9_x86_64.whl"
+upload-time = 2026-08-06 13:46:55.253092+00:00
+url = "https://files.pythonhosted.org/packages/30/70/b052a519a584663a7bd052841a2debe11c8309ec49a7786340003f9c0a02/coverage-7.15.4-cp310-cp310-macosx_10_9_x86_64.whl"
+size = 222245
 
 [packages.wheels.hashes]
-sha256 = "3a82b2ceee91ba353e59fe2436d8a9eae799ff9825e5385423ea205d693e2949"
+sha256 = "d0be6daac4cce6b8c8dc65886bae1b082ddbca4da8e5cbb5e15166acf253e264"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp310-cp310-macosx_11_0_arm64.whl"
-upload-time = 2026-08-02 18:47:28.359879+00:00
-url = "https://files.pythonhosted.org/packages/1e/92/1c23aeb83c7239af07061abc6e96f00f9b62deec8fae022cab1b353e6d46/coverage-7.15.3-cp310-cp310-macosx_11_0_arm64.whl"
-size = 222723
+name = "coverage-7.15.4-cp310-cp310-macosx_11_0_arm64.whl"
+upload-time = 2026-08-06 13:46:57.848800+00:00
+url = "https://files.pythonhosted.org/packages/67/39/892fa511aba3d1c3c8f49509a0ff5c71eab9f9f88d08e1a38da395821660/coverage-7.15.4-cp310-cp310-macosx_11_0_arm64.whl"
+size = 222762
 
 [packages.wheels.hashes]
-sha256 = "3088cce65e54c2eefc08e7e1ca0b0acec1e95e8cf084ac848599103ed0367f74"
+sha256 = "b24e078eabcd6a9caa8b0713f9bc1eeb310bcc960a29d45a3b4fcd4b16d5b11d"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-08-02 18:47:31.445458+00:00
-url = "https://files.pythonhosted.org/packages/88/70/53e010accfea3340905c5bb9207a2e461bba9b372621f1b88c1bd0e1392a/coverage-7.15.3-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 251290
+name = "coverage-7.15.4-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-08-06 13:47:00.764674+00:00
+url = "https://files.pythonhosted.org/packages/0b/4f/b1973f67a1382af65b572a31ed692f8e490a6ad707191eab59148376832a/coverage-7.15.4-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 251328
 
 [packages.wheels.hashes]
-sha256 = "b51f279a2477b0e1f288b98f141fd227acfdd1d3f0370400e473788879b47871"
+sha256 = "83cf06cdd687677742caff1a9134833b7a8b75f111519d2cb0e0ba1b9a851e15"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-08-02 18:47:33.033060+00:00
-url = "https://files.pythonhosted.org/packages/5b/13/d916056137fb6969e9d9f58ee11d1ef56778673843828315030733a3a0b6/coverage-7.15.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 253156
+name = "coverage-7.15.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-08-06 13:47:01.976545+00:00
+url = "https://files.pythonhosted.org/packages/a2/09/03efa6722a132abcac91b32a60b64b240dd707c189c64eee697e48992c96/coverage-7.15.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 253194
 
 [packages.wheels.hashes]
-sha256 = "7835176988cbcf1f014db683bc33aa15e0558e412bf08deaa99757335b88df15"
+sha256 = "8fa4de68e2a752468ff14b4e15db7def689a71be759e826a31ccecbef69c5fd0"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp310-cp310-win_amd64.whl"
-upload-time = 2026-08-02 18:47:47.668157+00:00
-url = "https://files.pythonhosted.org/packages/53/8a/f1032fb2714c28fedf00d73562c4bb9f713fa8a90593ed577bbb708a7de1/coverage-7.15.3-cp310-cp310-win_amd64.whl"
-size = 224886
+name = "coverage-7.15.4-cp310-cp310-win_amd64.whl"
+upload-time = 2026-08-06 13:47:14.170514+00:00
+url = "https://files.pythonhosted.org/packages/7b/06/9a318fc3ae040d4d6cb2d86101c6aa963fab20899a5c58666adf52cde0ca/coverage-7.15.4-cp310-cp310-win_amd64.whl"
+size = 224919
 
 [packages.wheels.hashes]
-sha256 = "179fbf847e6c3d90ea71bfd570fe57f1ddb1c51474754894871c1e11099efaa0"
+sha256 = "3fc2130bf37df31852a8384f12601563a45a0024bccc6624f38355cba7a8d360"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp311-cp311-macosx_10_9_x86_64.whl"
-upload-time = 2026-08-02 18:47:49.228115+00:00
-url = "https://files.pythonhosted.org/packages/b3/9c/c8a3a923c24f631695cea2d5e2f02e776bc0af6e03800626e13a6c05a615/coverage-7.15.3-cp311-cp311-macosx_10_9_x86_64.whl"
-size = 222328
+name = "coverage-7.15.4-cp311-cp311-macosx_10_9_x86_64.whl"
+upload-time = 2026-08-06 13:47:15.578595+00:00
+url = "https://files.pythonhosted.org/packages/2a/66/edcec7d7a0b524aa8923e22925fde6fe50ce005a113dca13ae1581455c4c/coverage-7.15.4-cp311-cp311-macosx_10_9_x86_64.whl"
+size = 222367
 
 [packages.wheels.hashes]
-sha256 = "5f3f854ab4599d98f7799ac9b91e34e8ec9ebc9a6372ee8c1f3413a68cc8b5e9"
+sha256 = "bbac5abad70df71019988f83f26ac7092ff2642975def4429e98dc7585ef3490"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp311-cp311-macosx_11_0_arm64.whl"
-upload-time = 2026-08-02 18:47:51.219614+00:00
-url = "https://files.pythonhosted.org/packages/92/51/dda77f34cbd2513d6ffb898c901d19e9ca55f48c0cbc4a1eb173a97d157a/coverage-7.15.3-cp311-cp311-macosx_11_0_arm64.whl"
-size = 222832
+name = "coverage-7.15.4-cp311-cp311-macosx_11_0_arm64.whl"
+upload-time = 2026-08-06 13:47:16.961506+00:00
+url = "https://files.pythonhosted.org/packages/e6/c6/ab8de429e2e8548faf58ec7e1674a4ce00414b4113942d3fe87109cf0f68/coverage-7.15.4-cp311-cp311-macosx_11_0_arm64.whl"
+size = 222874
 
 [packages.wheels.hashes]
-sha256 = "75268348fee1f199653b8a846262aec5581c6bb008c4f58824959fb708cc688f"
+sha256 = "357a173465c7ce028d07a95cc2b63b5bf59f50ecdd5ad75c5cbb78ada984048e"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-08-02 18:47:54.404019+00:00
-url = "https://files.pythonhosted.org/packages/14/e2/4b1e0eeb727ffb471e411c1bd3402184b5dd54a77a762b0e55e87cdf9ae3/coverage-7.15.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 255160
+name = "coverage-7.15.4-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-08-06 13:47:19.765915+00:00
+url = "https://files.pythonhosted.org/packages/fb/65/ec03b743a2a229c72cc1eff3e57be9d3564e9c6b4d5aba2d70744a3fc0d8/coverage-7.15.4-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 255199
 
 [packages.wheels.hashes]
-sha256 = "718d366251b060c10731c7dd359de6caea72250036eb94576aa56dacbf830a11"
+sha256 = "7a2b580774a4786c1053157c0165e04476e03ff293993d7c148eee784a94bae6"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-08-02 18:47:56.157542+00:00
-url = "https://files.pythonhosted.org/packages/e9/9e/a602d2d48f9db9f795e578a86aa914f7b20008e9330902defcfb73d17b3a/coverage-7.15.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 257269
+name = "coverage-7.15.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-08-06 13:47:21.206658+00:00
+url = "https://files.pythonhosted.org/packages/41/4b/5163729e4b6582d61975cfd3ccab45b4ec53e21cf156d9941cb025188468/coverage-7.15.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 257308
 
 [packages.wheels.hashes]
-sha256 = "fa1bbaa502a6e877f3ee67cbac3eba2bb637f623e454e6c37b81b38896dbd48f"
+sha256 = "a9464451c4efffe8d47ace5a540b10b0dc10e879066290f8600872b7f54a419d"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp311-cp311-win_amd64.whl"
-upload-time = 2026-08-02 18:48:11.611051+00:00
-url = "https://files.pythonhosted.org/packages/b4/98/0050c692d120988f1973a15196f52dee4ae221848b760281461a2005b613/coverage-7.15.3-cp311-cp311-win_amd64.whl"
-size = 224906
+name = "coverage-7.15.4-cp311-cp311-win_amd64.whl"
+upload-time = 2026-08-06 13:47:34.205864+00:00
+url = "https://files.pythonhosted.org/packages/e2/6d/81fa4161dfb3ed9d74e40d58647eff83a56b7612e78352581280fce2f477/coverage-7.15.4-cp311-cp311-win_amd64.whl"
+size = 224937
 
 [packages.wheels.hashes]
-sha256 = "28743dad31622e8c474b17446118037361f5b1f4f2ecdf72d4f6fde246d64446"
+sha256 = "63fd6fcd1dd6e158f7eb78606e72933b3f6d01e7b747f99c6c12d764307a0fdc"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp312-cp312-macosx_10_13_x86_64.whl"
-upload-time = 2026-08-02 18:48:15.018777+00:00
-url = "https://files.pythonhosted.org/packages/d1/6c/bac99d9d4c6abe856e93bf3f5212982ac0bfac126dd4a042753bd53bc5af/coverage-7.15.3-cp312-cp312-macosx_10_13_x86_64.whl"
-size = 222499
+name = "coverage-7.15.4-cp312-cp312-macosx_10_13_x86_64.whl"
+upload-time = 2026-08-06 13:47:37.562250+00:00
+url = "https://files.pythonhosted.org/packages/1d/48/bc8d4ba7b37551a767bd863f15b3f80182b271c2f55975356f5f7dbe94c2/coverage-7.15.4-cp312-cp312-macosx_10_13_x86_64.whl"
+size = 222543
 
 [packages.wheels.hashes]
-sha256 = "79a3e32e83227d83d9684459ed579769b56c369ac2d7313099b2d9e031d2e10f"
+sha256 = "d4fedd1f7f428f9fe83b1ead5e7cc87a43427be31aadafbac3ac0636dc7abb22"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp312-cp312-macosx_11_0_arm64.whl"
-upload-time = 2026-08-02 18:48:16.884964+00:00
-url = "https://files.pythonhosted.org/packages/aa/bc/cb9a39b083bc1aa70586482dab25c9be20bab0ec6c155340e50d9066bb1e/coverage-7.15.3-cp312-cp312-macosx_11_0_arm64.whl"
-size = 222866
+name = "coverage-7.15.4-cp312-cp312-macosx_11_0_arm64.whl"
+upload-time = 2026-08-06 13:47:38.927299+00:00
+url = "https://files.pythonhosted.org/packages/20/dd/88d6f83f1fffc974a3691a34a97951c5b12df7512a6782c5963883cbc058/coverage-7.15.4-cp312-cp312-macosx_11_0_arm64.whl"
+size = 222905
 
 [packages.wheels.hashes]
-sha256 = "767feb87c5886d781d0a69fafd450a20826ddab7b79bce1665deb64d21441b60"
+sha256 = "37e2f0cdf58e2e1fed4e4d5a8f8786ae2f7eb80b478016876667dc4a01d60a97"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-08-02 18:48:20.172593+00:00
-url = "https://files.pythonhosted.org/packages/66/64/43e72500ed6815cef189f9193f29d7af4b078830337c95ea976cd0c0d427/coverage-7.15.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 257103
+name = "coverage-7.15.4-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-08-06 13:47:41.931828+00:00
+url = "https://files.pythonhosted.org/packages/8c/3f/f0642a372f494bd0d7dad3b497083b910194a5f1c88be2c94fef707c3b59/coverage-7.15.4-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 257145
 
 [packages.wheels.hashes]
-sha256 = "63a4ff67364afb2cac826b8bbd78a5c50ce656a7b7137436b44d7b96a9271088"
+sha256 = "899b9da30f3c6c336566e3707495bb23e8302d39d862f01fa78c48b99b9437e2"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-08-02 18:48:21.963498+00:00
-url = "https://files.pythonhosted.org/packages/66/3a/2893e2937adfe02f45fd38e4a8a0a0d8b7a02ff9e012ac3d009bee3c4f16/coverage-7.15.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 258220
+name = "coverage-7.15.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-08-06 13:47:43.527105+00:00
+url = "https://files.pythonhosted.org/packages/71/17/8b46d0ed68251016002ec972c8fc0119961a765d0984cafb8bf317c43758/coverage-7.15.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 258257
 
 [packages.wheels.hashes]
-sha256 = "6e95e42856509675fe26560310313a6117640e96f9a1e19bb3d220116a27c94c"
+sha256 = "d15715e8c46552827e5e4f30a35575a2dbcad14454cf3284c54483946bd16931"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp312-cp312-win_amd64.whl"
-upload-time = 2026-08-02 18:48:38.941989+00:00
-url = "https://files.pythonhosted.org/packages/b1/0f/df90cc1e8d095ce263968a93e04829821b2afb31ac2752c06a2e0a8e3c13/coverage-7.15.3-cp312-cp312-win_amd64.whl"
-size = 225098
+name = "coverage-7.15.4-cp312-cp312-win_amd64.whl"
+upload-time = 2026-08-06 13:47:57.520954+00:00
+url = "https://files.pythonhosted.org/packages/49/b9/5c5f80cc55f5acaaca6dee677626bfcec8c87204a7809b438b08e84f4571/coverage-7.15.4-cp312-cp312-win_amd64.whl"
+size = 225135
 
 [packages.wheels.hashes]
-sha256 = "fa7b17902c3c1dd8a7adb52679b7f6340bba08443d710c8838e04db8cf62be2a"
+sha256 = "6befeab5fb2b51c958ca4ac6c5d141a1e8240f4f76e46350f1911963deda49cd"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp313-cp313-macosx_10_13_x86_64.whl"
-upload-time = 2026-08-02 18:48:42.476817+00:00
-url = "https://files.pythonhosted.org/packages/68/6e/62ae61e1fc434956bec38ed1d5b1c494f58cf579dbd998e77abffe7b3e6b/coverage-7.15.3-cp313-cp313-macosx_10_13_x86_64.whl"
-size = 222522
+name = "coverage-7.15.4-cp313-cp313-macosx_10_13_x86_64.whl"
+upload-time = 2026-08-06 13:48:00.796792+00:00
+url = "https://files.pythonhosted.org/packages/f1/84/651a9310859673aaa3b3203f1aa1641ca60fcf2494683e1c9474c7172780/coverage-7.15.4-cp313-cp313-macosx_10_13_x86_64.whl"
+size = 222565
 
 [packages.wheels.hashes]
-sha256 = "1182eed05674c63d40951fae27c43e822749f04d25f75df64c2e4fa3168678de"
+sha256 = "c705b28feb2775dc82a25f1d473a370bc37ff93f5177f4e29ce2425f560f6921"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp313-cp313-macosx_11_0_arm64.whl"
-upload-time = 2026-08-02 18:48:44.274728+00:00
-url = "https://files.pythonhosted.org/packages/13/ff/c74c673d81e0e77b6608c3d21331e3db42e30daeb3c8a0a8860d4c9e2e14/coverage-7.15.3-cp313-cp313-macosx_11_0_arm64.whl"
-size = 222894
+name = "coverage-7.15.4-cp313-cp313-macosx_11_0_arm64.whl"
+upload-time = 2026-08-06 13:48:02.391936+00:00
+url = "https://files.pythonhosted.org/packages/82/f9/4dcf700137e8af550670f4d74d1b63828ce93e1e2b05e5f10710eb2ea987/coverage-7.15.4-cp313-cp313-macosx_11_0_arm64.whl"
+size = 222936
 
 [packages.wheels.hashes]
-sha256 = "c0c4b0d7c4cd56e470d0c9d8441f42e8a96cdfd95050fec027f1d4dd9f11006c"
+sha256 = "3ff205ab5e3ecc670f6a4dd19d9cbf12ede53dd41cfc1e15716ec961ea6d314e"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-08-02 18:48:47.846801+00:00
-url = "https://files.pythonhosted.org/packages/29/c6/e92a66cda49a2751b09826d51258f199b92aa0cb005bc5f34e9729a52a9c/coverage-7.15.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 256484
+name = "coverage-7.15.4-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-08-06 13:48:05.996722+00:00
+url = "https://files.pythonhosted.org/packages/b0/04/d1cff1c2ead4708a6a79c01d3736b6a25bd38a36678398f72a8dd33dfad9/coverage-7.15.4-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 256523
 
 [packages.wheels.hashes]
-sha256 = "7a47e2a0a0ace9241e70ee00e44520f88b843094603dd54303f1bafecd929c30"
+sha256 = "12b59c90084e3234fb11184886bf4a40f4f16a8c8f867be2e087b81f8e8868d4"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-08-02 18:48:49.664817+00:00
-url = "https://files.pythonhosted.org/packages/96/7a/730929164b457cf25cf76c23898b90f9039a104a647890801b6586797b14/coverage-7.15.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 257723
+name = "coverage-7.15.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-08-06 13:48:08.036066+00:00
+url = "https://files.pythonhosted.org/packages/b9/80/d34e13fb4b293cbdb9665838cf5522077b8ad14ef947550631a4bced36a5/coverage-7.15.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 257759
 
 [packages.wheels.hashes]
-sha256 = "95bad94f83807ae60ed76f3ac012f69b2605ac9ea81bee959a5a483f7fa09c10"
+sha256 = "349062d66f00b40fa2c1c222438bad25fabf755631b5d82937fe985c8008615c"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp313-cp313-win_amd64.whl"
-upload-time = 2026-08-02 18:49:06.894452+00:00
-url = "https://files.pythonhosted.org/packages/1c/64/88f762ea80de2070207246faef514513be874486b2773528f2cc2b4b515c/coverage-7.15.3-cp313-cp313-win_amd64.whl"
-size = 225116
+name = "coverage-7.15.4-cp313-cp313-win_amd64.whl"
+upload-time = 2026-08-06 13:48:23.376105+00:00
+url = "https://files.pythonhosted.org/packages/e0/e2/2946c7f0b42b152ecb21ff1bdad72e3d301e790c0c487e4a86e8c9f69347/coverage-7.15.4-cp313-cp313-win_amd64.whl"
+size = 225148
 
 [packages.wheels.hashes]
-sha256 = "835528518a1d823cf336740324b2f335f7c01e609e74abcb5d5163b3e66661e3"
+sha256 = "2ff8f5e9b8f7a94f0c11c45631eee103dbcb7d63274edd12c56efe1be690b3b4"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp314-cp314-macosx_10_15_x86_64.whl"
-upload-time = 2026-08-02 18:49:11.242670+00:00
-url = "https://files.pythonhosted.org/packages/35/6f/8c2dc014357618b3226c90f731b8282766c3685786f422558991dc49fbf2/coverage-7.15.3-cp314-cp314-macosx_10_15_x86_64.whl"
-size = 222571
+name = "coverage-7.15.4-cp314-cp314-macosx_10_15_x86_64.whl"
+upload-time = 2026-08-06 13:48:26.806172+00:00
+url = "https://files.pythonhosted.org/packages/ea/ac/748cf29eeb2d6be34a3176ce26a4f49e38085ee08e8935f05f6f26ed7e0f/coverage-7.15.4-cp314-cp314-macosx_10_15_x86_64.whl"
+size = 222608
 
 [packages.wheels.hashes]
-sha256 = "1e3bb08ad574bd9fb6a991f645728f70d333c1c1958dd5fcde65e24cb862813d"
+sha256 = "770e9325ab5ea6d56f77e59b29ecfe0ac20b57a82a601876f90494a4dda0386f"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp314-cp314-macosx_11_0_arm64.whl"
-upload-time = 2026-08-02 18:49:13.448301+00:00
-url = "https://files.pythonhosted.org/packages/07/50/d867c7ceae9d56b7e74ee61ea834f1aa4f9a1e1c7f0ce39393ba573b1c12/coverage-7.15.3-cp314-cp314-macosx_11_0_arm64.whl"
-size = 222902
+name = "coverage-7.15.4-cp314-cp314-macosx_11_0_arm64.whl"
+upload-time = 2026-08-06 13:48:28.432135+00:00
+url = "https://files.pythonhosted.org/packages/0b/02/1abbf5c984677b0aa439cdacaccbf38d248939d8ef8fe1cc7a50d73edb77/coverage-7.15.4-cp314-cp314-macosx_11_0_arm64.whl"
+size = 222940
 
 [packages.wheels.hashes]
-sha256 = "9e5860eaff02a0b7f1b73304bdf846596ee62ab3a78d25c68044ebf684cb1fef"
+sha256 = "d12b33a3a50a1676b7784dc8d00a0c6d66a9f2add4b85a041c19b6a7e53ef23c"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-08-02 18:49:17.801831+00:00
-url = "https://files.pythonhosted.org/packages/16/8a/6777f192af264165103e2a3d3768dbadb9894a0a2359a16877141d9ae8f5/coverage-7.15.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 256452
+name = "coverage-7.15.4-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-08-06 13:48:31.634898+00:00
+url = "https://files.pythonhosted.org/packages/a1/26/595759762e514e81be1d7d01ed03444303bcd152226a6529998d253f9201/coverage-7.15.4-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 256492
 
 [packages.wheels.hashes]
-sha256 = "f9147be876e9d83765e0b82176674dc248a6b9283e25e01e7462611b97e9b731"
+sha256 = "ff97a14362eef486483ed44042ca2027ea257df6ff768e62358ee0c9776925ac"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-08-02 18:49:19.878255+00:00
-url = "https://files.pythonhosted.org/packages/7d/7b/3d7ac46a0234bc684f41ee42be95e29b2b6525695adb04083609d5ac2149/coverage-7.15.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 257798
+name = "coverage-7.15.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-08-06 13:48:33.186086+00:00
+url = "https://files.pythonhosted.org/packages/24/68/b79aabac54d482be23b5fcdd4f4662bff24a78edc4ee29201726929936d5/coverage-7.15.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 257837
 
 [packages.wheels.hashes]
-sha256 = "61a01f8c3804760fcc5a3d31c4f3cab792d660d44e17bf7adeaf0ea51e07821e"
+sha256 = "5a325e815318638aed1655d9c06e6d7c2d3d46c09231ce988070428a8762d734"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-cp314-cp314-win_amd64.whl"
-upload-time = 2026-08-02 18:49:38.366697+00:00
-url = "https://files.pythonhosted.org/packages/b3/78/5c93ec43784fd3e404ca23cd0584ae24bc1732de4a3fc194b68c3be88db0/coverage-7.15.3-cp314-cp314-win_amd64.whl"
-size = 225246
+name = "coverage-7.15.4-cp314-cp314-win_amd64.whl"
+upload-time = 2026-08-06 13:48:49.513627+00:00
+url = "https://files.pythonhosted.org/packages/ee/90/219484e476d6e101ba0a444852579e05f5b75c37c611a42ed1190f73ef62/coverage-7.15.4-cp314-cp314-win_amd64.whl"
+size = 225259
 
 [packages.wheels.hashes]
-sha256 = "64d0845f9c3ed47302bed265c15ab4dbb64aa4ec1490839b8e328f4e7fa914d2"
+sha256 = "f0204ed122758782970526057093f448051a39db9d810d4e344bb87a3546f425"
 
 [[packages.wheels]]
-name = "coverage-7.15.3-py3-none-any.whl"
-upload-time = 2026-08-02 18:50:14.709301+00:00
-url = "https://files.pythonhosted.org/packages/37/e7/7069b3d6c018917f49ba2e1c5fb910e498c7fefa3a1b78cb1b79e61ff45d/coverage-7.15.3-py3-none-any.whl"
-size = 214297
+name = "coverage-7.15.4-py3-none-any.whl"
+upload-time = 2026-08-06 13:50:22.192922+00:00
+url = "https://files.pythonhosted.org/packages/b4/d9/e70c286c979378f061d8266e279b686ab0b0b688e1fe0af864684f23a77d/coverage-7.15.4-py3-none-any.whl"
+size = 214332
 
 [packages.wheels.hashes]
-sha256 = "da78fa6fc7dafe4212839173133ee85afcf42c5cd5f3e47fa7c1c210453b445e"
+sha256 = "964730a1e9de9c0cf11be6a1a3c79ce419c34882842abd256086ba4698705e84"
 
 [[packages]]
 name = "exceptiongroup"
@@ -624,7 +624,7 @@ sha256 = "b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5"
 
 [[packages]]
 name = "hypothesis"
-version = "6.165.1"
+version = "6.165.10"
 marker = "\"tests\" in dependency_groups"
 requires-python = ">=3.10"
 dependencies = [
@@ -634,308 +634,308 @@ dependencies = [
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "hypothesis-6.165.1.tar.gz"
-upload-time = 2026-08-04 21:02:05.394980+00:00
-url = "https://files.pythonhosted.org/packages/29/ba/6a79ef3edd4d32f011267ba709393ba0bb018751fe019032f9b63a3a29fc/hypothesis-6.165.1.tar.gz"
-size = 496225
+name = "hypothesis-6.165.10.tar.gz"
+upload-time = 2026-08-16 22:56:15.404426+00:00
+url = "https://files.pythonhosted.org/packages/5c/e2/0fad246d2b6330e1f78479bfc566b5c22be82aee8a865cde9a08f648487d/hypothesis-6.165.10.tar.gz"
+size = 503703
 
 [packages.sdist.hashes]
-sha256 = "0fe3ae25bd0b0938d8681eacaa8ebc981761f1387db7bef609b22cfdec848dc2"
+sha256 = "68b45e09834cd80523cb1eb274463073c7a9af4e4ef7cff34d9615f355572d32"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp310-abi3-macosx_10_12_x86_64.whl"
-upload-time = 2026-08-04 21:00:47.014918+00:00
-url = "https://files.pythonhosted.org/packages/c0/24/ad0c5136b1d82b6955f79edbc39f7092dced8c09e9b08aec5a3ec02c02b5/hypothesis-6.165.1-cp310-abi3-macosx_10_12_x86_64.whl"
-size = 775946
+name = "hypothesis-6.165.10-cp310-abi3-macosx_10_12_x86_64.whl"
+upload-time = 2026-08-16 22:55:44.058264+00:00
+url = "https://files.pythonhosted.org/packages/05/c1/9a9538e6d185baf5cc7f15bc3b76e08efbb3de4b3c782f234356449c0dd7/hypothesis-6.165.10-cp310-abi3-macosx_10_12_x86_64.whl"
+size = 783243
 
 [packages.wheels.hashes]
-sha256 = "1a5640b5e52211e6a876a53af28ec292b984bb02a57be1e39fac38f2f28c6921"
+sha256 = "f839d29d0cc12048cf073d88ca4fdf94d420bc2b8afd69641ff6d496422ccd4f"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp310-abi3-macosx_11_0_arm64.whl"
-upload-time = 2026-08-04 21:00:35.334223+00:00
-url = "https://files.pythonhosted.org/packages/67/4f/c6dc9b300c2da163cc20d857f87e5d7f21240d99f071d1da3c27ac3d6269/hypothesis-6.165.1-cp310-abi3-macosx_11_0_arm64.whl"
-size = 771443
+name = "hypothesis-6.165.10-cp310-abi3-macosx_11_0_arm64.whl"
+upload-time = 2026-08-16 22:55:46.948220+00:00
+url = "https://files.pythonhosted.org/packages/a1/30/b70d9d79e871a75cbdeccd9067f20ecdb9eb2a1dfa03c630be3ad13b8b30/hypothesis-6.165.10-cp310-abi3-macosx_11_0_arm64.whl"
+size = 778815
 
 [packages.wheels.hashes]
-sha256 = "49c385fefc6d43c1f94792718d0f6bdb3dec894239d1118cfcceb48a4eaa495c"
+sha256 = "e10858f57ed0e74baa04393845f469fe8ad502c16ece4499bef7700c575611bd"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-upload-time = 2026-08-04 21:01:07.771642+00:00
-url = "https://files.pythonhosted.org/packages/b7/9a/8e9ecb2d0d1608e64cadca9297654c07fecbef8d66a9dce5d26db02bdf19/hypothesis-6.165.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-size = 1100733
+name = "hypothesis-6.165.10-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+upload-time = 2026-08-16 22:54:53.082995+00:00
+url = "https://files.pythonhosted.org/packages/db/52/6f0a9b7aab24b0635e2238f3fbddea5b54b17879ac813df42a3cc3384c5c/hypothesis-6.165.10-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+size = 1108009
 
 [packages.wheels.hashes]
-sha256 = "559f37d914f2a7c5d2b28b3ef7282814992082c1492343fed644244d984208ce"
+sha256 = "76a7be86d986223b9f1bdb7e7cbcdb048649901fdb956c598ef73bdab1786cd5"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-upload-time = 2026-08-04 21:00:42.104256+00:00
-url = "https://files.pythonhosted.org/packages/a0/d4/97fcc4d2fc69c71856cc4b7ff8f85d00d0cdc9218e8272630e52a83e8cae/hypothesis-6.165.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-size = 1150180
+name = "hypothesis-6.165.10-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+upload-time = 2026-08-16 22:56:02.159775+00:00
+url = "https://files.pythonhosted.org/packages/7d/18/8a26c24d3d9db20265f39df341ab265858c094e209571e3179cf237935f4/hypothesis-6.165.10-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+size = 1157528
 
 [packages.wheels.hashes]
-sha256 = "829a45c5459f7070277ac0fb0e7b052a7d9bdc2f54a546bfc34279213b6fa858"
+sha256 = "2abb50cf1cf77d721de0a24c3f99d9c4ffdeb2cbd1e12aebb5a7a93e2b6b6d1f"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp310-abi3-win_amd64.whl"
-upload-time = 2026-08-04 21:01:11.382705+00:00
-url = "https://files.pythonhosted.org/packages/b6/15/b6e98c68799f381123c872ca3493f1eb400b0e28550be938d1d3d63743c2/hypothesis-6.165.1-cp310-abi3-win_amd64.whl"
-size = 667859
+name = "hypothesis-6.165.10-cp310-abi3-win_amd64.whl"
+upload-time = 2026-08-16 22:55:01.697546+00:00
+url = "https://files.pythonhosted.org/packages/2c/fc/ff2988b72b5705ad9ca500444bf3f43e3c2f41edfa034bbfeb23b215791a/hypothesis-6.165.10-cp310-abi3-win_amd64.whl"
+size = 675213
 
 [packages.wheels.hashes]
-sha256 = "d30337baadfdaccf0ad6d70fe135201722f67f7522584b2a7494cfd7e03798a6"
+sha256 = "e9f924aa610c0618445e1e8738c822c3190ce2a2699a0cb48ec3a351a96761f2"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp310-cp310-macosx_10_12_x86_64.whl"
-upload-time = 2026-08-04 21:01:20.695173+00:00
-url = "https://files.pythonhosted.org/packages/2f/49/afc3102bb18ed2f5cbfa4ca2dfb2927e6af5ddc992a366494b946ae8021f/hypothesis-6.165.1-cp310-cp310-macosx_10_12_x86_64.whl"
-size = 776629
+name = "hypothesis-6.165.10-cp310-cp310-macosx_10_12_x86_64.whl"
+upload-time = 2026-08-16 22:55:29.078640+00:00
+url = "https://files.pythonhosted.org/packages/26/61/5e89268ce03317fb9f82449a1b3efd9e599dee090288fd0cf7586c532fb1/hypothesis-6.165.10-cp310-cp310-macosx_10_12_x86_64.whl"
+size = 783959
 
 [packages.wheels.hashes]
-sha256 = "7d71de7bab66af3152de2d03e615055fda7000c1f2325588bca9bba1ec0e8534"
+sha256 = "73e6df02a6a62f8045b511c272f894d08e56d174504c793c9effcbc6778051a8"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp310-cp310-macosx_11_0_arm64.whl"
-upload-time = 2026-08-04 21:01:26.716510+00:00
-url = "https://files.pythonhosted.org/packages/de/db/c4450c471fa77c70fe4f296d0ad87c984dcd2fd138a10fb475b7f74fe005/hypothesis-6.165.1-cp310-cp310-macosx_11_0_arm64.whl"
-size = 772365
+name = "hypothesis-6.165.10-cp310-cp310-macosx_11_0_arm64.whl"
+upload-time = 2026-08-16 22:54:57.698906+00:00
+url = "https://files.pythonhosted.org/packages/e1/e9/f4e0832e81bb53b70cf1712e28c867db64245b32595b594217452e7dbd8d/hypothesis-6.165.10-cp310-cp310-macosx_11_0_arm64.whl"
+size = 779684
 
 [packages.wheels.hashes]
-sha256 = "be98424c7501b3f2946d2fb96678688afdb127429be1a101befbae8e3312b6aa"
+sha256 = "8b20f44773a9ab84400465e318712d8c2ca16418d35b9f80aa27fdf2d690ad10"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-upload-time = 2026-08-04 21:00:51.784748+00:00
-url = "https://files.pythonhosted.org/packages/6f/92/1e0dd48e68e456045ebb04c50f95147b3484226e97a96e3aa9b0f58aaf4a/hypothesis-6.165.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-size = 1101229
+name = "hypothesis-6.165.10-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+upload-time = 2026-08-16 22:55:03.282605+00:00
+url = "https://files.pythonhosted.org/packages/77/de/ea072d3359d5678771bed407f80439e8ac7ca905d1031b0372f61bf5746e/hypothesis-6.165.10-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+size = 1108540
 
 [packages.wheels.hashes]
-sha256 = "4d1d91ef9f2a9618a80a34211f6269fabd79338f8cd9e258a2e379a4093b04a1"
+sha256 = "bb8c7d05ea27a093a92b250904095d71d924b6b44e5795a415c1b20c265f0c65"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-upload-time = 2026-08-04 21:01:02.114422+00:00
-url = "https://files.pythonhosted.org/packages/3a/a7/9f32f6dcfa18c5c6662942b6b264faa5b441951e4af347270f161722c23d/hypothesis-6.165.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-size = 1150647
+name = "hypothesis-6.165.10-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+upload-time = 2026-08-16 22:54:36.205289+00:00
+url = "https://files.pythonhosted.org/packages/28/56/e7c395cdaa3d6c28b944c1c3c516dee50d2b7b3aeafa31874b57009ca51f/hypothesis-6.165.10-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+size = 1158089
 
 [packages.wheels.hashes]
-sha256 = "dfcdf827ec449c59429eac5230c45d6bc297fb3da127621b7360df7c29ba6a6d"
+sha256 = "f4dafd6d6ababfa3b14dd6e5f0378cb7c7d291895a31a40abcbb7cc74f396131"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp310-cp310-win_amd64.whl"
-upload-time = 2026-08-04 21:00:16.200901+00:00
-url = "https://files.pythonhosted.org/packages/59/a7/0bdd0561abd5901044ecdb533077693f5bb8ed37ed0d2a29794cb270381b/hypothesis-6.165.1-cp310-cp310-win_amd64.whl"
-size = 667742
+name = "hypothesis-6.165.10-cp310-cp310-win_amd64.whl"
+upload-time = 2026-08-16 22:54:29.872104+00:00
+url = "https://files.pythonhosted.org/packages/70/99/9d844330f570d6a4f127a683eab1e78c8263e6e72b16189f3534fa6bf6de/hypothesis-6.165.10-cp310-cp310-win_amd64.whl"
+size = 675082
 
 [packages.wheels.hashes]
-sha256 = "44d701a2d1078aacec9d473ece2f63b12e7b1bb1afef058408d83eefdcd6a0fd"
+sha256 = "56cb8c9055e50545fe6e3e5a560ec25a724673b2e4051f3c24d44e3ebc35dd72"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp311-cp311-macosx_10_12_x86_64.whl"
-upload-time = 2026-08-04 21:00:55.428416+00:00
-url = "https://files.pythonhosted.org/packages/50/34/6cc747835aebec9d481b908c762bf552beec2ae7b95d1db3de40a66ef120/hypothesis-6.165.1-cp311-cp311-macosx_10_12_x86_64.whl"
-size = 776390
+name = "hypothesis-6.165.10-cp311-cp311-macosx_10_12_x86_64.whl"
+upload-time = 2026-08-16 22:55:36.624360+00:00
+url = "https://files.pythonhosted.org/packages/ed/c2/b9546ace11f241c9c02d389f258cb80c14447a8c885771c9f1f0bc1d85ca/hypothesis-6.165.10-cp311-cp311-macosx_10_12_x86_64.whl"
+size = 783716
 
 [packages.wheels.hashes]
-sha256 = "2dac5c816124efec59dcb8117a4a521e0647faad1041c5280d0009304145ad79"
+sha256 = "592107a0faf6c9c3a63a8dbf13dfb1cbda1cf599b0bc11c953221b00204b9ce1"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp311-cp311-macosx_11_0_arm64.whl"
-upload-time = 2026-08-04 21:00:20.007100+00:00
-url = "https://files.pythonhosted.org/packages/65/da/98025b789cc9ed7e1136176b3528029ee0c758733cfedc8963f6671e4c7b/hypothesis-6.165.1-cp311-cp311-macosx_11_0_arm64.whl"
-size = 772175
+name = "hypothesis-6.165.10-cp311-cp311-macosx_11_0_arm64.whl"
+upload-time = 2026-08-16 22:55:07.633139+00:00
+url = "https://files.pythonhosted.org/packages/37/10/27c2fdd574fd798caf5e91eb51f7834b098f5d840ce733efb3fba79ef86e/hypothesis-6.165.10-cp311-cp311-macosx_11_0_arm64.whl"
+size = 779507
 
 [packages.wheels.hashes]
-sha256 = "f2d3bf3b4035271024f215ae592b4adeaf5c95569b8a64362f358e6c2fa1fe83"
+sha256 = "f9180c362bde06fd05380298ded4e234fbc0d6ede0a864835bfd91c1e24283d5"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-upload-time = 2026-08-04 21:00:32.251930+00:00
-url = "https://files.pythonhosted.org/packages/df/47/4689ddf832a43bcb2fff4045aa37ba3eb5387ede2648488d010d61fc0cdc/hypothesis-6.165.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-size = 1101069
+name = "hypothesis-6.165.10-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+upload-time = 2026-08-16 22:55:39.653728+00:00
+url = "https://files.pythonhosted.org/packages/5e/b6/70bc23695f3783c4b0486b6cad47b08a20f791db4a3c1b25250add9659fa/hypothesis-6.165.10-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+size = 1108406
 
 [packages.wheels.hashes]
-sha256 = "52a23badd21024ea3e4767121ed47309a349171e0614ce0069037d891e68a0f9"
+sha256 = "d623801ae3dcd97b77b983400ef3d48bf976648e4efff19929175322eaae074d"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-upload-time = 2026-08-04 21:01:52.536928+00:00
-url = "https://files.pythonhosted.org/packages/ee/25/b71cac1cc16d633c4b8da876a078d55e1e6b2702acbbc701492390c01cfc/hypothesis-6.165.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-size = 1150514
+name = "hypothesis-6.165.10-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+upload-time = 2026-08-16 22:55:24.394291+00:00
+url = "https://files.pythonhosted.org/packages/71/4c/32e200bd7a352af4b7f4e3729aaa4cd002cb5fe8c4c6aef5599d0019f152/hypothesis-6.165.10-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+size = 1157850
 
 [packages.wheels.hashes]
-sha256 = "f57a7340e2cfbb0143b9d1cbe982d663560f0eef39e6aa99c6a711f29c072c27"
+sha256 = "20f6236cfb90b7817bb1a6a087589ca4aa46d73170f0dd62963952ed5dadc589"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp311-cp311-win_amd64.whl"
-upload-time = 2026-08-04 21:01:34.042968+00:00
-url = "https://files.pythonhosted.org/packages/f2/8d/4d226b095da3e1b99d7e5d3621f3f964f2a7b5bfbbb82126992a8f6e799b/hypothesis-6.165.1-cp311-cp311-win_amd64.whl"
-size = 667598
+name = "hypothesis-6.165.10-cp311-cp311-win_amd64.whl"
+upload-time = 2026-08-16 22:55:42.613036+00:00
+url = "https://files.pythonhosted.org/packages/82/ac/bc16faba4b42883e3d290bfaceff51e258b63fbbdf789bf9fe88df1ce537/hypothesis-6.165.10-cp311-cp311-win_amd64.whl"
+size = 674920
 
 [packages.wheels.hashes]
-sha256 = "9763c1cb9dd6b9a1ab395481d4067b2e8a3b148a97e599b419788e8775106b54"
+sha256 = "5671d2b2bf83bd4b6f02e55b32d432506eff5358c82f39b460a849ce19a2666e"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp312-cp312-macosx_10_12_x86_64.whl"
-upload-time = 2026-08-04 21:01:14.907426+00:00
-url = "https://files.pythonhosted.org/packages/30/48/7a8de755d9b9cab7caa9ef9051ffa2a5a21f7b20f813c902b0123952ed33/hypothesis-6.165.1-cp312-cp312-macosx_10_12_x86_64.whl"
-size = 777509
+name = "hypothesis-6.165.10-cp312-cp312-macosx_10_12_x86_64.whl"
+upload-time = 2026-08-16 22:54:45.429027+00:00
+url = "https://files.pythonhosted.org/packages/e9/45/cde4f78afe2b9e29caecf38319eedc1deb76aebcacbdd128e03cbb2511c3/hypothesis-6.165.10-cp312-cp312-macosx_10_12_x86_64.whl"
+size = 784835
 
 [packages.wheels.hashes]
-sha256 = "53b3d1e8ed9140994955f7bf27c185d45a475dc9d4bc95c69e7bd48b5c3c426f"
+sha256 = "637445c1593a2a9d1024fda50082f07bb56baedda78d90a25f64b8111727ef94"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp312-cp312-macosx_11_0_arm64.whl"
-upload-time = 2026-08-04 21:00:48.553670+00:00
-url = "https://files.pythonhosted.org/packages/54/2b/97224357923b13c3dd84ebbcd39bd414368543306e60b72b72deb0743f4a/hypothesis-6.165.1-cp312-cp312-macosx_11_0_arm64.whl"
-size = 769074
+name = "hypothesis-6.165.10-cp312-cp312-macosx_11_0_arm64.whl"
+upload-time = 2026-08-16 22:55:33.633066+00:00
+url = "https://files.pythonhosted.org/packages/7f/81/847f30b81cbfd07607296b3ce43067cf4f80799bd9244167f587de9c8081/hypothesis-6.165.10-cp312-cp312-macosx_11_0_arm64.whl"
+size = 776419
 
 [packages.wheels.hashes]
-sha256 = "8f4b0e0664e058fdf1637d1ca9d984e5286372ad58b70222195dc535a771c4bd"
+sha256 = "713f4ce4e82c26b53031f139de959bc9e8b54d3995aa824b89bbdf8229df2a45"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-upload-time = 2026-08-04 21:00:38.915552+00:00
-url = "https://files.pythonhosted.org/packages/e4/f4/e00e850e4e3b1d25b2b7b6528b8fc0dd3ce5c5989cdb4863b6b9cd814b06/hypothesis-6.165.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-size = 1099519
+name = "hypothesis-6.165.10-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+upload-time = 2026-08-16 22:55:10.389496+00:00
+url = "https://files.pythonhosted.org/packages/04/66/4c71c5be7a49d84b8c3a9278c1807c4c81181ab5474beb27df9d4c40dc0e/hypothesis-6.165.10-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+size = 1106830
 
 [packages.wheels.hashes]
-sha256 = "616df752e3b2f8db6e463a86ad42942024094050adf4406bda4543b6b91333c3"
+sha256 = "f9ff356e97e3ab09db07c8b675efa67340103874a0bae7465acb83dad7a35f7f"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-upload-time = 2026-08-04 21:00:45.151152+00:00
-url = "https://files.pythonhosted.org/packages/59/cb/24498d5b5a0d73c780a31d9b2269ff032cdacb772a986f8fb52444aa3dae/hypothesis-6.165.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-size = 1149568
+name = "hypothesis-6.165.10-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+upload-time = 2026-08-16 22:55:53.350534+00:00
+url = "https://files.pythonhosted.org/packages/e3/c4/e2cbd2810e79f7a452a8ea9f6c6438ee718ce938d8cc12252cf0b36a81d3/hypothesis-6.165.10-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+size = 1156952
 
 [packages.wheels.hashes]
-sha256 = "38a67b9f6807dade978d293be183c7487968a9c3c9a656c33effd75ddc8405f8"
+sha256 = "1a380bc99aa3b035e6a95a2201bf792d4082a04ca75babcc21849c2d0914bb28"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp312-cp312-win_amd64.whl"
-upload-time = 2026-08-04 21:01:50.588633+00:00
-url = "https://files.pythonhosted.org/packages/08/85/ee8ea059d01971fd7c0d9498911eac5b94ef6678a39575eebe37fdf2d49b/hypothesis-6.165.1-cp312-cp312-win_amd64.whl"
-size = 665024
+name = "hypothesis-6.165.10-cp312-cp312-win_amd64.whl"
+upload-time = 2026-08-16 22:54:49.110755+00:00
+url = "https://files.pythonhosted.org/packages/74/59/6caf69dd5fe03499ada94c9cec016bffcc164511c6b93fe680f01209b9ff/hypothesis-6.165.10-cp312-cp312-win_amd64.whl"
+size = 672337
 
 [packages.wheels.hashes]
-sha256 = "16b63ec033a0dceb6e00da6cc5d49bb38803c6825ca68f52604e424a2e3682ed"
+sha256 = "3376f2594763aef14faa519b0fb27cae7ce9eeaab4c69efa07777499110306c9"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp313-cp313-macosx_10_12_x86_64.whl"
-upload-time = 2026-08-04 21:01:48.265736+00:00
-url = "https://files.pythonhosted.org/packages/58/ae/6154945a7603e305273f98fc10bc3364a6e67d347ff810e02f864a7b7843/hypothesis-6.165.1-cp313-cp313-macosx_10_12_x86_64.whl"
-size = 777400
+name = "hypothesis-6.165.10-cp313-cp313-macosx_10_12_x86_64.whl"
+upload-time = 2026-08-16 22:54:32.371117+00:00
+url = "https://files.pythonhosted.org/packages/b1/fb/c82c5bd92864ffcf319772fedc8c9bf2dbe4ca14baa0fee6e49e67b5ba1c/hypothesis-6.165.10-cp313-cp313-macosx_10_12_x86_64.whl"
+size = 784726
 
 [packages.wheels.hashes]
-sha256 = "57c235a348b544455e13300e6cf11e0bf3eea4b692331beb42854edc8e661045"
+sha256 = "9d77c3be7b429875036ad0f0597c6e5cc6bb17894a4da005e3807de64d2673ad"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp313-cp313-macosx_11_0_arm64.whl"
-upload-time = 2026-08-04 21:00:50.295697+00:00
-url = "https://files.pythonhosted.org/packages/b7/75/3817a4878664895e2f9c5518aa4918366db5bc2521a6498e480a6ada1b1c/hypothesis-6.165.1-cp313-cp313-macosx_11_0_arm64.whl"
-size = 769040
+name = "hypothesis-6.165.10-cp313-cp313-macosx_11_0_arm64.whl"
+upload-time = 2026-08-16 22:55:13.303522+00:00
+url = "https://files.pythonhosted.org/packages/0e/b9/3d7acd08506da85557e65147b7f3fca8c47684e33be90bee0acb523920db/hypothesis-6.165.10-cp313-cp313-macosx_11_0_arm64.whl"
+size = 776375
 
 [packages.wheels.hashes]
-sha256 = "28b1aae4f2cf6cb99d34b1979d06d21f36ef771afb42418c9243da145e36e09a"
+sha256 = "490c56b830772b0eca3b4b2cecb3741a1ed26b1d7206a279e1525dbf0aa95ee4"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-upload-time = 2026-08-04 21:00:37.215988+00:00
-url = "https://files.pythonhosted.org/packages/e3/12/34d55b84b761448f76a493e1d71ce1ceb0529a92db013635e74dbbd64030/hypothesis-6.165.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-size = 1099438
+name = "hypothesis-6.165.10-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+upload-time = 2026-08-16 22:55:06.129333+00:00
+url = "https://files.pythonhosted.org/packages/38/6b/922e8b3f9a706dd89d440b9545d2c6231c65e74da1c1fee3ff36c251b9c4/hypothesis-6.165.10-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+size = 1106763
 
 [packages.wheels.hashes]
-sha256 = "33fb3293d3b7a56749b34ac64012540bec5c4d2ca701fa47a88cbc88846d1228"
+sha256 = "ed68e27b8a61e57a3ccdc7c5a14499e00b54dfe223087204d5d40b3b5ef58b6d"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-upload-time = 2026-08-04 21:01:22.695223+00:00
-url = "https://files.pythonhosted.org/packages/1c/23/cf88d3ec0521089258000ff17d3a6bd13c78c2efcfaaece9af06e5b0f2d5/hypothesis-6.165.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-size = 1149379
+name = "hypothesis-6.165.10-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+upload-time = 2026-08-16 22:54:33.824194+00:00
+url = "https://files.pythonhosted.org/packages/01/39/f5b9a5d390d4edd1ad472334493ac442963ebeb4daaa74ff4bdac6ef292f/hypothesis-6.165.10-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+size = 1156778
 
 [packages.wheels.hashes]
-sha256 = "9ca1f560b9b0a9b000619d199748994eb8703915bbaf60a5377feaf296f7514f"
+sha256 = "6caadcd1afb62630ff5c5ff353626eaa616553a5971295ad6dc2b19ca8a39620"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp313-cp313-win_amd64.whl"
-upload-time = 2026-08-04 21:00:24.428403+00:00
-url = "https://files.pythonhosted.org/packages/54/d5/eda5cc31ac6c56a238ae5b341737c812fbc1fb84e93ad47088da96f4a953/hypothesis-6.165.1-cp313-cp313-win_amd64.whl"
-size = 665035
+name = "hypothesis-6.165.10-cp313-cp313-win_amd64.whl"
+upload-time = 2026-08-16 22:56:03.792099+00:00
+url = "https://files.pythonhosted.org/packages/cc/cc/662b94880f260b0a88de1fdcf60fc9984f6e2a796da549542adc10a7bc83/hypothesis-6.165.10-cp313-cp313-win_amd64.whl"
+size = 672346
 
 [packages.wheels.hashes]
-sha256 = "55ed0599c5e5fdf7ada0b48ee1de05f314bcf6f01e49ad92a786da3d169c9d1c"
+sha256 = "c01dd04044c472e47193b54f68e84e08d6ebf4f29551885aa959b015f7cd9747"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp314-cp314-macosx_10_12_x86_64.whl"
-upload-time = 2026-08-04 21:01:46.361154+00:00
-url = "https://files.pythonhosted.org/packages/c7/c5/d7c53d4e6a76f2d27a2179e9ea80ebcc76dcc151e17fa4df07efb943c7ae/hypothesis-6.165.1-cp314-cp314-macosx_10_12_x86_64.whl"
-size = 777613
+name = "hypothesis-6.165.10-cp314-cp314-macosx_10_12_x86_64.whl"
+upload-time = 2026-08-16 22:55:21.255200+00:00
+url = "https://files.pythonhosted.org/packages/3f/77/55e020c9c576532ff7d20bf8b1dfa052ecbd5ada1949b02f76c44c966f7e/hypothesis-6.165.10-cp314-cp314-macosx_10_12_x86_64.whl"
+size = 784833
 
 [packages.wheels.hashes]
-sha256 = "99c0b348dd0090418ecac8e3f072e7db8f3d4d745b80ed29cb7e6413eba578d5"
+sha256 = "9ccac776b2ca93b324806facd526ccb45da0fd035001c899a35b02c44431e209"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp314-cp314-macosx_11_0_arm64.whl"
-upload-time = 2026-08-04 21:01:18.729973+00:00
-url = "https://files.pythonhosted.org/packages/7f/ad/d1854bb869e840c0406a271a5f9e82377900317aad38c51a05d31f783df6/hypothesis-6.165.1-cp314-cp314-macosx_11_0_arm64.whl"
-size = 769175
+name = "hypothesis-6.165.10-cp314-cp314-macosx_11_0_arm64.whl"
+upload-time = 2026-08-16 22:56:10.159054+00:00
+url = "https://files.pythonhosted.org/packages/4f/f2/01da2adf829cf549eaddcabb8e8072077fb3d26da4275f4c1e89b2c0af74/hypothesis-6.165.10-cp314-cp314-macosx_11_0_arm64.whl"
+size = 776545
 
 [packages.wheels.hashes]
-sha256 = "d37ca9b20de6413e931280fce4428cf49ed769dc421d80b4ecce2b2e47266eae"
+sha256 = "e5f95f7b622e4171096d92175dda0a560f0955ade9b8a3a07bdcf151f7359611"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-upload-time = 2026-08-04 21:00:27.566914+00:00
-url = "https://files.pythonhosted.org/packages/fd/5b/eecf6b1ad0d41007f88a3347be19e83fb04d53dffcc7c372e20b509bc366/hypothesis-6.165.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-size = 1099937
+name = "hypothesis-6.165.10-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+upload-time = 2026-08-16 22:54:50.266066+00:00
+url = "https://files.pythonhosted.org/packages/cf/8e/58d4f842895220b793c53fc94a6489705b3665bb4d0ae4d338ce03fdf9fb/hypothesis-6.165.10-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+size = 1107271
 
 [packages.wheels.hashes]
-sha256 = "c2dbf82a127e4a598745e6708535dab8e5dafbe498664b6dfaf451f305a8b3fc"
+sha256 = "f76d1562643693b8a40066f1f96af795b93fd9bcfc9690a1af2ff4c5867ee29e"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-upload-time = 2026-08-04 21:00:12.050571+00:00
-url = "https://files.pythonhosted.org/packages/55/9b/c58c4910cf6766857a7dd31da294f32b26d03e94d05b225c0dcc83fb41b9/hypothesis-6.165.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-size = 1149618
+name = "hypothesis-6.165.10-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+upload-time = 2026-08-16 22:54:25.890564+00:00
+url = "https://files.pythonhosted.org/packages/8f/b8/206468912d2153306bb8a41afdfc59e45b7a73a0495bbe4b9cb4f0e79c1d/hypothesis-6.165.10-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+size = 1156915
 
 [packages.wheels.hashes]
-sha256 = "6b60824e0a15dd712d0ac93940029cdc79f5a10f1e9289ec0a82bddd8d43a3c4"
+sha256 = "60cab3ab4ea468d31a33739ffd7e94ec3e37dea891d65a6582ecc8a477175191"
 
 [[packages.wheels]]
-name = "hypothesis-6.165.1-cp314-cp314-win_amd64.whl"
-upload-time = 2026-08-04 21:00:43.606865+00:00
-url = "https://files.pythonhosted.org/packages/ce/4f/98603203f2e7838c180bd2b3bd32c07aecc02d62ce46d040cba4d1b892e9/hypothesis-6.165.1-cp314-cp314-win_amd64.whl"
-size = 664903
+name = "hypothesis-6.165.10-cp314-cp314-win_amd64.whl"
+upload-time = 2026-08-16 22:54:24.831851+00:00
+url = "https://files.pythonhosted.org/packages/48/86/9b4fb75f520a028edec50ffc904a94d724180395d71feb6d7a0ce7bb6f00/hypothesis-6.165.10-cp314-cp314-win_amd64.whl"
+size = 672145
 
 [packages.wheels.hashes]
-sha256 = "6bb8b5899151b35b4453face837536430c3835aabb71431b60ef26f4281a386e"
+sha256 = "d1ea02fa8ab3d33eb1125eade81f7136341eb429152c6dbe2ae6f8bc33b3fbdd"
 
 [[packages]]
 name = "idna"
-version = "3.18"
+version = "3.19"
 marker = "\"tests\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "idna-3.18.tar.gz"
-upload-time = 2026-06-02 14:34:07.794523+00:00
-url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz"
-size = 196711
+name = "idna-3.19.tar.gz"
+upload-time = 2026-08-18 05:14:24.270231+00:00
+url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz"
+size = 215237
 
 [packages.sdist.hashes]
-sha256 = "ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"
+sha256 = "5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15"
 
 [[packages.wheels]]
-name = "idna-3.18-py3-none-any.whl"
-upload-time = 2026-06-02 14:34:06.319954+00:00
-url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl"
-size = 65455
+name = "idna-3.19-py3-none-any.whl"
+upload-time = 2026-08-18 05:14:22.343598+00:00
+url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl"
+size = 68550
 
 [packages.wheels.hashes]
-sha256 = "7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"
+sha256 = "815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4"
 
 [[packages]]
 name = "importlib-metadata"
@@ -1065,28 +1065,28 @@ sha256 = "e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"
 
 [[packages]]
 name = "pygments"
-version = "2.20.0"
+version = "2.21.0"
 marker = "\"tests\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "pygments-2.20.0.tar.gz"
-upload-time = 2026-03-29 13:29:33.898791+00:00
-url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz"
-size = 4955991
+name = "pygments-2.21.0.tar.gz"
+upload-time = 2026-08-17 08:02:48.824391+00:00
+url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz"
+size = 5005329
 
 [packages.sdist.hashes]
-sha256 = "6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"
+sha256 = "610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c"
 
 [[packages.wheels]]
-name = "pygments-2.20.0-py3-none-any.whl"
-upload-time = 2026-03-29 13:29:30.038266+00:00
-url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl"
-size = 1231151
+name = "pygments-2.21.0-py3-none-any.whl"
+upload-time = 2026-08-17 08:02:44.912148+00:00
+url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl"
+size = 1250147
 
 [packages.wheels.hashes]
-sha256 = "81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"
+sha256 = "2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9"
 
 [[packages]]
 name = "pyproject-hooks"
@@ -1637,7 +1637,7 @@ sha256 = "25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f"
 
 [tool.nab]
 nab-version = "0.0.16.dev0"
-created-at = 2026-08-12 13:49:17.654697+00:00
+created-at = 2026-09-02 00:02:36.706040+00:00
 command-line = [
     "nab",
     "lock",
@@ -1648,6 +1648,7 @@ command-line = [
     "--no-emit-workspace",
     "--output",
     ".github/requirements/pylock.tests.toml",
+    "--upgrade",
 ]
 input-path = "pyproject.toml"
 mode = "universal"

--- a/.github/requirements/pylock.types.toml
+++ b/.github/requirements/pylock.types.toml
@@ -2430,7 +2430,7 @@ sha256 = "c401b88742e8a501c68f4ec605d7ebc6a63401653c15f0173a76febe161bd53e"
 
 [tool.nab]
 nab-version = "0.0.16.dev0"
-created-at = 2026-08-30 20:01:02.354773+00:00
+created-at = 2026-09-02 00:02:40.601090+00:00
 command-line = [
     "nab",
     "lock",

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Run property-based tests
         # CrossHair tests run in the dedicated crosshair-tests job; the
         # crosshair backend is not installed here, so skip that file.
-        run: python -m pytest -n auto -m property --ignore=nab-resolver/tests/property/test_crosshair_ranges.py
+        run: python -m pytest -n auto --dist worksteal -m property --ignore=nab-resolver/tests/property/test_crosshair_ranges.py
 
   crosshair-tests:
     name: CrossHair property tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
   test:
     name: ${{ matrix.os }} / ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}-latest
-    timeout-minutes: 45
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,14 +14,14 @@ repos:
         exclude: ^tasks/vendoring/
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: aab412d509121cb5f7533134b7e67f9fab59c682  # frozen: v0.16.4
+    rev: 1f1e8bf348ff38fc88619a38d3ca4d9c56abea49  # frozen: v0.16.5
     hooks:
       - id: ruff-check
         args: [--fix]
       - id: ruff-format
 
   - repo: https://github.com/crate-ci/typos
-    rev: b859c0df7f391deba73030f79b957e62b4d81dc6  # frozen: varcon-core-v5.0.7
+    rev: d43b6c087ac471e2ea7b8af622ff15f05c0c365b  # frozen: v1.50.1
     hooks:
       - id: typos
         # Benchmarks, CI lockfiles, captured lock data and vendored code are
@@ -30,7 +30,7 @@ repos:
         args: []
 
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: 451b56af716f9f0d0c2b816503a3fd0cf8b036fa  # frozen: v1.29.0
+    rev: cef8b8350da46d8114c7e6b7272aebdccdf193ce  # frozen: v1.30.0
     hooks:
       - id: zizmor
         files: "^\\.github"

--- a/conftest.py
+++ b/conftest.py
@@ -3,10 +3,10 @@
 Three hypothesis profiles, selectable via the ``HYPOTHESIS_PROFILE`` env var:
 
 - ``dev`` (default): low ``max_examples`` (20) for fast feedback.
-- ``ci``: more thorough (200 examples) plus ``derandomize=True`` so
-  failures are reproducible from the seed printed in the assertion;
-  ``deadline=None`` so a slow CI machine doesn't fail tests on
-  the basis of wall time alone.
+- ``ci``: more thorough (200 examples), drawn fresh each run so the
+  runs together search more of the space than any one could; a failure
+  prints the ``@reproduce_failure`` blob that replays it. ``deadline=None``
+  so a slow CI machine doesn't fail tests on the basis of wall time alone.
 - ``deep``: 2000 examples; for nightly counter-example hunts.
 
 Loading a profile only changes the default settings; tests that
@@ -48,7 +48,7 @@ settings.register_profile(
     "ci",
     max_examples=200,
     deadline=None,
-    derandomize=True,
+    print_blob=True,
     suppress_health_check=[HealthCheck.too_slow],
 )
 settings.register_profile(

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -121,11 +121,13 @@ package: `nab_resolver`, `nab_markersets`, `nab_provider`,
 `nab_project`, `nab_index`, and `nab`.
 
 The full local suite under `coverage run -m pytest` checks all six
-together. Nox splits them per workspace in CI, with `nab_index` and
-`nab_provider` gated in the `project` workspace, whose tests are the
-only ones that reach every line of both. The `provider` workspace runs
-`nab-markersets/tests` and `nab-provider/tests` without `nab-index`
-installed, and gates `nab_markersets`.
+together. Nox splits them per workspace in CI and runs each suite once,
+appending to one coverage data file, so a workspace gates on its own
+suites plus every suite run before it. `nab_index` and `nab_provider`
+are gated in the `project` workspace, since reaching every line of both
+takes `nab-project/tests` as well as `nab-provider/tests`. The `provider`
+workspace runs `nab-markersets/tests` and `nab-provider/tests` without
+`nab-index` installed, and gates `nab_markersets`.
 
 When code is unreachable from the default suite, prefer:
 

--- a/nab-markersets/src/nab_markersets/_markersets.py
+++ b/nab-markersets/src/nab_markersets/_markersets.py
@@ -15,13 +15,12 @@ import threading
 import weakref
 from functools import lru_cache
 from itertools import pairwise, product
-from typing import TYPE_CHECKING, NamedTuple, cast
+from typing import TYPE_CHECKING, Literal, NamedTuple, Protocol, cast
 
 from ._packaging import (
     InvalidMarker,
     InvalidSpecifier,
     InvalidVersion,
-    Marker,
     Op,
     ParserSyntaxError,
     Specifier,
@@ -38,6 +37,7 @@ from .errors import IntractableMarkerSet, UnserializableMarkerSet
 
 if TYPE_CHECKING:
     from collections.abc import Container, Iterable, Iterator, Mapping, Sequence
+    from collections.abc import Set as AbstractSet
     from typing import TypeAlias
 
     # packaging's parse tree, narrowed to what ``parse_marker`` builds. Its own
@@ -465,6 +465,20 @@ def make_not(node: Formula) -> Formula:
 # ------------------------------------------------------------------- construction
 
 
+class MarkerLike(Protocol):
+    """A packaging ``Marker`` from either copy: released, or the fork nab vendors.
+
+    Structural, so a checker admits a ``Marker`` built by the copy the algebra
+    did not bind; :func:`_is_marker` is the same test at runtime.
+    """
+
+    def evaluate(
+        self,
+        environment: Mapping[str, str | AbstractSet[str]] | None = None,
+        context: Literal["metadata", "lock_file", "requirement"] = "metadata",
+    ) -> bool: ...
+
+
 def _is_marker(source: object) -> bool:
     """Whether ``source`` is a packaging ``Marker``, from either copy.
 
@@ -498,13 +512,13 @@ def _parse_ast(source: object) -> list[MarkerNode] | None:
         raise InvalidMarker(str(exc)) from exc
 
 
-def parse(source: str | Marker) -> Formula:
+def parse(source: str | MarkerLike) -> Formula:
     """Parse a marker into the normalised op-tree."""
     parsed = _parse_ast(source)
     return TRUE if parsed is None else _convert(parsed)
 
 
-def variable_names(source: str | Marker) -> frozenset[str]:
+def variable_names(source: str | MarkerLike) -> frozenset[str]:
     """Return every marker variable ``source`` names, in the parser's spelling.
 
     Builds no atoms, so a marker the algebra rejects still yields its names.

--- a/nab-markersets/src/nab_markersets/markersets.py
+++ b/nab-markersets/src/nab_markersets/markersets.py
@@ -25,8 +25,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
     from collections.abc import Set as AbstractSet
 
-    from ._markersets import Formula
-    from ._packaging import Marker
+    from ._markersets import Formula, MarkerLike
 
 # Resource caps, not semantic parameters: no answer depends on their value, so
 # neither reaches the public surface. `_MAX_CELLS` bounds one decision and
@@ -141,12 +140,12 @@ class MarkerSet:
 
     @classmethod
     @_bounded
-    def from_marker(cls, marker: str | Marker) -> MarkerSet:
+    def from_marker(cls, marker: str | MarkerLike) -> MarkerSet:
         """Return the set of environments a marker denotes.
 
-        A ``Marker`` argument has to come from the copy of packaging the algebra
-        bound; ``str(marker)`` is the spelling that always works. A blank string
-        is the absent marker and gives the full set, where packaging refuses it.
+        A ``Marker`` from either copy of packaging is read through ``str()``. A
+        blank string is the absent marker and gives the full set, where
+        packaging refuses it.
 
         :raises ValueError: packaging's ``InvalidMarker`` if ``marker`` is a
             string the grammar rejects, and its ``UndefinedComparison`` if an

--- a/nab-project/src/nab_project/_build/env.py
+++ b/nab-project/src/nab_project/_build/env.py
@@ -40,7 +40,6 @@ from installer import install as installer_install
 from installer.destinations import SchemeDictionaryDestination
 from installer.sources import WheelFile
 from installer.utils import get_launcher_kind
-
 from nab_index.client import extract_sdist_archive
 from nab_index.urllib3_async_transport import Urllib3AsyncTransport
 from nab_provider._vendor.packaging.requirements import InvalidRequirement
@@ -61,6 +60,7 @@ from nab_provider.requirements_file import InvalidProjectRequirementError
 from nab_provider.target import ResolveTarget, host_environment
 from nab_provider.vcs_admission import UnsupportedVcsError
 
+from .._compat import override
 from ..download import DownloadError, download_lock
 from ..inputs import ResolveInputs
 from ..lockfile import IndexPin, strip_userinfo
@@ -106,11 +106,13 @@ class _FastSchemeDictionaryDestination(SchemeDictionaryDestination):
         default_factory=list, init=False, repr=False
     )
 
+    @override
     def _compile_bytecode(self, scheme: Scheme, record: RecordEntry) -> None:
         if not self.bytecode_optimization_levels:
             return
         super()._compile_bytecode(scheme, record)
 
+    @override
     def finalize_installation(
         self,
         scheme: Scheme,

--- a/nab-project/src/nab_project/_build/runner.py
+++ b/nab-project/src/nab_project/_build/runner.py
@@ -170,7 +170,7 @@ def _metadata_output_dir(backend: str) -> tempfile.TemporaryDirectory[str]:
 @contextmanager
 def _prepared_project(
     source_dir: Path,
-    data: dict,
+    data: dict[str, Any],
     *,
     config: ResolveInputs,
     offline: bool,
@@ -251,7 +251,7 @@ def _validate_extra_requires(extra: list[Any], *, backend: str) -> None:
             raise BuildBackendError(msg) from exc
 
 
-def _read_pyproject(source_dir: Path) -> dict:
+def _read_pyproject(source_dir: Path) -> dict[str, Any]:
     """Return the parsed ``pyproject.toml``, or ``{}`` for a legacy setup.py tree."""
     pyproject = source_dir / "pyproject.toml"
     state = path_state(pyproject)
@@ -277,7 +277,7 @@ def _read_pyproject(source_dir: Path) -> dict:
 
 
 def _read_build_system(
-    data: dict,
+    data: dict[str, Any],
 ) -> tuple[str, tuple[str, ...], tuple[str, ...] | None]:
     """Return ``(backend, requires, backend_path)`` per PEP 517 / 518.
 
@@ -361,7 +361,7 @@ def _validate_backend_path(
             raise BuildBackendError(msg)
 
 
-def _should_skip_prepare(backend: str, data: dict) -> bool:
+def _should_skip_prepare(backend: str, data: dict[str, Any]) -> bool:
     """Skip ``prepare_metadata_for_build_wheel`` when it would lie.
 
     uv documents one specific quirk: hatchling's prepare-metadata

--- a/nab-project/src/nab_project/_compat.py
+++ b/nab-project/src/nab_project/_compat.py
@@ -1,0 +1,20 @@
+"""Runtime fallback for :func:`typing.override`, so ``typing_extensions`` is not needed.
+
+``override`` runs at class-body time, so unlike the annotation-only helpers it
+cannot hide under ``TYPE_CHECKING``.  Looking it up by name rather than by
+interpreter version keeps this free of a version-gated branch.  Before 3.12 the
+fallback is the identity and so does not set ``__override__``, which nothing
+here reads.
+"""
+
+from __future__ import annotations
+
+import typing
+from typing import TYPE_CHECKING
+
+__all__ = ["override"]
+
+if TYPE_CHECKING:
+    from typing_extensions import override
+else:
+    override = getattr(typing, "override", lambda method: method)

--- a/nab-project/src/nab_project/_lockfile/builder.py
+++ b/nab-project/src/nab_project/_lockfile/builder.py
@@ -35,6 +35,7 @@ from .groups import BASE_MEMBER
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping, Sequence
 
+    from nab_provider._vendor.packaging.utils import NormalizedName
     from nab_provider._vendor.packaging.version import Version
     from nab_provider.policy import ArchiveSource, LocalSource, VcsSource
     from nab_provider.records import IndexConfig
@@ -92,8 +93,10 @@ class LockInputProvider(Protocol):
     may supply a stub without inheriting the full Provider class.
     """
 
-    deps_cache: Mapping[tuple[str, Version], Mapping[str, object]]
-    """Direct dependencies per ``(canonical name, version)``."""
+    @property
+    def deps_cache(self) -> Mapping[tuple[str, Version], Mapping[str, object]]:
+        """Direct dependencies per ``(canonical name, version)``."""
+        ...
 
     @property
     def extra_deps_map(
@@ -400,7 +403,7 @@ def _membership_gates(
 
 def _reachable_names(
     provider: LockInputProvider,
-    pinned: Mapping[str, Version],
+    pinned: Mapping[NormalizedName, Version],
     roots: Iterable[str],
 ) -> set[str]:
     """Return the pinned names reachable from ``roots`` at their pinned versions.

--- a/nab-project/src/nab_project/_lockfile/disjointness.py
+++ b/nab-project/src/nab_project/_lockfile/disjointness.py
@@ -238,7 +238,7 @@ def _conflict_respecting_selections(
             msg = f"conflict-respecting selections exceed {_MAX_SELECTIONS}"
             raise IntractableMarkerSet(msg)
 
-    group_options = [
+    group_options: list[list[frozenset[tuple[str, str]]]] = [
         [frozenset()] + [frozenset({member}) for member in choice]
         for choice in conflict_choices
     ]

--- a/nab-project/src/nab_project/_lockfile/pylock.py
+++ b/nab-project/src/nab_project/_lockfile/pylock.py
@@ -350,7 +350,8 @@ def _name_base_group(lock_input: LockInput) -> LockInput:
     and stay unconditional.
     """
     name = lock_input.base_group
-    member = (KIND_GROUP, name)
+    # Unnamed, the base gates are cut below, so nothing is renamed.
+    member = BASE_MEMBER if name is None else (KIND_GROUP, name)
     targets = {
         label: replace(
             lock,
@@ -802,7 +803,7 @@ def _group_pins_by_pin(
     Walked in sorted label order so the output is independent of dict
     insertion order.
     """
-    by_key: dict[tuple, tuple[list[PinShape], list[str]]] = {}
+    by_key: dict[tuple[object, ...], tuple[list[PinShape], list[str]]] = {}
     for label in sorted(per_target):
         pin = per_target[label]
         key = _pin_discriminator(pin)
@@ -813,7 +814,7 @@ def _group_pins_by_pin(
     return list(by_key.values())
 
 
-def _pin_discriminator(pin: PinShape) -> tuple:
+def _pin_discriminator(pin: PinShape) -> tuple[object, ...]:
     """Return a hashable key that identifies the source + version of ``pin``."""
     from ..lockfile import ArchivePin, IndexPin, LocalPin, VcsPin
 
@@ -1224,7 +1225,7 @@ def _project_fork(
     name: str,
     label: str,
     limit: _Members,
-    same_pin: AbstractSet[str],
+    same_pin: frozenset[str],
     *,
     is_base: bool,
 ) -> _Projection:

--- a/nab-project/src/nab_project/_resolve/engine.py
+++ b/nab-project/src/nab_project/_resolve/engine.py
@@ -15,7 +15,7 @@ import logging
 import time
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol, TypedDict
 
 from nab_index.cache import ARCHIVE_BUCKET, VCS_BUCKET
 from nab_provider._vendor.packaging.ranges import VersionRange
@@ -27,6 +27,7 @@ from nab_resolver.errors import ResolutionError
 from nab_resolver.resolver import Resolver, ResolverObserver
 from nab_resolver.types import IncompatibilityCause
 
+from .._compat import override
 from ..lockfile import build_target_lock
 
 if TYPE_CHECKING:
@@ -79,11 +80,13 @@ class _ResolveObserver(ResolverObserver[str, "Version"]):
     def __init__(self, sink: ProgressSink | None) -> None:
         self._sink = sink
 
+    @override
     def on_decision(self, package: str, version: Version, level: int) -> None:
         _logger.debug("pinned %s %s", package, version)
         if self._sink is not None:
             self._sink.on_pin(level)
 
+    @override
     def on_backjump(self, from_level: int, to_level: int) -> None:
         _logger.debug("backjumped from level %d to %d", from_level, to_level)
         if self._sink is not None:
@@ -716,9 +719,18 @@ def _consulted_markers(
     return frozenset(consulted)
 
 
-def _target_stats(
-    resolver: Resolver[str, Version], provider: Provider
-) -> dict[str, int]:
+class _TargetStats(TypedDict):
+    """The counters a :class:`TargetResult` carries."""
+
+    rounds: int
+    decisions: int
+    conflicts: int
+    backjumps: int
+    metadata_fetched: int
+    distributions_seen: int
+
+
+def _target_stats(resolver: Resolver[str, Version], provider: Provider) -> _TargetStats:
     """Return the resolver and provider counters for a :class:`TargetResult`."""
     return {
         "rounds": resolver.stats.rounds,

--- a/nab-project/src/nab_project/build_backend.py
+++ b/nab-project/src/nab_project/build_backend.py
@@ -11,7 +11,7 @@ settings a resolve runs under.
 from __future__ import annotations
 
 from functools import lru_cache
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import tomli
 
@@ -114,7 +114,7 @@ def extract_static_metadata(source_dir: Path) -> WheelMetadata | None:
     return _project_to_metadata(project)
 
 
-def _project_to_metadata(project: dict) -> WheelMetadata | None:
+def _project_to_metadata(project: dict[str, Any]) -> WheelMetadata | None:
     """Convert a static ``[project]`` table to :class:`WheelMetadata`."""
     name = project.get("name")
     version_raw = project.get("version")
@@ -170,7 +170,7 @@ def _static_requires_python(raw: object) -> SpecifierSet | None:
     return specifier_set
 
 
-def _collect_requires_dist(project: dict) -> list[Requirement]:
+def _collect_requires_dist(project: dict[str, Any]) -> list[Requirement]:
     """Concatenate PEP 631 ``dependencies`` + ``optional-dependencies``.
 
     Optional-dependencies entries get an ``; extra == "name"`` marker
@@ -212,7 +212,7 @@ def _extend_with_dep_strings(
     )
 
 
-def _require_optional_dependencies(project: dict) -> dict:
+def _require_optional_dependencies(project: dict[str, Any]) -> dict[str, Any]:
     """Return ``[project.optional-dependencies]`` as a table, or raise."""
     optional = project.get("optional-dependencies", {})
     if not isinstance(optional, dict):
@@ -221,7 +221,7 @@ def _require_optional_dependencies(project: dict) -> dict:
     return optional
 
 
-def _collect_provides_extra(project: dict) -> set[str]:
+def _collect_provides_extra(project: dict[str, Any]) -> set[str]:
     return {
         canonicalize_name(str(extra))
         for extra in _require_optional_dependencies(project)

--- a/nab-project/src/nab_project/fetch.py
+++ b/nab-project/src/nab_project/fetch.py
@@ -55,6 +55,7 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from nab_index.parsed_listing import ParsedListing
+    from nab_provider.overrides import IndexOverride, PackageOverride
 
 __all__ = [
     "DEFAULT_INDEX_NAME",
@@ -174,7 +175,10 @@ def _builds_remote_sdists(inputs: ResolveInputs | None) -> bool:
         return False
     if inputs.build_policy is BuildPolicy.BUILD_REMOTE:
         return True
-    overrides = (*inputs.package_overrides, *inputs.index_overrides.values())
+    overrides: tuple[PackageOverride | IndexOverride, ...] = (
+        *inputs.package_overrides,
+        *inputs.index_overrides.values(),
+    )
     return any(o.build_policy is BuildPolicy.BUILD_REMOTE for o in overrides)
 
 
@@ -862,7 +866,7 @@ class FetchCoordinator:
 
         queue: asyncio.Queue[_QueueItem] = asyncio.Queue()
         sem = asyncio.Semaphore(self._max_concurrency)
-        tasks: set[asyncio.Task] = set()
+        tasks: set[asyncio.Task[None]] = set()
 
         try:
             client = self._build_client()
@@ -917,7 +921,7 @@ class FetchCoordinator:
         item: FetchRequest | list[FetchRequest],
         client: CachedAsyncSimpleClient | LocalIndexClient | MultiIndexClient,
         sem: asyncio.Semaphore,
-        tasks: set[asyncio.Task],
+        tasks: set[asyncio.Task[None]],
     ) -> None:
         """Create async tasks for a single request or a batch."""
         if isinstance(item, list):

--- a/nab-project/src/nab_project/inputs.py
+++ b/nab-project/src/nab_project/inputs.py
@@ -6,7 +6,7 @@ Declared here rather than by the host because nab-project may not import ``nab``
 from __future__ import annotations
 
 from types import MappingProxyType
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from nab_provider.policy import (
     BuildPolicy,
@@ -131,5 +131,8 @@ class ResolveInputs(ValueType):
 
     def replace(self, **changes: object) -> ResolveInputs:
         """Return a copy with ``changes`` applied, as ``dataclasses.replace`` would."""
-        kept = {name: getattr(self, name) for name in self.__match_args__}
-        return ResolveInputs(**{**kept, **changes})
+        kept: dict[str, Any] = {
+            name: getattr(self, name) for name in self.__match_args__
+        }
+        kept.update(changes)
+        return ResolveInputs(**kept)

--- a/nab-project/src/nab_project/lockfile.py
+++ b/nab-project/src/nab_project/lockfile.py
@@ -276,8 +276,11 @@ class IndexPin(ValueType):
 
     def replace(self, **changes: object) -> IndexPin:
         """Return a copy with ``changes`` applied, as ``dataclasses.replace`` would."""
-        kept = {name: getattr(self, name) for name in self.__match_args__}
-        return IndexPin(**{**kept, **changes})
+        kept: dict[str, Any] = {
+            name: getattr(self, name) for name in self.__match_args__
+        }
+        kept.update(changes)
+        return IndexPin(**kept)
 
 
 class LocalPin(ValueType):

--- a/nab-project/src/nab_project/resolve.py
+++ b/nab-project/src/nab_project/resolve.py
@@ -649,6 +649,7 @@ def _selector_requirements(
     """
     selectors: dict[tuple[str, str], tuple[Requirement, ...]] = {}
     for context in contexts:
+        assert context.name is not None  # _carried_by keeps only named contexts
         selectors[(ConflictKind.GROUP.value, context.name)] = context.requirements
     for extra in fork.active_extras:
         member = (ConflictKind.EXTRA.value, str(canonicalize_name(extra)))

--- a/nab-provider/src/nab_provider/_compat.py
+++ b/nab-provider/src/nab_provider/_compat.py
@@ -1,0 +1,20 @@
+"""Runtime fallback for :func:`typing.override`, so ``typing_extensions`` is not needed.
+
+``override`` runs at class-body time, so unlike the annotation-only helpers it
+cannot hide under ``TYPE_CHECKING``.  Looking it up by name rather than by
+interpreter version keeps this free of a version-gated branch.  Before 3.12 the
+fallback is the identity and so does not set ``__override__``, which nothing
+here reads.
+"""
+
+from __future__ import annotations
+
+import typing
+from typing import TYPE_CHECKING
+
+__all__ = ["override"]
+
+if TYPE_CHECKING:
+    from typing_extensions import override
+else:
+    override = getattr(typing, "override", lambda method: method)

--- a/nab-provider/src/nab_provider/_provider/build_remote.py
+++ b/nab-provider/src/nab_provider/_provider/build_remote.py
@@ -64,7 +64,9 @@ def build_remote_sdist(
     event.wait()
 
     # The port raises on failure, so a request that returned left the metadata.
-    built = provider.coordinator.index.get_built_metadata(canonical, ver_str)
+    built: WheelMetadata | None = provider.coordinator.index.get_built_metadata(
+        canonical, ver_str
+    )
     assert built is not None
 
     target = provider.target

--- a/nab-provider/src/nab_provider/_provider/listing_diagnosis.py
+++ b/nab-provider/src/nab_provider/_provider/listing_diagnosis.py
@@ -58,6 +58,7 @@ if TYPE_CHECKING:
         "offline-miss",
         "unreadable-only",
         "unreachable-only",
+        "none-usable",
         "yanked-only",
         "absent",
         "pinned-absent",
@@ -172,6 +173,10 @@ class Remedy:
 
     __slots__ = ("covers", "field", "label", "layer", "selector")
 
+    # Declared, or a checker widens the assigned literal to ``str``.
+    field: Field
+    layer: Layer
+
     def __init__(
         self,
         field: Field,
@@ -204,6 +209,8 @@ class DroppedFile:
         "raw_version",
         "version",
     )
+
+    cause: Cause
 
     def __init__(
         self,
@@ -278,6 +285,8 @@ class Blocker:
 
     __slots__ = ("declared", "held", "kind", "package")
 
+    kind: Blocked
+
     def __init__(
         self,
         kind: Blocked,
@@ -319,6 +328,8 @@ class NoVersionsReason:
     """What the resolve recorded when a package ran out of candidates."""
 
     __slots__ = ("blockers", "declaring_version", "kind", "metadata", "version_range")
+
+    kind: Kind
 
     def __init__(
         self,

--- a/nab-provider/src/nab_provider/_provider/lookahead.py
+++ b/nab-provider/src/nab_provider/_provider/lookahead.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
 
     from nab_provider._vendor.packaging.version import Version
+    from nab_resolver.types import RangeProtocol
 
     from ..provider import Provider
 
@@ -169,9 +170,12 @@ def _blocked_by_solution(
     return True
 
 
+# The two range builders below are typed as the resolver's range rather than
+# the VersionRange they build: solved from VersionRange alone, ty reads the
+# terms they feed as ``Term[str, Version | str]``.
 def _widen_or_singleton(
     provider: Provider, package: str, version: Version
-) -> VersionRange:
+) -> RangeProtocol[Version]:
     """Return ``version``'s widened neighbor gap, or its singleton without one.
 
     Look-ahead needs the gap rather than a ``widen_decision`` span: the gap
@@ -184,7 +188,7 @@ def _widen_or_singleton(
 
 def _candidate_union(
     provider: Provider, package: str, versions: Iterable[Version]
-) -> VersionRange:
+) -> RangeProtocol[Version]:
     """Return the widened union of one group's rejected candidate versions."""
     union = VersionRange.empty()
     for version in versions:
@@ -334,15 +338,15 @@ def flush_pending_blocks(provider: Provider) -> None:
 
     # Permanent rejections: a root requirement is fixed for the whole resolve,
     # and a version whose metadata will not read is unusable in every state.
-    unusable: defaultdict[str, VersionRange] = defaultdict(VersionRange.empty)
+    unusable: defaultdict[str, RangeProtocol[Version]] = defaultdict(VersionRange.empty)
 
     for (candidate_pkg, *_), versions in provider.pending_root_blocks.items():
         unusable[candidate_pkg] |= _candidate_union(provider, candidate_pkg, versions)
 
-    for candidate_pkg, versions in provider.pending_metadata_blocks.items():
-        unusable[candidate_pkg] |= _candidate_union(provider, candidate_pkg, versions)
+    for candidate_pkg, blocks in provider.pending_metadata_blocks.items():
+        unusable[candidate_pkg] |= _candidate_union(provider, candidate_pkg, blocks)
         # The ban outlives this flush, so its reason has to as well.
-        provider.record_metadata_ban(candidate_pkg, versions)
+        provider.record_metadata_ban(candidate_pkg, blocks)
 
     for candidate_pkg, rejected in unusable.items():
         provider.pending_clauses.append(

--- a/nab-provider/src/nab_provider/_provider/metadata_resolver.py
+++ b/nab-provider/src/nab_provider/_provider/metadata_resolver.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Literal, NamedTuple, TypeGuard
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypeGuard
 from urllib.parse import urlsplit
 
 from nab_provider._vendor.packaging.ranges import VersionRange
@@ -19,6 +19,7 @@ from nab_provider._vendor.packaging.utils import canonicalize_name
 from nab_provider._vendor.packaging.version import InvalidVersion, Version
 from nab_provider.records import RangeOutcome, SdistFile, WheelFile
 
+from .._compat import override
 from ..errors import (
     ForeignMetadataError,
     IncompatiblePythonError,
@@ -462,7 +463,9 @@ def pick_dist(
     else:
         # Sidecars first: ``pick`` keeps input order among wheels it ranks equally.
         installed = tags.pick(sorted(wheels, key=lambda w: not w.has_metadata))
-    return installed or next((w for w in wheels if w.has_metadata), wheels[0])
+    if installed is not None:
+        return installed
+    return next((w for w in wheels if w.has_metadata), wheels[0])
 
 
 def _sdist_deps_need_dynamic(
@@ -507,7 +510,9 @@ def resolve_dynamic_sdist(
     version_str = str(version)
     index = provider.coordinator.index
 
-    cached = index.get_resolved_sdist_metadata(canonical, version_str)
+    cached: WheelMetadata | None = index.get_resolved_sdist_metadata(
+        canonical, version_str
+    )
     if cached is not None:
         return cached
 
@@ -584,7 +589,9 @@ def augment_from_pyproject(
     )
 
 
-def extend_with_extras(requires_dist: list[Requirement], optional: dict) -> list[str]:
+def extend_with_extras(
+    requires_dist: list[Requirement], optional: dict[str, Any]
+) -> list[str]:
     """Append extras-gated requirements and return Provides-Extra names.
 
     A per-extra value that is not an array of strings, or a per-extra entry
@@ -602,7 +609,7 @@ def extend_with_extras(requires_dist: list[Requirement], optional: dict) -> list
     return provides_extra
 
 
-def parse_pyproject_deps(deps: list) -> list[Requirement]:
+def parse_pyproject_deps(deps: list[str]) -> list[Requirement]:
     """Parse a ``project.dependencies`` list, raising on a malformed entry.
 
     Entries are already validated as strings by :func:`require_string_list`;
@@ -983,6 +990,7 @@ class ExtraDepsMap(Mapping[tuple[str, Version], dict[str, dict[str, VersionRange
         self._provider = provider
         self._extra_deps = extra_deps
 
+    @override
     def __getitem__(
         self, cache_key: tuple[str, Version]
     ) -> dict[str, dict[str, VersionRange]]:
@@ -993,12 +1001,15 @@ class ExtraDepsMap(Mapping[tuple[str, Version], dict[str, dict[str, VersionRange
             )
         return built
 
+    @override
     def __contains__(self, cache_key: object) -> bool:
         return cache_key in self._extra_deps
 
+    @override
     def __iter__(self) -> Iterator[tuple[str, Version]]:
         return iter(self._extra_deps)
 
+    @override
     def __len__(self) -> int:
         return len(self._extra_deps)
 
@@ -1126,7 +1137,7 @@ def target_dep_signature(
             continue
         if req.url is not None:
             entry = (canonicalize_name(req.name), frozenset(req.extras), req.url)
-            for key in req_extras or {None}:
+            for key in req_extras or (None,):
                 url_buckets.setdefault(key, set()).add(entry)
             continue
         add_classified_dep(

--- a/nab-provider/src/nab_provider/provider.py
+++ b/nab-provider/src/nab_provider/provider.py
@@ -705,7 +705,7 @@ class Provider:
         self._widened_ranges: dict[tuple[str, Version], VersionRange] = {}
         self._gap_widened_ranges: dict[tuple[str, Version], VersionRange] = {}
 
-        self.solution_ranges: Mapping[str, RangeProtocol[Version]] = {}
+        self.solution_ranges: Mapping[str, VersionRange] = {}
         self.solution_decisions: Mapping[str, Version] = {}
         self.pending_clauses: list[Incompatibility[str, Version]] = []
         self.pending_blocks: defaultdict[tuple[str, str, Version], list[Version]] = (
@@ -737,8 +737,7 @@ class Provider:
         # Root-requirement rejections, keyed by (candidate, blocker, the
         # candidate's dependency range, the blocker's root range).
         self.pending_root_blocks: defaultdict[
-            tuple[str, str, RangeProtocol[Version], RangeProtocol[Version]],
-            list[Version],
+            tuple[str, str, VersionRange, VersionRange], list[Version]
         ] = defaultdict(list)
 
         # Metadata-error rejections, carrying the message so the failure can
@@ -2221,9 +2220,11 @@ class Provider:
         derivations because backjumping a decision also undoes its derivations.
 
         Both maps are read-only and pinned to the moment the caller took them,
-        so storing the references is enough.
+        so storing the references is enough. The resolver builds its ranges
+        from the :class:`VersionRange` values this provider hands it, which
+        the cast records.
         """
-        self.solution_ranges = positive_ranges
+        self.solution_ranges = cast("Mapping[str, VersionRange]", positive_ranges)
         self.solution_decisions = decisions
 
     def _look_ahead_ok(

--- a/nab-provider/src/nab_provider/records.py
+++ b/nab-provider/src/nab_provider/records.py
@@ -12,12 +12,14 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit, urlunsplit
 
+from ._compat import override
 from .digest import is_hex_digest
 from .serialization import SimpleSerialization
 
 if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
+    from types import MemberDescriptorType
 
 __all__ = [
     "ACCEPTED_HASH_ALGORITHMS",
@@ -201,6 +203,7 @@ class _WheelIntegrity(_DeferredIntegrity, _MetadataUrlMemo):
 
     _raw_metadata: object
 
+    @override
     def __getattr__(self, name: str) -> object:
         if name != "metadata_hash":
             return super().__getattr__(name)
@@ -255,7 +258,8 @@ def _slot_writer(cls: type, name: str) -> Callable[[object, object], None]:
     fills its slots through these instead, leaving ``__setattr__`` frozen for
     callers.
     """
-    return cls.__dict__[name].__set__
+    slot: MemberDescriptorType = cls.__dict__[name]
+    return slot.__set__
 
 
 @dataclass(frozen=True, slots=True, init=False)

--- a/nab-provider/src/nab_provider/resolver_inputs.py
+++ b/nab-provider/src/nab_provider/resolver_inputs.py
@@ -18,6 +18,7 @@ from nab_provider._vendor.packaging.utils import canonicalize_name
 from nab_resolver.errors import ResolutionError
 from nab_resolver.types import RootRequirement
 
+from ._compat import override
 from .conflict_kind import (
     KIND_EXTRA,
     MARKER_VARIABLE_FOR_KIND,
@@ -32,6 +33,8 @@ if TYPE_CHECKING:
 
     from nab_provider._vendor.packaging.markers import Marker
     from nab_provider._vendor.packaging.requirements import Requirement
+    from nab_provider._vendor.packaging.version import Version
+    from nab_resolver.types import RangeProtocol
 
     from .vcs_admission import VcsConfig
 
@@ -124,10 +127,21 @@ def _warn_dropped_membership_marker(
     )
 
 
+def _root(
+    package: str, constraint: RangeProtocol[Version], origin: str
+) -> RootRequirement[str, Version]:
+    """Build a root requirement on the resolver's version type.
+
+    Solved from ``VersionRange`` alone, ty reads that type as ``Version | str``,
+    which the parameter here pins to ``Version``.
+    """
+    return RootRequirement(package, constraint, origin)
+
+
 class _ResolverInputs(NamedTuple):
     """What one requirement set gives the resolver and the provider."""
 
-    roots: list[RootRequirement[str, VersionRange]]
+    roots: list[RootRequirement[str, Version]]
     ranges: dict[str, VersionRange]
     extras: set[tuple[str, str]]
 
@@ -161,7 +175,7 @@ def build_resolver_inputs(
     callers sharing one set warn once between them, a caller that omits it
     warns per call.
     """
-    roots: list[RootRequirement[str, VersionRange]] = []
+    roots: list[RootRequirement[str, Version]] = []
     resolver_requirements: dict[str, VersionRange] = {}
     root_extras: set[tuple[str, str]] = set()
     already_warned: set[tuple[str, str]] = set() if warned is None else warned
@@ -191,7 +205,7 @@ def build_resolver_inputs(
             else VersionRange.full(admit_arbitrary=False)
         )
         resolver_requirements[name] = previous & term
-        roots.append(RootRequirement(name, term, str(req)))
+        roots.append(_root(name, term, str(req)))
 
         for extra in sorted(req.extras):
             extra_key = join_extra(name, extra)
@@ -201,7 +215,7 @@ def build_resolver_inputs(
             if extra_key not in resolver_requirements:
                 proxy = VersionRange.full(admit_arbitrary=False)
                 resolver_requirements[extra_key] = proxy
-                roots.append(RootRequirement(extra_key, proxy, str(req)))
+                roots.append(_root(extra_key, proxy, str(req)))
 
             _, normalized_extra = split_extra(extra_key)
             assert normalized_extra is not None  # join_extra always sets one
@@ -228,14 +242,17 @@ class ProxyConstraints(Mapping[str, VersionRange]):
         """Wrap the per-package ranges the user's constraints folded to."""
         self._ranges = ranges
 
+    @override
     def __getitem__(self, package: str) -> VersionRange:
         """Answer with the base's bound; a proxy has no bound of its own."""
         return self._ranges[split_extra(package)[0]]
 
+    @override
     def __iter__(self) -> Iterator[str]:
         """Enumerate only the keys the user wrote."""
         return iter(self._ranges)
 
+    @override
     def __len__(self) -> int:
         """Count the keys the user wrote."""
         return len(self._ranges)

--- a/nab-provider/src/nab_provider/tags.py
+++ b/nab-provider/src/nab_provider/tags.py
@@ -21,12 +21,13 @@ interpreter and abi, which is what pip's ``--python-version`` does.
 
 from __future__ import annotations
 
+import enum
 import re
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from functools import cache, cached_property, lru_cache
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Literal, Protocol, TypeVar
+from typing import TYPE_CHECKING, Final, Literal, Protocol, TypeVar
 
 from nab_provider._vendor.packaging import tags as ptags
 from nab_provider._vendor.packaging.version import Version
@@ -542,9 +543,15 @@ _WheelT = TypeVar("_WheelT", bound=_NamedWheel)
 # platform axis multiplies it.
 _AxisEntry = tuple[str, str, str | None]
 
+
 # Stands in for "not looked up yet" in ``TagSet._placed``, which holds a real
-# None for a tag set the target accepts nothing from.
-_UNPLACED = object()
+# None for a tag set the target accepts nothing from. An enum member, so a
+# checker narrows the lookup's result once the sentinel is ruled out.
+class _Unplaced(enum.Enum):
+    TOKEN = enum.auto()
+
+
+_UNPLACED: Final = _Unplaced.TOKEN
 
 
 @dataclass(frozen=True)

--- a/nab-provider/src/nab_provider/testing.py
+++ b/nab-provider/src/nab_provider/testing.py
@@ -19,7 +19,7 @@ keywords cannot express, and read the calls back with
 from __future__ import annotations
 
 import threading
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypedDict, TypeVar
 
 from ._vendor.packaging.utils import canonicalize_name
 from .errors import IndexAccessError
@@ -30,10 +30,14 @@ from .store import InMemoryIndex
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping, Sequence
+    from datetime import datetime
     from pathlib import Path
 
+    from typing_extensions import Unpack
+
+    from ._vendor.packaging.requirements import Requirement
     from .metadata import WheelMetadata
-    from .policy import SourceMaterialization, SourceRequest
+    from .policy import BuildPolicy, DistPolicy, SourceMaterialization, SourceRequest
     from .records import RangeMetadataResult, SdistFile, WheelFile
 
 __all__ = ["REQUESTS", "FakeFetchPort", "make_coordinator", "pkg_override"]
@@ -69,14 +73,30 @@ def _done_event() -> threading.Event:
     return ev
 
 
-def pkg_override(req_str: str, **body: object) -> PackageOverride:
+class _OverrideBody(TypedDict, total=False):
+    """The body of a :class:`~nab_provider.overrides.PackageOverride`."""
+
+    dist_policy: DistPolicy | None
+    dist_trust_unverified_deps: bool | None
+    build_policy: BuildPolicy | None
+    uploaded_prior_to: datetime | None
+    uploaded_prior_to_disabled: bool
+    index: str | None
+    dependencies: tuple[Requirement, ...] | None
+    requires_python: str | None
+    provides_extra: tuple[str, ...] | None
+    name_keyed: bool
+    source_label: str
+
+
+def pkg_override(req_str: str, **body: Unpack[_OverrideBody]) -> PackageOverride:
     """Build a :class:`~nab_provider.overrides.PackageOverride` from a requirement."""
     requirement = parse_requirement(req_str)
     return PackageOverride(
         requirement=requirement,
         name=canonicalize_name(requirement.name),
         version_range=requirement.specifier.to_range(),
-        **body,  # type: ignore[arg-type]
+        **body,
     )
 
 
@@ -257,7 +277,7 @@ class FakeFetchPort:
     ) -> _T:
         """Record the call to ``name``, then run its override or ``default``."""
         self._calls[name].append(args)
-        handler = self._overrides.get(name, default)
+        handler: Callable[..., _T] = self._overrides.get(name, default)
         return handler(*args)
 
     def request_listing(

--- a/noxfile.py
+++ b/noxfile.py
@@ -161,30 +161,32 @@ def _test_steps(session: nox.Session, selected: set[str]) -> list[_Step]:
     return steps[: last + 1]
 
 
-def _run_workspace(session: nox.Session, step: _Step) -> bool:
-    """Run one workspace's suites and coverage gates; True when they all passed.
+def _run_workspace(session: nox.Session, step: _Step, paths: list[str]) -> bool:
+    """Run ``paths`` under coverage, then gate the workspace; True when both passed.
 
+    ``paths`` is the workspace's suites less any an earlier workspace already
+    ran; the coverage they recorded is still in the session's data file.
     Returns instead of raising so the caller can go on to the workspaces after
     this one. Within a workspace the first failure stops the rest.
     """
     try:
-        session.run("coverage", "erase")
-
         # pytest-cov measures the xdist workers, which a bare `coverage run`
         # cannot see, and combines their data files at the end. Its own gate is
         # off because it scores every source package at once, and a workspace
         # only imports the ones it owns.
-        session.run(
-            "python",
-            "-m",
-            "pytest",
-            "-n",
-            "auto",
-            "--cov",
-            "--cov-report=",
-            "--cov-fail-under=0",
-            *step.paths,
-        )
+        if paths:
+            session.run(
+                "python",
+                "-m",
+                "pytest",
+                "-n",
+                "auto",
+                "--cov",
+                "--cov-append",
+                "--cov-report=",
+                "--cov-fail-under=0",
+                *paths,
+            )
 
         for package in step.gated:
             session.run("coverage", "report", f"--include=*/{package}/*")
@@ -206,6 +208,10 @@ def tests(session: nox.Session) -> None:
     exactly the packages it declares. A reused environment would already hold
     what the last run installed, so this session never reuses one.
 
+    One coverage data file serves them all too. A suite runs once, in the first
+    selected workspace that lists it, and a later workspace gates on what every
+    suite before it recorded.
+
     A failing workspace does not stop the others, so one run reports them all.
     """
     selected = set(session.posargs) or set(WORKSPACES)
@@ -215,11 +221,18 @@ def tests(session: nox.Session) -> None:
 
     steps = _test_steps(session, selected)
     _install_lock(session, TESTS_LOCK)
+    session.run("coverage", "erase")
 
+    ran: set[str] = set()
     failed: list[str] = []
     for step in steps:
         _install_editable(session, step.adds)
-        if step.selected and not _run_workspace(session, step):
+        if not step.selected:
+            continue
+
+        paths = [path for path in step.paths if path not in ran]
+        ran.update(paths)
+        if not _run_workspace(session, step, paths):
             failed.append(step.workspace)
 
     if failed:

--- a/noxfile.py
+++ b/noxfile.py
@@ -71,10 +71,16 @@ WORKSPACES = {
     ),
 }
 
-# nab-provider and nab-project are left out: neither is held to the strict
-# checker configs yet, and nab-provider carries the vendored packaging tree,
-# which is rebuilt from upstream and cannot be edited to satisfy a checker.
-TYPED_TREES = ["nab-resolver/src", "nab-markersets/src", "nab-index/src", "src"]
+# Every shipped tree. The vendored packaging tree under nab-provider is rebuilt
+# from upstream, so each checker's config in pyproject.toml leaves it out.
+TYPED_TREES = [
+    "nab-resolver/src",
+    "nab-markersets/src",
+    "nab-provider/src",
+    "nab-project/src",
+    "nab-index/src",
+    "src",
+]
 
 # The generated bijection goes to every checker, not to pyright alone: it
 # exists to be read by one, and a row typed wrong for its parameter is an
@@ -82,12 +88,14 @@ TYPED_TREES = ["nab-resolver/src", "nab-markersets/src", "nab-index/src", "src"]
 CHECKED = [*TYPED_TREES, "tests/cli_bijection.py"]
 
 # checker -> command; pyright reads its targets from [tool.pyright] in
-# pyproject.toml, the rest take them on the command line.
+# pyproject.toml, the rest take them on the command line. Paths on pyrefly's
+# command line switch off the excludes in its config, so the vendored tree is
+# excluded again here.
 TYPE_CHECKERS = {
     "mypy": ["mypy", *CHECKED],
     "pyright": ["pyright"],
     "ty": ["ty", "check", *CHECKED],
-    "pyrefly": ["pyrefly", "check", *CHECKED],
+    "pyrefly": ["pyrefly", "check", "--project-excludes", "**/_vendor/**", *CHECKED],
     "zuban": ["zuban", "check", *CHECKED],
 }
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -181,6 +181,8 @@ def _run_workspace(session: nox.Session, step: _Step, paths: list[str]) -> bool:
                 "pytest",
                 "-n",
                 "auto",
+                "--dist",
+                "worksteal",
                 "--cov",
                 "--cov-append",
                 "--cov-report=",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,7 +188,10 @@ addopts = [
     "--showlocals",
     "-m",
     "not property and not crosshair and not network and not benchmark",
+    "--durations=15",
 ]
+# A hung test fails here with a traceback instead of at the job's limit.
+timeout = 300
 testpaths = [
     "nab-resolver/tests",
     "nab-markersets/tests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -417,10 +417,14 @@ include = [
     "nab-resolver/src",
     "nab-resolver/tests",
     "nab-markersets/src",
+    "nab-provider/src",
+    "nab-project/src",
     "nab-index/src",
     "src",
     "tests/cli_bijection.py",
 ]
+# The vendored packaging tree is rebuilt from upstream, so no checker holds it.
+exclude = ["**/_vendor"]
 # Editable installs hide the workspace packages from pyright's auto-detection;
 # point it at the source trees directly so cross-package imports resolve.
 extraPaths = [
@@ -434,7 +438,19 @@ extraPaths = [
 
 # https://pyrefly.org/en/docs/configuration/
 [tool.pyrefly]
-project-includes = ["nab-resolver/src", "nab-markersets/src", "nab-index/src", "src"]
+project-includes = [
+    "nab-resolver/src",
+    "nab-markersets/src",
+    "nab-provider/src",
+    "nab-project/src",
+    "nab-index/src",
+    "src",
+]
+project-excludes = ["**/_vendor/**"]
+
+# https://docs.astral.sh/ty/reference/configuration/
+[tool.ty.src]
+exclude = ["**/_vendor"]
 
 # https://mypy.readthedocs.io/en/stable/config_file.html#using-a-pyproject-toml-file
 [tool.mypy]
@@ -445,7 +461,14 @@ explicit_package_bases = true
 # Each checked tree is a package base. Without "src" the umbrella resolves
 # under two module names ("nab._version" and "src.nab._version") and mypy
 # stops before checking anything.
-mypy_path = ["nab-resolver/src", "nab-markersets/src", "nab-index/src", "src"]
+mypy_path = [
+    "nab-resolver/src",
+    "nab-markersets/src",
+    "nab-provider/src",
+    "nab-project/src",
+    "nab-index/src",
+    "src",
+]
 enable_error_code = [
     "redundant-expr",
     "truthy-bool",
@@ -453,3 +476,13 @@ enable_error_code = [
     "explicit-override",
     "mutable-override",
 ]
+
+[[tool.mypy.overrides]]
+module = "nab_provider._vendor.*"
+ignore_errors = true
+
+# zuban reads [tool.mypy] and turns this on where mypy leaves it off. The
+# guards it calls dead sit after exhaustive isinstance chains and are reached
+# by tests with objects outside the declared type.
+[tool.zuban]
+warn_unreachable = false


### PR DESCRIPTION
Every checker now covers all six shipped trees, each test suite runs once per CI cell, hypothesis draws fresh examples on every run, and a hung test fails with a traceback.

**Type checking.** `nab-provider/src` and `nab-project/src` ship `py.typed` but no checker ran on them. Both are in every checker's scope now, with the vendored packaging tree excluded, and the errors that surfaced are fixed: missing `@override`, bare generics, a `MarkerLike` protocol so a `Marker` from either copy of packaging types, TypedDicts where `**kwargs` reached a typed constructor, and an enum sentinel where a lookup's miss value was an `object()`. `override` comes through the same per-package `_compat.py` shim as #1151, so no module imports `typing_extensions` at runtime. One cast, at the resolver-hint seam, since the resolver is not generic over its range type; one old `type: ignore` removed, no new suppressions; zuban's `warn_unreachable` is switched off to match mypy. Checker jobs grow by 5 to 10 s each.

**One run per suite.** The `project` workspace re-ran the 2933 tests in `nab-provider/tests` the `provider` workspace had just run, because `nab_provider` is gated there and needs both suites' data. The nox session now erases once, appends coverage, and skips a suite an earlier workspace ran. One run each side against the base commit: the four Windows cells on 3.10 to 3.13 went from 295 to 342 s down to 255 to 272 s, and the 15-cell total from about 3,400 s to about 3,000 s. Single runs, so a cell can move by tens of seconds either way; macOS 3.11 went up by 53 s.

**Hypothesis.** The `ci` profile drops `derandomize=True`, so the property job stops replaying the same 200 examples per test; `print_blob=True` keeps a failure reproducible from the log.

**Settings.** `pytest-timeout` was loaded in every cell but never configured. `timeout = 300` fails a hung test with its stack, the job limit drops from 45 to 20 minutes, `--durations=15` lists the slowest tests, and xdist runs `--dist worksteal`.

**Dependencies.** Locks refreshed with the cooldown anchored to now (nox 2026.8.17, hypothesis 6.165.10, coverage 7.15.4). Dependabot had moved the typos hook from v1.49.0 to the tag `varcon-core-v5.0.7`, which is the v1.44.0 release; it is pinned to v1.50.1 and that repo's `>=2` tags are ignored. ruff goes to 0.16.5, zizmor to 1.30.0. The pre-commit job's extra 40 s on this run is its hook cache rebuilding.
