### PR TITLE
Hand-write the two override value types, 1.2% off an offline `nab lock`

### DIFF
--- a/nab-project/src/nab_project/_build/env.py
+++ b/nab-project/src/nab_project/_build/env.py
@@ -756,7 +756,7 @@ def _without_build_permission(override: _OverrideT) -> _OverrideT:
     """
     if override.build_policy in (None, BuildPolicy.NEVER):
         return override
-    return replace(override, build_policy=None)
+    return override.replace(build_policy=None)
 
 
 def _inner_resolve_inputs(inputs: ResolveInputs) -> ResolveInputs:

--- a/nab-provider/src/nab_provider/_value.py
+++ b/nab-provider/src/nab_provider/_value.py
@@ -1,9 +1,9 @@
-"""The shared base under the package's declared-source value types.
+"""The shared base under this package's hand-written value types.
 
-Those types are written out by hand instead of declared with
-``@dataclass(slots=True)``, because applying the decorator is import-time work
-every ``nab`` invocation pays for.  The comparison, hash and repr all eight
-share live here; each type declares its own fields and constructor.
+They are written out instead of declared with ``@dataclass(slots=True)``,
+because applying the decorator is import-time work every ``nab`` invocation
+pays for.  The comparison, hash and repr they share live here; each type
+declares its own fields and constructor.
 """
 
 from __future__ import annotations
@@ -16,7 +16,7 @@ __all__ = ["SlottedValue"]
 class SlottedValue:
     """Comparison, hashing and repr over a subclass's declared fields.
 
-    A subclass lists its fields in ``__slots__`` and repeats them, in
+    A subclass lists its fields in ``__slots__`` and names them, in
     declaration order, in ``__match_args__``, which is the order read here.
     Comparison tests the exact class, so a subclass holding equal field
     values is not equal.

--- a/nab-provider/src/nab_provider/overrides.py
+++ b/nab-provider/src/nab_provider/overrides.py
@@ -6,8 +6,10 @@ them; they live here.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
+
+from ._compat import override
+from ._value import SlottedValue
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -20,13 +22,13 @@ if TYPE_CHECKING:
 __all__ = ["IndexOverride", "PackageOverride"]
 
 
-@dataclass(frozen=True, slots=True)
-class PackageOverride:
+class PackageOverride(SlottedValue):
     """One per-package override: a requirement plus a body.
 
     Built from either ``[tool.nab.packages.<name>]`` (the name-keyed sugar
     table, which sets ``name_keyed``) or a ``[[tool.nab.package-rules]]``
     entry (one body across the requirements in its ``match`` selector).
+    TOML admits that table only once per name.
 
     The selector is a single PEP 508 ``requirement`` (name plus an optional
     version specifier; no extras, marker, or URL); ``name`` is its canonical
@@ -44,32 +46,95 @@ class PackageOverride:
     the distribution over the matched version range (uv ``dependency-metadata``
     parity).  ``None`` means the entry does not set the field; an empty value
     (``()`` for the two tuples) means "replace with nothing".
