### PR TITLE
Cache one parse per METADATA text, ~1.1% off a 12-target universal resolve

### DIFF
--- a/nab-project/tests/test_fetch.py
+++ b/nab-project/tests/test_fetch.py
@@ -473,6 +473,14 @@ class TestInMemoryIndex:
         assert idx.get_parsed_metadata("foo", "1.0", "TEXT-1") == "v1"
         assert idx.get_parsed_metadata("foo", "2.0", "TEXT-2") == "v2"
 
+    def test_parsed_metadata_keeps_every_text_of_a_version(self) -> None:
+        """Each text of one ``(package, version)`` keeps its own parse."""
+        idx = InMemoryIndex()
+        idx.store_parsed_metadata("foo", "1.0", "linux-parse", "LINUX-METADATA")
+        idx.store_parsed_metadata("foo", "1.0", "win-parse", "WIN-METADATA")
+        assert idx.get_parsed_metadata("foo", "1.0", "LINUX-METADATA") == "linux-parse"
+        assert idx.get_parsed_metadata("foo", "1.0", "WIN-METADATA") == "win-parse"
+
     def test_parsed_metadata_answers_only_for_its_own_text(self) -> None:
         """The sdist's parse is not served to a reader holding wheel METADATA.
 

--- a/nab-project/tests/test_resolve_targets.py
+++ b/nab-project/tests/test_resolve_targets.py
@@ -61,12 +61,14 @@ from nab_project.resolve import (
     resolve_with_coordinator,
 )
 from nab_provider._provider import listing as listing_mod
+from nab_provider._provider import metadata_resolver
 from nab_provider._vendor.packaging.markers import Marker
 from nab_provider._vendor.packaging.ranges import VersionRange
 from nab_provider._vendor.packaging.requirements import Requirement
 from nab_provider._vendor.packaging.version import Version
 from nab_provider.errors import ConfigError
 from nab_provider.marker_holds import dependency_marker_holds
+from nab_provider.metadata import WheelMetadata
 from nab_provider.overrides import IndexOverride, PackageOverride
 from nab_provider.provider import (
     ArchiveSource,
@@ -1147,6 +1149,57 @@ class TestMatrixMetadataReadGranularity:
         self._resolve_three_targets(coordinator)
 
         assert len(coordinator.calls_to("request_sdist")) == 1
+
+    def test_a_wheel_text_is_parsed_once_across_pythons(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Two platforms across two Pythons parse two texts, not four.
+
+        The targets alternate platforms, so each wheel's text is read again
+        after the other platform's.
+        """
+        linux = self._wheel("py3-none-manylinux_2_17_x86_64")
+        windows = self._wheel("py3-none-win_amd64")
+        assert linux.metadata_url is not None
+        assert windows.metadata_url is not None
+
+        coordinator = make_coordinator(
+            listings={"pkg": [linux, windows]},
+            metadata_by_url={
+                linux.metadata_url: "Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\n",
+                windows.metadata_url: (
+                    "Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\n"
+                    "Requires-Python: >=3.8\n"
+                ),
+            },
+        )
+
+        parsed: list[str] = []
+        real_parse = metadata_resolver.parse_metadata
+
+        def counting_parse(text: str) -> WheelMetadata:
+            parsed.append(text)
+            return real_parse(text)
+
+        monkeypatch.setattr(metadata_resolver, "parse_metadata", counting_parse)
+
+        targets = Matrix(
+            python=">=3.11,<3.13",
+            platforms=(PlatformSpec("linux_x86_64"), PlatformSpec("windows_amd64")),
+        ).expand()
+        assert [t.label for t in targets] == [
+            "py311-linux_x86_64",
+            "py311-windows_amd64",
+            "py312-linux_x86_64",
+            "py312-windows_amd64",
+        ]
+
+        result = resolve_with_coordinator(
+            coordinator, targets, _reqs("pkg"), inputs=_no_build()
+        )
+
+        assert result.success
+        assert len(parsed) == len(set(parsed)) == 2
 
 
 _FORTY_SHA = "0123456789abcdef0123456789abcdef01234567"

