### PR TITLE
Drop re.VERBOSE from the vendored specifier pattern, 0.77% off a nab lock

### DIFF
--- a/nab-provider/src/nab_provider/_vendor/packaging/PROVENANCE.md
+++ b/nab-provider/src/nab_provider/_vendor/packaging/PROVENANCE.md
@@ -44,18 +44,20 @@ most one checked-in patch.
     quotes when that body is ASCII and holds no backslash, newline, carriage
     return or NUL, and calls `ast.literal_eval` otherwise. The `QUOTED_STRING`
     rule admits no string prefix, so a token takes the same value either way.
-  - `specifiers.py` and `_tokenizer.py`: `Specifier._regex` compiles the
-    specifier pattern without the surrounding `\s*`, and `Specifier.__init__`
-    strips the string before matching it, so `DEFAULT_RULES["SPECIFIER"]` can be
-    that same compiled object instead of a second compile of the same pattern.
+  - `specifiers.py` and `_tokenizer.py`: `Specifier._regex` compiles
+    `_condensed_regex_str`, which is `_specifier_regex_str` with the
+    `re.VERBOSE` whitespace and comments removed, under `re.IGNORECASE` alone.
+    It carries no surrounding `\s*` and `Specifier.__init__` strips the string
+    before matching it, so `DEFAULT_RULES["SPECIFIER"]` can be that same
+    compiled object instead of a second compile of the same pattern.
 
   Upstream PRs are planned for the bound ordering, the direct subset and
   disjoint walks, `filter`'s `assume_sorted` fast path,
   `from_bounds`/`snap_bounds`/`release_intervals`, the prepared marker
   environment, and the marker-item serialisation. `relation` is not proposed
   yet: most of its win is available from the direct walks alone. The
-  quoted-string slice is not proposed anywhere yet, and neither is the
-  `Marker.__str__` memo.
+  quoted-string slice, the `Marker.__str__` memo, and the condensed specifier
+  pattern are not proposed anywhere yet.
 - `tasks/vendor-packaging.sh` fetches `pypa/packaging` at the pin, replaces this
   package with the pristine `src/packaging/` tree plus the repo-root license
   texts, and reapplies the patch. `--check` rebuilds into a temp location and

--- a/nab-provider/src/nab_provider/_vendor/packaging/specifiers.py
+++ b/nab-provider/src/nab_provider/_vendor/packaging/specifiers.py
@@ -329,8 +329,13 @@ class Specifier(BaseSpecifier):
         )
         """
 
+    # The grammar above with re.VERBOSE's whitespace and comments removed, which re's
+    # parser would otherwise walk at every import. Edit both: a corpus differential in
+    # nab-provider/tests/test_vendor_specifier_pattern_shared.py compares the two.
+    _condensed_regex_str = r"(?:(?:===\s*[^\s;)]*)|(?:(?:==|!=)\s*v?(?:[0-9]+!)?[0-9]+(?:\.[0-9]+)*(?:\.\*|(?a:[-_\.]?(alpha|beta|preview|pre|a|b|c|rc)[-_\.]?[0-9]*)?(?a:(?:-[0-9]+)|(?:[-_\.]?(post|rev|r)[-_\.]?[0-9]*))?(?a:[-_\.]?dev[-_\.]?[0-9]*)?(?a:\+[a-z0-9]+(?:[-_\.][a-z0-9]+)*)?)?)|(?:(?:~=)\s*v?(?:[0-9]+!)?[0-9]+(?:\.[0-9]+)+(?:[-_\.]?(alpha|beta|preview|pre|a|b|c|rc)[-_\.]?[0-9]*)?(?:(?:-[0-9]+)|(?:[-_\.]?(post|rev|r)[-_\.]?[0-9]*))?(?:[-_\.]?dev[-_\.]?[0-9]*)?)|(?:(?:<=|>=|<|>)\s*v?(?:[0-9]+!)?[0-9]+(?:\.[0-9]+)*(?a:[-_\.]?(alpha|beta|preview|pre|a|b|c|rc)[-_\.]?[0-9]*)?(?a:(?:-[0-9]+)|(?:[-_\.]?(post|rev|r)[-_\.]?[0-9]*))?(?a:[-_\.]?dev[-_\.]?[0-9]*)?))"
+
     # No surrounding \s*, so _tokenizer can share this object; __init__ strips first.
-    _regex = re.compile(_specifier_regex_str, re.VERBOSE | re.IGNORECASE)
+    _regex = re.compile(_condensed_regex_str, re.IGNORECASE)
 
     # Legacy unused attribute, kept for backward compatibility
     _operators: Final = {

--- a/nab-provider/tests/test_vendor_specifier_pattern_shared.py
+++ b/nab-provider/tests/test_vendor_specifier_pattern_shared.py
@@ -1,13 +1,20 @@
-"""Tests for the vendored patch that shares one compiled specifier pattern.
+"""Tests for the vendored specifier-pattern patch.
 
 The tokenizer rule is ``Specifier._regex`` itself, and that pattern matches no
-surrounding whitespace, so ``Specifier.__init__`` strips before matching. Both
-are pinned: ``re`` caches on the pattern text, so the identity assertion alone
-would still hold if the tokenizer compiled the string a second time.
+surrounding whitespace, so ``Specifier.__init__`` strips before matching. ``re``
+caches on the pattern text, so the identity assertion alone would still hold if
+the tokenizer compiled the string a second time; the whitespace assertion is
+what pins the sharing.
+
+``_regex`` compiles ``_condensed_regex_str``, which is the verbose
+``_specifier_regex_str`` with its whitespace and comments removed. Nothing in
+the vendoring patch ties the two together, so the differential over ``CORPUS``
+catches a condensed twin left stale by an upstream edit to the grammar.
 """
 
 from __future__ import annotations
 
