### PR TITLE
Defer platform imports in config values, ~9% off `nab cache dir`

### DIFF
--- a/src/nab/config/values.py
+++ b/src/nab/config/values.py
@@ -48,14 +48,6 @@ from nab_provider.policy import (
 from nab_provider.records import IndexConfig
 from nab_provider.serialization import SimpleSerialization
 from nab_provider.subdir import subdirectory_escapes
-from nab_provider.tags import (
-    DEFAULT_LIBC,
-    LIBC_MAJOR,
-    Libc,
-    PlatformSpec,
-    platform_kind,
-)
-from nab_provider.target import PLATFORM_MARKERS, Matrix
 from nab_provider.vcs_admission import VcsConfig, VcsPolicy, known_vcs_schemes
 
 if TYPE_CHECKING:
@@ -63,6 +55,8 @@ if TYPE_CHECKING:
     from collections.abc import Iterator, Mapping, Sequence
 
     from nab_provider._vendor.packaging.requirements import Requirement
+    from nab_provider.tags import Libc, PlatformSpec
+    from nab_provider.target import Matrix
 
 
 __all__ = [
@@ -174,6 +168,9 @@ class MatrixConfig(ValueType):
 
 def matrix_from_config(matrix: MatrixConfig) -> Matrix:
     """Build the expandable :class:`Matrix` from its parsed config table."""
+    # Deferred to keep nab_provider.target off the CLI's import path.
+    from nab_provider.target import Matrix  # noqa: PLC0415
+
     return Matrix(
         python=matrix.python,
         platforms=matrix.platforms,
@@ -639,6 +636,9 @@ def validate_environment_values(environment: Mapping[str, Any]) -> None:
             raise SourceConfigError(msg) from exc
     platform = environment.get("platform")
     if platform is not None:
+        # Deferred to keep nab_provider.target off the CLI's import path.
+        from nab_provider.target import PLATFORM_MARKERS  # noqa: PLC0415
+
         platform_id = environment_platform_spec(platform).platform_id
         if platform_id not in PLATFORM_MARKERS:
             valid = sorted(PLATFORM_MARKERS)
@@ -1819,6 +1819,9 @@ def _parse_matrix_platforms(value: object, label: str) -> tuple[PlatformSpec, ..
 
 def _platform_spec(where: str, **knobs: Any) -> PlatformSpec:
     """Build a :class:`PlatformSpec`, reporting its knob check as a config error."""
+    # Deferred to keep nab_provider.tags off the CLI's import path.
+    from nab_provider.tags import PlatformSpec  # noqa: PLC0415
+
     try:
         return PlatformSpec(**knobs)
     except ValueError as exc:
@@ -1873,6 +1876,9 @@ def _reject_foreign_knobs(where: str, value: dict[str, Any], platform_id: str) -
     unknown ``platform_id`` is left to the matrix, which names the whole
     unknown set at once.
     """
+    # Deferred to keep nab_provider.tags off the CLI's import path.
+    from nab_provider.tags import platform_kind  # noqa: PLC0415
+
     kind = platform_kind(platform_id)
     if kind is None:
         return
@@ -1890,6 +1896,9 @@ def _reject_foreign_knobs(where: str, value: dict[str, Any], platform_id: str) -
 
 def _parse_libc(key: str, value: object) -> Libc:
     """Parse a libc family name; an absent key takes the default family."""
+    # Deferred to keep nab_provider.tags off the CLI's import path.
+    from nab_provider.tags import DEFAULT_LIBC, LIBC_MAJOR  # noqa: PLC0415
+
     if value is None:
         return DEFAULT_LIBC
     text = _parse_string_value(key, value)

--- a/tests/test_cli_imports.py
+++ b/tests/test_cli_imports.py
@@ -11,8 +11,8 @@ the heavier stdlib modules the rest of nab uses.  ``nab._cli.dispatch``,
 sanctioned exemptions, and each is loaded only by a line that asked for it.
 
 The last cases ban what a command holds after it has dispatched: a line
-that only reads settings loads nothing a resolve needs, and a line that
-locks holds no part of ``email``.
+that only reads settings loads nothing a resolve needs and no platform
+table; a line that locks holds no part of ``email``.
 """
 
 from __future__ import annotations
@@ -266,3 +266,30 @@ def test_a_lock_command_holds_no_email_module(tmp_path: Path) -> None:
     (tmp_path / "pyproject.toml").write_text(_PROJECT, encoding="utf-8")
 
     assert _run(_HELD_PROBE, "email", "lock", "--offline", cwd=tmp_path) == ""
+
+
+# The platform vocabulary the matrix and environment tables are written in.
+# ``nab_provider.target`` pulls ``nab_provider.marker_holds`` and
+# ``nab_markersets`` in behind it.
+_MATRIX_VOCABULARY = (
+    "nab_provider.tags",
+    "nab_provider.target",
+    "nab_provider.marker_holds",
+    "nab_markersets",
+)
+
+
+@pytest.mark.parametrize("line", [("cache", "dir"), ("config", "list")])
+def test_a_settings_command_loads_no_platform_vocabulary(
+    line: tuple[str, ...], tmp_path: Path
+) -> None:
+    """Probe H: a project declaring no matrix builds no platform tag table.
+
+    :mod:`nab.config.values` is on the import path of every line that
+    reads the configuration ladder, and it names these modules only in
+    the parsers a ``[tool.nab.matrix]`` or ``[tool.nab.environment]``
+    table reaches.
+    """
+    (tmp_path / "pyproject.toml").write_text(_PROJECT, encoding="utf-8")
+
+    assert _run(_HELD_PROBE, ",".join(_MATRIX_VOCABULARY), *line, cwd=tmp_path) == ""


### PR DESCRIPTION
`nab cache dir` retires 293,270,907 instructions instead of 322,727,363, 9.1% of the process, and imports 200 modules instead of 209. Peak traced bytes fall from 6,004,522 to 4,987,919, 17% off.

`src/nab/config/values.py` binds the platform and matrix vocabulary at module scope, and every command that reads configuration imports it. So `cache dir` and `config list` on a project with no `[tool.nab.matrix]` build `nab_provider.tags`, `nab_provider.target`, `nab_provider.marker_holds` and the six `nab_markersets` modules behind them, then call none of it. Those names move under `TYPE_CHECKING`, imported at the call site by the parsers a `[tool.nab.matrix]` or `[tool.nab.environment]` table reaches.

Locally `nab cache dir` runs between about 3% and 12% faster over 600 runs, with a middle estimate near 7%. The 19-scenario canary set rules out a wall regression there above about 3.4%.

The counts reproduce on any machine; the timings are off this one.
