### PR TITLE
Fix the matrix.python patch hint naming a table nab.toml refuses

### DIFF
--- a/src/nab/config/hooks.py
+++ b/src/nab/config/hooks.py
@@ -4,10 +4,11 @@ Every row of :data:`nab.config.ladder.OPTIONS` names one ``parse`` and one
 ``render``.  Most rows name a parser in :mod:`nab.config.values` directly;
 the ones here either render a merged value back to a line of ``nab config``,
 or need a piece of parse state that varies per pass and cannot travel in the
-fixed ``(value, where)`` pair.  Three such pieces ride on context variables
+fixed ``(value, where)`` pair.  Four such pieces ride on context variables
 the ladder binds around a read: the resolve anchor a ``P<n>D`` duration is
-measured from, the one ``now`` an inspector pass shares, and the directory a
-relative path in the file being read resolves against.
+measured from, the one ``now`` an inspector pass shares, the directory a
+relative path in the file being read resolves against, and the matrix
+header that file writes.
 """
 
 from __future__ import annotations
@@ -36,8 +37,10 @@ if TYPE_CHECKING:
 __all__ = [
     "declaring_dir",
     "inspector_anchor",
+    "matrix_table",
     "parse_index_overrides",
     "parse_local_sources",
+    "parse_matrix",
     "parse_package_rules",
     "parse_packages",
     "parse_uploaded_prior_to",
@@ -80,6 +83,12 @@ _RESOLVE_ANCHOR: ContextVar[datetime | None] = ContextVar(
 # carried structurally on a ContextVar (bound by :func:`declaring_dir`)
 # rather than re-derived by splitting a human-facing ``where`` label.
 _DECLARING_DIR: ContextVar[Path | None] = ContextVar("_DECLARING_DIR", default=None)
+
+# The matrix header the TOML file being parsed writes: ``tool.nab.matrix``
+# in a pyproject.toml, ``matrix`` in a nab.toml, whose keys sit at the top
+# level.  Bound by :func:`matrix_table` from the ladder's own key-path rule;
+# the patch-table refusal spells its header from here.
+_MATRIX_TABLE: ContextVar[str] = ContextVar("_MATRIX_TABLE", default="tool.nab.matrix")
 
 # A single ``now`` for one inspector pass, so override-body ``P<n>D``
 # durations in the two project files anchor against the same instant.
@@ -156,6 +165,22 @@ def declaring_dir(directory: Path) -> Iterator[None]:
         _DECLARING_DIR.reset(token)
 
 
+@contextmanager
+def matrix_table(table: str) -> Iterator[None]:
+    """Bind the matrix header of the file being read.
+
+    The ladder wraps each TOML source's parse in this, so
+    :func:`parse_matrix` names the python-patches table the way the
+    declaring file writes it: ``[tool.nab.matrix.python-patches]`` in a
+    pyproject.toml, ``[matrix.python-patches]`` in a nab.toml.
+    """
+    token = _MATRIX_TABLE.set(table)
+    try:
+        yield
+    finally:
+        _MATRIX_TABLE.reset(token)
+
+
 def parse_uploaded_prior_to(value: Any, where: str) -> Any:
     """Parse ``uploaded-prior-to`` without re-anchoring relative durations.
 
@@ -200,6 +225,11 @@ def _current_declaring_dir() -> Path:
         msg = "local-sources parsed without a declaring directory"
         raise SourceConfigError(msg)
     return base
+
+
+def parse_matrix(value: Any, where: str) -> values.MatrixConfig:
+    """Return the ``matrix`` row's config, its table named for the declaring file."""
+    return values.parse_matrix(value, where, table=_MATRIX_TABLE.get())
 
 
 def _override_anchor() -> datetime:

--- a/src/nab/config/ladder.py
+++ b/src/nab/config/ladder.py
@@ -43,7 +43,7 @@ from nab_project.value import ValueType
 
 from .. import env
 from ..optiondefs import Opt, Scope
