### PR TITLE
Preserve double-slash path roots in file URLs

### DIFF
--- a/nab-index/src/nab_index/file_urls.py
+++ b/nab-index/src/nab_index/file_urls.py
@@ -35,8 +35,8 @@ def parse_file_url(url: str) -> Path:
     local machine; any other host becomes a UNC share on Windows and is
     rejected elsewhere.
 
-    :mod:`pathlib` accepts a decoded null character, which cannot name a file,
-    so this function raises :class:`ValueError` instead.
+    Raise :class:`ValueError` for decoded null characters or paths rejected by
+    :func:`urllib.request.url2pathname`.
     """
     return _parsed_file_url_path(urlparse(url), url)
 
@@ -54,17 +54,38 @@ def _parsed_file_url_path(parsed: ParseResult, url: str) -> Path:
     from urllib.request import url2pathname  # noqa: PLC0415
 
     netloc = parsed.netloc
+    url_path = parsed.path
+
     if not netloc or netloc == "localhost":
         netloc = ""
+        if url_path.startswith("//") and not _is_windows_drive_root(url_path):
+            # Preserve the path root through url2pathname's authority parsing.
+            url_path = "/%2F" + url_path[2:]
     elif sys.platform == "win32":
         netloc = "\\\\" + netloc
     else:
         msg = f"non-local file:// URL is not supported on this platform: {url!r}"
         raise ValueError(msg)
 
-    path = url2pathname(netloc + parsed.path)
+    try:
+        path = url2pathname(netloc + url_path)
+    except OSError as exc:
+        msg = f"file:// URL {url!r} does not name a path: {exc}"
+        raise ValueError(msg) from exc
+
     if "\x00" in path:
         msg = f"file:// URL decodes to a path containing a null character: {url!r}"
         raise ValueError(msg)
 
     return Path(path)
+
+
+def _is_windows_drive_root(url_path: str) -> bool:
+    """Check the drive prefix of a ``//``-rooted Windows path."""
+    letter, colon = url_path[2:3], url_path[3:4]
+    return (
+        sys.platform == "win32"
+        and colon == ":"
+        and letter.isascii()
+        and letter.isalpha()
+    )

