### PR TITLE
Share a release's equal metadata texts, ~6.6% off a matrix's traced peak

### DIFF
--- a/nab-project/tests/test_fetch.py
+++ b/nab-project/tests/test_fetch.py
@@ -197,6 +197,32 @@ class TestInMemoryIndex:
         )
         assert idx.get_metadata("foo", "1.0") == "Name: foo\nVersion: 1.0\n"
 
+    def test_equal_metadata_texts_in_a_release_share_one_str(self) -> None:
+        """Wheels of one version whose header blocks match hold one shared str."""
+        idx = InMemoryIndex()
+        linux = "Name: foo\nVersion: 1.0\nRequires-Dist: linux-only\n\n"
+        macos = "Name: foo\nVersion: 1.0\nRequires-Dist: macos-only\n\n"
+        windows = "Name: foo\nVersion: 1.0\nRequires-Dist: windows-only\n\n"
+        wheels = [
+            ("https://example.com/foo-linux.whl", linux),
+            ("https://example.com/foo-manylinux.whl", linux),
+            ("https://example.com/foo-macos.whl", macos),
+            ("https://example.com/foo-macos-arm.whl", macos),
+            ("https://example.com/foo-windows.whl", windows),
+        ]
+        for url, header in wheels:
+            idx.store_metadata(
+                "foo", "1.0", header + "A long description.\n", metadata_url=url
+            )
+
+        held = [idx.get_metadata("foo", "1.0", metadata_url=url) for url, _ in wheels]
+
+        assert held == [linux, linux, macos, macos, windows]
+
+        assert held[0] is held[1]
+        assert held[2] is held[3]
+        assert held[0] is not held[2]
+
     def test_store_metadata_none(self) -> None:
         idx = InMemoryIndex()
         idx.store_metadata("foo", "1.0", None)

--- a/nab-provider/src/nab_provider/store.py
+++ b/nab-provider/src/nab_provider/store.py
@@ -93,6 +93,8 @@ class InMemoryIndex:
         # Versions whose version-level slot was written from an sdist PKG-INFO;
         # only sdist deps go through the PEP 643 gate.
         self._metadata_from_sdist: set[tuple[str, str]] = set()
+        # The distinct texts a release's slots hold, so equal ones share a str.
+        self._slot_texts: dict[tuple[str, str], tuple[str, ...]] = {}
 
         # Empty metadata slots that stand for a rung skipped offline, keyed by
         # that rung's URL.
@@ -309,6 +311,20 @@ class InMemoryIndex:
         with self._lock:
             return self._read_metadata(package, version, metadata_url)
 
+    def _share_slot_text(self, release: tuple[str, str], text: str) -> str:
+        """Return the str already held for ``release`` equal to ``text``, or hold it.
+
+        Caller holds the lock.  ``release`` is ``(package, version)``.  A matrix
+        writes one slot per target of a release, and targets whose wheels
+        declare the same headers would otherwise hold a copy of the text each.
+        """
+        held = self._slot_texts.get(release, ())
+        for seen in held:
+            if seen == text:
+                return seen
+        self._slot_texts[release] = (*held, text)
+        return text
+
     def _write_metadata_slot(
         self,
         slot: tuple[str, str, str | None],
@@ -325,7 +341,10 @@ class InMemoryIndex:
         if data is None:
             text = None
         else:
-            text = metadata_without_description(metadata_header_block(data))
+            text = self._share_slot_text(
+                (package, version),
+                metadata_without_description(metadata_header_block(data)),
+            )
 
         if metadata_url is None:
             if self._metadata.get(slot) != text:


### PR DESCRIPTION
Sharing one str across the metadata slots of a `(package, version)` takes 2.71 MB off the 41.2 MB traced peak of a 12-target `universal:scientific-python-multi` resolve, 6.6%, and about 1.3 MB off its peak RSS locally.

A matrix writes one metadata slot per target of a release, and those targets' wheels often declare the same headers: that resolve's 189 slots over 43 releases held 189 separate str objects, and now hold 62. The slots still total 4,036,511 characters: nothing is dropped, only shared.

`_write_metadata_slot` now passes its header block to a new `_share_slot_text`, which returns a str the release already holds when it compares equal. It compares rather than hashing, since a block runs to tens of kilobytes and a hash reads all of it.

The comparison adds about 4,030 instructions per metadata write, roughly 760,000 across the 189 that resolve makes, 0.02% of the 3.7 billion or so it retires.

A 1-target control over the same requirements keeps its 34 slots on separate strs and adds under 6 KB to a 37.6 MB peak. The timing runs on the matrix scenario rule out a wall or CPU change above about 3%.
