### PR TITLE
Stop reading an HTML page of unreachable links as a missing package

### DIFF
--- a/nab-index/src/nab_index/_pep503.py
+++ b/nab-index/src/nab_index/_pep503.py
@@ -87,14 +87,22 @@ def _file_entry(anchor: Anchor, base_url: str) -> dict[str, object] | None:
     """Render one anchor as a PEP 691 file entry, or ``None`` if it names no file.
 
     An href with a malformed authority (an unterminated IPv6 bracket) makes
-    both the join and the split raise, so it is dropped like an href that
-    names no file rather than failing the whole listing.
+    both the join and the split raise. The entry is kept, with the href
+    unresolved, when the last segment names a wheel or ``.tar.gz`` sdist,
+    since this body is the only record that the page offered that release.
     """
     try:
         url, _, fragment = urljoin(base_url, anchor.href).partition("#")
         filename = unquote(urlsplit(url).path.rsplit("/", 1)[-1])
     except ValueError:
-        return None
+        # Deferred because nab_index.client imports this module.
+        from .client import is_readable_filename  # noqa: PLC0415
+
+        url, _, fragment = anchor.href.partition("#")
+        filename = unquote(url.rsplit("/", 1)[-1])
+        if not is_readable_filename(filename):
+            return None
+
     if not filename:
         return None
 
@@ -123,12 +131,13 @@ def json_listing(text: str, page_url: str) -> bytes:
 
     Hrefs are resolved here, against the page's ``<base href>`` when it has
     one and otherwise against ``page_url``, so the cached body stands on its
-    own.
+    own. An href whose own authority cannot be parsed is kept unresolved
+    instead; see :func:`_file_entry`.
 
     Raises :class:`ValueError` when the page's ``<base href>`` cannot be
     parsed. Every relative anchor resolves against it, so the whole page's
     targets are unknown; the caller maps this to its own malformed-listing
-    error. A single unparseable anchor is dropped instead.
+    error. A single unparseable anchor does not raise.
 
     Also raises :class:`ValueError` for a page carrying neither a link nor
     the :pep:`629` ``pypi:repository-version`` marker, since nothing in it

--- a/nab-project/tests/test_cached_client.py
+++ b/nab-project/tests/test_cached_client.py
@@ -2661,6 +2661,26 @@ class TestHtmlListing:
 
         return (asyncio.run(go()), transport)
 
+    def _fetch_with_mark(self, cache: OnDiskCache, body: bytes) -> tuple[list, bool]:
+        """Return ``torch``'s records and whether its page was marked unreachable.
+
+        The mark is per-client state, so it is read while the client that
+        made the call is still alive.
+        """
+        transport = _FakeTransport(
+            [_FakeResponse(body, headers={"content-type": "text/html"})]
+        )
+
+        async def go() -> tuple[list, bool]:
+            client = CachedAsyncSimpleClient(transport, cache, self._INDEX)
+            try:
+                files = await client.get_files("torch")
+            finally:
+                await client.aclose()
+            return files, client.served_unreachable_only("torch")
+
+        return asyncio.run(go())
+
     def test_pep503_page_is_read(self, tmp_path: Path) -> None:
         files, _ = self._fetch(_make_cache(tmp_path), self._PAGE, "text/html")
         (wheel,) = files
@@ -2732,6 +2752,45 @@ class TestHtmlListing:
         )
         files, _ = self._fetch(_make_cache(tmp_path), page, "text/html")
         assert [f.filename for f in files] == ["torch-2.7.0-py3-none-any.whl"]
+
+    def test_malformed_ipv6_wheel_href_is_kept_unresolved(self, tmp_path: Path) -> None:
+        # The converted body is the only record of what the page offered, so
+        # dropping the anchor here loses it on every later read of the cache.
+        page = b'<a href="https://[::1/torch-2.7.0-py3-none-any.whl">torch</a>'
+        cache = _make_cache(tmp_path)
+
+        files, unreachable_only = self._fetch_with_mark(cache, page)
+
+        assert files == []
+        assert unreachable_only
+        cached = cache.get_simple("torch")
+        assert cached is not None
+        assert json.loads(cached[0]) == {
+            "files": [
+                {
+                    "filename": "torch-2.7.0-py3-none-any.whl",
+                    "url": "https://[::1/torch-2.7.0-py3-none-any.whl",
+                }
+            ]
+        }
+
+    def test_malformed_href_naming_no_distribution_is_dropped(
+        self, tmp_path: Path
+    ) -> None:
+        # The last segment of an href that will not parse is a filename only
+        # when it names a wheel or a .tar.gz sdist; anything else is a
+        # navigation link the page never offered as a release.
+        cache = _make_cache(tmp_path)
+
+        files, unreachable_only = self._fetch_with_mark(
+            cache, b'<a href="http://[bad">bad</a>'
+        )
+
+        assert files == []
+        assert not unreachable_only
+        cached = cache.get_simple("torch")
+        assert cached is not None
+        assert json.loads(cached[0]) == {"files": []}
 
     def test_href_wrapped_in_whitespace_is_read(self, tmp_path: Path) -> None:
         # HTML allows a URL attribute's value to be surrounded by whitespace.

--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -2009,6 +2009,34 @@ class TestNoVersionsReasons:
             "the index lists this package but nab cannot reach any of its links"
         )
 
+    @respx.mock
+    def test_remote_html_page_of_unreachable_links_names_the_links(
+        self, tmp_path: Path
+    ) -> None:
+        """A page served as HTML reads like the same page served as JSON.
+
+        The wheel sits behind a URL with an unterminated IPv6 bracket, so
+        the conversion to JSON has to keep the anchor for the page to read
+        as unreachable rather than absent.
+        """
+        respx.get(f"{DEFAULT_INDEX_URL}foo/").mock(
+            return_value=httpx.Response(
+                200,
+                headers={"content-type": "text/html"},
+                text='<a href="https://[::1/foo-1.0-py3-none-any.whl">foo-1.0</a>',
+            )
+        )
+
+        with FetchCoordinator(
+            transport=HttpxAsyncTransport(), cache_dir=tmp_path
+        ) as coordinator:
+            provider = Provider(coordinator)
+            provider.choose_version("foo", SpecifierSet("").to_range())
+
+        assert rendered_reason(provider, "foo") == (
+            "the index lists this package but nab cannot reach any of its links"
+        )
+
     def test_remote_page_naming_another_project_is_not_absence(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
The same project page reads two ways. A wheel behind a URL with an unterminated IPv6 bracket, served as `text/html`, reports:

    package not found on any configured index

and the identical file entry served as PEP 691 JSON reports:

    the index lists this package but nab cannot reach any of its links

`json_listing` converts an HTML page into the JSON body nab caches, and an href whose authority will not parse makes both `urljoin` and `urlsplit` raise. The anchor was dropped, so the body became `{"files": []}`, indistinguishable from a page that lists nothing. The cache keeps that body, so the release stays missing on every later read.

The entry is now kept with its href unresolved when the last segment names a wheel or a `.tar.gz` sdist, the check `local_index._resolve_local_link` already makes when a local index page's href will not parse. Anything else stays dropped, so a malformed navigation link does not make the page read as unreachable.