-from .hooks import declaring_dir
+from .hooks import declaring_dir, matrix_table
 from .registry import OPTIONS
 from .subflags import (
     BY_PARENT,
@@ -79,6 +79,7 @@ __all__ = [
     "orphan_rejections",
     "project_cli_override_notice",
     "project_cli_override_records",
+    "project_key_path",
     "pyproject_registry_keys",
     "read_env_layer",
     "reject_user_keys_in_pyproject",
@@ -121,6 +122,15 @@ PRECEDENCE: dict[SourceKind, int] = {
 }
 
 BY_KEY: dict[str, Opt] = {row.name: row for row in OPTIONS}
+
+
+def project_key_path(key: str, kind: SourceKind) -> str:
+    """Return the table path a project file of ``kind`` gives ``key``.
+
+    A project-dir nab.toml takes nab's keys at the top level; a
+    pyproject.toml takes them under ``[tool.nab]``.
+    """
+    return key if kind is SourceKind.PROJECT_TOML else f"tool.nab.{key}"
 
 
 def pyproject_registry_keys() -> frozenset[str]:
@@ -396,9 +406,10 @@ def _load_toml_layer(
     origin = Origin(kind, str(path))
     values: dict[str, Any] = {}
     raw_tables: dict[str, Any] = {}
-    # Carry the declaring file's directory structurally so a relative
-    # local-source path resolves against it.
-    with declaring_dir(path.parent):
+    # Carry the declaring file's directory and matrix header structurally: a
+    # relative local-source path resolves against the directory, and the
+    # patch-table refusal names the header this file writes.
+    with declaring_dir(path.parent), matrix_table(project_key_path("matrix", kind)):
         for key, value in raw.items():
             spec = BY_KEY.get(key)
             if spec is None:

--- a/src/nab/config/model.py
+++ b/src/nab/config/model.py
@@ -67,6 +67,7 @@ from .ladder import (
     SourceRoots,
     build_cli_layer,
     discover_layers,
+    project_key_path,
     pyproject_registry_keys,
     read_env_layer,
     reject_user_keys_in_pyproject,
@@ -1143,7 +1144,7 @@ def _environment_from_effective(
     if marker_environment:
         file_origin = _environment_file_origin(entry)
         if file_origin is not None:
-            environment_table = _project_key_path("environment", file_origin.kind)
+            environment_table = project_key_path("environment", file_origin.kind)
             marker_table = _declared_table(effective["marker-environment"])
             msg = (
                 f"[{environment_table}] and the deprecated [{marker_table}]"
@@ -1168,7 +1169,7 @@ def _environment_from_effective(
         origin = _environment_file_origin(entry)
         if origin is None:
             origin = _environment_source(effective).origin
-        table = _project_key_path("environment", origin.kind)
+        table = project_key_path("environment", origin.kind)
 
         valid = sorted(PLATFORM_MARKERS)
         msg = (
@@ -1235,16 +1236,7 @@ def _environment_source(
 
 def _declared_table(value: EffectiveValue) -> str:
     """Return the table path the file that declared ``value`` writes for its key."""
-    return _project_key_path(value.spec.name, value.origin.kind)
-
-
-def _project_key_path(key: str, kind: SourceKind) -> str:
-    """Return the table path a project file of ``kind`` gives ``key``.
-
-    A project-dir nab.toml takes nab's keys at the top level; a
-    pyproject.toml takes them under ``[tool.nab]``.
-    """
-    return key if kind is SourceKind.PROJECT_TOML else f"tool.nab.{key}"
+    return project_key_path(value.spec.name, value.origin.kind)
 
 
 def _reject_vcs_sources_under_block(
@@ -1279,8 +1271,8 @@ def _reject_vcs_sources_under_block(
         if vcs.origin.kind is SourceKind.DEFAULT
         else vcs.origin.kind
     )
-    sources_table = _project_key_path("vcs-sources", vcs_sources.origin.kind)
-    vcs_table = _project_key_path("vcs", policy_kind)
+    sources_table = project_key_path("vcs-sources", vcs_sources.origin.kind)
+    vcs_table = project_key_path("vcs", policy_kind)
 
     msg = (
         f"[[{sources_table}]] is declared but [{vcs_table}].policy is"

--- a/src/nab/config/registry.py
+++ b/src/nab/config/registry.py
@@ -356,7 +356,7 @@ OPTIONS: tuple[Opt, ...] = (
         "matrix",
         scope=Scope.PROJECT,
         rdefault=None,
-        parse=values.parse_matrix,
+        parse=hooks.parse_matrix,
         render=hooks.render_matrix,
         type_label="table(python,platforms)",
         help="the Python and platform axes a universal resolve covers",

--- a/src/nab/config/values.py
+++ b/src/nab/config/values.py
@@ -1750,19 +1750,20 @@ def _parse_conflict_member(item: object, where: str) -> ConflictMember:
 _MINOR_RELEASE_PARTS = 2
 
 
-def _patches_spelling(where: str) -> str:
+def _patches_spelling(where: str, table: str) -> str:
     """Spell python-patches the way the source behind ``where`` writes it.
 
     A CLI label ends in the ``*`` its sub-flags fill, so the key takes the
     star's place and the sentence names a flag the user can type.  Every
-    other source is a file, which writes the table.
+    other source is a file, and ``table`` is the matrix header as that file
+    writes it.
     """
     if where.endswith("*"):
         return f"{where[:-1]}python-patches"
-    return "[tool.nab.matrix.python-patches]"
+    return f"[{table}.python-patches]"
 
 
-def _validate_matrix_python(spec: str, where: str) -> None:
+def _validate_matrix_python(spec: str, where: str, table: str) -> None:
     """Reject a python axis finer than major.minor.
 
     The axis lists language (minor) Python versions; patch pins belong in
@@ -1792,7 +1793,7 @@ def _validate_matrix_python(spec: str, where: str) -> None:
             msg = (
                 f"{where}.python axis is a language (minor) version only; "
                 f"{clause} is finer than major.minor. Put patch versions in "
-                f"{_patches_spelling(where)}."
+                f"{_patches_spelling(where, table)}."
             )
             raise SourceConfigError(msg)
 
@@ -1961,8 +1962,16 @@ _MATRIX_KEYS = frozenset(
 )
 
 
-def parse_matrix(value: object, where: str) -> MatrixConfig:
-    """Read ``[tool.nab.matrix]`` into its five axes."""
+def parse_matrix(
+    value: object, where: str, *, table: str = "tool.nab.matrix"
+) -> MatrixConfig:
+    """Read a matrix table into its five axes.
+
+    ``table`` is the matrix header the declaring file writes, which a
+    standalone nab.toml puts at the top level as ``matrix``, so an error
+    naming a sub-table spells it the same way.  The default is the
+    pyproject header, for a caller that read no file.
+    """
     if not isinstance(value, dict):
         msg = f"{where} must be a table, got {type(value).__name__}"
         raise SourceConfigError(msg)
@@ -1981,7 +1990,7 @@ def parse_matrix(value: object, where: str) -> MatrixConfig:
     if not isinstance(python, str):
         msg = f"{where}.python must be a string PEP 440 specifier"
         raise SourceConfigError(msg)
-    _validate_matrix_python(python, where)
+    _validate_matrix_python(python, where, table)
     platforms = _parse_matrix_platforms(platforms_raw, where)
     if not platforms:
         msg = f"{where}.platforms must list at least one platform id"

--- a/src/nab/optiontable.py
+++ b/src/nab/optiontable.py
@@ -412,7 +412,7 @@ class ProjectKeys(
     matrix = Key(
         Layer[MatrixConfig | None](
             rdefault=None,
-            parse=values.parse_matrix,
+            parse=hooks.parse_matrix,
             render=hooks.render_matrix,
             label="table(python,platforms)",
         ),

--- a/tests/test_cli_table.py
+++ b/tests/test_cli_table.py
@@ -395,7 +395,7 @@ class TestDerivedSpellings:
             "matrix",
             scope=Scope.PROJECT,
             rdefault=None,
-            parse=values.parse_matrix,
+            parse=hooks.parse_matrix,
             render=hooks.render_matrix,
             help="the axes",
             docs="reference/cli.md",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5472,7 +5472,7 @@ class TestMatrix:
         with pytest.raises(ConfigError, match="must be a PEP 440 specifier"):
             read_pyproject_config(write(tmp_path, body))
 
-    def test_a_patch_python_axis_sends_a_file_user_to_the_table(
+    def test_a_patch_python_axis_sends_a_pyproject_user_to_the_table(
         self, tmp_path: Path
     ) -> None:
         """The refusal names the table to write, not the file it read."""
@@ -5485,6 +5485,34 @@ class TestMatrix:
         message = str(caught.value)
         assert "Put patch versions in [tool.nab.matrix.python-patches]." in message
         assert f"in {path}" not in message
+
+    def test_a_patch_python_axis_sends_a_nab_toml_user_to_its_own_table(
+        self, tmp_path: Path
+    ) -> None:
+        """A nab.toml holds nab's keys at the top level, so the header drops the prefix.
+
+        The header it names is then written into that file and accepted.
+        """
+        path = write(tmp_path, '[project]\nname = "x"\nversion = "0"\n')
+        nab_toml = tmp_path / "nab.toml"
+        head = 'mode = "universal"\n[matrix]\nplatforms = ["linux_x86_64"]\n'
+        nab_toml.write_text(head + 'python = ">=3.11.4,<3.13"\n', encoding="utf-8")
+
+        with pytest.raises(ConfigError) as caught:
+            read_pyproject_config(path, discover_workspace=False)
+
+        message = str(caught.value)
+        assert "Put patch versions in [matrix.python-patches]." in message
+        assert "tool.nab" not in message
+
+        repaired = head + (
+            'python = ">=3.11,<3.13"\n[matrix.python-patches]\n"3.11" = "3.11.4"\n'
+        )
+        nab_toml.write_text(repaired, encoding="utf-8")
+
+        config = read_pyproject_config(path, discover_workspace=False)
+        assert config.matrix is not None
+        assert config.matrix.python_patches == {"3.11": "3.11.4"}
 
     def test_python_patches_must_be_table(self, tmp_path: Path) -> None:
         path = write(


### PR DESCRIPTION
A project-directory `nab.toml` with `python = ">=3.11.4,<3.13"` under `[matrix]` is told to put the patch pin in a table that file cannot have:

    <project>/nab.toml: matrix.python axis is a language (minor) version only; >=3.11.4 is finer than major.minor. Put patch versions in [tool.nab.matrix.python-patches].

Follow it and the next read fails on the header:

    <project>/nab.toml: 'tool' is not a valid nab setting; the known keys are ['archive-sources', ..., 'matrix', ...].

The refusal already varies with the source: the same clause passed as `--project-matrix-python` is sent to `--project-matrix-python-patches`. Its file branch is a hard-coded pyproject header, and the two project files write `matrix` differently: `[tool.nab.matrix]` in a pyproject.toml, `[matrix]` in a nab.toml.

The environment and vcs refusals already spell their header from a private helper in `config/model.py`, but a parse hook receives only `(value, where)` and has no origin to read it from. That helper moves to `config/ladder.py` as `project_key_path`, and the ladder binds the header it returns around each TOML parse, beside the declaring directory it already binds there. A nab.toml gets `[matrix.python-patches]`; a pyproject.toml and the command line are unchanged.
