### PR TITLE
Test the sdist archive hold is sized by max_concurrency

### DIFF
--- a/nab-project/tests/test_fetch.py
+++ b/nab-project/tests/test_fetch.py
@@ -4140,3 +4140,19 @@ class TestSdistArchiveHolding:
         coord.shutdown()
 
         assert hold.take("pkg", "1.0") is None
+
+    def test_the_hold_is_as_wide_as_the_fetcher(self) -> None:
+        """A run's hold is sized by ``max_concurrency``, not by its own default."""
+        config = ResolveInputs(build_policy=BuildPolicy.BUILD_REMOTE)
+
+        with _coord(build_config=config, max_concurrency=3) as coord:
+            hold = coord._sdist_archive_hold
+            assert hold is not None
+
+            for minor in range(4):
+                hold.put("pkg", f"1.{minor}", b"archive bytes")
+
+            assert hold.take("pkg", "1.0") is None
+
+            for minor in (1, 2, 3):
+                assert hold.take("pkg", f"1.{minor}") == b"archive bytes"


### PR DESCRIPTION
Nothing pins the run's sdist archive hold to the fetcher's width. Drop the argument where `_async_fetcher` builds the hold in `nab-project/src/nab_project/fetch.py` and no test fails, because the two defaults happen to agree: `DEFAULT_MAX_CONCURRENCY` and `_DEFAULT_HELD_ARCHIVES` are both 50.

Only that coincidence hides it. The CLI's `max-concurrency` default is 8, so a break in the wiring would leave a build-remote resolve holding up to 50 sdist archives against 8 fetches in flight, each one a whole archive body in memory until a build takes it or eviction drops it.

No test covers the capacity the coordinator sets. `TestSdistArchiveHold` in `test_cached_client.py` builds its holds directly, and the coordinator tests only check that a hold exists or has been cleared.

The new test reads the hold off a coordinator at `max_concurrency=3` and checks that a fourth archive evicts the first.
