### PR TITLE
Fix matrix and environment errors naming tables nab.toml cannot hold

### DIFF
--- a/src/nab/config/model.py
+++ b/src/nab/config/model.py
@@ -61,6 +61,7 @@ from nab_provider.vcs_admission import VcsConfig, VcsPolicy
 from .hooks import resolve_anchor
 from .ladder import (
     EffectiveValue,
+    Origin,
     SourceKind,
     SourceRoots,
     build_cli_layer,
@@ -345,7 +346,7 @@ def _config_from_effective(
     environment = _environment_from_effective(effective)
     if matrix is not None and environment is not None:
         raise ConfigError(
-            _matrix_environment_message(matrix_value, effective["environment"])
+            _matrix_environment_message(matrix_value, _environment_source(effective))
         )
 
     targets = _plan_targets(matrix, environment)
@@ -448,17 +449,25 @@ def _specific_mode_message(matrix_value: EffectiveValue) -> str:
 def _matrix_environment_message(
     matrix_value: EffectiveValue, environment_value: EffectiveValue
 ) -> str:
-    """Say why a matrix and a declared environment cannot both stand."""
+    """Say why a matrix and a declared environment cannot both stand.
+
+    ``environment_value`` is the surface the environment came from, so the
+    deprecated overlay is named as the overlay.  Each file side is named the
+    way the file that declared it writes it, since a matrix in a
+    ``pyproject.toml`` can sit beside an environment in a ``nab.toml``.
+    """
     matrix_flags = _declared_by(matrix_value)
     environment_flags = _declared_by(environment_value)
+    matrix = " and ".join(matrix_flags) or f"[{_declared_table(matrix_value)}]"
+    environment = (
+        " and ".join(environment_flags) or f"[{_declared_table(environment_value)}]"
+    )
     if not matrix_flags and not environment_flags:
         return (
-            "[tool.nab.matrix] and [tool.nab.environment] cannot both be set:"
+            f"{matrix} and {environment} cannot both be set:"
             " the matrix declares one environment per tuple, so a single"
             " declared environment would contradict it.  Drop one."
         )
-    matrix = " and ".join(matrix_flags) or "[tool.nab.matrix]"
-    environment = " and ".join(environment_flags) or "[tool.nab.environment]"
     return (
         f"{matrix} {_declares(matrix_flags)} a matrix and"
         f" {environment} {_declares(environment_flags)} one environment;"
@@ -1023,11 +1032,13 @@ def _environment_from_effective(
     declared: Mapping[str, Any] = entry.value
     marker_environment: Mapping[str, str] = effective["marker-environment"].value
     if marker_environment:
-        if _file_declares_environment(entry):
+        file_origin = _environment_file_origin(entry)
+        if file_origin is not None:
+            environment_table = _project_key_path("environment", file_origin.kind)
+            marker_table = _declared_table(effective["marker-environment"])
             msg = (
-                "[tool.nab.environment] and the deprecated"
-                " [tool.nab.marker-environment] are both set; drop the"
-                " marker-environment table."
+                f"[{environment_table}] and the deprecated [{marker_table}]"
+                " are both set; drop the marker-environment table."
             )
             raise ConfigError(msg)
         declared = {
@@ -1043,26 +1054,35 @@ def _environment_from_effective(
         implementation=declared.get("implementation"),
     )
     if environment.implementation is not None and environment.platform is None:
+        # The message asks for environment.platform, so name that table even
+        # when the deprecated overlay is what declared it.
+        origin = _environment_file_origin(entry)
+        if origin is None:
+            origin = _environment_source(effective).origin
+        table = _project_key_path("environment", origin.kind)
+
         valid = sorted(PLATFORM_MARKERS)
         msg = (
-            "[tool.nab.environment].implementation needs a platform: an"
-            " interpreter is modelled on a declared machine, not on the host's."
+            f"[{table}].implementation needs a platform: an interpreter is"
+            " modelled on a declared machine, not on the host's."
             f"  Add platform = one of {valid!r}."
         )
         raise ConfigError(msg)
     return environment
 
 
-def _file_declares_environment(entry: EffectiveValue) -> bool:
-    """Whether a configuration file declared ``[tool.nab.environment]``.
+def _environment_file_origin(entry: EffectiveValue) -> Origin | None:
+    """Return the file layer that declared ``[tool.nab.environment]``, if any.
 
     Read off the stack rather than the effective value: the command line
     folds its keys into the same key, and a flag narrowing the deprecated
-    overlay is not a second declaration of the table.
+    overlay is not a second declaration of the table.  The origin rather than
+    a bare yes, so a message can name the table the way that file writes it.
     """
-    return any(
-        value for origin, value in entry.stack if origin.kind is not SourceKind.CLI
-    )
+    for origin, value in reversed(entry.stack):
+        if value and origin.kind is not SourceKind.CLI:
+            return origin
+    return None
 
 
 def _reject_duplicate_source_names(
@@ -1094,6 +1114,19 @@ def _reject_duplicate_source_names(
             )
             raise ConfigError(msg)
         seen[canonical] = source.name
+
+
+def _environment_source(
+    effective: Mapping[str, EffectiveValue],
+) -> EffectiveValue:
+    """Return the surface the environment came from, table or deprecated overlay."""
+    environment = effective["environment"]
+    return environment if environment.value else effective["marker-environment"]
+
+
+def _declared_table(value: EffectiveValue) -> str:
+    """Return the table path the file that declared ``value`` writes for its key."""
+    return _project_key_path(value.spec.name, value.origin.kind)
 
 
 def _project_key_path(key: str, kind: SourceKind) -> str:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2636,6 +2636,42 @@ class TestEnvironment:
         ):
             read_pyproject_config(path)
 
+    def test_implementation_without_platform_named_for_nab_toml(
+        self, tmp_path: Path
+    ) -> None:
+        """The repair goes in the file that declared the environment."""
+        path = write(tmp_path, '[project]\nname = "x"\nversion = "0"\n')
+        (tmp_path / "nab.toml").write_text(
+            '[environment]\nimplementation = "pypy"\n', encoding="utf-8"
+        )
+
+        with pytest.raises(ConfigError) as excinfo:
+            read_pyproject_config(path, discover_workspace=False)
+
+        message = str(excinfo.value)
+        assert "[environment].implementation needs a platform" in message
+        assert "tool.nab" not in message
+
+    def test_implementation_without_platform_named_for_nab_toml_under_a_flag(
+        self, tmp_path: Path
+    ) -> None:
+        """A flag on another axis does not move the repair out of nab.toml."""
+        path = write(tmp_path, '[project]\nname = "x"\nversion = "0"\n')
+        (tmp_path / "nab.toml").write_text(
+            '[environment]\nimplementation = "pypy"\n', encoding="utf-8"
+        )
+
+        with pytest.raises(ConfigError) as excinfo:
+            read_pyproject_config(
+                path,
+                discover_workspace=False,
+                cli_overrides={"environment": _cli_environment(python="3.12")},
+            )
+
+        message = str(excinfo.value)
+        assert "[environment].implementation needs a platform" in message
+        assert "tool.nab" not in message
+
     def test_rejected_alongside_a_matrix(self, tmp_path: Path) -> None:
         path = write(
             tmp_path,
@@ -2648,6 +2684,65 @@ class TestEnvironment:
             match=r"\[tool.nab.matrix\] and \[tool.nab.environment\] cannot both",
         ):
             read_pyproject_config(path)
+
+    def test_nab_toml_matrix_and_environment_named_at_top_level(
+        self, tmp_path: Path
+    ) -> None:
+        """nab.toml takes both tables at the top level, so neither is prefixed."""
+        path = write(tmp_path, '[project]\nname = "x"\nversion = "0"\n')
+        (tmp_path / "nab.toml").write_text(
+            'mode = "universal"\n'
+            '[matrix]\npython = ">=3.11,<3.12"\nplatforms = ["linux_x86_64"]\n'
+            '[environment]\npython = "3.11"\n',
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ConfigError) as excinfo:
+            read_pyproject_config(path, discover_workspace=False)
+
+        message = str(excinfo.value)
+        assert "[matrix] and [environment] cannot both be set" in message
+        assert "tool.nab" not in message
+
+    def test_environment_in_nab_toml_named_for_its_own_file(
+        self, tmp_path: Path
+    ) -> None:
+        """A matrix in pyproject.toml keeps its prefix beside a nab.toml environment."""
+        path = write(
+            tmp_path,
+            '[project]\nname = "x"\nversion = "0"\n'
+            '[tool.nab]\nmode = "universal"\n' + _UNIVERSAL_MATRIX,
+        )
+        (tmp_path / "nab.toml").write_text(
+            '[environment]\npython = "3.11"\n', encoding="utf-8"
+        )
+
+        with pytest.raises(ConfigError) as excinfo:
+            read_pyproject_config(path, discover_workspace=False)
+
+        assert "[tool.nab.matrix] and [environment] cannot both be set" in str(
+            excinfo.value
+        )
+
+    def test_matrix_in_nab_toml_named_for_its_own_file(self, tmp_path: Path) -> None:
+        """A matrix in nab.toml drops its prefix beside a pyproject.toml environment."""
+        path = write(
+            tmp_path,
+            '[project]\nname = "x"\nversion = "0"\n'
+            '[tool.nab.environment]\npython = "3.11"\n',
+        )
+        (tmp_path / "nab.toml").write_text(
+            'mode = "universal"\n'
+            '[matrix]\npython = ">=3.11,<3.12"\nplatforms = ["linux_x86_64"]\n',
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ConfigError) as excinfo:
+            read_pyproject_config(path, discover_workspace=False)
+
+        assert "[matrix] and [tool.nab.environment] cannot both be set" in str(
+            excinfo.value
+        )
 
 
 class TestMarkerEnvironmentDeprecation:
@@ -2807,18 +2902,29 @@ class TestMarkerEnvironmentDeprecation:
             "[tool.nab.marker-environment]\n"
             'python_version = "3.11"\n',
         )
-        with pytest.raises(ConfigError, match="are both set"):
+        with pytest.raises(
+            ConfigError,
+            match=r"\[tool.nab.environment\] and the deprecated"
+            r" \[tool.nab.marker-environment\] are both set",
+        ):
             read_pyproject_config(path)
 
     def test_both_surfaces_rejected_under_a_cli_key(self, tmp_path: Path) -> None:
-        """A file table beside the overlay still refuses, flag or no flag."""
+        """A file table beside the overlay still refuses, flag or no flag.
+
+        The flag wins the key, so the table is named for the file under it.
+        """
         path = write(
             tmp_path,
             '[tool.nab.environment]\npython = "3.12"\n'
             "[tool.nab.marker-environment]\n"
             'python_version = "3.11"\n',
         )
-        with pytest.raises(ConfigError, match="are both set"):
+        with pytest.raises(
+            ConfigError,
+            match=r"\[tool.nab.environment\] and the deprecated"
+            r" \[tool.nab.marker-environment\] are both set",
+        ):
             read_pyproject_config(
                 path,
                 discover_workspace=False,
@@ -2865,6 +2971,44 @@ class TestMarkerEnvironmentDeprecation:
         assert config.environment == EnvironmentConfig(
             platform=PlatformSpec("macos_arm64"), implementation="pypy"
         )
+
+    def test_both_surfaces_in_nab_toml_named_at_top_level(self, tmp_path: Path) -> None:
+        """Both surfaces come from nab.toml, so neither is named under tool.nab."""
+        path = write(tmp_path, '[project]\nname = "x"\nversion = "0"\n')
+        (tmp_path / "nab.toml").write_text(
+            '[environment]\npython = "3.12"\n'
+            '[marker-environment]\npython_version = "3.11"\n',
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ConfigError) as excinfo:
+            read_pyproject_config(path, discover_workspace=False)
+
+        message = str(excinfo.value)
+        assert "[environment] and the deprecated [marker-environment]" in message
+        assert "tool.nab" not in message
+
+    def test_both_surfaces_in_nab_toml_named_under_a_cli_key(
+        self, tmp_path: Path
+    ) -> None:
+        """A flag wins the key, so the table is named for the file below it."""
+        path = write(tmp_path, '[project]\nname = "x"\nversion = "0"\n')
+        (tmp_path / "nab.toml").write_text(
+            '[environment]\npython = "3.12"\n'
+            '[marker-environment]\npython_version = "3.11"\n',
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ConfigError) as excinfo:
+            read_pyproject_config(
+                path,
+                discover_workspace=False,
+                cli_overrides={"environment": _cli_environment(python="3.13")},
+            )
+
+        message = str(excinfo.value)
+        assert "[environment] and the deprecated [marker-environment]" in message
+        assert "tool.nab" not in message
 
     def test_must_be_table(self, tmp_path: Path) -> None:
         path = write(tmp_path, '[tool.nab]\nmarker-environment = "no"\n')
@@ -2931,9 +3075,27 @@ class TestMarkerEnvironmentDeprecation:
         )
         with pytest.raises(
             ConfigError,
-            match=r"\[tool.nab.matrix\] and \[tool.nab.environment\] cannot both",
+            match=r"\[tool.nab.matrix\] and \[tool.nab.marker-environment\]"
+            r" cannot both",
         ):
             read_pyproject_config(path)
+
+    def test_rejected_in_universal_mode_from_nab_toml(self, tmp_path: Path) -> None:
+        """The message names the overlay nab.toml holds, not the environment."""
+        path = write(tmp_path, '[project]\nname = "x"\nversion = "0"\n')
+        (tmp_path / "nab.toml").write_text(
+            'mode = "universal"\n'
+            '[matrix]\npython = ">=3.11"\nplatforms = ["linux_x86_64"]\n'
+            '[marker-environment]\npython_version = "3.11"\n',
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ConfigError) as excinfo:
+            read_pyproject_config(path, discover_workspace=False)
+
+        message = str(excinfo.value)
+        assert "[matrix] and [marker-environment] cannot both be set" in message
+        assert "tool.nab" not in message
 
 
 class TestIndexes:


### PR DESCRIPTION
A project-dir `nab.toml` that declares both tables gets an error naming tables that file cannot hold:

```
error: [tool.nab.matrix] and [tool.nab.environment] cannot both be set: ...
```

`nab.toml` takes nab's keys at the top level. Writing `[tool.nab.matrix]` into it fails with `'tool' is not a valid nab setting`, so following the message lands on a second error. It now reads `[matrix] and [environment] cannot both be set`.

Both names go through `_project_key_path`, the helper the vcs-sources message already uses. Each is resolved against the file that declared it, since a matrix in `pyproject.toml` can sit beside an environment in `nab.toml`.

The same fix lands on two more messages, and on a case that shows in `pyproject.toml` too:

- `[environment]` beside the deprecated `[marker-environment]`
- `[environment].implementation` declared without a platform
- the matrix rejection when `marker-environment` is what declared the environment: it named `[tool.nab.environment]`, a table not in the file at all

A `--project-environment-*` flag folds into the `environment` key, so the marker-environment refusal and the implementation error take the origin from the file layer under the flag rather than from the winning value.