+
+    ``source_label`` is the config surface the entry was declared on (e.g.
+    ``packages.'numpy'`` or ``package-rules[0]``).
     """
 
-    requirement: Requirement
-    name: str
-    version_range: VersionRange
-    dist_policy: DistPolicy | None = None
-    dist_trust_unverified_deps: bool | None = None
-    build_policy: BuildPolicy | None = None
-    uploaded_prior_to: datetime | None = None
-    uploaded_prior_to_disabled: bool = False
-    index: str | None = None
-    dependencies: tuple[Requirement, ...] | None = None
-    requires_python: str | None = None
-    provides_extra: tuple[str, ...] | None = None
-    # Whether the entry is a table keyed by this selector, which a second
-    # entry under the same key cannot be declared beside.
-    name_keyed: bool = False
-    # The config surface this entry was declared on (e.g. "packages.'numpy'"
-    # or "package-rules[0]").  Only used to name the source in an error that
-    # is raised after the two project files merge, so it is excluded from
-    # equality.
-    source_label: str = field(default="", compare=False)
+    __slots__ = __match_args__ = (
+        "requirement",
+        "name",
+        "version_range",
+        "dist_policy",
+        "dist_trust_unverified_deps",
+        "build_policy",
+        "uploaded_prior_to",
+        "uploaded_prior_to_disabled",
+        "index",
+        "dependencies",
+        "requires_python",
+        "provides_extra",
+        "name_keyed",
+        "source_label",
+    )
+
+    # ``source_label`` records where an entry was written rather than what it
+    # declares, so it sits last and stays out of comparison and hashing.
+    _COMPARED = __match_args__[:-1]
+
+    def __init__(  # noqa: PLR0913 - one keyword per key an entry's body may set
+        self,
+        *,
+        requirement: Requirement,
+        name: str,
+        version_range: VersionRange,
+        dist_policy: DistPolicy | None = None,
+        dist_trust_unverified_deps: bool | None = None,
+        build_policy: BuildPolicy | None = None,
+        uploaded_prior_to: datetime | None = None,
+        uploaded_prior_to_disabled: bool = False,
+        index: str | None = None,
+        dependencies: tuple[Requirement, ...] | None = None,
+        requires_python: str | None = None,
+        provides_extra: tuple[str, ...] | None = None,
+        name_keyed: bool = False,
+        source_label: str = "",
+    ) -> None:
+        """Record one entry's selector and the body it declares."""
+        self.requirement = requirement
+        self.name = name
+        self.version_range = version_range
+
+        self.dist_policy = dist_policy
+        self.dist_trust_unverified_deps = dist_trust_unverified_deps
+        self.build_policy = build_policy
+        self.uploaded_prior_to = uploaded_prior_to
+        self.uploaded_prior_to_disabled = uploaded_prior_to_disabled
+        self.index = index
+
+        self.dependencies = dependencies
+        self.requires_python = requires_python
+        self.provides_extra = provides_extra
+
+        self.name_keyed = name_keyed
+        self.source_label = source_label
+
+    @override
+    def __eq__(self, other: object) -> bool:
+        """Compare every field but ``source_label``."""
+        if other.__class__ is not self.__class__:
+            return NotImplemented
+
+        names = self._COMPARED
+        return tuple(getattr(self, name) for name in names) == tuple(
+            getattr(other, name) for name in names
+        )
+
+    @override
+    def __hash__(self) -> int:
+        """Hash every field but ``source_label``."""
+        return hash(tuple(getattr(self, name) for name in self._COMPARED))
+
+    def replace(self, **changes: object) -> PackageOverride:
+        """Return a copy with ``changes`` applied, as ``dataclasses.replace`` would."""
+        kept: dict[str, Any] = {
+            name: getattr(self, name) for name in self.__match_args__
+        }
+        kept.update(changes)
+        return PackageOverride(**kept)
 
 
-@dataclass(frozen=True, slots=True)
-class IndexOverride:
+class IndexOverride(SlottedValue):
     """One ``[tool.nab.index.<name>]`` entry: policy for an index.
 
     Keyed by a declared index name and applied to every package served from
@@ -78,9 +143,37 @@ class IndexOverride:
     Simple listing.
     """
 
-    dist_policy: DistPolicy | None = None
-    dist_trust_unverified_deps: bool | None = None
-    build_policy: BuildPolicy | None = None
-    uploaded_prior_to: datetime | None = None
-    uploaded_prior_to_disabled: bool = False
-    assume_fresh_seconds: int | None = None
+    __slots__ = __match_args__ = (
+        "dist_policy",
+        "dist_trust_unverified_deps",
+        "build_policy",
+        "uploaded_prior_to",
+        "uploaded_prior_to_disabled",
+        "assume_fresh_seconds",
+    )
+
+    def __init__(
+        self,
+        *,
+        dist_policy: DistPolicy | None = None,
+        dist_trust_unverified_deps: bool | None = None,
+        build_policy: BuildPolicy | None = None,
+        uploaded_prior_to: datetime | None = None,
+        uploaded_prior_to_disabled: bool = False,
+        assume_fresh_seconds: int | None = None,
+    ) -> None:
+        """Record the policy declared for one index."""
+        self.dist_policy = dist_policy
+        self.dist_trust_unverified_deps = dist_trust_unverified_deps
+        self.build_policy = build_policy
+        self.uploaded_prior_to = uploaded_prior_to
+        self.uploaded_prior_to_disabled = uploaded_prior_to_disabled
+        self.assume_fresh_seconds = assume_fresh_seconds
+
+    def replace(self, **changes: object) -> IndexOverride:
+        """Return a copy with ``changes`` applied, as ``dataclasses.replace`` would."""
+        kept: dict[str, Any] = {
+            name: getattr(self, name) for name in self.__match_args__
+        }
+        kept.update(changes)
+        return IndexOverride(**kept)