+import itertools
 import re
 
 import pytest
@@ -30,13 +37,99 @@ PADDED = [
 # Strings the pattern refuses however they are padded.
 REFUSED = ["", " ", "=1.0", "== ", "==1.0 2.0", "~=1"]
 
+# Every operator the pattern accepts, plus two it must refuse.
+OPERATORS = ["==", "!=", "<=", ">=", "<", ">", "~=", "===", "=", ""]
+
+# Version cores reaching each optional segment of the grammar, and junk it refuses.
+VERSION_CORES = [
+    "",
+    "1",
+    "1.0",
+    "1.0.0",
+    "v1.0",
+    "2!1.0",
+    "1.0a1",
+    "1.0PRE1",
+    "1.0-alpha-2",
+    "1.0.post1",
+    "1.0.post",
+    "1.0.dev0",
+    "1.0dev",
+    "1.0rc1.post2.dev3",
+    "1.0+local.1",
+    "1.0+",
+    "1.0++a",
+    "1.0.*",
+    "1.*.*",
+    "*",
+    "1_0_0",
+    "1.0-",
+    "abc",
+    "1.0 2.0",
+    # Prerelease and post words the cores above leave out, plus "release",
+    # which the grammar does not name.
+    "1.0beta1",
+    "1.0b2",
+    "1.0c3",
+    "1.0preview1",
+    "1.0.rev2",
+    "1.0r4",
+    "1.0.release5",
+    # The arbitrary-version class stops at ";" and ")" and runs through ",".
+    "1.0;x",
+    "1.0)",
+    "1.0,2",
+    # Under Unicode case folding these read as "1.0+s", "1.0.post1" and
+    # "1.0preview1", so they tell the (?a:) scopes from a plain IGNORECASE group.
+    "1.0+\u017f",
+    "1.0.po\u017ft1",
+    "1.0prev\u0131ew1",
+]
+
+# Padding goes before the operator, after it, and at the end.
+PADDINGS = ["", " ", "\t", "\n"]
+
+CORPUS = [
+    f"{left}{operator}{middle}{core}{right}"
+    for operator, core, left, middle, right in itertools.product(
+        OPERATORS, VERSION_CORES, PADDINGS, PADDINGS, PADDINGS
+    )
+]
+
+
+def verdicts(
+    pattern: re.Pattern[str], candidate: str
+) -> list[tuple[object, ...] | None]:
+    """What ``match`` and then ``fullmatch`` make of one candidate: span and groups."""
+    return [
+        None if found is None else (found.span(), found.groups())
+        for found in (pattern.match(candidate), pattern.fullmatch(candidate))
+    ]
+
 
 def test_the_tokenizer_rule_is_the_specifier_pattern_object() -> None:
     assert DEFAULT_RULES["SPECIFIER"] is Specifier._regex
 
 
 def test_the_pattern_carries_no_surrounding_whitespace() -> None:
-    assert Specifier._regex.pattern == Specifier._specifier_regex_str
+    assert not Specifier._regex.pattern.startswith(r"\s*")
+    assert not Specifier._regex.pattern.endswith(r"\s*")
+
+
+def test_the_condensed_pattern_reads_a_corpus_as_the_verbose_grammar_does() -> None:
+    verbose = re.compile(Specifier._specifier_regex_str, re.VERBOSE | re.IGNORECASE)
+
+    disagreements = [
+        candidate
+        for candidate in CORPUS
+        if verdicts(verbose, candidate) != verdicts(Specifier._regex, candidate)
+    ]
+
+    # Sliced so a failure names a few candidates rather than thousands.
+    assert disagreements[:5] == []
+
+    assert Specifier._regex.groups == verbose.groups
+    assert Specifier._regex.groupindex == verbose.groupindex
 
 
 @pytest.mark.parametrize(("spec", "expected"), PADDED)

--- a/tasks/vendoring/packaging.patch
+++ b/tasks/vendoring/packaging.patch
@@ -1162,22 +1162,27 @@ index 4fbf48e..d52f359 100644
      def _from_specifier_set(cls, specifier_set: SpecifierSet) -> VersionRange:
          """Build the range accepted by ``specifier_set``.
 diff --git a/nab-provider/src/nab_provider/_vendor/packaging/specifiers.py b/nab-provider/src/nab_provider/_vendor/packaging/specifiers.py
-index dd46b56..6f02085 100644
+index dd46b56..df2d424 100644
 --- a/nab-provider/src/nab_provider/_vendor/packaging/specifiers.py
 +++ b/nab-provider/src/nab_provider/_vendor/packaging/specifiers.py
-@@ -329,9 +329,8 @@ class Specifier(BaseSpecifier):
+@@ -329,9 +329,13 @@ class Specifier(BaseSpecifier):
          )
          """
  
 -    _regex = re.compile(
 -        r"\s*" + _specifier_regex_str + r"\s*", re.VERBOSE | re.IGNORECASE
 -    )
++    # The grammar above with re.VERBOSE's whitespace and comments removed, which re's
++    # parser would otherwise walk at every import. Edit both: a corpus differential in
++    # nab-provider/tests/test_vendor_specifier_pattern_shared.py compares the two.
++    _condensed_regex_str = r"(?:(?:===\s*[^\s;)]*)|(?:(?:==|!=)\s*v?(?:[0-9]+!)?[0-9]+(?:\.[0-9]+)*(?:\.\*|(?a:[-_\.]?(alpha|beta|preview|pre|a|b|c|rc)[-_\.]?[0-9]*)?(?a:(?:-[0-9]+)|(?:[-_\.]?(post|rev|r)[-_\.]?[0-9]*))?(?a:[-_\.]?dev[-_\.]?[0-9]*)?(?a:\+[a-z0-9]+(?:[-_\.][a-z0-9]+)*)?)?)|(?:(?:~=)\s*v?(?:[0-9]+!)?[0-9]+(?:\.[0-9]+)+(?:[-_\.]?(alpha|beta|preview|pre|a|b|c|rc)[-_\.]?[0-9]*)?(?:(?:-[0-9]+)|(?:[-_\.]?(post|rev|r)[-_\.]?[0-9]*))?(?:[-_\.]?dev[-_\.]?[0-9]*)?)|(?:(?:<=|>=|<|>)\s*v?(?:[0-9]+!)?[0-9]+(?:\.[0-9]+)*(?a:[-_\.]?(alpha|beta|preview|pre|a|b|c|rc)[-_\.]?[0-9]*)?(?a:(?:-[0-9]+)|(?:[-_\.]?(post|rev|r)[-_\.]?[0-9]*))?(?a:[-_\.]?dev[-_\.]?[0-9]*)?))"
++
 +    # No surrounding \s*, so _tokenizer can share this object; __init__ strips first.
-+    _regex = re.compile(_specifier_regex_str, re.VERBOSE | re.IGNORECASE)
++    _regex = re.compile(_condensed_regex_str, re.IGNORECASE)
  
      # Legacy unused attribute, kept for backward compatibility
      _operators: Final = {
-@@ -358,10 +357,11 @@ class Specifier(BaseSpecifier):
+@@ -358,10 +362,11 @@ class Specifier(BaseSpecifier):
          :raises InvalidSpecifier:
              If the given specifier is invalid (i.e. bad syntax).
          """


### PR DESCRIPTION
Compiling the vendored `Specifier._regex` without `re.VERBOSE` takes 6,375,772 instructions off an offline `nab lock` over a five-package project, 0.77% of its 832,882,638. That cost is fixed per process, so it is a larger share of a smaller command: 1.97% of `nab cache dir`.

| workload | base | branch | removed | share |
| --- | ---: | ---: | ---: | ---: |
| offline `nab lock`, 5 packages | 832,882,638 | 826,506,866 | 6,375,772 | 0.77% |
| `import nab._lock` | 640,335,768 | 634,068,083 | 6,267,685 | 0.98% |
| `nab cache dir` | 316,130,535 | 309,897,516 | 6,233,019 | 1.97% |

`re`'s parser reads a pattern one character at a time, so under `re.VERBOSE` every character of whitespace and comment costs a tokenizer step. `_regex` now compiles `_condensed_regex_str`, the same grammar with those removed, 3,852 characters down to 643. Over `import nab._lock` the call census shows 3,209 fewer calls to each of `Tokenizer.get` and `Tokenizer.__next`, one per character removed.

Those counts reproduce anywhere. Locally, `-X importtime` shows the specifiers module body losing about 0.4 to 0.5 ms.

The verbose grammar stays as the readable form and the test's reference: a differential runs both patterns over 23,680 candidates (every operator plus two it refuses, 37 version cores, padding in three positions) and compares `match` and `fullmatch` span and groups.

Peak memory moves 214 bytes on a 12.5 MB import. Timing runs over the lock command and the 19-scenario canary rule out a wall regression above about 2.3%, which is all runs that size can say.

`tasks/vendoring/packaging.patch` is regenerated, so `tasks/vendor-packaging.sh --check` still passes.