--- a/nab-provider/src/nab_provider/_provider/metadata_resolver.py
+++ b/nab-provider/src/nab_provider/_provider/metadata_resolver.py
@@ -757,11 +757,10 @@ def parse_and_cache_metadata(
     :class:`UnsupportedSdistError` under :class:`BuildPolicy.NEVER`.
 
     The parsed :class:`WheelMetadata` is shared via the
-    :class:`~nab_provider.store.InMemoryIndex` so that universal-mode
-    resolves only run :func:`parse_metadata` once per
-    ``(package, version)`` regardless of how many tuples ask for it.  The
-    cache is keyed on ``metadata_text`` as well, so a tuple holding another
-    artifact's text for that version parses it itself.
+    :class:`~nab_provider.store.InMemoryIndex`, keyed by the text it was
+    parsed from, so a universal-mode resolve runs :func:`parse_metadata`
+    once per distinct text, however many tuples read it.
+
     Per-tuple classification (marker evaluation, extras admission)
     still runs locally in :func:`cache_deps_from_metadata`.  The
     sdist-dynamic-deps reconciliation in

--- a/nab-provider/src/nab_provider/store.py
+++ b/nab-provider/src/nab_provider/store.py
@@ -108,9 +108,10 @@ class InMemoryIndex:
         # the provider's tier accounting.
         self._range_outcomes: dict[tuple[str, str, str], RangeOutcome] = {}
 
-        # A parse is a pure function of its text, so ``(source_text, parsed)``
-        # entries are shared across the per-target providers of one resolve.
-        self._parsed_metadata: dict[tuple[str, str], tuple[str, Any]] = {}
+        # A parse is a pure function of its text, so a version's
+        # ``(source_text, parsed)`` entries are shared across the per-target
+        # providers of one resolve.
+        self._parsed_metadata: dict[tuple[str, str], tuple[tuple[str, Any], ...]] = {}
 
         # Sdist metadata after PEP 643 dynamic deps have been resolved from the
         # bundled pyproject.toml or a PEP 517 backend.  Shared across targets so
@@ -570,21 +571,27 @@ class InMemoryIndex:
     ) -> Any | None:
         """Return the cached parse of ``source_text``, or ``None``.
 
-        A parse of any other text is a miss: wheel METADATA and sdist PKG-INFO
-        share one ``(package, version)`` slot, so a key-only hit could hand
-        back another artifact's deps.
+        A version's entries are matched by text: wheel METADATA, sdist
+        PKG-INFO and per-platform wheels all parse under one ``(package,
+        version)``, so a key-only hit could hand back another artifact's deps.
         """
-        entry = self._parsed_metadata.get((package, version))
-        if entry is None or entry[0] != source_text:
-            return None
-        return entry[1]
+        for text, metadata in self._parsed_metadata.get((package, version), ()):
+            if text == source_text:
+                return metadata
+        return None
 
     def store_parsed_metadata(
         self, package: str, version: str, metadata: Any, source_text: str
     ) -> None:
-        """Cache the parse of ``source_text``."""
+        """Cache the parse of ``source_text`` beside the version's other parses.
+
+        The entries are a tuple replaced whole, so a read without the lock
+        never sees a half-built one.
+        """
+        key = (package, version)
         with self._lock:
-            self._parsed_metadata[(package, version)] = (source_text, metadata)
+            entries = self._parsed_metadata.get(key, ())
+            self._parsed_metadata[key] = (*entries, (source_text, metadata))
 
     def get_resolved_sdist_metadata(self, package: str, version: str) -> Any | None:
         """Return cached post-reconciliation sdist metadata or ``None``.


### PR DESCRIPTION
A `scientific-python-multi` universal resolve parses METADATA 81 times for 30 distinct texts. The memo held one `(source_text, parsed)` entry per `(package, version)`, so the macOS target's parse evicted the Linux one and the next Linux target re-parsed the same text. The scenario spans 4 Pythons and 3 platforms as 12 targets that alternate platforms, so a version's wheels keep displacing each other.

Keeping every text's parse under its `(package, version)` drops `parse_metadata` to 30 calls. Two callgrind runs of that resolve, `PYTHONHASHSEED=0` and a warm cache:

| run | base | branch | change |
| --- | --- | --- | --- |
| 1 | 3,806,505,256 | 3,762,355,128 | -1.16% |
| 2 | 3,804,805,687 | 3,761,620,304 | -1.14% |

`get_parsed_metadata` is still called 222 times either way, and matching on text made each miss-then-store dearer: 87,248 instructions more across the 30 distinct documents that resolve reads, about 2,900 each. A single-target resolve never repeats a text, so it pays that and saves nothing.

The clock cannot see a change this small, so the timing runs only rule out a slowdown: above about 2.4% on `scientific-python-multi` and `max-25-tuples`, and above about 1.9% across the 19-scenario canary set.
