### PR TITLE
Check the bound-name census against _packaging.__all__, not against itself

### DIFF
--- a/nab-markersets/tests/test_packaging_backend.py
+++ b/nab-markersets/tests/test_packaging_backend.py
@@ -147,10 +147,15 @@ def test_the_bound_copy_clears_the_floor() -> None:
 
 
 def test_every_bound_name_comes_from_the_bound_backend() -> None:
-    """No name is left over from the copy that lost the probe."""
+    """No name is left over from the copy that lost the probe.
+
+    ``BOUND_NAMES`` is pinned to ``__all__`` first, so a name added to the
+    module fails here until the census covers it too.
+    """
+    assert set(BOUND_NAMES) == set(_packaging.__all__) - {"BACKEND"}
+
     homes = {name: getattr(_packaging, name).__module__ for name in BOUND_NAMES}
 
-    assert set(homes) == set(BOUND_NAMES)
     assert all(home.startswith(BACKEND) for home in homes.values()), homes
 
 


### PR DESCRIPTION
`test_every_bound_name_comes_from_the_bound_backend` asserted `set(homes) == set(BOUND_NAMES)` over a `homes` built by comprehension over `BOUND_NAMES`. Its keys were that tuple by construction, so the assertion held whatever `_packaging` exported.

That left the `__module__` walk as the only real check, and it walked the 15 names hand-copied into `BOUND_NAMES`. `_packaging.__all__` has 16: those plus `BACKEND`, which is the bound copy's import path rather than a re-export from it. A name added to the module and not to the tuple was never checked for coming from the copy that won the probe.

`BOUND_NAMES` is now pinned to `set(_packaging.__all__) - {"BACKEND"}` before the walk, so a name added to `__all__` fails here until the census lists it too.
