### PR TITLE
Declare Scope in nab.optiondefs, 0.26% off an offline nab lock

### DIFF
--- a/src/nab/config/registry.py
+++ b/src/nab/config/registry.py
@@ -17,10 +17,10 @@ from . import (
 from ..optiondefs import (
     Kind,
     Opt,
+    Scope,
     Tokens,
     VType,
 )
-from ..optionrows import Scope
 from nab_provider.policy import (
     BuildPolicy,
     DecisionOrder,

--- a/src/nab/optiondefs.py
+++ b/src/nab/optiondefs.py
@@ -9,7 +9,6 @@ import enum
 from typing import TYPE_CHECKING, Any
 
 from ._compat import override
-from .optionrows import Scope
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -74,6 +73,13 @@ class Tokens(enum.Enum):
     ITEM = "item"
     ITEMS = "items"
     PAIRS = "pairs"
+
+
+class Scope(enum.Enum):
+    """Whether an option configures the project or the user's environment."""
+
+    PROJECT = "project"
+    USER = "user"
 
 
 class _Unset:

--- a/src/nab/optionrows.py
+++ b/src/nab/optionrows.py
@@ -6,13 +6,15 @@ the row objects on each table class.
 
 from __future__ import annotations
 
-import enum
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from ._compat import override
 
 if TYPE_CHECKING:
+    import enum
     from collections.abc import Callable
+
+    from .optiondefs import Scope
 
 T = TypeVar("T")
 C = TypeVar("C")
@@ -21,13 +23,6 @@ C = TypeVar("C")
 # omitted default checks against any T while a written one is checked;
 # nab.optionlower turns it into the Opt sentinel or into None.
 OMITTED: Any = object()
-
-
-class Scope(enum.Enum):
-    """Whether an option configures the project or the user's environment."""
-
-    PROJECT = "project"
-    USER = "user"
 
 
 class Layer(Generic[C]):

--- a/src/nab/optiontable.py
+++ b/src/nab/optiontable.py
@@ -40,7 +40,7 @@ from .flagtypes import (
     ModeFlag,
     ResolutionFlag,
 )
-from .optiondefs import GLOBAL, Opt
+from .optiondefs import GLOBAL, Opt, Scope
 from .optionlower import table_rows
 from .optionrows import (
     Count,
@@ -52,7 +52,6 @@ from .optionrows import (
     Many,
     Operand,
     Pairs,
-    Scope,
     Star,
     Switch,
     Table,

--- a/tests/test_option_imports.py
+++ b/tests/test_option_imports.py
@@ -1,9 +1,9 @@
 """Import boundaries for command invocations.
 
 Runtime code imports ``optiondefs`` through the generated configuration
-registry and never imports ``optiontable``. Commands resolve their ``Literal``
-aliases from ``flagtypes``. Fresh subprocesses keep earlier test imports from
-masking dependencies.
+registry and never imports ``optiontable`` or ``optionrows``. Commands resolve
+their ``Literal`` aliases from ``flagtypes``. Fresh subprocesses keep earlier
+test imports from masking dependencies.
 """
 
 from __future__ import annotations
@@ -35,19 +35,19 @@ def _after_importing(module: str) -> list[str]:
     return _probe(f"import sys\nimport {module}\n{_REPORT}")
 
 
-def test_a_command_invocation_imports_neither_the_model_nor_the_table() -> None:
+def test_a_command_invocation_imports_no_option_module() -> None:
     """Only the generators and the tests build the 64 rows."""
     assert _after_importing("nab.cli")[0] == "clean"
 
 
 def test_a_run_reads_the_registry_and_never_the_declaration() -> None:
-    """The ladder's rows come from the generated module, so the tables stay unbuilt."""
+    """A run loads ``nab.optiondefs`` and no other option module."""
     loaded = _probe(
         "import sys\n"
         "import nab._lock\n"
         "print(sorted(n for n in sys.modules if n.startswith('nab.option')))\n"
     )
-    assert loaded == ["['nab.optiondefs', 'nab.optionrows']"]
+    assert loaded == ["['nab.optiondefs']"]
 
 
 def test_the_command_signatures_reach_their_aliases_through_a_leaf() -> None:


### PR DESCRIPTION
An offline `nab lock` of a five-package project retires 2,208,512 fewer instructions, 0.265% of 833,566,943. `nab config list` drops 2,248,672 of 294,409,400 (0.764%), and `import nab._lock` on its own 2,734,509 of 640,080,905 (0.427%). Those counts come from callgrind with `PYTHONHASHSEED=0`, so they reproduce anywhere.

`nab.optiondefs` imported `Scope` from `nab.optionrows`, so a command that reads configuration built that module's 19 classes, ten of them with subscripted generic bases, to get a two-member enum. `Scope` is now declared in `optiondefs`, and `optionrows` takes it back under `TYPE_CHECKING`, since its three uses there are annotations. `optiontable` and the generated `config/registry` read it from `optiondefs`, which already exported it.

The saving is the module not loading rather than the declaration moving: add `import nab.optionrows` back to both sides and the branch costs 57,048 instructions more than the base (+0.0089%).

`import nab._lock` also makes 672 fewer calls, 171,879 to 171,207, and holds 80,405 fewer bytes at exit.

The clock cannot resolve an effect this small, so the timing runs on the lock command only rule out a slowdown above about 2.2%.
