### PR TITLE
Fix VCS policy reference: allowing a direct-URL requirement never resolves

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -644,15 +644,23 @@ both satisfy every requirement.
 
 ## VCS policy
 
-`[tool.nab.vcs]` controls whether direct-URL VCS requirements
-(`pkg @ git+https://...`) are honored.  Default posture is fully
-restrictive.
+`[tool.nab.vcs]` is the gate a VCS URL passes before nab clones it.
+Default posture is fully restrictive.  The form that resolves is a
+`[[tool.nab.vcs-sources]]` entry, described under "Pinned VCS sources"
+below.
+
+A direct-URL requirement (`pkg @ git+https://...`) at the project root
+or in a dependency's metadata passes the same gate, then fails the
+resolve, because nab has no resolver path for that form.  A requirement
+whose marker excludes it, or one behind an extra the resolve never
+requests, never reaches the gate.  See
+[Add a VCS dependency](../how-to/vcs.md).
 
 ```toml
 [tool.nab.vcs]
 policy = "block"                # "block" | "allow"
 allowed-schemes = ["git+https"]
-allowed-repos = ["github.com/me/x"]
+allowed-repos = ["https://github.com/me/x"]
 require-pin = true
 ```
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import errno
 import re
-from dataclasses import fields
+from dataclasses import fields, replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
+import tomli
 
 from nab.config.ladder import (
     OPTIONS,
@@ -80,6 +81,7 @@ from nab_provider.serialization import SimpleSerialization
 from nab_provider.tags import PlatformSpec
 from nab_provider.target import ResolveTarget, declared_range_marker, host_environment
 from nab_provider.testing import pkg_override
+from nab_provider.vcs_admission import admit_vcs_url
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -137,18 +139,23 @@ def universal_mode_section() -> str:
     return match.group(0)
 
 
-def indexes_doc_example() -> str:
-    """Return the first fenced TOML block of the config reference's Indexes section.
+def section_doc_example(heading: str) -> str:
+    """Return the first TOML example under ``## <heading>`` in the config reference.
 
     ``first_tool_nab_example`` only returns blocks that open with ``[tool.nab]``.
     """
     text = DOCS_CONFIGURATION.read_text()
-    section = re.search(r"^## Indexes.*?(?=^## )", text, flags=re.DOTALL | re.MULTILINE)
+    section = re.search(
+        rf"^## {re.escape(heading)}\n.*?(?=^## )", text, flags=re.DOTALL | re.MULTILINE
+    )
     if section is None:
-        raise AssertionError("no indexes section in configuration.md")
+        msg = f"no {heading} section in configuration.md"
+        raise AssertionError(msg)
+
     blocks = re.findall(r"```toml\n(.*?)```", section.group(0), re.DOTALL)
     if not blocks:
-        raise AssertionError("no TOML example in configuration.md's indexes section")
+        msg = f"no TOML example in configuration.md's {heading} section"
+        raise AssertionError(msg)
     return blocks[0]
 
 
@@ -2747,7 +2754,7 @@ class TestIndexSerialization:
         assert positional.serialization is SimpleSerialization.NEGOTIATE
 
     def test_reference_example_parses(self, tmp_path: Path) -> None:
-        path = write(tmp_path, indexes_doc_example())
+        path = write(tmp_path, section_doc_example("Indexes"))
         pins = {i.name: i.serialization for i in read_pyproject_config(path).indexes}
         assert pins["pypi"] is SimpleSerialization.NEGOTIATE
         assert pins["internal"] is SimpleSerialization.HTML
@@ -2825,6 +2832,23 @@ class TestVcs:
         )
         vcs = read_pyproject_config(path).vcs
         assert vcs.allowed_repos == ("https://[2001:db8::1]:7999/org/repo",)
+
+
+class TestVcsDocExample:
+    """The config reference's ``[tool.nab.vcs]`` example is a working allowlist."""
+
+    def test_example_shows_every_key(self) -> None:
+        """The example names each key ``[tool.nab.vcs]`` accepts."""
+        example = tomli.loads(section_doc_example("VCS policy"))
+        shown = set(example["tool"]["nab"]["vcs"])
+        assert shown == {f.name.replace("_", "-") for f in fields(VcsConfig)}
+
+    def test_allowlists_admit_the_repo_they_name(self, tmp_path: Path) -> None:
+        """Opened to ``allow``, the example admits a pinned URL to its own repo."""
+        path = write(tmp_path, section_doc_example("VCS policy"))
+        opened = replace(read_pyproject_config(path).vcs, policy=VcsPolicy.ALLOW)
+        pinned = f"git+https://github.com/me/x@{'a' * 40}"
+        assert admit_vcs_url(pinned, opened) == "git+https"
 
 
 class TestLocalSources:


### PR DESCRIPTION
`[tool.nab.vcs]` said it controls "whether direct-URL VCS requirements (`pkg @ git+https://...`) are honored". Nothing honors one. The root requirement path (`build_resolver_inputs`) and the dependency-metadata path (`refuse_url_dep`) both call `admit_vcs_url` and then raise `NotImplementedError`.

So a reader who opens the policy to get `pkg @ git+https://...` working gets `cannot lock: VCS requirement admitted by policy but resolver path is not implemented` instead of a resolve. The form that does resolve, `[[tool.nab.vcs-sources]]`, sits two sections lower and was not mentioned.

The example was wrong as well. A prefix is matched against the URL with only `git+` stripped, so `allowed-repos = ["github.com/me/x"]` refuses `git+https://github.com/me/x@<sha>`, the one repo it names. Written with the scheme, `https://github.com/me/x`, it is admitted.

Two tests now read the example back out of `configuration.md`: that it names every `VcsConfig` field, and that opened to `allow` it admits its own repo.
