### PR TITLE
Read a lone sha256 digest with dict.get, ~2% of a resolve's instructions

### DIFF
--- a/nab-provider/src/nab_provider/records.py
+++ b/nab-provider/src/nab_provider/records.py
@@ -115,9 +115,12 @@ def _compact_table(table: dict[object, object]) -> object:
     served as.
     """
     if len(table) == 1:
+        # Looking sha256 up directly skips building the items view.
+        sha256 = table.get("sha256")
+        if type(sha256) is str:
+            return sha256
+
         ((algo, digest),) = table.items()
-        if algo == "sha256" and type(digest) is str:
-            return digest
         if type(algo) is str:
             return (sys.intern(algo), digest)
     return table
@@ -132,9 +135,11 @@ def _compact_shared_table(table: dict[object, object]) -> object:
     nothing here.
     """
     if len(table) == 1:
+        sha256 = table.get("sha256")
+        if type(sha256) is str:
+            return sha256
+
         ((algo, digest),) = table.items()
-        if algo == "sha256" and type(digest) is str:
-            return digest
         if type(algo) is str:
             return (algo, digest)
     return table


### PR DESCRIPTION
Removes 66,044,010 of 3,862,525,916 instructions (1.7%) from a warm `pip:google-bigquery-soda@lowest` resolve, and 175,266,253 of 7,424,411,591 (2.4%) from `airflow:airflow-3-0-2-awswrangler@lowest-direct`. Both counted under callgrind with `PYTHONHASHSEED=0`, so they reproduce exactly.

`_compact_shared_table` runs 75,727 times on that soda resolve, holding 96% of the 78,655 `dict.items()` calls the whole process makes. Each call built a `dict_items` view and an iterator to read a one-entry table whose key is nearly always `"sha256"`. Looking that key up first answers without either: `dict.items()` calls fall to 2,928, and about 150,000 of the run's 2.57 million allocations go away under memcheck.

Both `_compact_table` and `_compact_shared_table` keep the `((algo, digest),) = table.items()` unpack as the fallback for other algorithms.

The allocations are churn rather than footprint: peak traced bytes go from 55,012,314 to 55,012,848 on that scenario, with four more live blocks. The clock cannot see a change this size, so the timing runs over the 19-scenario canary set only rule out a wall regression above about 5% and a CPU regression above about 3.4%.
