### PR TITLE
Reuse the kept pair in the wheel-tag pass, ~6% off legacy-36-root-stress

### DIFF
--- a/nab-provider/src/nab_provider/_provider/listing.py
+++ b/nab-provider/src/nab_provider/_provider/listing.py
@@ -660,9 +660,10 @@ def _apply_wheel_tags(
     run_version: Version | None = None
     run_length = 0
 
-    for version, dist in base:
+    for pair in base:
+        version, dist = pair  # a kept pair is appended as-is, not rebuilt
         if not excluded_by_wheel_tags(dist, tags):
-            result.append((version, dist))
+            result.append(pair)
             continue
 
         if release_refused:


### PR DESCRIPTION
Locally `universal:legacy-36-root-stress` runs between about 4% and 11% faster, with a middle estimate near 6%. Under callgrind the same scenario retires 152,967,868 fewer instructions of 6,577,267,189, or 2.3%, and 147,845,418 fewer on a repeat.

`_apply_wheel_tags` unpacked each `(version, dist)` pair to test the wheel's tags, then built a fresh tuple for the ones it kept. Appending the pair it already has removes 42,434 tuples on that scenario, out of 159,362 pairs walked over 174 calls.

Nearly all of that saving is collection work rather than allocation: with the garbage collector disabled the same runs save between 7.7 and 10.3 million instructions instead of about 150 million. Collections fall from about 373/33/3 to 319/28/2 across the three generations, and peak traced bytes from 110.7 MB to 109.9 MB.

Instruction counts on the other three scenarios measured fall less: 0.37% on `universal:max-25-tuples`, 0.30% on `pip:google-bigquery-soda@lowest`, 0.13% on `universal:scientific-python-multi`. Across the 19-scenario canary set the timing runs rule out a wall regression above about 2.8% and cannot see anything smaller. Decisions are identical on all three universal scenarios.
