### PR TITLE
Stop storing PKG-INFO's folded Description field, ~4% off peak memory

### DIFF
--- a/nab-project/tests/test_fetch.py
+++ b/nab-project/tests/test_fetch.py
@@ -188,6 +188,15 @@ class TestInMemoryIndex:
         assert idx.get_metadata("foo", "1.0") == "Name: foo\nVersion: 1.0\n\n"
         assert idx.metadata_from_sdist("foo", "1.0")
 
+    def test_sdist_metadata_slot_drops_the_folded_description(self) -> None:
+        idx = InMemoryIndex()
+        idx.store_sdist_metadata(
+            "foo",
+            "1.0",
+            "Name: foo\nDescription: Foo\n        A long description.\nVersion: 1.0\n",
+        )
+        assert idx.get_metadata("foo", "1.0") == "Name: foo\nVersion: 1.0\n"
+
     def test_store_metadata_none(self) -> None:
         idx = InMemoryIndex()
         idx.store_metadata("foo", "1.0", None)

--- a/nab-provider/src/nab_provider/metadata.py
+++ b/nab-provider/src/nab_provider/metadata.py
@@ -31,6 +31,7 @@ __all__ = [
     "intern_version",
     "metadata_deps_are_static",
     "metadata_header_block",
+    "metadata_without_description",
     "parse_metadata",
     "static_project_from_table",
     "validate_specifier_versions",
@@ -234,6 +235,14 @@ _LOGICAL_LINE = re.compile(r"\n(?![ \t])")
 _LOGICAL_LINE_CR = re.compile(r"(?:\r\n|\r(?!\n)|\n)(?![ \t])")
 
 
+def _logical_line_boundary(text: str) -> re.Pattern[str]:
+    """Return the pattern for a line ending that closes a logical line of ``text``."""
+    # Equal counts mean every \r begins a \r\n, so no line ends on a bare one.
+    if "\r" in text and text.count("\r") != text.count("\r\n"):
+        return _LOGICAL_LINE_CR
+    return _LOGICAL_LINE
+
+
 def _logical_lines(text: str) -> list[str]:
     r"""Split ``text`` into RFC 822 logical lines, each holding its own folds.
 
@@ -241,10 +250,31 @@ def _logical_lines(text: str) -> list[str]:
     goes, except that the common pattern splits on the ``\n`` of a ``\r\n``
     and leaves the ``\r`` at the end of the line.
     """
-    # Equal counts mean every \r begins a \r\n, so no line ends on a bare one.
-    if "\r" in text and text.count("\r") != text.count("\r\n"):
-        return _LOGICAL_LINE_CR.split(text)
-    return _LOGICAL_LINE.split(text)
+    return _logical_line_boundary(text).split(text)
+
+
+def _description_start(text: str) -> int:
+    """Return the index where a ``Description:`` line starts in ``text``, or -1."""
+    if text.startswith("Description:"):
+        return 0
+    at = text.find("\nDescription:")
+    return -1 if at < 0 else at + 1
+
+
+def metadata_without_description(text: str) -> str:
+    """Return ``text`` with its ``Description:`` field cut out, folds included.
+
+    distutils writes the long description as a folded header field, which
+    :func:`metadata_header_block` keeps and :func:`parse_metadata` never reads.
+    Only the first one is cut, and the name is matched case-sensitively.
+    """
+    start = _description_start(text)
+    if start < 0:
+        return text
+
+    boundary = _logical_line_boundary(text).search(text, start)
+    end = len(text) if boundary is None else boundary.end()
+    return text[:start] + text[end:]
 
 
 def _read_header_fields(text: str) -> dict[str, list[str]]:

--- a/nab-provider/src/nab_provider/store.py
+++ b/nab-provider/src/nab_provider/store.py
@@ -9,7 +9,7 @@ import threading
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
 
-from nab_provider.metadata import metadata_header_block
+from nab_provider.metadata import metadata_header_block, metadata_without_description
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Mapping, Sequence
@@ -87,7 +87,7 @@ class InMemoryIndex:
         # Metadata text is keyed by the artifact it came from: the sidecar URL
         # for a wheel's METADATA, or None for text that stands for the version
         # itself, such as an sdist's PKG-INFO.  Each is cut to its header block
-        # on the way in.
+        # less the description on the way in.
         self._metadata: dict[tuple[str, str, str | None], str | None] = {}
         self._metadata_errors: dict[tuple[str, str, str | None], BaseException] = {}
         # Versions whose version-level slot was written from an sdist PKG-INFO;
@@ -275,7 +275,7 @@ class InMemoryIndex:
     def get_metadata(
         self, package: str, version: str, metadata_url: str | None = None
     ) -> str | None:
-        """Return the cached header block, or ``None`` if not yet stored."""
+        """Return the cached header block less the description, or ``None``."""
         with self._lock:
             return self._read_metadata(package, version, metadata_url)[0]
 
@@ -315,13 +315,17 @@ class InMemoryIndex:
         *,
         from_sdist: bool,
     ) -> None:
