### PR TITLE
Keep a refused pre-release's filter and remedy when a final is refused too

### DIFF
--- a/nab-provider/src/nab_provider/_provider/listing_diagnosis.py
+++ b/nab-provider/src/nab_provider/_provider/listing_diagnosis.py
@@ -696,7 +696,11 @@ def in_range_diagnostic(
         for record in diagnosis.dropped
         if record.version is not None and record.version not in diagnosis.kept
     ]
-    in_range = set(version_range.filter({record.version for record in named}))
+    # Every version here was refused, so PEP 440's default of yielding a
+    # pre-release only when no final matched would leave its filter unnamed.
+    in_range = set(
+        version_range.filter({record.version for record in named}, prereleases=True)
+    )
     asked = [record for record in named if record.version in in_range]
 
     groups = _groups(asked)

--- a/nab-provider/tests/test_listing_diagnosis.py
+++ b/nab-provider/tests/test_listing_diagnosis.py
@@ -1554,14 +1554,43 @@ class TestTheInRangeLead:
         """A range holding only a dropped pre-release still reaches the walk.
 
         The screen filters the dropped versions through the range rather
-        than testing each one, so the pre-release is admitted where no
-        final release in range could stand in for it.
+        than testing each one, so a range whose only match is a pre-release
+        still admits it.
         """
         assert reason_for(
             [wheel("0.5"), wheel("1.0b1", upload_time=AFTER)],
             spec=">=0.9",
             **WITH_CUTOFF,
         ).startswith("uploaded-prior-to excluded every version in range")
+
+    def test_a_refused_final_does_not_hide_a_refused_pre_release(self) -> None:
+        """A refused final and a refused pre-release both name their filter.
+
+        Under PEP 440's default the final in range would suppress the
+        pre-release, dropping the cutoff that refused it from the report.
+        """
+        diagnostic = diagnostic_for(
+            [
+                wheel("1.0"),
+                wheel("2.0", requires_python=">=3.99"),
+                wheel("3.0b1", upload_time=AFTER),
+            ],
+            spec=">=2",
+            target=_LINUX312,
+            uploaded_prior_to=CUTOFF,
+        )
+
+        assert render(diagnostic) == (
+            "uploaded-prior-to and requires-python excluded every version in range"
+            "\nthe uploaded-prior-to cutoff 2026-05-01T00:00:00+00:00 excluded 1"
+            " file uploaded at 2030-01-01T00:00:00Z (3.0b1)"
+            "\nrequires-python excluded 1 file (2.0 requires >=3.99, the resolve"
+            " targets Python 3.12)"
+            "\nnote: the project-level uploaded-prior-to set that cutoff; setting"
+            ' packages."pkg".uploaded-prior-to = false lifts it for this package'
+        )
+
+        assert diagnostic.remedy == 'set packages."pkg".uploaded-prior-to = false'
 
     def test_a_recorded_range_of_none_stays_a_no_match(self) -> None:
         """A scan that rejected every candidate without a range says no match.


### PR DESCRIPTION
A diagnostic whose range holds both a refused final release and a refused pre-release names only the final's filter, and loses the `try:` line that would unblock the resolve. Asking for `pkg>=2` on Python 3.12, against a listing of `1.0`, `2.0` (requires Python >=3.99) and `3.0b1` (past the `uploaded-prior-to` cutoff):

    no version in range supports Python 3.12
    requires-python excluded 1 file (2.0 requires >=3.99, the resolve targets Python 3.12)

Lifting the cutoff resolves to `3.0b1`, and nothing in the report points there.

`in_range_diagnostic` filters the refused versions through the range under PEP 440's default pre-release policy, which yields a pre-release only when no final release is in range. `2.0` is, so the filter drops `3.0b1`, and its clause and its `packages."pkg".uploaded-prior-to = false` remedy go with it.

Every version reaching that filter has already been refused, so a final in range can never stand in for a pre-release there. The diagnostic now passes `prereleases=True`, as `priority.py` already does where it counts in-range versions.