--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -328,8 +328,9 @@ def _resolve_local_link(
     # page's, so the split round trip is what drops a tab, CR or LF.
     try:
         if absolute is None:
-            absolute = urljoin(base_url, href_no_frag)
-        url = _normalized_url(absolute)
+            url = _joined_url(base_url, href_no_frag)
+        else:
+            url = _normalized_url(absolute)
         parsed = urlparse(url)
         page = urlparse(base_url)
     except ValueError:
@@ -358,7 +359,7 @@ def _resolve_local_link(
     if parsed.scheme in {"http", "https"}:
         return _Link(unquote(last_segment), url, None, hashes)
 
-    # Drop an anchor naming no local file rather than fail the whole listing.
+    # Distinguish an unusable release link from a non-package link.
     try:
         path = _parsed_file_url_path(parsed, url)
     except ValueError:
@@ -371,6 +372,17 @@ def _resolve_local_link(
         )
 
     return _Link(path.name, url, path, hashes)
+
+
+def _joined_url(base_url: str, href: str) -> str:
+    """Resolve and normalize a link while preserving a ``//`` path root."""
+    if not href.startswith("////"):
+        return _normalized_url(urljoin(base_url, href))
+
+    # Some urljoin versions discard the empty authority before a // path.
+    escaped_path = f"/%2F{href[4:]}"
+    joined = _normalized_url(urljoin(base_url, f"//{escaped_path}"))
+    return joined.replace("/%2F", "//", 1)
 
 
 # A mirror href climbs out of the package directory to the shared packages

--- a/nab-project/tests/test_local_index.py
+++ b/nab-project/tests/test_local_index.py
@@ -8,10 +8,12 @@ import io
 import struct
 import sys
 import tarfile
+import urllib.request
 import zipfile
 import zlib
 from pathlib import Path
 from typing import TYPE_CHECKING, TypeVar
+from urllib.parse import unquote, urlsplit
 
 import pytest
 
@@ -364,6 +366,46 @@ class TestErrorHierarchy:
         assert issubclass(HttpError, IndexAccessError)
 
 
+def _url2pathname_with_authority(url: str) -> str:
+    """``url2pathname`` as Python 3.14 defines it off Windows.
+
+    It resolves an authority out of its argument and rejects a non-local one.
+    """
+    _, authority, path = urlsplit("file:" + url)[:3]
+    if authority not in ("", "localhost"):
+        msg = f"file:// scheme is supported only on localhost: {authority!r}"
+        raise OSError(msg)
+    return unquote(path)
+
+
+def _url2pathname_on_windows(url: str) -> str:
+    """Python 3.14's Windows ``url2pathname``, cut down to the drive rule.
+
+    It reads the authority of ``//C:/tmp`` as a drive rather than a host.
+    No other clause is modelled, since only this one is under test.
+    """
+    _, authority, path = urlsplit("file:" + url)[:3]
+    if authority[1:2] == ":":
+        path = authority + path
+    return unquote(path.replace("/", "\\"))
+
+
+@pytest.fixture(params=["stdlib", "authority"])
+def url2pathname_contract(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Run the test against the installed ``url2pathname`` and against 3.14's.
+
+    What ``url2pathname`` does with an authority in its argument changed in
+    3.12 and again in 3.14, so one interpreter's version does not stand in
+    for the rest.
+    """
+    if request.param == "authority":
+        monkeypatch.setattr(
+            urllib.request, "url2pathname", _url2pathname_with_authority
+        )
+
+
 class TestParseFileUrl:
     def test_absolute_path(self, tmp_path: Path) -> None:
         url = tmp_path.as_uri()
@@ -390,6 +432,54 @@ class TestParseFileUrl:
         # RFC 8089: a "localhost" authority resolves like an empty one.
         with_host = tmp_path.as_uri().replace("file://", "file://localhost", 1)
         assert parse_file_url(with_host) == tmp_path
+
+    def test_double_slash_root_survives_an_empty_authority(
+        self, url2pathname_contract: None
+    ) -> None:
+        # pathlib keeps a "//" root on POSIX, and Path.as_uri writes four slashes.
+        url = "file:////srv/wheels/foo-1.0-py3-none-any.whl"
+        assert parse_file_url(url) == Path("//srv/wheels/foo-1.0-py3-none-any.whl")
+
+    def test_double_slash_root_keeps_a_localhost_first_segment(
+        self, url2pathname_contract: None
+    ) -> None:
+        url = "file:////localhost/srv/wheels"
+        assert parse_file_url(url) == Path("//localhost/srv/wheels")
+
+    def test_localhost_authority_keeps_a_double_slash_root(
+        self, url2pathname_contract: None
+    ) -> None:
+        url = "file://localhost//srv/wheels"
+        assert parse_file_url(url) == Path("//srv/wheels")
+
+    def test_drive_root_stays_a_drive_on_windows(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Windows reads ``C:`` in a ``//C:`` root as a drive, so it is not escaped."""
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(urllib.request, "url2pathname", _url2pathname_on_windows)
+        assert parse_file_url("file:////C:/tmp/x.whl") == Path("C:\\tmp\\x.whl")
+
+    def test_drive_shaped_root_is_a_root_off_windows(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Off Windows ``C:`` is an ordinary first segment, not a drive."""
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.setattr(
+            urllib.request, "url2pathname", _url2pathname_with_authority
+        )
+        assert parse_file_url("file:////C:/tmp/x.whl") == Path("//C:/tmp/x.whl")
+
+    def test_url2pathname_failure_is_a_value_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def reject(_url: str) -> str:
+            msg = "Bad URL"
+            raise OSError(msg)
+
+        monkeypatch.setattr(urllib.request, "url2pathname", reject)
+        with pytest.raises(ValueError, match="does not name a path"):
+            parse_file_url("file:///srv/wheels")
 
     def test_remote_authority_rejected_off_windows(
         self, monkeypatch: pytest.MonkeyPatch
@@ -998,6 +1088,19 @@ class TestPep503Directory:
         assert result[0].url.endswith("foo-1.0-py3-none-any.whl")
         assert (
             result[0].local_path == package_dir.resolve() / "foo-1.0-py3-none-any.whl"
+        )
+
+    def test_network_path_href_keeps_its_double_slash_root(
+        self, tmp_path: Path
+    ) -> None:
+        """The record's local path names the file its URL names."""
+        body = '<a href="////localhost/packages/foo-1.0-py3-none-any.whl">foo</a>'
+        self._make_index(tmp_path, body)
+        client = LocalIndexClient(tmp_path.as_uri())
+        result = run(client.get_files("foo"))
+        assert result[0].url == "file:////localhost/packages/foo-1.0-py3-none-any.whl"
+        assert result[0].local_path == Path(
+            "//localhost/packages/foo-1.0-py3-none-any.whl"
         )
 
     def test_relative_href_resolves_outside_package_dir(self, tmp_path: Path) -> None:

--- a/nab-project/tests/test_local_index.py
+++ b/nab-project/tests/test_local_index.py
@@ -13,10 +13,11 @@ import zipfile
 import zlib
 from pathlib import Path
 from typing import TYPE_CHECKING, TypeVar
-from urllib.parse import unquote, urlsplit
+from urllib.parse import unquote, urljoin, urlsplit
 
 import pytest
 
+from nab_index import local_index
 from nab_index.client import SdistFile, WheelFile, zip_sdist_version
 from nab_index.local_index import (
     LocalIndexClient,
@@ -367,10 +368,7 @@ class TestErrorHierarchy:
 
 
 def _url2pathname_with_authority(url: str) -> str:
-    """``url2pathname`` as Python 3.14 defines it off Windows.
-
-    It resolves an authority out of its argument and rejects a non-local one.
-    """
+    """Model Python 3.14's non-Windows file-URL authority handling."""
     _, authority, path = urlsplit("file:" + url)[:3]
     if authority not in ("", "localhost"):
         msg = f"file:// scheme is supported only on localhost: {authority!r}"
@@ -379,27 +377,38 @@ def _url2pathname_with_authority(url: str) -> str:
 
 
 def _url2pathname_on_windows(url: str) -> str:
-    """Python 3.14's Windows ``url2pathname``, cut down to the drive rule.
-
-    It reads the authority of ``//C:/tmp`` as a drive rather than a host.
-    No other clause is modelled, since only this one is under test.
-    """
+    """Model Python 3.14's Windows drive-prefix handling."""
     _, authority, path = urlsplit("file:" + url)[:3]
     if authority[1:2] == ":":
         path = authority + path
     return unquote(path.replace("/", "\\"))
 
 
+def _urljoin_dropping_an_empty_authority(base: str, href: str) -> str:
+    """Model loss of an empty authority for the root-path examples."""
+    joined = urljoin(base, href)
+    scheme, netloc, path, _, _ = urlsplit(joined)
+    if netloc or not path.startswith("//"):
+        return joined
+    return f"{scheme}:{path}"
+
+
+@pytest.fixture(params=["stdlib", "collapsing"])
+def urljoin_contract(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Exercise installed urljoin and the variant that drops an empty authority."""
+    if request.param == "collapsing":
+        monkeypatch.setattr(
+            local_index, "urljoin", _urljoin_dropping_an_empty_authority
+        )
+
+
 @pytest.fixture(params=["stdlib", "authority"])
 def url2pathname_contract(
     request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Run the test against the installed ``url2pathname`` and against 3.14's.
-
-    What ``url2pathname`` does with an authority in its argument changed in
-    3.12 and again in 3.14, so one interpreter's version does not stand in
-    for the rest.
-    """
+    """Exercise installed and Python 3.14 authority handling."""
     if request.param == "authority":
         monkeypatch.setattr(
             urllib.request, "url2pathname", _url2pathname_with_authority
@@ -1091,9 +1100,9 @@ class TestPep503Directory:
         )
 
     def test_network_path_href_keeps_its_double_slash_root(
-        self, tmp_path: Path
+        self, tmp_path: Path, urljoin_contract: None
     ) -> None:
-        """The record's local path names the file its URL names."""
+        """The parsed link preserves matching URL and local path."""
         body = '<a href="////localhost/packages/foo-1.0-py3-none-any.whl">foo</a>'
         self._make_index(tmp_path, body)
         client = LocalIndexClient(tmp_path.as_uri())


### PR DESCRIPTION
File URLs with a `//` path root could lose their first segment or fail an entire local package listing, depending on the Python version. Preserve that root through URL decoding and HTML link resolution.

On POSIX, these URLs retain their paths:

| URL | Path |
| --- | --- |
| `file:////srv/wheels` | `//srv/wheels` |
| `file:////localhost/srv/wheels` | `//localhost/srv/wheels` |
| `file://localhost//srv/wheels` | `//srv/wheels` |

Windows drive prefixes such as `//C:/tmp` reach the decoder unescaped. Decoder `OSError`s become `ValueError`s, which the local-index reader records as an unusable link.