-        """Write one metadata slot, cut to its header block. Caller holds the lock.
+        """Write one metadata slot, cut to its header block less the description.
 
-        Reconciled sdist metadata is derived from the version-level text, so
-        replacing that text drops it.
+        Caller holds the lock. Reconciled sdist metadata is derived from the
+        version-level text, so replacing that text drops it.
         """
         package, version, metadata_url = slot
-        text = None if data is None else metadata_header_block(data)
+        if data is None:
+            text = None
+        else:
+            text = metadata_without_description(metadata_header_block(data))
+
         if metadata_url is None:
             if self._metadata.get(slot) != text:
                 self._resolved_sdist_metadata.pop((package, version), None)
@@ -342,15 +346,16 @@ class InMemoryIndex:
         *,
         metadata_url: str | None = None,
     ) -> None:
-        """Cache the header block of ``data``, or ``None`` when no sidecar was served.
+        """Cache the header block of ``data`` less the description.
 
         ``metadata_url`` is the sidecar the text came from; ``None`` stores it
         as standing for the version rather than one artifact.  It is
         keyword-only: it and ``data`` are both ``str | None``, so a transposed
         call would type-check.
 
-        A ``data`` of ``None`` lands in the sidecar's own slot, so it cannot
-        erase sdist PKG-INFO from the version-level one.
+        A ``data`` of ``None`` says no sidecar was served.  It lands in the
+        sidecar's own slot, so it cannot erase sdist PKG-INFO from the
+        version-level one.
         """
         key = metadata_pending_key(package, version, metadata_url)
         slot = (package, version, metadata_url)

--- a/nab-provider/tests/test_metadata.py
+++ b/nab-provider/tests/test_metadata.py
@@ -14,6 +14,7 @@ from nab_provider.metadata import (
     _read_header_fields,
     metadata_deps_are_static,
     metadata_header_block,
+    metadata_without_description,
     parse_metadata,
     validate_specifier_versions,
 )
@@ -235,6 +236,53 @@ class TestMetadataHeaderBlock:
 
         parser = email.parser.Parser()
         assert parser.parsestr(cut).items() == parser.parsestr(text).items()
