### PR TITLE
Release a tag-refused wheel's payload, ~22% off a resolve's peak memory

### DIFF
--- a/nab-project/benchmarks/benchmark_config.py
+++ b/nab-project/benchmarks/benchmark_config.py
@@ -741,7 +741,11 @@ def build_benchmark_provider(
     target: ResolveTarget,
     inputs: _BenchmarkResolveInputs,
 ) -> Provider:
-    """Build a provider from a benchmark scenario's settings and roots."""
+    """Build a provider from a benchmark scenario's settings and roots.
+
+    One provider per coordinator, as in a single-target ``nab lock``, so it
+    may release the wheels its tags refuse.
+    """
     return Provider(
         coordinator,
         target=target,
@@ -760,4 +764,5 @@ def build_benchmark_provider(
         resolution_strategy=config.resolution,
         direct_packages=direct_packages_from_requirements(inputs.requirements),
         constraints=inputs.constraints,
+        release_refused_wheels=True,
     )

--- a/nab-project/src/nab_project/_resolve/engine.py
+++ b/nab-project/src/nab_project/_resolve/engine.py
@@ -496,6 +496,10 @@ class _EngineSettings:
     # of the listing filter reads are fixed for the run.
     listing_filter_cache: ListingFilterCache = field(default_factory=ListingFilterCache)
 
+    # Whether the wheel-tag filter may release what it refuses; see
+    # ``resolve_with_coordinator``.
+    release_refused_wheels: bool = False
+
     # The (kind, text) pairs already reported, so an entry read once per
     # target per fork and again in the base pass warns once.
     warned_dropped_markers: set[tuple[str, str]] = field(default_factory=set)
@@ -598,6 +602,7 @@ def _resolve_one_target(
         ),
         preferences=dict(preferences),
         listing_filter_cache=settings.listing_filter_cache,
+        release_refused_wheels=settings.release_refused_wheels,
     )
 
     observer = _ResolveObserver(settings.progress)

--- a/nab-project/src/nab_project/fetch.py
+++ b/nab-project/src/nab_project/fetch.py
@@ -1087,6 +1087,10 @@ class FetchCoordinator:
         One wheel per version: the first with a sidecar is the one the provider
         picks for that version's metadata. The backwards walk assigns
         unconditionally, so that first wheel is the one left in place.
+
+        The resolver thread filters these same records while this walk
+        runs, so a wheel it releases mid-walk answers no metadata URL and
+        is skipped (:func:`~nab_provider.records.release_wheel_payload`).
         """
         wanted = self.PREFETCH_METADATA_COUNT
         newest: dict[str, WheelFile] = {}
@@ -1098,9 +1102,14 @@ class FetchCoordinator:
             newest[f.version] = f
 
         for w in reversed(newest.values()):
+            # A release clears the URL first, so a URL read after the hash
+            # means the release had not begun when the hash was read.
+            metadata_hash = w.metadata_hash
             url = w.metadata_url
-            assert url is not None
-            self.request_metadata(package, w.version, url, w.metadata_hash)
+            if url is None:
+                continue
+
+            self.request_metadata(package, w.version, url, metadata_hash)
 
     def _run_listing_tail(
         self, package: str, records: Sequence[WheelFile | SdistFile]

--- a/nab-project/src/nab_project/resolve.py
+++ b/nab-project/src/nab_project/resolve.py
@@ -208,6 +208,7 @@ def resolve_for_targets(  # noqa: PLR0913 - the knobs of a project resolve
             base_requirements=base_requirements,
             resolution_strategy=resolution_strategy,
             progress=progress,
+            release_refused_wheels=True,
         )
 
 
@@ -225,6 +226,7 @@ def resolve_with_coordinator(  # noqa: PLR0913 - the knobs of a bare resolve
     preferences: Mapping[str, Version] | None = None,
     progress: ProgressSink | None = None,
     marker_holds: MarkerHolds | None = None,
+    release_refused_wheels: bool = False,
 ) -> ResolveResult:
     """Resolve ``targets`` against an already-open coordinator.
 
