### PR TITLE
Fix vcs-sources error telling nab.toml users to set [tool.nab.vcs]

### DIFF
--- a/src/nab/config/model.py
+++ b/src/nab/config/model.py
@@ -389,8 +389,9 @@ def _config_from_effective(
     vcs_sources = effective["vcs-sources"].value
     archive_sources = effective["archive-sources"].value
     _reject_duplicate_source_names(local_sources, vcs_sources, archive_sources)
+
     vcs_config = effective["vcs"].value
-    _reject_vcs_sources_under_block(vcs_sources, vcs_config)
+    _reject_vcs_sources_under_block(effective["vcs-sources"], effective["vcs"])
 
     del pyproject_dir  # paths were resolved per-layer by the registry.
     return NabProjectConfig(
@@ -1079,38 +1080,66 @@ def _reject_duplicate_source_names(
         canonical = canonicalize_name(source.name)
         if canonical in seen:
             msg = (
-                "[tool.nab] local-sources/vcs-sources/archive-sources declare"
-                f" duplicate canonical name {canonical!r} via {seen[canonical]!r}"
+                "local-sources/vcs-sources/archive-sources declare duplicate"
+                f" canonical name {canonical!r} via {seen[canonical]!r}"
                 f" and {source.name!r}"
             )
             raise ConfigError(msg)
         seen[canonical] = source.name
 
 
+def _project_key_path(key: str, kind: SourceKind) -> str:
+    """Return the table path a project file of ``kind`` gives ``key``.
+
+    A project-dir nab.toml takes nab's keys at the top level; a
+    pyproject.toml takes them under ``[tool.nab]``.
+    """
+    return key if kind is SourceKind.PROJECT_TOML else f"tool.nab.{key}"
+
+
 def _reject_vcs_sources_under_block(
-    vcs_sources: tuple[VcsSource, ...],
-    vcs_config: VcsConfig,
+    vcs_sources: EffectiveValue,
+    vcs: EffectiveValue,
 ) -> None:
     """Reject vcs-sources declared while the VCS policy blocks cloning.
 
-    Cloning is opt-in, so a ``[[tool.nab.vcs-sources]]`` entry under the
-    default ``policy = "block"`` is contradictory. Raising ConfigError here
-    fails at parse time and names the token to set.
+    Cloning is opt-in, so a declared source under the default
+    ``policy = "block"`` is contradictory. Raising ConfigError here fails
+    at parse time and names the token to set.
+
+    Each table is named for the file that has to carry the repair: the
+    sources for the file declaring them, the policy for the file that set
+    it. The two project files share a precedence rank, so a policy written
+    into the other one conflicts instead of overriding.
 
     ``policy = "allow"`` opens the gate but does not on its own admit a
     URL: ``allowed-schemes`` and ``allowed-repos`` are empty by default
     and each denies every URL until an entry is added, so the message
     points at the whole gate rather than promising that one key is enough.
     """
-    if vcs_sources and vcs_config.policy is VcsPolicy.BLOCK:
-        msg = (
-            "[[tool.nab.vcs-sources]] is declared but [tool.nab.vcs].policy is"
-            f" {vcs_config.policy.value!r}, which refuses every clone; remove"
-            ' the sources, or set [tool.nab.vcs].policy = "allow" and open the'
-            " rest of the gate (vcs.allowed-schemes and vcs.allowed-repos are"
-            " empty by default and each denies every URL)"
-        )
-        raise ConfigError(msg)
+    sources: tuple[VcsSource, ...] = vcs_sources.value
+    config: VcsConfig = vcs.value
+    if not sources or config.policy is not VcsPolicy.BLOCK:
+        return
+
+    # The default policy sits in no file, so its repair goes in the one that
+    # declared the sources.
+    policy_kind = (
+        vcs_sources.origin.kind
+        if vcs.origin.kind is SourceKind.DEFAULT
+        else vcs.origin.kind
+    )
+    sources_table = _project_key_path("vcs-sources", vcs_sources.origin.kind)
+    vcs_table = _project_key_path("vcs", policy_kind)
+
+    msg = (
+        f"[[{sources_table}]] is declared but [{vcs_table}].policy is"
+        f" {config.policy.value!r}, which refuses every clone; remove"
+        f' the sources, or set [{vcs_table}].policy = "allow" and open the'
+        " rest of the gate (vcs.allowed-schemes and vcs.allowed-repos are"
+        " empty by default and each denies every URL)"
+    )
+    raise ConfigError(msg)
 
 
 def _validate_default_groups_against_conflicts(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3035,6 +3035,57 @@ class TestVcsSources:
         with pytest.raises(ConfigError, match=r'\[tool\.nab\.vcs\]\.policy = "allow"'):
             read_pyproject_config(path)
 
+    def test_nab_toml_sources_under_block_named_at_top_level(
+        self, tmp_path: Path
+    ) -> None:
+        """The error names top-level keys when nab.toml declares the sources."""
+        path = write(tmp_path, '[project]\nname = "x"\nversion = "0"\n')
+        nab_toml = tmp_path / "nab.toml"
+        sources = (
+            '[[vcs-sources]]\nname = "pkg"\n'
+            'url = "git+https://github.com/org/pkg.git@abc"\n'
+        )
+        nab_toml.write_text(sources, encoding="utf-8")
+
+        with pytest.raises(ConfigError) as excinfo:
+            read_pyproject_config(path, discover_workspace=False)
+
+        message = str(excinfo.value)
+        assert "[[vcs-sources]] is declared" in message
+        assert '[vcs].policy = "allow"' in message
+        assert "tool.nab" not in message
+
+        nab_toml.write_text(sources + '[vcs]\npolicy = "allow"\n', encoding="utf-8")
+        config = read_pyproject_config(path, discover_workspace=False)
+        assert config.vcs_sources == (
+            VcsSource(name="pkg", url="git+https://github.com/org/pkg.git@abc"),
+        )
+
+    def test_policy_named_in_the_file_that_set_it(self, tmp_path: Path) -> None:
+        """The repair goes where the policy is, not where the sources are.
+
+        Both project files sit at the same precedence rank, so writing the
+        policy into nab.toml as well would conflict rather than override.
+        """
+        pyproject = '[project]\nname = "x"\nversion = "0"\n[tool.nab.vcs]\npolicy = '
+        path = write(tmp_path, pyproject + '"block"\n')
+        (tmp_path / "nab.toml").write_text(
+            '[[vcs-sources]]\nname = "pkg"\n'
+            'url = "git+https://github.com/org/pkg.git@abc"\n',
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ConfigError) as excinfo:
+            read_pyproject_config(path, discover_workspace=False)
+
+        message = str(excinfo.value)
+        assert "[[vcs-sources]] is declared" in message
+        assert '[tool.nab.vcs].policy = "allow"' in message
+
+        write(tmp_path, pyproject + '"allow"\n')
+        config = read_pyproject_config(path, discover_workspace=False)
+        assert config.vcs.policy is VcsPolicy.ALLOW
+
     def test_must_be_array(self, tmp_path: Path) -> None:
         path = write(tmp_path, '[tool.nab]\nvcs-sources = "x"\n')
         with pytest.raises(ConfigError, match="vcs-sources must be an array"):
@@ -3093,6 +3144,23 @@ class TestVcsSources:
         )
         with pytest.raises(ConfigError, match="duplicate canonical name"):
             read_pyproject_config(path)
+
+    def test_duplicate_name_message_names_no_table(self, tmp_path: Path) -> None:
+        """The three key names read the same in both project files."""
+        path = write(tmp_path, '[project]\nname = "x"\nversion = "0"\n')
+        (tmp_path / "nab.toml").write_text(
+            '[[local-sources]]\nname = "Foo-Bar"\npath = "../a"\n'
+            '[[vcs-sources]]\nname = "foo_bar"\n'
+            'url = "git+https://github.com/me/b.git@abc"\n',
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ConfigError) as excinfo:
+            read_pyproject_config(path, discover_workspace=False)
+
+        message = str(excinfo.value)
+        assert "local-sources/vcs-sources/archive-sources declare" in message
+        assert "tool.nab" not in message
 
 
 class TestArchiveSources:


### PR DESCRIPTION
Declaring `[[vcs-sources]]` in a project-directory `nab.toml` gets an error telling you to set `[tool.nab.vcs].policy = "allow"`. Put that in the file that raised it and nab rejects it:

    error: .../nab.toml: 'tool' is not a valid nab setting; the known keys are ['archive-sources', ...].

A `nab.toml` takes nab's keys at the top level, and the guard always named them the pyproject way.

The guard now names each table for the file that has to carry the repair: the sources for the file declaring them, the policy for the file that set it. Sources in `nab.toml` under the default policy report `[[vcs-sources]]` and `[vcs]`. Sources in `nab.toml` against `policy = "block"` in `pyproject.toml` still report `[tool.nab.vcs]`, since both project files sit at the same precedence level and a second copy of the key conflicts instead of overriding.

The duplicate-source-name error drops its `[tool.nab]` prefix: `local-sources`, `vcs-sources` and `archive-sources` are written the same way in both files.