+        assert parse_metadata(cut) == parse_metadata(text)
+
+
+_FOLDED_DESCRIPTION = (
+    "Metadata-Version: 1.1\nName: foo\nVersion: 1.0\n"
+    "Description: Foo\n        ===\n        \n        A long description.\n"
+    "Classifier: Programming Language :: Python\nRequires-Python: >=3.9\n"
+)
+
+
+class TestMetadataWithoutDescription:
+    """Cutting the folded ``Description:`` field out of a header block."""
+
+    def test_folded_field_goes_and_the_fields_after_it_stay(self) -> None:
+        assert metadata_without_description(_FOLDED_DESCRIPTION) == (
+            "Metadata-Version: 1.1\nName: foo\nVersion: 1.0\n"
+            "Classifier: Programming Language :: Python\nRequires-Python: >=3.9\n"
+        )
+
+    def test_document_without_the_field_comes_back_whole(self) -> None:
+        text = "Name: foo\nVersion: 1.0\nDescription-Content-Type: text/x-rst\n"
+        assert metadata_without_description(text) is text
+
+    def test_a_continuation_line_is_not_the_field(self) -> None:
+        text = "Summary: foo\n Description: still the summary\nVersion: 1.0\n"
+        assert metadata_without_description(text) is text
+
+    def test_field_opening_the_document(self) -> None:
+        text = "Description: Foo\n        more\nName: foo\nVersion: 1.0\n"
+        assert metadata_without_description(text) == "Name: foo\nVersion: 1.0\n"
+
+    def test_field_closing_the_document_without_a_line_ending(self) -> None:
+        text = "Name: foo\nVersion: 1.0\nDescription: Foo\n        more"
+        assert metadata_without_description(text) == "Name: foo\nVersion: 1.0\n"
+
+    def test_crlf_folds(self) -> None:
+        text = "Name: foo\r\nDescription: Foo\r\n\tmore\r\nVersion: 1.0\r\n\r\n"
+        assert metadata_without_description(text) == "Name: foo\r\nVersion: 1.0\r\n\r\n"
+
+    def test_bare_cr_line_ending_closes_the_field(self) -> None:
+        text = "Name: foo\nDescription: Foo\r  more\rVersion: 1.0\n"
+        assert metadata_without_description(text) == "Name: foo\nVersion: 1.0\n"
+
+    @pytest.mark.parametrize("text", [*_HEADER_BLOCK_DOCUMENTS, _FOLDED_DESCRIPTION])
+    def test_the_cut_parses_the_same(self, text: str) -> None:
+        """The description holds no field :func:`parse_metadata` reads."""
+        cut = metadata_without_description(metadata_header_block(text))
         assert parse_metadata(cut) == parse_metadata(text)
 
 


### PR DESCRIPTION
Cutting the `Description:` field out of stored metadata takes about 4% off peak traced memory on `pip:trustllm` and `pip:langchain-ml-course`, both at `--resolution lowest`. distutils writes the long description into PKG-INFO as a folded `Description:` header, and `metadata_header_block` cuts only at the first blank line, so the whole README sits in a slot `parse_metadata` never reads: 11,067,936 bytes of it on `pip:trustllm`.

| scenario | peak traced bytes | sdist slot bytes | wheel slot bytes |
| --- | --- | --- | --- |
| `pip:trustllm` | 67,718,987 -> 65,006,271 | 11,563,335 -> 495,399 (585 slots) | 3,792,184, identical (430) |
| `pip:langchain-ml-course` | 156,622,775 -> 150,190,365 | 7,423,344 -> 1,472,924 (1,344 slots) | 6,159,024, identical (2,564) |

Wheel slots do not move: a wheel's METADATA keeps the description in the payload, past the blank line the header cut ends at.

Instructions drop with the bytes, 5,201,692,876 to 5,140,217,268 on `pip:trustllm`, 1.2% of that run. On `airflow:airflow-3-0-2-awswrangler --resolution lowest-direct`, which stores no sdist metadata, the scan costs 1,008,236 instructions, 0.014%.

Peak RSS falls about 3.8% on `pip:trustllm` and between about 0.7% and 3.3% across the 19-scenario canary set, middle estimate 2.4%. Wall and CPU rule out a slowdown above about 3.6% and 1.7% on those two runs. The counts reproduce anywhere, the timings are local.

`metadata_without_description` cuts to the end of the logical line, so a field written after the description survives and the stored text parses to the same metadata.