--- a/nab-provider/tests/test_source_value_types.py
+++ b/nab-provider/tests/test_source_value_types.py
@@ -1,10 +1,10 @@
-"""What the declared-source value types promise.
+"""What this package's hand-written value types promise.
 
-Each names its fields three times, in ``__slots__``, in ``__match_args__`` and
-in its own constructor, and :class:`SlottedValue` reads ``__match_args__`` for
-comparison, hashing and repr.  A field missing from one of the three is
-otherwise silent.  The cases below drive every field of every type through all
-of them, and through the defaults, copying and pickling.
+Each names its fields in ``__slots__``, in ``__match_args__`` and in its own
+constructor, and :class:`SlottedValue` reads ``__match_args__`` for comparison,
+hashing and repr.  A field missing from one of those is otherwise silent.  The
+cases below drive every field of every type through all of them, and through
+the defaults, copying and pickling.
 """
 
 from __future__ import annotations
@@ -13,18 +13,22 @@ import copy
 import dataclasses
 import inspect
 import pickle
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, NamedTuple
 
 import pytest
 
 from nab_provider._value import SlottedValue
+from nab_provider._vendor.packaging.requirements import Requirement
 from nab_provider._vendor.packaging.version import Version
 from nab_provider.archive import ArchiveRequest
 from nab_provider.metadata import WheelMetadata
+from nab_provider.overrides import IndexOverride, PackageOverride
 from nab_provider.policy import (
     ArchiveSource,
     BuildPolicy,
+    DistPolicy,
     LocalSource,
     SourceMaterialization,
     SourceRequest,
@@ -39,6 +43,11 @@ OTHER_SHA = "1" * 40
 METADATA = WheelMetadata(name="pkg", version=Version("1.0"))
 OTHER_METADATA = WheelMetadata(name="other", version=Version("2.0"))
 
+SELECTOR = Requirement("pkg>=1")
+OTHER_SELECTOR = Requirement("other<2")
+CUTOFF = datetime(2026, 1, 1, tzinfo=timezone.utc)
+LATER_CUTOFF = datetime(2026, 2, 1, tzinfo=timezone.utc)
+
 
 class Case(NamedTuple):
     """One value type and the field values the tests drive it through.
@@ -46,7 +55,9 @@ class Case(NamedTuple):
     ``alt`` differs from ``base`` in every field, so varying one field at a
     time reaches a field that a comparison or a hash left out.  ``defaults``
     is every constructor parameter that carries one, and ``keyword_only``
