### PR TITLE
Inline the wheel-tag test into the listing loop, ~0.37% off a soda resolve

### DIFF
--- a/nab-provider/src/nab_provider/_provider/listing.py
+++ b/nab-provider/src/nab_provider/_provider/listing.py
@@ -620,7 +620,9 @@ def _apply_wheel_tags(
     if tags is None:
         return base
 
+    accepts = tags.accepts
     release_refused = provider.release_refused_wheels
+
     result: list[tuple[Version, DistFile]] = []
     tag_rejected_versions: set[Version] = set()
     run_version: Version | None = None
@@ -628,7 +630,9 @@ def _apply_wheel_tags(
 
     for pair in base:
         version, dist = pair  # a kept pair is appended as-is, not rebuilt
-        if not excluded_by_wheel_tags(dist, tags):
+
+        # Copied from excluded_by_wheel_tags rather than called: this runs per file.
+        if not isinstance(dist, WheelFile) or accepts(dist.filename):
             result.append(pair)
             continue
 

--- a/nab-provider/src/nab_provider/_provider/listing_diagnosis.py
+++ b/nab-provider/src/nab_provider/_provider/listing_diagnosis.py
@@ -425,11 +425,11 @@ def walk_listing(provider: Provider, normalized: str) -> ListingDiagnosis | None
     """Re-walk ``normalized``'s raw listing, recording what refused each file.
 
     Returns ``None`` when the index served nothing, which leaves the walk
-    with nothing to attribute.  The predicates are the filter's own; the
-    order it asks them in is re-expressed here, and the differential-oracle
-    test is what holds the two in step.  Counter bumps those predicates
-    make are taken back by the caller, see
-    :meth:`~nab_provider.provider.Provider.diagnose_listing`.
+    with nothing to attribute.  The predicates are the filter's own, apart
+    from the wheel-tag test the filter runs inline; the order it asks them
+    in is re-expressed here, and the differential-oracle test is what holds
+    the two in step.  Counter bumps those predicates make are taken back by
+    the caller, see :meth:`~nab_provider.provider.Provider.diagnose_listing`.
     """
     files = provider.coordinator.index.get_listing(normalized)
     if not files:


### PR DESCRIPTION
A warm `pip:google-bigquery-soda@lowest` resolve retires about 14 million fewer instructions out of 3.78 billion. Two counts of the same pair put the saving between 0.36% and 0.38% of the run.

`_apply_wheel_tags` called `excluded_by_wheel_tags` once per candidate file. Writing the test out in the loop and binding `tags.accepts` before it removes all 28,878 of those calls and takes the run's total from 2,571,218 to 2,542,153.

`TagSet.accepts` still runs 25,121 times and `release_wheel_payload` 22,007, so the short circuit and the release path fire as often as before, and nothing else moves by more than 46 calls. The helper stays for `listing_diagnosis.py`. The timing runs cannot see an effect this small; they rule out a slowdown above about 1.4% CPU and 3.5% wall.

Stacked on #1175 (`opt/wheel-tag-pass-reuses-kept-pairs`), which rewrites the same loop; every figure above is against its head. Too small to be worth its own review, so I would rather it landed as a second commit there: from `main`, the two together take about 0.67% off the same resolve.

`excluded_by_wheel_tags` is 1.1% of soda's calls against 0.6% of `pip:airflow-october-regression`'s, so expect a smaller share on a bigger resolve.