@@ -246,6 +248,12 @@ def resolve_with_coordinator(  # noqa: PLR0913 - the knobs of a bare resolve
     :func:`~nab_provider.marker_holds.dependency_marker_holds`.  A host
     with its own marker machinery passes that instead and keeps
     ``nab_markersets`` off the engine's path.
+
+    ``release_refused_wheels`` drops the URL, hashes and sidecar
+    declaration of every wheel a target's tags refuse.  The records come
+    from ``coordinator`` and outlive the resolve, so pass it only when
+    nothing else reads them.  A matrix keeps the payload either way: one
+    target's refusal is another target's candidate.
     """
     inputs = ResolveInputs() if inputs is None else inputs
     with _source_root(cache_dir, inputs) as source_root:
@@ -266,6 +274,7 @@ def resolve_with_coordinator(  # noqa: PLR0913 - the knobs of a bare resolve
             listing_filter_cache=ListingFilterCache(
                 len({target.python_full_version for target in targets})
             ),
+            release_refused_wheels=release_refused_wheels and len(targets) == 1,
         )
 
         fork_list = (

--- a/nab-project/tests/test_fetch.py
+++ b/nab-project/tests/test_fetch.py
@@ -884,6 +884,33 @@ class TestFetchCoordinator:
             )
         ]
 
+    def test_prefetch_after_listing_skips_a_wheel_released_mid_walk(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A release clears the URL first, so the walk finds none to request."""
+        half_released = WheelFile(
+            filename="pkg-1.0-py3-none-any.whl",
+            url="",
+            version="1.0",
+            requires_python=None,
+            has_metadata=True,
+            upload_time=None,
+            metadata_hash=("sha256", "h1"),
+        )
+        calls: list[tuple[object, ...]] = []
+
+        def _spy(*args: object, **kwargs: object) -> threading.Event:
+            calls.append(args)
+            done = threading.Event()
+            done.set()
+            return done
+
+        coord = _coord()
+        monkeypatch.setattr(coord, "request_metadata", _spy)
+        coord._prefetch_metadata_after_listing("pkg", [half_released])
+
+        assert calls == []
+
     @respx.mock
     def test_listing_entry_with_unsplittable_url_is_dropped(self) -> None:
         """Only the entry whose URL urllib cannot split is dropped."""

--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -92,6 +92,7 @@ from nab_provider.provider import (
     VcsPolicy,
     VcsSource,
 )
+from nab_provider.records import rehydrated_wheel
 from nab_provider.tags import PlatformSpec
 from nab_provider.target import ResolveTarget
 from nab_provider.testing import pkg_override
@@ -117,6 +118,10 @@ _PY312 = ResolveTarget.for_host_python("3.12.0")
 # A declared linux/3.11 target: host-independent tags for the tie tests.
 _LINUX311 = ResolveTarget.for_declared(
     python_version="3.11", spec=PlatformSpec("linux_x86_64")
+)
+
+_WINDOWS311 = ResolveTarget.for_declared(
+    python_version="3.11", spec=PlatformSpec("windows_amd64")
 )
 
 
@@ -12033,6 +12038,123 @@ class TestConsultedMarkers:
         provider = Provider(self._coordinator("bar"), target=_PY312)
         provider.get_dependencies("foo", V("1.0"))
         assert provider.consulted_markers == set()
+
+
+class TestTagRefusedWheelPayload:
+    """A refused wheel keeps its record; the caller says whether it keeps more."""
+
+    LINUX_URL = "https://example.com/foo-1.0-cp311-manylinux.whl"
+    WINDOWS_URL = "https://example.com/foo-1.0-cp311-win_amd64.whl"
+
+    def _wheels(self) -> list[WheelFile]:
+        """One wheel a linux cp311 target installs and one it cannot.
+
+        Both hold the index's tables unparsed, the form a listing's records
+        take and the one the release drops.
+        """
+        return [
+            rehydrated_wheel(
+                filename="foo-1.0-cp311-cp311-manylinux_2_17_x86_64.whl",
+                url=self.LINUX_URL,
+                version="1.0",
+                requires_python=None,
+                has_metadata=True,
+                upload_time="2024-01-01T00:00:00Z",
+                hashes={"sha256": "ab"},
+                size=None,
+                metadata_hash={"sha256": "cd"},
+            ),
+            rehydrated_wheel(
+                filename="foo-1.0-cp311-cp311-win_amd64.whl",
+                url=self.WINDOWS_URL,
+                version="1.0",
+                requires_python=None,
+                has_metadata=True,
+                upload_time="2024-01-01T00:00:00Z",
+                hashes={"sha256": "ef"},
+                size=None,
+                metadata_hash={"sha256": "01"},
+            ),
+        ]
+
+    def _filtered(self, *, release_refused_wheels: bool) -> list[WheelFile]:
+        """Both wheels, after a linux cp311 target has filtered the listing."""
+        files = self._wheels()
+        provider = Provider(
+            make_coordinator(files, package="foo"),
+            target=_LINUX311,
+            release_refused_wheels=release_refused_wheels,
+        )
+        kept = [dist for _, dist in provider.fetch_versions("foo")]
+        assert [w.filename for w in kept] == [files[0].filename]
+        return files
+
+    def _resolved(
+        self, targets: Sequence[ResolveTarget], *, release_refused_wheels: bool
+    ) -> list[WheelFile]:
+        """Both wheels, after ``targets`` have resolved over one coordinator."""
+        files = self._wheels()
+        result = resolve_with_coordinator(
+            make_coordinator(files, package="foo", auto_metadata=True),
+            targets,
+            [Requirement("foo")],
+            inputs=ResolveInputs(build_policy=BuildPolicy.NEVER),
+            release_refused_wheels=release_refused_wheels,
+        )
+        assert result.success
+        return files
+
+    def test_the_only_reader_releases_the_refused_wheel(self) -> None:
+        """Nothing reads a refused wheel's URL, hashes or sidecar again."""
+        _, refused = self._filtered(release_refused_wheels=True)
+
+        assert refused.url == ""
+        assert refused.has_metadata is False
+        assert refused.metadata_url is None
+        assert refused.raw_hashes() is None
+        assert refused.raw_sidecar() is None
+
+    def test_the_only_reader_leaves_the_installable_wheel_whole(self) -> None:
+        """Only the refused wheel is released; the kept one is untouched."""
+        kept, _ = self._filtered(release_refused_wheels=True)
+
+        assert kept.url == self.LINUX_URL
+        assert kept.hashes == (("sha256", "ab"),)
+        assert kept.metadata_hash == ("sha256", "cd")
+
+    def test_a_shared_listing_keeps_the_refused_wheel(self) -> None:
+        """Another target over the same coordinator still reads the record."""
+        _, refused = self._filtered(release_refused_wheels=False)
+
+        assert refused.url == self.WINDOWS_URL
+        assert refused.hashes == (("sha256", "ef"),)
+        assert refused.metadata_hash == ("sha256", "01")
+
+    def test_a_one_target_resolve_releases_the_refused_wheel(self) -> None:
+        """``resolve_with_coordinator`` passes the flag down to the provider."""
+        _, refused = self._resolved([_LINUX311], release_refused_wheels=True)
+
+        assert refused.url == ""
+        assert refused.hashes == ()
+        assert refused.metadata_hash is None
+
+    def test_a_resolve_that_does_not_ask_keeps_the_refused_wheel(self) -> None:
+        """One target is not enough on its own: the caller has to ask."""
+        _, refused = self._resolved([_LINUX311], release_refused_wheels=False)
+
+        assert refused.url == self.WINDOWS_URL
+        assert refused.hashes == (("sha256", "ef"),)
+        assert refused.metadata_hash == ("sha256", "01")
+
+    def test_a_matrix_keeps_a_wheel_its_other_target_installs(self) -> None:
+        """One target's refusal is the next target's pick, so nothing is released."""
+        _, windows = self._resolved(
+            [_LINUX311, _WINDOWS311], release_refused_wheels=True
+        )
+
+        assert windows.url == self.WINDOWS_URL
+        assert windows.hashes == (("sha256", "ef"),)
+        assert windows.metadata_hash == ("sha256", "01")
 
 
 class TestPrereleaseHostTarget:

--- a/nab-provider/src/nab_provider/_provider/listing.py
+++ b/nab-provider/src/nab_provider/_provider/listing.py
@@ -9,11 +9,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from functools import partial
-from typing import TYPE_CHECKING, Final
+from typing import TYPE_CHECKING, Final, TypeGuard
 
 from nab_provider._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
 from nab_provider._vendor.packaging.version import InvalidVersion, Version
-from nab_provider.records import SdistFile, WheelFile
+from nab_provider.records import SdistFile, WheelFile, release_wheel_payload
 
 from ..errors import (
     ForeignMetadataError,
@@ -645,11 +645,16 @@ def _apply_wheel_tags(
 
     Runs per target: the tags are the one axis of the filter the targets
     of a matrix do not share.
+
+    Where the provider's caller allows it, a refused wheel is released as
+    it is dropped, since nothing fetches it again
+    (:func:`~nab_provider.records.release_wheel_payload`).
     """
     tags = provider.wheel_tags
     if tags is None:
         return base
 
+    release_refused = provider.release_refused_wheels
     result: list[tuple[Version, DistFile]] = []
     tag_rejected_versions: set[Version] = set()
     run_version: Version | None = None
@@ -659,6 +664,9 @@ def _apply_wheel_tags(
         if not excluded_by_wheel_tags(dist, tags):
             result.append((version, dist))
             continue
+
+        if release_refused:
+            release_wheel_payload(dist)
 
         # ``base`` is sorted by version, so a version's rejected wheels arrive
         # together and fold into one tally update.  Identity is enough for the
@@ -727,7 +735,7 @@ def python_or_time_cause(
     return cause
 
 
-def excluded_by_wheel_tags(dist: DistFile, tags: TagSet) -> bool:
+def excluded_by_wheel_tags(dist: DistFile, tags: TagSet) -> TypeGuard[WheelFile]:
     """Return True when ``dist`` is a wheel the target cannot install.
 
     An sdist is never excluded here: it carries no tags, and building it

--- a/nab-provider/src/nab_provider/provider.py
+++ b/nab-provider/src/nab_provider/provider.py
@@ -433,6 +433,13 @@ class Provider:
     ``decision_order`` chooses whether the decision scan may rank a
     package on whether its listing has landed yet.  See
     :meth:`settled_listing`.
+
+    ``release_refused_wheels`` lets the wheel-tag filter drop the payload
+    of the wheels it refuses
+    (:func:`nab_provider.records.release_wheel_payload`).  Only the caller
+    that builds the providers knows whether that is safe: pass it when no
+    other reader of this coordinator's listings needs the URL, hashes or
+    sidecar of a wheel these tags refuse.
     """
 
     # Declared in ``_provider.listing``; the scan reads it off the instance.
@@ -505,6 +512,7 @@ class Provider:
         constraints: Mapping[str, VersionRange] | None = None,
         trust_unverified_sdist_deps: bool = False,
         decision_order: DecisionOrder = DecisionOrder.ARRIVAL,
+        release_refused_wheels: bool = False,
     ) -> None:
         """Construct the provider; see the class docstring for parameters."""
         if isinstance(resolution_strategy, str):
@@ -524,6 +532,8 @@ class Provider:
         # The pre-tag half of the listing filter, shared with the other
         # targets of this resolve.  ``None`` computes it here instead.
         self.listing_filter_cache = listing_filter_cache
+
+        self.release_refused_wheels = release_refused_wheels
 
         self.extras_mode = extras_mode
         self.root_extras = root_extras or set()

--- a/nab-provider/src/nab_provider/records.py
+++ b/nab-provider/src/nab_provider/records.py
@@ -34,6 +34,7 @@ __all__ = [
     "parse_hash_table",
     "rehydrated_sdist",
     "rehydrated_wheel",
+    "release_wheel_payload",
     "select_artifact_hash",
     "sidecar_hash",
 ]
@@ -321,8 +322,10 @@ class WheelFile(_WheelIntegrity):
         """Return the PEP 658/714 metadata URL, or None when unsupported.
 
         The suffix goes on the path, so a PEP 503 hash fragment is dropped.
+        An empty URL answers ``None``: no listing entry carries one, so it
+        marks a record :func:`release_wheel_payload` has reached.
         """
-        if not self.has_metadata:
+        if not self.has_metadata or not self.url:
             return None
 
         try:
@@ -347,6 +350,28 @@ _set_wheel_metadata_hash = _slot_writer(WheelFile, "metadata_hash")
 
 _set_wheel_raw_hashes = _slot_writer(_WheelIntegrity, "_raw_hashes")
 _set_wheel_raw_metadata = _slot_writer(_WheelIntegrity, "_raw_metadata")
+
+
+def release_wheel_payload(wheel: WheelFile) -> None:
+    """Drop what only an installable wheel still reads.
+
+    A wheel the target's tags refuse is never fetched, verified or written
+    to a lock, so its URL, integrity tables and sidecar declaration have no
+    reader left.  The record stays in the listing for the version tallies
+    and the diagnosis walk.  Only the raw tables go, so a record that
+    parsed its hashes at construction keeps them.
+
+    The URL is cleared first so a concurrent reader can order itself
+    against the release: an empty URL makes :attr:`WheelFile.metadata_url`
+    answer ``None``, so a reader that takes a hash and then a URL that is
+    still there took the hash before the release began.
+    """
+    _set_wheel_url(wheel, "")
+    _set_wheel_has_metadata(wheel, False)  # noqa: FBT003 - the slot's __set__ is positional-only
+
+    # A deferred slot holding ``None`` reads back as one holding nothing.
+    _set_wheel_raw_hashes(wheel, None)
+    _set_wheel_raw_metadata(wheel, None)
 
 
 def rehydrated_wheel(  # noqa: PLR0913, PLR0917 - the record's fields, in its own order

--- a/nab-provider/tests/test_record_deferral.py
+++ b/nab-provider/tests/test_record_deferral.py
@@ -13,6 +13,7 @@ from nab_provider.records import (
     defer_hashes,
     defer_sidecar_hash,
     rehydrated_wheel,
+    release_wheel_payload,
 )
 
 DIGEST = "a" * 64
@@ -244,3 +245,57 @@ def test_deferral_does_not_answer_for_an_unknown_attribute() -> None:
 
     with pytest.raises(AttributeError, match="no_such_field"):
         wheel.no_such_field  # noqa: B018
+
+
+def test_releasing_a_wheel_drops_the_tables_it_deferred() -> None:
+    """The listing filter releases a refused wheel; the raw tables go with it."""
+    wheel = _deferred_wheel({"sha256": DIGEST}, sidecar={"sha256": DIGEST})
+
+    release_wheel_payload(wheel)
+
+    assert wheel.raw_hashes() is None
+    assert wheel.raw_sidecar() is None
+    assert wheel.hashes == ()
+    assert wheel.metadata_hash is None
+
+
+def test_releasing_a_wheel_clears_what_a_fetch_would_have_read() -> None:
+    wheel = _deferred_wheel({"sha256": DIGEST}, sidecar={"sha256": DIGEST})
+
+    release_wheel_payload(wheel)
+
+    assert wheel.url == ""
+    assert wheel.has_metadata is False
+    assert wheel.metadata_url is None
+
+
+def test_releasing_a_wheel_that_deferred_nothing_keeps_its_parsed_values() -> None:
+    """Only the raw tables go, and a record built from parsed values holds none."""
+    wheel = WheelFile(
+        filename="pkg-1.0-py3-none-any.whl",
+        url="https://files.example/pkg-1.0-py3-none-any.whl",
+        version="1.0",
+        requires_python=None,
+        has_metadata=True,
+        upload_time=None,
+        hashes=((SHA256, DIGEST),),
+        metadata_hash=(SHA256, DIGEST),
+    )
+
+    release_wheel_payload(wheel)
+
+    assert wheel.url == ""
+    assert wheel.hashes == ((SHA256, DIGEST),)
+    assert wheel.metadata_hash == (SHA256, DIGEST)
+
+
+def test_releasing_a_wheel_leaves_the_rest_of_the_record_readable() -> None:
+    """The version tallies and the diagnosis walk still read the record."""
+    wheel = _deferred_wheel({"sha256": DIGEST}, sidecar={"sha256": DIGEST})
+
+    release_wheel_payload(wheel)
+
+    assert wheel.filename == "pkg-1.0-py3-none-any.whl"
+    assert wheel.version == "1.0"
+    assert wheel.upload_time is None
+    assert wheel.requires_python is None

--- a/nab-provider/tests/test_records.py
+++ b/nab-provider/tests/test_records.py
@@ -17,11 +17,13 @@ WHEEL_URL = "https://pypi.example/pkg-1.0-py3-none-any.whl"
 HAND_WRITTEN_INIT_RECORDS = [WheelFile, SdistFile]
 
 
-def make_wheel(*, has_metadata: bool = True) -> WheelFile:
-    """A wheel whose URL carries a PEP 503 hash fragment."""
+def make_wheel(
+    *, has_metadata: bool = True, url: str = f"{WHEEL_URL}#sha256=ab"
+) -> WheelFile:
+    """A wheel whose URL carries a PEP 503 hash fragment by default."""
     return WheelFile(
         filename="pkg-1.0-py3-none-any.whl",
-        url=f"{WHEEL_URL}#sha256=ab",
+        url=url,
         version="1.0",
         requires_python=None,
         has_metadata=has_metadata,
@@ -42,6 +44,11 @@ def test_metadata_url_appends_suffix_to_path() -> None:
 def test_metadata_url_none_without_sidecar() -> None:
     """A wheel the index advertised no sidecar for has no metadata URL."""
     assert make_wheel(has_metadata=False).metadata_url is None
+
+
+def test_metadata_url_none_without_a_url() -> None:
+    """A released record has no URL for the suffix to go on."""
+    assert make_wheel(url="").metadata_url is None
 
 
 def test_metadata_url_reuses_first_result() -> None:


### PR DESCRIPTION
Peak traced allocation on a warm `pip:langchain-ml-course --resolution lowest` drops from 199 MB to 155 MB, about 22% off, and peak RSS from 244 MB to 197 MB, about 19%. `ai-stack:vllm-transformers-floor --resolution highest` and `airflow:airflow-3-0-2-awswrangler --resolution lowest-direct` come down between about 15% and 29%; those two vary by up to 18% run to run on unchanged code.

A wheel the target's tags refuse is never fetched, verified or locked, but its record stays in the listing for the version tallies and the failure diagnosis, still holding a URL, a raw hash table and a sidecar declaration: about 413 bytes a record, and langchain refuses 109,896 of them. `release_wheel_payload` drops the three at the refusal.

`upload_time` stays: the diagnosis walk re-reads it to tell a tag refusal from an upload-cutoff one. The URL clears first, so a prefetch racing the release finds no metadata URL and skips the wheel.

Releasing is not free: about 2,800 instructions a wheel, so awswrangler's 56,693 refusals cost roughly 0.16 billion against a resolve counting near 7.3 billion. Live bytes and blocks at exit land inside about 1% either way, so the win is the high-water mark, not what a lock retains.

Off by default, since one target's refused wheel is another's candidate. A single-target `nab lock` turns it on; a matrix keeps the payload.