-    every one a caller cannot pass positionally.
+    every one a caller cannot pass positionally.  ``uncompared`` names the
+    fields the comparison and the hash skip, and ``rebuildable`` is False
+    where a field value refuses to be deep-copied or pickled.
     """
 
     cls: type[SlottedValue]
@@ -55,6 +66,8 @@ class Case(NamedTuple):
     defaults: dict[str, Any]
     keyword_only: frozenset[str] = frozenset()
     hashable: bool = True
+    uncompared: frozenset[str] = frozenset()
+    rebuildable: bool = True
 
 
 CASES = [
@@ -123,6 +136,85 @@ CASES = [
         ("https://e/y.tar.gz", (("sha512", "cd"),), "sub"),
         {"subdirectory": ""},
     ),
+    Case(
+        PackageOverride,
+        (
+            SELECTOR,
+            "pkg",
+            SELECTOR.specifier.to_range(),
+            DistPolicy.WHEEL_ONLY,
+            False,
+            BuildPolicy.NEVER,
+            CUTOFF,
+            False,
+            "private",
+            (Requirement("dep"),),
+            ">=3.10",
+            ("cpu",),
+            False,
+            "packages.'pkg'",
+        ),
+        (
+            OTHER_SELECTOR,
+            "other",
+            OTHER_SELECTOR.specifier.to_range(),
+            DistPolicy.SDIST_ONLY,
+            True,
+            BuildPolicy.BUILD_REMOTE,
+            LATER_CUTOFF,
+            True,
+            "public",
+            (Requirement("other-dep"),),
+            ">=3.11",
+            ("gpu",),
+            True,
+            "package-rules[0]",
+        ),
+        {
+            "dist_policy": None,
+            "dist_trust_unverified_deps": None,
+            "build_policy": None,
+            "uploaded_prior_to": None,
+            "uploaded_prior_to_disabled": False,
+            "index": None,
+            "dependencies": None,
+            "requires_python": None,
+            "provides_extra": None,
+            "name_keyed": False,
+            "source_label": "",
+        },
+        keyword_only=frozenset(PackageOverride.__match_args__),
+        uncompared=frozenset({"source_label"}),
+        rebuildable=False,
+    ),
+    Case(
+        IndexOverride,
+        (
+            DistPolicy.WHEEL_ONLY,
+            False,
+            BuildPolicy.NEVER,
+            CUTOFF,
+            False,
+            3600,
+        ),
+        (
+            DistPolicy.SDIST_ONLY,
+            True,
+            BuildPolicy.BUILD_REMOTE,
+            LATER_CUTOFF,
+            True,
+            60,
+        ),
+        {
+            "dist_policy": None,
+            "dist_trust_unverified_deps": None,
+            "build_policy": None,
+            "uploaded_prior_to": None,
+            "uploaded_prior_to_disabled": False,
+            "assume_fresh_seconds": None,
+        },
+        keyword_only=frozenset(IndexOverride.__match_args__),
+    ),
 ]
 
 VALUE_TYPES = [pytest.param(case, id=case.cls.__name__) for case in CASES]
@@ -146,6 +238,15 @@ def _vary(base: tuple[Any, ...], alt: tuple[Any, ...], index: int) -> tuple[Any,
     return (*base[:index], alt[index], *base[index + 1 :])
 
 
+def _compared(case: Case, values: tuple[Any, ...]) -> tuple[Any, ...]:
+    """Return ``values`` less the fields the comparison and the hash skip."""
+    return tuple(
+        value
+        for name, value in zip(case.cls.__match_args__, values, strict=True)
+        if name not in case.uncompared
+    )
+
+
 @pytest.mark.parametrize("case", VALUE_TYPES)
 def test_init_takes_the_declared_fields_in_order(case: Case) -> None:
     parameters = inspect.signature(case.cls.__init__).parameters
@@ -163,7 +264,6 @@ def test_init_takes_the_declared_fields_in_order(case: Case) -> None:
 
 @pytest.mark.parametrize("case", VALUE_TYPES)
 def test_the_fields_a_caller_must_name_are_the_expected_ones(case: Case) -> None:
-    """Pins the keyword-only set, which is where both boolean fields sit."""
     parameters = inspect.signature(case.cls.__init__).parameters
     keyword_only = {
         name
@@ -187,12 +287,16 @@ def test_init_carries_exactly_the_expected_defaults(case: Case) -> None:
 
 
 @pytest.mark.parametrize("case", VALUE_TYPES)
-def test_equality_reads_every_field(case: Case) -> None:
+def test_equality_reads_every_compared_field(case: Case) -> None:
+    """Two values differing only in a skipped field are still equal."""
     assert _build(case, case.base) == _build(case, case.base)
 
-    for index in range(len(case.base)):
+    for index, name in enumerate(case.cls.__match_args__):
         varied = _build(case, _vary(case.base, case.alt, index))
-        assert _build(case, case.base) != varied, case.cls.__match_args__[index]
+        if name in case.uncompared:
+            assert _build(case, case.base) == varied, name
+        else:
+            assert _build(case, case.base) != varied, name
 
 
 @pytest.mark.parametrize("case", VALUE_TYPES)
@@ -211,7 +315,7 @@ def test_equality_rejects_a_subclass_holding_the_same_values(case: Case) -> None
 
 
 @pytest.mark.parametrize("case", VALUE_TYPES)
-def test_hash_is_the_field_tuple(case: Case) -> None:
+def test_hash_is_the_compared_field_tuple(case: Case) -> None:
     instance = _build(case, case.base)
     if not case.hashable:
         # One field is itself unhashable, so hashing the field tuple raises.
@@ -219,11 +323,15 @@ def test_hash_is_the_field_tuple(case: Case) -> None:
             hash(instance)
         return
 
-    assert hash(instance) == hash(case.base)
+    assert hash(instance) == hash(_compared(case, case.base))
     assert len({instance, _build(case, case.base)}) == 1
 
-    for index in range(len(case.base)):
-        assert hash(instance) != hash(_build(case, _vary(case.base, case.alt, index)))
+    for index, name in enumerate(case.cls.__match_args__):
+        varied = hash(_build(case, _vary(case.base, case.alt, index)))
+        if name in case.uncompared:
+            assert hash(instance) == varied, name
+        else:
+            assert hash(instance) != varied, name
 
 
 @pytest.mark.parametrize("case", VALUE_TYPES)
@@ -251,18 +359,25 @@ def test_a_write_reaches_only_a_declared_field(case: Case) -> None:
     assert tuple(sorted(case.cls.__match_args__)) == tuple(sorted(case.cls.__slots__))
 
 
-@pytest.mark.parametrize("clone", [copy.copy, copy.deepcopy])
 @pytest.mark.parametrize("case", VALUE_TYPES)
-def test_copying_restores_every_field(case: Case, clone: Any) -> None:
+def test_a_shallow_copy_restores_every_field(case: Case) -> None:
     instance = _build(case, case.base)
 
-    assert clone(instance) == instance
+    assert copy.copy(instance) == instance
 
 
 @pytest.mark.parametrize("case", VALUE_TYPES)
-def test_pickling_restores_every_field(case: Case) -> None:
+def test_deep_copying_and_pickling_restore_every_field(case: Case) -> None:
+    """Both rebuild every field value, which the vendored ``VersionRange`` refuses."""
     instance = _build(case, case.base)
+    if not case.rebuildable:
+        with pytest.raises(TypeError):
+            copy.deepcopy(instance)
+        with pytest.raises(TypeError):
+            pickle.loads(pickle.dumps(instance))  # noqa: S301
+        return
 
+    assert copy.deepcopy(instance) == instance
     assert pickle.loads(pickle.dumps(instance)) == instance  # noqa: S301
 
 


### PR DESCRIPTION
An offline `nab lock` over a five-package project retires about 10.3 million fewer instructions, 1.2% of the roughly 859 million it costs on main. A bare `import nab._lock` sheds about the same, 1.76% of its 587 million, so the work removed is at import rather than per package.

`PackageOverride` and `IndexOverride` were `@dataclass(frozen=True, slots=True)`, and applying that decorator to a 14-field and a 6-field class runs at import. They now subclass `nab_provider._value.SlottedValue`, as the package's eight other value types already do, each with its own `__slots__`/`__match_args__`, a keyword-only `__init__` and a `replace()`. `PackageOverride` keeps `source_label` out of `__eq__` and `__hash__`, as `field(compare=False)` did.

Peak traced bytes fall about 0.2% on the import and 0.1% on the lock, with the same GC collection counts.

CPU on that lock run is between about 0.7% and 1.8% lower locally, with a middle estimate near 1.1%. The clock cannot see an effect this size: those runs rule out a wall regression above about 2.4%, and the 19-scenario canary set above about 1%.

The constructors are keyword-only, and every call site already passed by keyword. `frozen=True` is gone to match the rest; nothing assigns to an override or keys a dict with one.
