### PR TITLE
Bisect the listing for a version's dists, ~3.8% off a 25-tuple lock

### DIFF
--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -58,6 +58,7 @@ from nab_provider._provider.metadata_resolver import (
     add_classified_dep,
     cache_deps_from_metadata,
     classify_requirement,
+    dists_at_version,
     pick_dist_for_metadata,
     target_dep_signature,
 )
@@ -92,7 +93,7 @@ from nab_provider.provider import (
     VcsPolicy,
     VcsSource,
 )
-from nab_provider.records import rehydrated_wheel
+from nab_provider.records import DistFile, rehydrated_wheel
 from nab_provider.tags import PlatformSpec
 from nab_provider.target import ResolveTarget
 from nab_provider.testing import pkg_override
@@ -204,6 +205,60 @@ def make_sdist(
         local_path=local_path,
         hashes=hashes,
     )
+
+
+class _CountingVersion(Version):
+    """A version that counts every comparison it takes part in.
+
+    Python tries a subclass's reflected comparison first, so a listing entry
+    compared as ``entry == version`` counts here too. Every operator is
+    defined so the count does not depend on which one the caller reaches for.
+    """
+
+    def __init__(self, version: str) -> None:
+        super().__init__(version)
+        self.comparisons = 0
+
+    def __lt__(self, other: Version) -> bool:
+        self.comparisons += 1
+        return super().__lt__(other)
+
+    def __le__(self, other: Version) -> bool:
+        self.comparisons += 1
+        return super().__le__(other)
+
+    def __eq__(self, other: object) -> bool:
+        self.comparisons += 1
+        return super().__eq__(other)
+
+    def __ne__(self, other: object) -> bool:
+        self.comparisons += 1
+        return super().__ne__(other)
+
+    def __gt__(self, other: Version) -> bool:
+        self.comparisons += 1
+        return super().__gt__(other)
+
+    def __ge__(self, other: Version) -> bool:
+        self.comparisons += 1
+        return super().__ge__(other)
+
+    # Defining ``__eq__`` would otherwise drop the inherited hash.
+    __hash__ = Version.__hash__
+
+
+def _one_wheel_releases(count: int) -> list[tuple[Version, DistFile]]:
+    """A newest-first listing of ``count`` releases, one wheel each."""
+    return [(V(f"{n}.0"), make_wheel(f"{n}.0")) for n in range(count, 0, -1)]
+
+
+def _wheel_and_sdist_releases(count: int) -> list[tuple[Version, DistFile]]:
+    """A newest-first listing of ``count`` releases, a wheel then an sdist each."""
+    listing: list[tuple[Version, DistFile]] = []
+    for n in range(count, 0, -1):
+        listing.append((V(f"{n}.0"), make_wheel(f"{n}.0")))
+        listing.append((V(f"{n}.0"), make_sdist(f"{n}.0")))
+    return listing
 
 
 def _blocker_reason(
@@ -10397,6 +10452,25 @@ class TestSharedSlotProvenance:
                 assert "wheel-dep" in provider.get_dependencies("pkg", V("1.0"))
 
 
+class TestDistsAtVersion:
+    @pytest.mark.parametrize(("version", "start"), [("3.0", 0), ("2.0", 2), ("1.0", 4)])
+    def test_yields_the_release_run_in_listing_order(
+        self, version: str, start: int
+    ) -> None:
+        """The head, an interior release and the tail each yield wheel then sdist."""
+        listing = _wheel_and_sdist_releases(3)
+        expected = [dist for _, dist in listing[start : start + 2]]
+        assert dists_at_version(listing, V(version)) == expected
+
+    @pytest.mark.parametrize("version", ["4.0", "2.5", "0.5"])
+    def test_an_unlisted_version_yields_nothing(self, version: str) -> None:
+        """Above the head, between two releases, and below the tail."""
+        assert dists_at_version(_wheel_and_sdist_releases(3), V(version)) == []
+
+    def test_an_empty_listing_yields_nothing(self) -> None:
+        assert dists_at_version([], V("1.0")) == []
+
+
 class TestPickDistForMetadata:
     def test_prefers_wheel_with_metadata_when_sdist_first(self) -> None:
         """A wheel-with-meta wins over an earlier sdist at the same version."""
@@ -10430,6 +10504,15 @@ class TestPickDistForMetadata:
         """No matching version yields ``None``."""
         versions = [(V("2.0"), make_wheel("2.0"))]
         assert pick_dist_for_metadata(versions, V("1.0"), None) is None
+
+    def test_bisects_the_newest_first_listing(self) -> None:
+        """A 256-entry listing costs about ten comparisons, not 256."""
+        listing = _one_wheel_releases(256)
+        mid_version, mid_dist = listing[127]
+        version = _CountingVersion(str(mid_version))
+
+        assert pick_dist_for_metadata(listing, version, None) is mid_dist
+        assert version.comparisons < 20
 
     def test_prefers_the_wheel_the_tags_rank_most_specific(self) -> None:
         """The tags rank the siblings; listing order does not.
@@ -11794,6 +11877,18 @@ class TestPublicAccessors:
         coordinator = make_coordinator(package="pkg")
         provider = Provider(coordinator, target=_PY312)
         assert provider.dist_files_for("unknown", V("1.0")) == []
+
+    def test_dist_files_for_bisects_the_listing(self) -> None:
+        """The accessor bisects too: about ten comparisons over 256 entries."""
+        provider = Provider(make_coordinator(package="pkg"), target=_PY312)
+        listing = _one_wheel_releases(256)
+        provider.versions_cache["pkg"] = listing
+
+        mid_version, mid_dist = listing[127]
+        version = _CountingVersion(str(mid_version))
+
+        assert provider.dist_files_for("pkg", version) == [mid_dist]
+        assert version.comparisons < 20
 
 
 class TestComputeTier:

--- a/nab-provider/src/nab_provider/_provider/metadata_resolver.py
+++ b/nab-provider/src/nab_provider/_provider/metadata_resolver.py
@@ -358,6 +358,32 @@ def _record_range_outcome(
         provider.stats.wheel_metadata_range_missing += 1
 
 
+def dists_at_version(
+    versions: Sequence[tuple[Version, DistFile]], version: Version
+) -> list[DistFile]:
+    """Every dist listed at ``version``, in listing order.
+
+    ``versions`` is the newest-first listing
+    :func:`~nab_provider._provider.listing.filter_distributions` emits, where a
+    release's dists sit together, so bisection finds them. :mod:`bisect`
+    searches ascending sequences only, hence the loop.
+    """
+    low, high = 0, len(versions)
+    while low < high:
+        mid = (low + high) // 2
+        # Newest first, so a smaller ``version`` lies to the right of ``mid``.
+        if version < versions[mid][0]:
+            low = mid + 1
+        else:
+            high = mid
+
+    stop = low
+    while stop < len(versions) and versions[stop][0] == version:
+        stop += 1
+
+    return [dist for _, dist in versions[low:stop]]
+
+
 def pick_dist_for_metadata(
     versions: Sequence[tuple[Version, DistFile]],
     version: Version,
@@ -365,7 +391,7 @@ def pick_dist_for_metadata(
     target: ResolveTarget | None = None,
 ) -> DistFile | None:
     """Pick the dist whose metadata answers for ``version``. See :func:`pick_dist`."""
-    dists = [d for v, d in versions if v == version]
+    dists = dists_at_version(versions, version)
     return pick_dist(dists, tags, target) if dists else None
 
 

--- a/nab-provider/src/nab_provider/provider.py
+++ b/nab-provider/src/nab_provider/provider.py
@@ -2739,7 +2739,7 @@ class Provider:
         """
         normalized = canonicalize_name(canonical_name)
         listing = self.versions_cache.get(normalized, [])
-        return [dist for v, dist in listing if v == version]
+        return _metadata_resolver.dists_at_version(listing, version)
 
     def tag_excluded_wheel_count(self, canonical_name: str, version: Version) -> int:
         """Return how many wheels the tag filter dropped at ``version`` (0 if none)."""


### PR DESCRIPTION
`max-25-tuples`, the universal lock of dask over 25 python/platform tuples, goes from 2,148,675,846 to 2,067,024,333 instructions, about 3.8% less. `scientific-python-multi` goes from 4,113,757,173 to 4,058,833,462, about 1.3%. Both counted with callgrind under `PYTHONHASHSEED=0` against `1cce9ffb9`.

Two call sites walked the whole version listing to collect one release's dists: `pick_dist_for_metadata` on the transitive prefetch path, and `Provider.dist_files_for`, which the lock builder calls per pinned package.

The listing is already newest-first with each release's dists contiguous, the order `filter_distributions` emits and `priority.py` already reads as descending, so both now bisect it through a new `dists_at_version`. `bisect` searches ascending sequences only, hence the loop by hand. Nothing is indexed or cached.

Counting calls on the same scenario, `Version.__eq__` drops from 63,084 to 5,176 against 3,430 added `Version.__lt__` calls, and total calls fall from 1,892,351 to 1,785,975.

A single-target resolve barely moves: `pip:google-bigquery-soda --resolution lowest` reaches only the prefetch site and goes from 3,705,742,646 to 3,696,946,117 instructions, about 0.24%. Timing on `max-25-tuples` rules out a slowdown above about 2.6% locally.
