### PR TITLE
Share lock artifacts across a resolve's targets, 520 objects down to 48

### DIFF
--- a/nab-project/src/nab_project/_lockfile/builder.py
+++ b/nab-project/src/nab_project/_lockfile/builder.py
@@ -13,7 +13,7 @@ import logging
 from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Protocol, overload
+from typing import TYPE_CHECKING, Protocol, TypeVar
 from urllib.parse import quote, urlsplit, urlunsplit
 
 import tomli
@@ -57,6 +57,7 @@ logger = logging.getLogger(__name__)
 
 
 __all__ = [
+    "ArtifactMemo",
     "MissingHashError",
     "MissingSdistError",
     "MissingVcsCommitError",
@@ -66,6 +67,8 @@ __all__ = [
     "require_artifact_hashes",
     "strip_userinfo",
 ]
+
+_Artifact = TypeVar("_Artifact", "WheelArtifact", "SdistArtifact")
 
 
 class _LockInputIndex(Protocol):
@@ -147,6 +150,21 @@ class LockInputProvider(Protocol):
     def tag_excluded_wheel_count(self, canonical_name: str, version: Version, /) -> int:
         """Return how many wheels the tag filter dropped at ``version``."""
         ...
+
+
+class ArtifactMemo:
+    """The lock artifacts one resolve has built, keyed by listing URL.
+
+    Targets of one matrix pin many of the same files, so sharing a memo
+    across them keeps one artifact object per file instead of one per
+    target.
+    """
+
+    __slots__ = ("sdists", "wheels")
+
+    def __init__(self) -> None:
+        self.wheels: dict[str, WheelArtifact] = {}
+        self.sdists: dict[str, SdistArtifact] = {}
 
 
 class MissingHashError(ValueError):
@@ -271,6 +289,7 @@ def build_target_lock(
     resolved_keys: Iterable[str] = (),
     base_roots: Iterable[str] | None = None,
     selector_roots: Mapping[tuple[str, str], Iterable[str]] | None = None,
+    artifacts: ArtifactMemo | None = None,
 ) -> TargetLock:
     """Build one target's :class:`~nab_project.lockfile.TargetLock`.
 
@@ -294,10 +313,13 @@ def build_target_lock(
     roots raises.
 
     Every wheel the target can install, plus the sdist, is recorded for
-    each pinned version.
+    each pinned version.  ``artifacts`` is the :class:`ArtifactMemo` the
+    run's targets share; a call without one gets a memo of its own.
     """
     from ..lockfile import LocalPin, TargetLock
 
+    if artifacts is None:
+        artifacts = ArtifactMemo()
     if base_roots is None:
         if selector_roots:
             msg = (
@@ -344,7 +366,7 @@ def build_target_lock(
             )
             continue
         lock_pins[canonical] = _index_pin_from_listing(
-            provider, canonical, version, indexes
+            provider, canonical, version, indexes, artifacts
         )
 
     dependencies, base_dependencies = _forward_dependency_graph(
@@ -502,6 +524,7 @@ def _index_pin_from_listing(
     canonical: str,
     version: Version,
     indexes: Sequence[IndexConfig],
+    artifacts: ArtifactMemo,
 ) -> IndexPin:
     """Construct an :class:`IndexPin` for an index-served package.
 
@@ -542,11 +565,15 @@ def _index_pin_from_listing(
             raise MissingSdistError(msg)
 
     wheels = tuple(
-        _build_artifact(f, WheelArtifact) for f in files if isinstance(f, WheelFile)
+        _build_artifact(f, WheelArtifact, artifacts.wheels)
+        for f in files
+        if isinstance(f, WheelFile)
     )
     sdist_file = next((f for f in files if isinstance(f, SdistFile)), None)
     sdist = (
-        _build_artifact(sdist_file, SdistArtifact) if sdist_file is not None else None
+        _build_artifact(sdist_file, SdistArtifact, artifacts.sdists)
+        if sdist_file is not None
+        else None
     )
 
     override_rp = provider.effective_requires_python(canonical, version)
@@ -578,29 +605,23 @@ def _index_pin_from_listing(
     )
 
 
-@overload
 def _build_artifact(
     source: WheelFile | SdistFile,
-    cls: type[WheelArtifact],
-) -> WheelArtifact: ...
-@overload
-def _build_artifact(
-    source: WheelFile | SdistFile,
-    cls: type[SdistArtifact],
-) -> SdistArtifact: ...
-def _build_artifact(
-    source: WheelFile | SdistFile,
-    cls: type[WheelArtifact | SdistArtifact],
-) -> WheelArtifact | SdistArtifact:
-    hashes = _filter_acceptable_hashes(source.hashes)
-    return cls(
-        filename=source.filename,
-        url=strip_userinfo(source.url),
-        hashes=hashes,
-        size=source.size,
-        upload_time=_parse_upload_time(source.upload_time),
-        local_path=source.local_path,
-    )
+    cls: type[_Artifact],
+    memo: dict[str, _Artifact],
+) -> _Artifact:
+    """Return ``source``'s lock artifact, reusing the one ``memo`` holds for its URL."""
+    artifact = memo.get(source.url)
+    if artifact is None:
+        artifact = memo[source.url] = cls(
+            filename=source.filename,
+            url=strip_userinfo(source.url),
+            hashes=_filter_acceptable_hashes(source.hashes),
+            size=source.size,
+            upload_time=_parse_upload_time(source.upload_time),
+            local_path=source.local_path,
+        )
+    return artifact
 
 
 def _parse_upload_time(raw: str | None) -> datetime | None:

--- a/nab-project/src/nab_project/_resolve/engine.py
+++ b/nab-project/src/nab_project/_resolve/engine.py
@@ -28,7 +28,7 @@ from nab_resolver.resolver import Resolver, ResolverObserver
 from nab_resolver.types import IncompatibilityCause
 
 from .._compat import override
-from ..lockfile import build_target_lock
+from ..lockfile import ArtifactMemo, build_target_lock
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -507,6 +507,9 @@ class _EngineSettings:
     # target per fork and again in the base pass warns once.
     warned_dropped_markers: set[tuple[str, str]] = field(default_factory=set)
 
+    # The lock artifacts built so far, so targets pinning the same file share one.
+    artifacts: ArtifactMemo = field(default_factory=ArtifactMemo)
+
 
 def _threaded_preferences(
     accumulated: dict[str, Version],
@@ -657,6 +660,7 @@ def _resolve_one_target(
             resolved_keys=raw,
             base_roots=base_roots,
             selector_roots=selector_roots,
+            artifacts=settings.artifacts,
         ),
         wall_time=elapsed,
         **_target_stats(resolver, provider),

--- a/nab-project/src/nab_project/lockfile.py
+++ b/nab-project/src/nab_project/lockfile.py
@@ -22,6 +22,7 @@ from nab_provider._vendor.packaging.utils import canonicalize_name
 from nab_provider._vendor.packaging.version import Version
 
 from ._lockfile.builder import (
+    ArtifactMemo,
     MissingHashError,
     MissingSdistError,
     MissingVcsCommitError,
@@ -69,6 +70,7 @@ __all__ = [
     "BASE_MEMBER",
     "LOCK_VERSION",
     "ArchivePin",
+    "ArtifactMemo",
     "DisjointnessError",
     "DivergentBaseDependencyError",
     "IndexPin",

--- a/nab-project/tests/test_lockfile.py
+++ b/nab-project/tests/test_lockfile.py
@@ -53,6 +53,7 @@ from nab_project.lockfile import (
     BASE_MEMBER,
     LOCK_VERSION,
     ArchivePin,
+    ArtifactMemo,
     DisjointnessError,
     DivergentBaseDependencyError,
     IndexPin,
@@ -3232,6 +3233,38 @@ class TestBuildTargetLock:
         assert len(pin.wheels) == 1
         assert pin.wheels[0].hashes == (("sha256", "a" * 64),)
         assert lock.target is _HOST
+
+    def test_shared_memo_builds_each_file_once(self) -> None:
+        """A repeated file reuses its artifact; a different file gets its own."""
+        provider = _FakeProvider(
+            listings={
+                "foo": [
+                    (Version("1.0"), _wheel_file(version="1.0")),
+                    (Version("1.0"), _sdist_file(version="1.0")),
+                    (Version("2.0"), _wheel_file(version="2.0")),
+                ]
+            }
+        )
+        memo = ArtifactMemo()
+
+        pins = [
+            build_target_lock(
+                provider, _HOST, {"foo": Version(version)}, artifacts=memo
+            ).pins["foo"]
+            for version in ("1.0", "2.0", "1.0")
+        ]
+
+        first, other, again = pins
+        assert isinstance(first, IndexPin)
+        assert isinstance(other, IndexPin)
+        assert isinstance(again, IndexPin)
+
+        assert again.wheels[0] is first.wheels[0]
+        assert again.sdist is first.sdist
+        assert other.wheels[0] != first.wheels[0]
+
+        assert len(memo.wheels) == 2
+        assert len(memo.sdists) == 1
 
     def test_index_pin_requires_python_override_scoped_to_selected_versions(
         self,

--- a/nab-project/tests/test_resolve_targets.py
+++ b/nab-project/tests/test_resolve_targets.py
@@ -2856,6 +2856,27 @@ class TestSharedListingFilter:
         assert len(result.target_results) == 2
         assert calls == ["pkg@3.11.0"]
 
+    def test_platform_targets_share_one_wheel_artifact(self) -> None:
+        """Two targets pinning the same wheel hold one lock artifact between them."""
+        result = resolve_with_coordinator(
+            self._coordinator([self._wheel("1.0"), self._wheel("2.0")]),
+            self._targets("==3.11"),
+            _reqs("pkg"),
+            inputs=_no_build(),
+        )
+
+        assert result.success
+        first, second = (tr.lock for tr in result.target_results)
+        assert first is not None
+        assert second is not None
+
+        first_pin, second_pin = first.pins["pkg"], second.pins["pkg"]
+        assert isinstance(first_pin, IndexPin)
+        assert isinstance(second_pin, IndexPin)
+
+        assert first_pin.version == "2.0"
+        assert second_pin.wheels[0] is first_pin.wheels[0]
+
     def test_shared_filter_runs_before_the_wheel_tag_pass(self) -> None:
         """Only the pre-tag list is shared: a linux-only wheel stays off Windows."""
         wheels = [


### PR DESCRIPTION
A 25-target resolve of `universal:max-25-tuples` built 520 lock artifact objects for 48 distinct files, one per target that pinned the file. It now builds 48, and every target pinning a file gets the same object.

| | `max-25-tuples`, 25 targets | `scientific-python-multi`, 12 targets |
| --- | --- | --- |
| peak traced bytes | about 105,000 off 17.9 million, 0.59% | about 59,000 off 41.4 million, 0.14% |
| instructions | 14,159,069 off 2,148,788,938, 0.66% | 8,836,857 off 4,115,604,625, 0.21% |

`build_target_lock` takes an `ArtifactMemo` that `_EngineSettings` creates once per resolve, so `_build_artifact` returns the artifact already held for a listing URL instead of rebuilding it. The per-file work behind it runs 48 times instead of 520: `_filter_acceptable_hashes`, `_parse_upload_time`, and the `datetime.astimezone` it calls. `strip_userinfo` drops from 780 calls to 308, and each of the 520 `_build_artifact` calls now does one dict lookup.

The memo keys on the listing URL rather than the record, because hashing a `WheelFile` by value would force the deferred metadata-hash parse it holds.

A single-target resolve gains nothing. The clock cannot see a change this size, so the timing runs only rule out a wall or CPU regression above about 2%.
