### PR TITLE
Skip the per-row rule pass on the generated config rows

### DIFF
--- a/src/nab/config/registry.py
+++ b/src/nab/config/registry.py
@@ -48,6 +48,7 @@ OPTIONS: tuple[Opt, ...] = (
         type_label="enum(highest|lowest|lowest-direct)",
         help="which version of each package to prefer",
         docs="reference/configuration.md",
+        generated=True,
     ),
     Opt(
         "decision-order",
@@ -64,6 +65,7 @@ OPTIONS: tuple[Opt, ...] = (
         type_label="enum(arrival|stable)",
         help="whether an arrived listing may steer the decision order",
         docs="reference/configuration.md",
+        generated=True,
     ),
     Opt(
         "mode",
@@ -80,6 +82,7 @@ OPTIONS: tuple[Opt, ...] = (
         type_label="enum(specific|universal)",
         help="resolve for this environment or across a matrix",
         docs="explanation/universal.md",
+        generated=True,
     ),
     Opt(
         "constraints",
@@ -95,6 +98,7 @@ OPTIONS: tuple[Opt, ...] = (
         sample="attrs<24",
         help="bound a package's versions without pulling it into the resolve",
         docs="reference/configuration.md",
+        generated=True,
     ),
     Opt(
         "default-groups",
@@ -110,6 +114,7 @@ OPTIONS: tuple[Opt, ...] = (
         sample="dev",
         help="a dependency group every resolve selects",
         docs="reference/selection.md",
+        generated=True,
     ),
     Opt(
         "base-group",
@@ -126,6 +131,7 @@ OPTIONS: tuple[Opt, ...] = (
         sample="runtime",
         help="the group name the project's own dependencies lock under",
         docs="reference/selection.md",
+        generated=True,
     ),
     Opt(
         "build-group",
@@ -142,6 +148,7 @@ OPTIONS: tuple[Opt, ...] = (
         sample="build",
         help="the group name [build-system].requires locks under",
         docs="reference/selection.md",
+        generated=True,
     ),
     Opt(
         "requires-python",
@@ -158,6 +165,7 @@ OPTIONS: tuple[Opt, ...] = (
         sample=">=3.11",
         help="the Python range the project supports, as a specifier",
         docs="reference/configuration.md",
+        generated=True,
     ),
     Opt(
         "uploaded-prior-to",
@@ -174,6 +182,7 @@ OPTIONS: tuple[Opt, ...] = (
         sample="P7D",
         help="ignore distributions uploaded after this point",
         docs="reference/configuration.md",
+        generated=True,
     ),
     Opt(
         "dist-policy",
@@ -191,6 +200,7 @@ OPTIONS: tuple[Opt, ...] = (
         type_label="enum(wheel-only|prefer-wheel|wheel-or-sdist|sdist-only|sdist-install)",
         help="which distribution kinds the resolve may pin",
         docs="reference/configuration.md",
+        generated=True,
     ),
     Opt(
         "build-policy",
@@ -207,6 +217,7 @@ OPTIONS: tuple[Opt, ...] = (
         type_label="enum(never|build-local|build-remote)",
         help="whether nab may build an sdist, and which ones",
         docs="reference/build-policy.md",
+        generated=True,
     ),
     Opt(
         "build-requires-depth",
@@ -223,6 +234,7 @@ OPTIONS: tuple[Opt, ...] = (
         sample="1",
         help="how many build environments nab may open beneath the first",
         docs="reference/build-policy.md",
+        generated=True,
     ),
     Opt(
         "environment",
@@ -233,6 +245,7 @@ OPTIONS: tuple[Opt, ...] = (
         type_label="table(python,platform[,knobs],implementation)",
         help="the target whose markers and wheel tags the resolve uses",
         docs="reference/configuration.md",
+        generated=True,
     ),
     Opt(
         "marker-environment",
@@ -244,6 +257,7 @@ OPTIONS: tuple[Opt, ...] = (
         deprecated=True,
         help="PEP 508 marker variables, set one at a time",
         docs="reference/configuration.md",
+        generated=True,
     ),
     Opt(
         "vcs",
@@ -254,6 +268,7 @@ OPTIONS: tuple[Opt, ...] = (
         type_label="table(vcs-policy)",
         help="whether a requirement may name a VCS URL, and which ones",
         docs="how-to/vcs.md",
+        generated=True,
     ),
     Opt(
         "workspace",
@@ -264,6 +279,7 @@ OPTIONS: tuple[Opt, ...] = (
         type_label="table(members)",
         help="the member paths a workspace root declares",
         docs="how-to/workspaces.md",
+        generated=True,
     ),
     Opt(
         "indexes",
@@ -274,6 +290,7 @@ OPTIONS: tuple[Opt, ...] = (
         type_label="array-of-tables(name,url,serialization)",
         help="the package indexes, consulted in the order declared",
         docs="how-to/multi-index.md",
+        generated=True,
     ),
     Opt(
         "local-sources",
@@ -284,6 +301,7 @@ OPTIONS: tuple[Opt, ...] = (
         type_label="array-of-tables(name,path)",
         help="a directory that becomes the only candidate for a named package",
         docs="how-to/local-sources.md",
+        generated=True,
     ),
     Opt(
         "vcs-sources",
@@ -294,6 +312,7 @@ OPTIONS: tuple[Opt, ...] = (
         type_label="array-of-tables(name,url)",
         help="a repository that becomes the only candidate for a named package",
         docs="how-to/vcs.md",
+        generated=True,
     ),
     Opt(
         "archive-sources",
@@ -304,6 +323,7 @@ OPTIONS: tuple[Opt, ...] = (
         type_label="array-of-tables(name,url)",
         help="a hashed .tar.gz URL a named package is pinned to",
         docs="reference/configuration.md",
+        generated=True,
     ),
     Opt(
         "packages",
@@ -314,6 +334,7 @@ OPTIONS: tuple[Opt, ...] = (
         type_label="table(package-override)",
         help="policy and metadata overrides keyed by package name",
         docs="reference/configuration.md",
+        generated=True,
     ),
     Opt(
         "package-rules",
@@ -324,6 +345,7 @@ OPTIONS: tuple[Opt, ...] = (
         type_label="array-of-tables(match,policy)",
         help="policy and metadata overrides selected by a list of requirements",
         docs="reference/configuration.md",
+        generated=True,
     ),
     Opt(
         "index",
@@ -334,6 +356,7 @@ OPTIONS: tuple[Opt, ...] = (
         type_label="table(index-override)",
         help="policy overrides keyed by index name",
         docs="how-to/multi-index.md",
+        generated=True,
     ),
     Opt(
         "conflicts",
@@ -344,6 +367,7 @@ OPTIONS: tuple[Opt, ...] = (
         type_label="array-of-tables(members,policy)",
         help="sets of groups and extras that cannot be selected together",
         docs="explanation/conflicts.md",
+        generated=True,
     ),
     Opt(
         "matrix",
@@ -354,6 +378,7 @@ OPTIONS: tuple[Opt, ...] = (
         type_label="table(python,platforms)",
         help="the Python and platform axes a universal resolve covers",
         docs="explanation/universal.md",
+        generated=True,
     ),
     Opt(
         "offline",
@@ -371,6 +396,7 @@ OPTIONS: tuple[Opt, ...] = (
         type_label="bool",
         help="never hit the network; resolve from the cache alone",
         docs="reference/cli.md",
+        generated=True,
     ),
     Opt(
         "cache-dir",
@@ -388,6 +414,7 @@ OPTIONS: tuple[Opt, ...] = (
         sample="nab-cache",
         help="the on-disk cache root",
         docs="reference/cache.md",
+        generated=True,
     ),
     Opt(
         "http-backend",
@@ -405,6 +432,7 @@ OPTIONS: tuple[Opt, ...] = (
         type_label="enum(httpx|urllib3)",
         help="the transport index and artefact fetches go through",
         docs="reference/cli.md",
+        generated=True,
     ),
     Opt(
         "max-concurrency",
@@ -422,6 +450,7 @@ OPTIONS: tuple[Opt, ...] = (
         sample="4",
         help="how many fetches may be in flight at once",
         docs="reference/cli.md",
+        generated=True,
     ),
 )
 
@@ -439,6 +468,7 @@ SUB_ROWS: tuple[Opt, ...] = (
         under="matrix",
         needed=True,
         tokens=Tokens.SCALAR,
+        generated=True,
     ),
     Opt(
         "platforms",
@@ -453,6 +483,7 @@ SUB_ROWS: tuple[Opt, ...] = (
         needed=True,
         tokens=Tokens.ITEMS,
         opened_by="id",
+        generated=True,
     ),
     Opt(
         "implementations",
@@ -465,6 +496,7 @@ SUB_ROWS: tuple[Opt, ...] = (
         docs="explanation/universal.md",
         under="matrix",
         tokens=Tokens.LIST,
+        generated=True,
     ),
     Opt(
         "python-order",
@@ -479,6 +511,7 @@ SUB_ROWS: tuple[Opt, ...] = (
         docs="explanation/universal.md",
         under="matrix",
         tokens=Tokens.SCALAR,
+        generated=True,
     ),
     Opt(
         "python-patches",
@@ -491,6 +524,7 @@ SUB_ROWS: tuple[Opt, ...] = (
         docs="explanation/universal.md",
         under="matrix",
         tokens=Tokens.PAIRS,
+        generated=True,
     ),
     Opt(
         "python",
@@ -504,6 +538,7 @@ SUB_ROWS: tuple[Opt, ...] = (
         docs="reference/configuration.md",
         under="environment",
         tokens=Tokens.SCALAR,
+        generated=True,
     ),
     Opt(
         "platform",
@@ -517,6 +552,7 @@ SUB_ROWS: tuple[Opt, ...] = (
         under="environment",
         tokens=Tokens.ITEM,
         opened_by="id",
+        generated=True,
     ),
     Opt(
         "implementation",
@@ -531,6 +567,7 @@ SUB_ROWS: tuple[Opt, ...] = (
         docs="reference/configuration.md",
         under="environment",
         tokens=Tokens.SCALAR,
+        generated=True,
     ),
 )
 

--- a/src/nab/optiondefs.py
+++ b/src/nab/optiondefs.py
@@ -216,8 +216,13 @@ class Opt:
         needed: bool = False,
         tokens: Tokens | None = None,
         opened_by: str = "",
+        generated: bool = False,
     ) -> None:
-        """Record one option and run the rules a single row can be judged by."""
+        """Record one option and run the rules a single row can be judged by.
+
+        ``generated=True`` skips them: ``tasks/gen_cli.py`` writes the call
+        from a row the rules already ran on.
+        """
         self.name = name
         self.scope = scope
         self.kind = kind
@@ -247,7 +252,8 @@ class Opt:
         self.tokens = tokens
         self.opened_by = opened_by
 
-        self._check()
+        if not generated:
+            self._check()
 
     @override
     def __repr__(self) -> str:

--- a/tasks/gen_cli.py
+++ b/tasks/gen_cli.py
@@ -344,11 +344,12 @@ within a table.
 # Package used to make generated nab imports relative.
 _REGISTRY_PACKAGE = "nab.config"
 
-# Opt keyword defaults in declaration order.
+# Opt keyword defaults in declaration order. generated is not stored on a row,
+# so the __slots__ filter drops it.
 _OPT_FIELDS: dict[str, object] = {
     name: parameter.default
     for name, parameter in inspect.signature(Opt.__init__).parameters.items()
-    if parameter.kind is inspect.Parameter.KEYWORD_ONLY
+    if parameter.kind is inspect.Parameter.KEYWORD_ONLY and name in Opt.__slots__
 }
 
 # Opt supplies defaults for omitted hooks, so compare these fields separately.
@@ -423,6 +424,8 @@ def _opt_lines(row: Opt, imports: _Imports) -> list[str]:
         if value != unwritten:
             lines.extend(_keyword(f"{name}=", value, imports, row))
 
+    # The per-row rules already ran on the declaration this row came from.
+    lines.append(f"{_INDENT * 2}generated=True,")
     lines.append(f"{_INDENT}),")
     return lines
 


### PR DESCRIPTION
Stacked on #1170.

Skipping the per-row rules on the 37 generated `Opt` rows takes 412,356 instructions off `nab cache dir` (314,964,863 to 314,552,507) and 406,209 off `nab config list` (321,695,613 to 321,289,404), about 0.13% of either process. Every dispatching command imports `nab.config.registry` and rebuilds those rows, and the rules had already run on the `nab.optiontable` declaration each was generated from.

`Opt.__init__` takes a keyword-only `generated`, and `tasks/gen_cli.py` writes `generated=True` as the closing keyword of every row it emits. A hand-written row still judges itself as it is built, so a mistake in `nab.optiontable` raises where it is written, and `tests/test_cli_generated.py` fails while the generated module and its declaration disagree.

An in-process `nab cache dir` makes 568 fewer calls of 102,337: `_check` and its three helpers go from 37 to none, `Opt.key` from 87, `Opt.is_positional` from 8, and nothing is called more often. The 37 added keywords cost 1,684 bytes of peak memory, 0.029%.

Those counts reproduce exactly. The end-to-end timing runs only rule out a slowdown above about 2.5%.
