### PR TITLE
Hand-write config.model's two value types, 13.6M instructions off nab lock

### DIFF
--- a/src/nab/config/model.py
+++ b/src/nab/config/model.py
@@ -9,8 +9,8 @@ module owns the project side.
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
 
 import tomli
@@ -26,6 +26,7 @@ from nab_project.conflicts import (
 )
 from nab_project.inputs import ResolveInputs
 from nab_project.paths import realpath
+from nab_project.value import ValueType
 from nab_project.workspace import (
     WorkspaceConfig,
     discover_workspace_root,
@@ -105,8 +106,12 @@ _TOOL_NAB_REQUIRES_PYTHON = "[tool.nab] requires-python"
 _PROJECT_REQUIRES_PYTHON = "[project] requires-python"
 
 
-@dataclass(frozen=True, slots=True)
-class EnvironmentConfig:
+_DEFAULT_INDEXES = (IndexConfig(DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL),)
+_NO_INDEX_OVERRIDES: Mapping[str, IndexOverride] = MappingProxyType({})
+_DEFAULT_VCS = VcsConfig()
+
+
+class EnvironmentConfig(ValueType):
     """The single environment ``[tool.nab.environment]`` declares.
 
     The axes a target is made of, the same ones a matrix entry carries.
@@ -120,65 +125,170 @@ class EnvironmentConfig:
     marker values, the free-threaded build) are declarable here too.
     """
 
-    python: str | None = None
-    platform: PlatformSpec | None = None
-    implementation: str | None = None
+    __slots__ = __match_args__ = ("python", "platform", "implementation")
+
+    python: str | None
+    platform: PlatformSpec | None
+    implementation: str | None
+
+    def __init__(
+        self,
+        python: str | None = None,
+        platform: PlatformSpec | None = None,
+        implementation: str | None = None,
+    ) -> None:
+        """Record the axes the table sets; an unset one is ``None``."""
+        self.python = python
+        self.platform = platform
+        self.implementation = implementation
 
 
-@dataclass(frozen=True, slots=True)
-class NabProjectConfig:
+class NabProjectConfig(ValueType):
     """Everything ``[tool.nab]`` says about how to resolve this project."""
 
-    mode: ResolveMode = ResolveMode.SPECIFIC
-    constraints: tuple[str, ...] = ()
-    default_groups: tuple[str, ...] = ()
-    base_group: str | None = None
-    build_group: str | None = None
+    __slots__ = __match_args__ = (
+        "mode",
+        "constraints",
+        "default_groups",
+        "base_group",
+        "build_group",
+        "requires_python",
+        "requires_python_source",
+        "uploaded_prior_to",
+        "dist_policy",
+        "build_policy",
+        "build_requires_depth",
+        "trust_unverified_sdist_deps",
+        "environment",
+        "indexes",
+        "vcs",
+        "local_sources",
+        "vcs_sources",
+        "archive_sources",
+        "matrix",
+        "resolution",
+        "decision_order",
+        "workspace",
+        "conflicts",
+        "package_overrides",
+        "index_overrides",
+        "workspace_member_names",
+    )
+
+    mode: ResolveMode
+    constraints: tuple[str, ...]
+    default_groups: tuple[str, ...]
+    base_group: str | None
+    build_group: str | None
     # The project's declared Python support range: recorded as the lock's
     # top-level ``requires-python`` and checked against the resolve target.
     # It does not choose the target; ``environment`` does.
-    requires_python: str | None = None
+    requires_python: str | None
     # The surface ``requires_python`` was read from, named by the error when
     # the declaration excludes a target.
-    requires_python_source: str = _TOOL_NAB_REQUIRES_PYTHON
-    uploaded_prior_to: datetime | None = None
-    dist_policy: DistPolicy = DistPolicy.WHEEL_OR_SDIST
-    build_policy: BuildPolicy = BuildPolicy.BUILD_LOCAL
+    requires_python_source: str
+    uploaded_prior_to: datetime | None
+    dist_policy: DistPolicy
+    build_policy: BuildPolicy
     # How many build environments may be opened beneath the first one, to
     # build a build requirement that publishes no wheel this host installs.
-    build_requires_depth: int = 0
-    trust_unverified_sdist_deps: bool = False
+    build_requires_depth: int
+    trust_unverified_sdist_deps: bool
     # The declared resolve environment from ``[tool.nab.environment]``, or
     # ``None`` for the host.  Mutually exclusive with ``matrix``.
-    environment: EnvironmentConfig | None = None
-    indexes: tuple[IndexConfig, ...] = (
-        IndexConfig(DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL),
-    )
-    vcs: VcsConfig = field(default_factory=VcsConfig)
-    local_sources: tuple[LocalSource, ...] = ()
-    vcs_sources: tuple[VcsSource, ...] = ()
-    archive_sources: tuple[ArchiveSource, ...] = ()
-    matrix: MatrixConfig | None = None
-    resolution: ResolutionStrategy = ResolutionStrategy.HIGHEST
-    decision_order: DecisionOrder = DecisionOrder.ARRIVAL
-    workspace: WorkspaceConfig | None = None
-    conflicts: tuple[ConflictSet, ...] = ()
+    environment: EnvironmentConfig | None
+    indexes: tuple[IndexConfig, ...]
+    vcs: VcsConfig
+    local_sources: tuple[LocalSource, ...]
+    vcs_sources: tuple[VcsSource, ...]
+    archive_sources: tuple[ArchiveSource, ...]
+    matrix: MatrixConfig | None
+    resolution: ResolutionStrategy
+    decision_order: DecisionOrder
+    workspace: WorkspaceConfig | None
+    conflicts: tuple[ConflictSet, ...]
     # Per-package overrides from ``[tool.nab.packages.<name>]`` and
     # ``[[tool.nab.package-rules]]``, one per requirement, in declared
     # order.  Version-scoped: a policy field applies only to candidate
     # versions inside its requirement's range.  Routing entries (those
     # that set ``index``) are also projected into coordinator routes by
     # ``nab_project.fetch.index_routes``.
-    package_overrides: tuple[PackageOverride, ...] = ()
+    package_overrides: tuple[PackageOverride, ...]
     # Per-index overrides from ``[tool.nab.index.<name>]``, keyed by
     # declared index name.  Each applies to every package served from
     # that index; no routing, no version scope.
-    index_overrides: Mapping[str, IndexOverride] = field(default_factory=dict)
+    index_overrides: Mapping[str, IndexOverride]
     # Canonical names of workspace members. Populated by
     # _apply_workspace_discovery; empty otherwise. Distinct from
     # ``local_sources``, which also carries explicit
     # ``[[tool.nab.local-sources]]`` entries.
-    workspace_member_names: frozenset[str] = field(default_factory=frozenset)
+    workspace_member_names: frozenset[str]
+
+    def __init__(  # noqa: PLR0913 - one keyword per [tool.nab] key
+        self,
+        *,
+        mode: ResolveMode = ResolveMode.SPECIFIC,
+        constraints: tuple[str, ...] = (),
+        default_groups: tuple[str, ...] = (),
+        base_group: str | None = None,
+        build_group: str | None = None,
+        requires_python: str | None = None,
+        requires_python_source: str = _TOOL_NAB_REQUIRES_PYTHON,
+        uploaded_prior_to: datetime | None = None,
+        dist_policy: DistPolicy = DistPolicy.WHEEL_OR_SDIST,
+        build_policy: BuildPolicy = BuildPolicy.BUILD_LOCAL,
+        build_requires_depth: int = 0,
+        trust_unverified_sdist_deps: bool = False,
+        environment: EnvironmentConfig | None = None,
+        indexes: tuple[IndexConfig, ...] = _DEFAULT_INDEXES,
+        vcs: VcsConfig = _DEFAULT_VCS,
+        local_sources: tuple[LocalSource, ...] = (),
+        vcs_sources: tuple[VcsSource, ...] = (),
+        archive_sources: tuple[ArchiveSource, ...] = (),
+        matrix: MatrixConfig | None = None,
+        resolution: ResolutionStrategy = ResolutionStrategy.HIGHEST,
+        decision_order: DecisionOrder = DecisionOrder.ARRIVAL,
+        workspace: WorkspaceConfig | None = None,
+        conflicts: tuple[ConflictSet, ...] = (),
+        package_overrides: tuple[PackageOverride, ...] = (),
+        index_overrides: Mapping[str, IndexOverride] = _NO_INDEX_OVERRIDES,
+        workspace_member_names: frozenset[str] = frozenset(),
+    ) -> None:
+        """Record the settings, each defaulting to what a bare project gets."""
+        self.mode = mode
+        self.constraints = constraints
+        self.default_groups = default_groups
+        self.base_group = base_group
+        self.build_group = build_group
+        self.requires_python = requires_python
+        self.requires_python_source = requires_python_source
+        self.uploaded_prior_to = uploaded_prior_to
+        self.dist_policy = dist_policy
+        self.build_policy = build_policy
+        self.build_requires_depth = build_requires_depth
+        self.trust_unverified_sdist_deps = trust_unverified_sdist_deps
+        self.environment = environment
+        self.indexes = indexes
+        self.vcs = vcs
+        self.local_sources = local_sources
+        self.vcs_sources = vcs_sources
+        self.archive_sources = archive_sources
+        self.matrix = matrix
+        self.resolution = resolution
+        self.decision_order = decision_order
+        self.workspace = workspace
+        self.conflicts = conflicts
+        self.package_overrides = package_overrides
+        self.index_overrides = index_overrides
+        self.workspace_member_names = workspace_member_names
+
+    def replace(self, **changes: object) -> NabProjectConfig:
+        """Return a copy with ``changes`` applied, as ``dataclasses.replace`` would."""
+        kept: dict[str, Any] = {
+            name: getattr(self, name) for name in self.__match_args__
+        }
+        kept.update(changes)
+        return NabProjectConfig(**kept)
 
     def resolve_inputs(self) -> ResolveInputs:
         """Return the settings nab-project resolves this project under."""
@@ -540,8 +650,7 @@ def _apply_workspace_discovery(
     merged = merge_workspace_local_sources(config.local_sources, discovered)
     _reject_duplicate_source_names(merged, config.vcs_sources, config.archive_sources)
     explicit_names = {canonicalize_name(src.name) for src in config.local_sources}
-    return replace(
-        config,
+    return config.replace(
         local_sources=merged,
         workspace_member_names=frozenset(
             canonicalize_name(src.name)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6234,7 +6234,7 @@ class TestSeamPartition:
 
     def test_every_config_field_crosses_the_seam_or_stays_in_nab(self) -> None:
         """A new ``[tool.nab]`` setting is either a slot or named as the host's."""
-        names = {f.name for f in fields(NabProjectConfig)}
+        names = set(NabProjectConfig.__match_args__)
 
         assert names == set(ResolveInputs.__slots__) | _STAYS_IN_NAB
 

--- a/tests/test_value_types.py
+++ b/tests/test_value_types.py
@@ -24,6 +24,7 @@ from nab.config.ladder import (
     SourceKind,
     SourceRoots,
 )
+from nab.config.model import EnvironmentConfig, NabProjectConfig
 from nab.config.subflags import CliKey, CliTable
 from nab.config.values import MatrixConfig
 from nab.optiondefs import Kind, Opt, Scope, VType
@@ -46,6 +47,7 @@ from nab_project.lockfile import (
     WheelArtifact,
 )
 from nab_project.value import ValueType
+from nab_project.workspace import WorkspaceConfig
 from nab_provider._vendor.packaging.requirements import Requirement
 from nab_provider.overrides import IndexOverride, PackageOverride
 from nab_provider.policy import (
@@ -55,6 +57,7 @@ from nab_provider.policy import (
     DistPolicy,
     LocalSource,
     ResolutionStrategy,
+    ResolveMode,
     VcsSource,
 )
 from nab_provider.records import IndexConfig
@@ -128,6 +131,8 @@ WHEEL = WheelArtifact(
 SDIST = SdistArtifact(
     "acme-1.0.tar.gz", "https://acme.test/acme-1.0.tar.gz", (("sha256", "b" * 64),)
 )
+MATRIX = MatrixConfig("3.12", (PlatformSpec("linux_x86_64"),))
+ENVIRONMENT = EnvironmentConfig(python="3.12", platform=PlatformSpec("macos_arm64"))
 
 
 class Case(NamedTuple):
@@ -296,6 +301,82 @@ CASES = [
             "uploaded_prior_to": None,
             "vcs": VcsConfig(policy=VcsPolicy.BLOCK),
             "vcs_sources": (VcsSource("beta", "git+https://beta.test/gamma"),),
+        },
+        hashable=False,
+        positional=False,
+    ),
+    Case(
+        EnvironmentConfig,
+        {
+            "python": "3.12",
+            "platform": PlatformSpec("linux_x86_64"),
+            "implementation": "cpython",
+        },
+        {
+            "python": "3.13",
+            "platform": PlatformSpec("macos_arm64"),
+            "implementation": "pypy",
+        },
+    ),
+    Case(
+        NabProjectConfig,
+        {
+            "mode": ResolveMode.SPECIFIC,
+            "constraints": ("pip<26",),
+            "default_groups": ("dev",),
+            "base_group": "project",
+            "build_group": "build",
+            "requires_python": ">=3.10",
+            "requires_python_source": "[tool.nab] requires-python",
+            "uploaded_prior_to": LOCKED_AT,
+            "dist_policy": DistPolicy.WHEEL_ONLY,
+            "build_policy": BuildPolicy.BUILD_REMOTE,
+            "build_requires_depth": 1,
+            "trust_unverified_sdist_deps": True,
+            "environment": ENVIRONMENT,
+            "indexes": (IndexConfig("private", "https://private.test/simple/"),),
+            "vcs": VcsConfig(policy=VcsPolicy.ALLOW),
+            "local_sources": (LocalSource("alpha", "alpha"),),
+            "vcs_sources": (VcsSource("beta", "git+https://beta.test/beta"),),
+            "archive_sources": (ArchiveSource("acme", "https://acme.test/a-1.zip"),),
+            "matrix": None,
+            "resolution": ResolutionStrategy.LOWEST,
+            "decision_order": DecisionOrder.STABLE,
+            "workspace": WorkspaceConfig(("packages/*",)),
+            "conflicts": (ConflictSet((ConflictMember(ConflictKind.EXTRA, "cpu"),)),),
+            "package_overrides": (),
+            "index_overrides": {
+                "private": IndexOverride(build_policy=BuildPolicy.NEVER)
+            },
+            "workspace_member_names": frozenset({"alpha"}),
+        },
+        {
+            "mode": ResolveMode.UNIVERSAL,
+            "constraints": ("pip<25",),
+            "default_groups": ("docs",),
+            "base_group": "runtime",
+            "build_group": "buildreqs",
+            "requires_python": ">=3.11",
+            "requires_python_source": "[project] requires-python",
+            "uploaded_prior_to": None,
+            "dist_policy": DistPolicy.SDIST_ONLY,
+            "build_policy": BuildPolicy.NEVER,
+            "build_requires_depth": 2,
+            "trust_unverified_sdist_deps": False,
+            "environment": None,
+            "indexes": (IndexConfig("public", "https://public.test/simple/"),),
+            "vcs": VcsConfig(policy=VcsPolicy.BLOCK),
+            "local_sources": (LocalSource("beta", "beta"),),
+            "vcs_sources": (VcsSource("beta", "git+https://beta.test/gamma"),),
+            "archive_sources": (ArchiveSource("acme", "https://acme.test/a-2.zip"),),
+            "matrix": MATRIX,
+            "resolution": ResolutionStrategy.HIGHEST,
+            "decision_order": DecisionOrder.ARRIVAL,
+            "workspace": None,
+            "conflicts": (ConflictSet((ConflictMember(ConflictKind.GROUP, "cpu"),)),),
+            "package_overrides": (PACKAGE_OVERRIDE,),
+            "index_overrides": {"private": IndexOverride(build_policy=None)},
+            "workspace_member_names": frozenset(),
         },
         hashable=False,
         positional=False,
@@ -471,6 +552,43 @@ DEFAULTS = [
         },
     ),
     (ConflictSet, {"members": ()}, {"policy": ConflictPolicy.AT_MOST_ONE}),
+    (
+        EnvironmentConfig,
+        {},
+        {"python": None, "platform": None, "implementation": None},
+    ),
+    (
+        NabProjectConfig,
+        {},
+        {
+            "mode": ResolveMode.SPECIFIC,
+            "constraints": (),
+            "default_groups": (),
+            "base_group": None,
+            "build_group": None,
+            "requires_python": None,
+            "requires_python_source": "[tool.nab] requires-python",
+            "uploaded_prior_to": None,
+            "dist_policy": DistPolicy.WHEEL_OR_SDIST,
+            "build_policy": BuildPolicy.BUILD_LOCAL,
+            "build_requires_depth": 0,
+            "trust_unverified_sdist_deps": False,
+            "environment": None,
+            "indexes": (IndexConfig("pypi", "https://pypi.org/simple/"),),
+            "vcs": VcsConfig(),
+            "local_sources": (),
+            "vcs_sources": (),
+            "archive_sources": (),
+            "matrix": None,
+            "resolution": ResolutionStrategy.HIGHEST,
+            "decision_order": DecisionOrder.ARRIVAL,
+            "workspace": None,
+            "conflicts": (),
+            "package_overrides": (),
+            "index_overrides": {},
+            "workspace_member_names": frozenset(),
+        },
+    ),
     (
         ConflictFork,
         {"selection": (), "active_extras": (), "active_groups": ()},


### PR DESCRIPTION
An offline `nab lock` of a five-package project against a prepopulated cache retires 842,482,604 instructions instead of 856,057,059: 13,574,455 fewer, or 1.59% of the command. `import nab._lock` on its own drops 13,742,796 of 663,551,464, 2.07%, and repeats to the digit. Both counts come from callgrind with `PYTHONHASHSEED=0` against base `8e11388cc`.

The cost is class creation at import. `@dataclass(frozen=True, slots=True)` compiles `__init__`, `__eq__`, `__hash__`, `__repr__` and a per-field `object.__setattr__` through `exec` every time it is applied, and `nab.config.model` is imported by `nab lock` and `nab resolve`.

`EnvironmentConfig` (3 fields) and `NabProjectConfig` (26) are now hand-written on `nab_project.value.ValueType`, the base that package's own value types already share for equality, hashing and repr. `NabProjectConfig` keeps a `replace(**changes)` for workspace discovery, the module's only `dataclasses.replace` caller.

Peak memory on the same lock falls 39,934 bytes to 18,563,794. That lock also runs between about 1% and 3% faster locally, with a middle estimate near 2%. The 19-scenario canary set does not reach this module, and its timing run only rules out a slowdown there above about 5%.
