### PR TITLE
Write a parsed-listing version cell only where it changes, -3% peak memory

### DIFF
--- a/nab-index/src/nab_index/parsed_listing.py
+++ b/nab-index/src/nab_index/parsed_listing.py
@@ -4,7 +4,8 @@ The UTF-8 JSON wire form is ``[header, rows]``. The header carries format,
 codec, sort-key scheme, source-body digest, and dropped zip-sdist versions.
 An incompatible header or digest is a cache miss.
 
-Rows preserve source order and tag each flat record as a wheel or sdist. Decode
+Rows preserve source order and tag each flat record as a wheel or sdist. A
+version cell is ``null`` where the row above carries the same version. Decode
 checks every field and restores interned strings. Integrity cells retain either
 the index table or parsed pairs so hash parsing stays deferred.
 
@@ -38,7 +39,7 @@ __all__ = ["ParsedListing", "corruption_reason", "decode", "encode"]
 # blob surfacing under the current bucket. Bump it when the header or row shape
 # changes, or when the same body parses to different records: ``body_digest``
 # pins only the input.
-FORMAT_VERSION = 4
+FORMAT_VERSION = 5
 # Serialization variant that wrote the rows, so a future codec switch
 # self-heals rather than misdecodes.
 CODEC = 1
@@ -106,14 +107,19 @@ def encode(
     is a derived property, so neither rides the wire.
     """
     rows: list[list[object]] = []
+    previous_version: str | None = None
     for record in files:
+        version = record.version
+        version_cell = None if version == previous_version else version
+        previous_version = version
+
         if isinstance(record, WheelFile):
             rows.append(
                 [
                     _TAG_WHEEL,
                     record.filename,
                     record.url,
-                    record.version,
+                    version_cell,
                     record.requires_python,
                     record.has_metadata,
                     record.upload_time,
@@ -128,7 +134,7 @@ def encode(
                     _TAG_SDIST,
                     record.filename,
                     record.url,
-                    record.version,
+                    version_cell,
                     record.requires_python,
                     record.upload_time,
                     _hashes_cell(record),
@@ -246,10 +252,16 @@ def _decode_rows(rows: object) -> list[WheelFile | SdistFile]:
     """Rehydrate every row, raising :class:`_BadRowError` on the first bad one."""
     if not isinstance(rows, list):
         raise _BadRowError
-    return [_decode_row(row) for row in rows]
+    decoded: list[WheelFile | SdistFile] = []
+    previous_version: str | None = None
+    for row in rows:
+        record = _decode_row(row, previous_version)
+        previous_version = record.version
+        decoded.append(record)
+    return decoded
 
 
-def _decode_row(row: object) -> WheelFile | SdistFile:
+def _decode_row(row: object, previous_version: str | None) -> WheelFile | SdistFile:
     """Rehydrate one row, dispatching on the tag its first element carries."""
     if not isinstance(row, list) or not row:
         raise _BadRowError
@@ -258,14 +270,17 @@ def _decode_row(row: object) -> WheelFile | SdistFile:
     if type(tag) is not int:
         raise _BadRowError
     if tag == _TAG_WHEEL:
-        return _decode_wheel(row)
+        return _decode_wheel(row, previous_version)
     if tag == _TAG_SDIST:
-        return _decode_sdist(row)
+        return _decode_sdist(row, previous_version)
     raise _BadRowError
 
 
-def _decode_wheel(row: Sequence[object]) -> WheelFile:
-    """Rehydrate a wheel row.
+def _decode_wheel(row: Sequence[object], previous_version: str | None) -> WheelFile:
+    """Rehydrate a wheel row, whose ``null`` version means ``previous_version``.
+
+    A ``null`` on the first row leaves the version ``None``, which the field
+    check rejects.
 
     An integrity cell holding the index's own table passes through unparsed,
     for the record to parse on first read; any other form is parsed here.
@@ -282,6 +297,9 @@ def _decode_wheel(row: Sequence[object]) -> WheelFile:
         size,
         metadata_hash,
     ) = row
+
+    if version is None:
+        version = previous_version
 
     # ``type() is`` rather than ``isinstance``: bool is a subclass of int, so
     # ``True`` would pass as a size.
@@ -311,9 +329,12 @@ def _decode_wheel(row: Sequence[object]) -> WheelFile:
     )
 
 
-def _decode_sdist(row: Sequence[object]) -> SdistFile:
+def _decode_sdist(row: Sequence[object], previous_version: str | None) -> SdistFile:
     """Rehydrate a source-distribution row; see :func:`_decode_wheel`."""
     _, filename, url, version, requires_python, upload_time, hashes, size = row
+
+    if version is None:
+        version = previous_version
 
     if (
         type(filename) is not str

--- a/nab-index/tests/test_parsed_listing_codec.py
+++ b/nab-index/tests/test_parsed_listing_codec.py
@@ -173,6 +173,33 @@ def test_blob_is_portable_json() -> None:
     assert [row[0] for row in rows] == [_TAG_WHEEL, _TAG_SDIST, _TAG_WHEEL, _TAG_SDIST]
 
 
+def test_only_the_first_row_of_a_repeat_carries_its_version() -> None:
+    """A repeated version rides as ``null``, on a wheel row and an sdist alike."""
+    _header, rows = json.loads(encode(SAMPLE, DIGEST))
+
+    # Both row kinds hold the version at the same index.
+    assert [row[_W_VERSION] for row in rows] == ["1.0", None, None, "2.0"]
+
+
+def test_adjacent_rows_of_one_version_decode_to_one_string() -> None:
+    """Adjacent rows of one version share a string; a change ends the run."""
+    decoded = _roundtrip(SAMPLE)
+
+    assert decoded[0].version is decoded[1].version
+    assert decoded[0].version is decoded[2].version
+    assert decoded[3].version == "2.0"
+
+
+def test_a_version_repeated_after_a_gap_is_written_again() -> None:
+    """A ``null`` means the row above, not the last distinct version."""
+    files: list[WheelFile | SdistFile] = [WHEEL_FULL, SDIST_BARE, WHEEL_BARE]
+
+    _header, rows = json.loads(encode(files, DIGEST))
+
+    assert [row[_W_VERSION] for row in rows] == ["1.0", "2.0", "1.0"]
+    assert [record.version for record in _roundtrip(files)] == ["1.0", "2.0", "1.0"]
+
+
 def _tamper_header(index: int, value: object) -> bytes:
     header, rows = json.loads(encode(SAMPLE, DIGEST))
     header[index] = value
@@ -281,6 +308,8 @@ def test_unknown_tag_on_a_well_formed_row_is_miss(tag: object) -> None:
         (_W_FILENAME, None),
         (_W_URL, None),
         (_W_VERSION, 1.0),
+        # A first row has nothing to repeat, so a leading null is never written.
+        (_W_VERSION, None),
         (_W_REQUIRES_PYTHON, 3),
         (_W_HAS_METADATA, "yes"),
         # bool is a subclass of int, so an int must not pass as a flag.
@@ -307,6 +336,7 @@ def test_wrong_field_type_is_miss(index: int, value: object) -> None:
     [
         (_S_FILENAME, 12345),
         (_S_URL, None),
+        # A first row has nothing to repeat, so a leading null is never written.
         (_S_VERSION, None),
         (_S_REQUIRES_PYTHON, 3),
         (_S_UPLOAD_TIME, 20230101),
@@ -395,12 +425,7 @@ def test_foreign_build_header_is_not_corruption() -> None:
 
 
 def test_a_previous_format_header_is_a_benign_miss() -> None:
-    """The header this build replaced is one cell shorter, and skew must not warn.
-
-    Every blob a cache already holds carries it, so reading the length as
-    corruption would warn once per package the first time an upgraded nab
-    reads them.
-    """
+    """A shorter header naming an older format is skew, not corruption."""
     _header, rows = json.loads(encode(SAMPLE, DIGEST))
     older = json.dumps([[FORMAT_VERSION - 1, CODEC, KEY_SCHEME, DIGEST], rows]).encode()
 


### PR DESCRIPTION
Peak allocated memory over a warm `pip:google-bigquery-soda --resolution lowest` resolve falls by about 1.7 MB, 3.1% of 54.5 MB, and by about 1.9 MB on `ecosystem:pandas-with-aws-s3 --resolution lowest`, 2.6% of 75.7 MB. Peak process memory locally is between about 1.8% and 2.7% lower on a run of both.

Decoding a parsed-listing cache entry allocated one version string per file: 40,049 of them over the 49 listings the soda resolve loads, holding 1,901,108 bytes for 2,694 distinct versions. Writing a row's version cell as `null` where the row above already named that version takes those to 4,596 strings and 215,346 bytes, and the 49 blobs from 16,954,395 bytes to 16,793,112.

None of that is paid for in CPU. Instructions retired over the soda resolve go from 3,695,324,480 to 3,687,135,413, down 0.22%, and pandas moves up 0.046%. The timing runs cannot see a change this small and only rule out a slowdown above about 2.4%.

`FORMAT_VERSION` goes from 4 to 5, so entries an older build wrote miss once and are rewritten.
