### PR TITLE
Fix `nab lock --locked` printing a refresh command nab rejects with exit 2

### DIFF
--- a/src/nab/_cli/parse.py
+++ b/src/nab/_cli/parse.py
@@ -25,6 +25,8 @@ __all__ = [
     "Table",
     "UsageError",
     "build",
+    "is_option",
+    "option_tokens",
     "parse",
 ]
 
@@ -233,7 +235,7 @@ def _walk(
         word = argv[index]
         index += 1
 
-        if not command and (ended or not _is_option(word)):
+        if not command and (ended or not is_option(word)):
             if word not in commands:
                 raise _unknown_command(prog_path, word, commands)
             command = word
@@ -261,7 +263,7 @@ def _walk(
             )
             if eager:
                 return _short_circuit(command, seen, prog_path, eager)
-        elif _is_option(word):
+        elif is_option(word):
             index, eager = _short(
                 word, argv, index, (table, root_table), seen, prog_path
             )
@@ -300,9 +302,24 @@ def _root_options(seen: dict[str, list[_Hit]]) -> dict[str, object]:
     return {dest: _reduce(hits) for dest, hits in seen.items() if hits[-1][0].root}
 
 
-def _is_option(word: str) -> bool:
+def is_option(word: str) -> bool:
     """Whether ``word`` is option-shaped: a dash and at least one more character."""
     return word[:1] == "-" and len(word) > 1
+
+
+def option_tokens(flag: str, values: tuple[str, ...]) -> list[str]:
+    """Render ``flag`` and ``values`` as tokens :func:`parse` reads back.
+
+    ``flag=value`` attaches the only value that may be option-shaped, so an
+    option-shaped value has to come first.  The walk ends a multi-value
+    option at the next option-shaped word, so it never hands one back in a
+    later position either.
+    """
+    if not values:
+        return []
+    if is_option(values[0]):
+        return [f"{flag}={values[0]}", *values[1:]]
+    return [flag, *values]
 
 
 def _match(tables: _Tables, name: str) -> Row | None:
@@ -424,7 +441,7 @@ def _separated(
         raise _missing_value(prog, name)
 
     following = argv[index]
-    if _is_option(following) and not _numeric(row, following):
+    if is_option(following) and not _numeric(row, following):
         raise _looks_like_option(prog, name, following)
 
     _store(seen, row, following)
@@ -467,7 +484,7 @@ def _star_value(
     groups.
     """
     taken = list(attached)
-    while index < len(argv) and not _is_option(argv[index]):
+    while index < len(argv) and not is_option(argv[index]):
         taken.append(argv[index])
         index += 1
 

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -71,6 +71,7 @@ from nab_provider.requirements_file import (
 )
 from nab_provider.target import IntractableMarkerError, UnevaluableMarkerError
 
+from ._cli.parse import is_option, option_tokens
 from ._resolve import (
     _check_targets_or_exit,
     _load_config,
@@ -332,7 +333,9 @@ def lock(  # noqa: PLR0913 - one keyword per flag is the public surface
         path=path,
         output=output,
         groups=selected_groups,
+        all_groups=all_groups,
         extras=selected_extras,
+        all_extras=all_extras,
         offline=offline,
         build_requirements=build_requirements,
         workspace_discovery=workspace_discovery,
@@ -519,7 +522,9 @@ class _LockRun:
     path: Path
     output: Path | None
     groups: tuple[str, ...]
+    all_groups: bool
     extras: tuple[str, ...]
+    all_extras: bool
     offline: bool | None
     build_requirements: bool
     workspace_discovery: bool
@@ -529,28 +534,49 @@ class _LockRun:
 
     def refresh_command(self) -> str:
         """Render this run without ``--locked``, ready to paste into a shell."""
-        return _join_command(
-            ["nab", "lock", *self._file_arguments(), *self._content_arguments()]
-        )
+        options = [*self._output_arguments(), *self._content_arguments()]
+        return _join_command(["nab", "lock", *self._with_project_path(options)])
 
-    def _file_arguments(self) -> list[str]:
-        """Return the arguments naming the project read and the file written."""
-        arguments: list[str] = []
-        if self.path != _DEFAULT_PROJECT_PATH:
-            arguments.append(str(self.path))
-        if self.output is not None:
-            arguments += ["--output", str(self.output)]
-        return arguments
+    def _with_project_path(self, options: list[str]) -> list[str]:
+        """Return ``options`` with the project path placed where nab reads it.
+
+        A path the parser would read as an option is only a path after
+        ``--``, which ends the options, so it goes last.
+        """
+        if self.path == _DEFAULT_PROJECT_PATH:
+            return options
+
+        path = str(self.path)
+        if is_option(path):
+            return [*options, "--", path]
+        return [path, *options]
+
+    def _output_arguments(self) -> list[str]:
+        """Return the argument naming the file written, when the run names one."""
+        if self.output is None:
+            return []
+        return option_tokens("--output", (str(self.output),))
 
     def _content_arguments(self) -> list[str]:
-        """Return the flags that decide what the rewritten lock holds."""
+        """Return the flags that decide what the rewritten lock holds.
+
+        ``--all-groups`` and ``--all-extras`` stay as themselves rather than
+        expanding into the names they selected, because only the first name
+        of an expanded list may be option-shaped.
+        """
         arguments: list[str] = []
-        if self.groups:
-            arguments += ["--groups", *self.groups]
-        if self.extras:
-            arguments += ["--extras", *self.extras]
+        if self.all_groups:
+            arguments.append("--all-groups")
+        else:
+            arguments += option_tokens("--groups", self.groups)
+
+        if self.all_extras:
+            arguments.append("--all-extras")
+        else:
+            arguments += option_tokens("--extras", self.extras)
+
         if self.offline is not None:
-            arguments += ["--offline", str(self.offline)]
+            arguments += option_tokens("--offline", (str(self.offline),))
 
         if self.build_requirements:
             arguments.append("--build-requirements")

--- a/src/nab/_run.py
+++ b/src/nab/_run.py
@@ -25,6 +25,7 @@ from nab_provider._vendor.packaging.version import Version
 from nab_provider.policy import ResolveMode
 
 from . import env
+from ._cli.parse import option_tokens
 from .config.hooks import inspector_anchor
 from .config.ladder import (
     OPTIONS,
@@ -335,14 +336,14 @@ def project_override_arguments(cli_overrides: Mapping[str, object]) -> list[str]
         value = cli_overrides.get(spec.name)
         if isinstance(value, CliTable):
             for key in value.keys:
-                arguments += [key.flag, *key.tokens]
+                arguments += option_tokens(key.flag, key.tokens)
             continue
         flag = spec.cli_flag
         if flag is None or value is None:
             continue
         items = value if isinstance(value, tuple) else (value,)
         for item in items:
-            arguments += [flag, str(item)]
+            arguments += option_tokens(flag, (str(item),))
     return arguments
 
 

--- a/tests/test_lock_locked.py
+++ b/tests/test_lock_locked.py
@@ -1279,6 +1279,159 @@ def test_remedy_names_a_custom_output_path(
     assert f"no lockfile at {out} to check; run `{remedy}` first." in err
 
 
+def test_remedy_puts_an_option_shaped_project_path_after_the_separator(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A project path that reads as an option is named after ``--``.
+
+    ``Path`` drops the ``./`` the user typed, so a path nab accepted as
+    ``./-weird.toml`` comes back out of the remedy as ``-weird.toml``.
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "-weird.toml").write_text(
+        '[project]\nname = "proj"\nversion = "0"\ndependencies = []\n', encoding="utf-8"
+    )
+
+    _lock_cli("./-weird.toml", "--offline", "True", "--no-cache", "--locked", status=1)
+
+    refresh = ["--offline", "True", "--", "-weird.toml"]
+    remedy = _remedy(*refresh)
+    assert (
+        f"no lockfile at pylock.toml to check; run `{remedy}` first."
+        in capsys.readouterr().err
+    )
+
+    _lock_cli("--no-cache", *refresh)
+
+    assert (tmp_path / "pylock.toml").is_file()
+
+
+def test_remedy_attaches_an_option_shaped_output_path(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An output path that reads as an option is attached to ``--output``."""
+    monkeypatch.chdir(tmp_path)
+    _write_pyproject(
+        tmp_path, '[project]\nname = "proj"\nversion = "0"\ndependencies = []\n'
+    )
+    (tmp_path / "-sub").mkdir()
+    out = Path("-sub/pylock.toml")
+
+    _lock_cli(
+        f"--output={out}", "--offline", "True", "--no-cache", "--locked", status=1
+    )
+
+    refresh = [f"--output={out}", "--offline", "True"]
+    remedy = _remedy(*refresh)
+    assert (
+        f"no lockfile at {out} to check; run `{remedy}` first."
+        in capsys.readouterr().err
+    )
+
+    _lock_cli("--no-cache", *refresh)
+
+    assert (tmp_path / out).is_file()
+
+
+def test_remedy_attaches_an_option_shaped_group_and_override(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A selected name that reads as an option is attached to the flag taking it.
+
+    ``-dev`` is a real group nab selects and writes into the lock, so the
+    remedy has to select it again.
+    """
+    monkeypatch.chdir(tmp_path)
+    _write_pyproject(
+        tmp_path,
+        '[project]\nname = "proj"\nversion = "0"\ndependencies = []\n'
+        "[dependency-groups]\n"
+        '"-dev" = []\ntest = []\n',
+    )
+
+    refresh = [
+        *["--groups=-dev", "test"],
+        *["--offline", "True"],
+        "--project-default-group=-dev",
+    ]
+
+    _lock_cli(*refresh, "--locked", status=1)
+
+    remedy = _remedy(*refresh)
+    assert (
+        f"no lockfile at pylock.toml to check; run `{remedy}` first."
+        in capsys.readouterr().err
+    )
+
+    _lock_cli("--no-cache", *refresh)
+
+    written = tomli.loads((tmp_path / "pylock.toml").read_text(encoding="utf-8"))
+    assert written["dependency-groups"] == ["-dev", "test"]
+    assert written["default-groups"] == ["-dev"]
+
+
+def test_remedy_names_all_groups_and_all_extras_not_what_they_selected(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``--all-groups`` reaches a declared name no expanded list could carry.
+
+    Only the first value of a multi-value option may be option-shaped, so a
+    ``-dev`` declared after ``test`` has no place in the expanded list.
+    """
+    monkeypatch.chdir(tmp_path)
+    _write_pyproject(
+        tmp_path,
+        '[project]\nname = "proj"\nversion = "0"\ndependencies = []\n'
+        "[project.optional-dependencies]\n"
+        "gpu = []\n"
+        "[dependency-groups]\n"
+        'test = []\n"-dev" = []\n',
+    )
+
+    refresh = ["--all-groups", "--all-extras", "--offline", "True"]
+
+    _lock_cli(*refresh, "--locked", status=1)
+
+    remedy = _remedy(*refresh)
+    assert (
+        f"no lockfile at pylock.toml to check; run `{remedy}` first."
+        in capsys.readouterr().err
+    )
+
+    _lock_cli("--no-cache", *refresh)
+
+    written = tomli.loads((tmp_path / "pylock.toml").read_text(encoding="utf-8"))
+    assert written["dependency-groups"] == ["-dev", "test"]
+    assert written["extras"] == ["gpu"]
+
+
+def test_remedy_for_an_option_shaped_extra_fails_on_the_name_not_the_parse(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Running the remedy reaches nab's refusal of ``-gpu``, not a parse error."""
+    monkeypatch.chdir(tmp_path)
+    _write_pyproject(
+        tmp_path,
+        '[project]\nname = "proj"\nversion = "0"\ndependencies = []\n'
+        "[project.optional-dependencies]\n"
+        '"-gpu" = []\n',
+    )
+
+    refresh = ["--extras=-gpu", "--offline", "True"]
+
+    _lock_cli(*refresh, "--locked", status=1)
+
+    remedy = _remedy(*refresh)
+    assert (
+        f"no lockfile at pylock.toml to check; run `{remedy}` first."
+        in capsys.readouterr().err
+    )
+
+    _lock_cli("--no-cache", *refresh, status=1)
+
+    assert "PEP 751 does not accept in 'extras'" in capsys.readouterr().err
+
+
 def test_remedy_carries_every_run_shaping_flag(
     tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
`nab lock --locked` prints the command to rerun, and when one of that run's values starts with a dash the printed command does not parse:

    $ nab lock ./-weird.toml --offline True --locked
    error: --locked: no lockfile at pylock.toml to check; run `nab lock -weird.toml --offline True` first.

    $ nab lock -weird.toml --offline True
    nab lock: unrecognized option '-w' in '-weird.toml'

`Path` drops the `./`, so a path nab accepted comes back out as an option. `--output`, `--groups`, `--extras` and the `--project-*` overrides hit the same thing, exit 2 each.

The printed command now places each value where the parser reads it back. A project path that starts with a dash goes last, after `--`; any other such value is attached to its flag as `--flag=value`.

`--all-groups` and `--all-extras` are named as themselves rather than expanded into the names they selected. Only the first value of a multi-value option may start with a dash, so a `-dev` declared after `test` has no place in an expanded list.
