### PR TITLE
Clarify output handling when a matrix target fails

### DIFF
--- a/docs/explanation/universal.md
+++ b/docs/explanation/universal.md
@@ -159,9 +159,9 @@ numpy==2.1.3
 One block per target. pip cannot install a single requirements.txt
 across multiple targets in hash-checking mode, so the per-target
 block format is for inspection or for tools that consume one block
-at a time. When a target fails resolution, the line reads
-`# <label>: FAILED` followed by the indented error and the process
-exits 1.
+at a time. If any target fails, no blocks are written: the run
+reports every target on stderr and exits 1. See
+[Resolution failures](../reference/diagnostics.md).
 
 ## Patch-release markers
 

--- a/docs/reference/diagnostics.md
+++ b/docs/reference/diagnostics.md
@@ -48,3 +48,19 @@ Diagnostics:
 | An extras line can be about the base package | `foo[bar]` has versions only where `foo` does, so a filter that empties `foo`'s listing gives the line and its `try:` under `foo[bar]`, naming `foo` as the entry to edit. |
 | Some lines name no setting | Nothing in the configuration produced them, such as `package not found on any configured index` or `the index lists this package but every file is yanked`. |
 | A routed package is missing from one index, not from all of them | An `index` entry is a strict pin, so the line names that index: `not found on index 'internal', the only index this package is routed to`. |
+
+## Several targets
+
+Universal matrices and declared extra or group conflicts can produce several resolve targets. If any fails, nab writes no lock or requirements output. The failure report goes to stderr, with one labelled block per target:
+
+```
+error: resolution failed:
+# py311-linux_x86_64
+attrs==26.1.0
+# py312-linux_x86_64: FAILED
+#   ResolutionError: because no versions of attrs <1.0 are available
+#   because your project depends on attrs <1.0
+#   so your project's requirements cannot be satisfied
+```
+
+Successful targets show their pins; failed targets show an indented error and any `Diagnostics:` details. A failure in a conflict's base selection adds a `# base/<label>: FAILED` block; see [Conflicting selections](../explanation/conflicts.md).

--- a/docs/reference/formats.md
+++ b/docs/reference/formats.md
@@ -61,7 +61,6 @@ all three formats:
   combined output as one hash-checked requirements file; use an output
   template to create one file per target.
 
-A failed target renders as `# {label}: FAILED`, followed by the
-commented, indented error. The command exits `1`.
+If any target fails, nab writes no lock or requirements output. The report goes to stderr and the command exits `1`; see [Resolution failures](diagnostics.md).
 
 [PEP 751]: https://peps.python.org/pep-0751/

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3326,6 +3326,57 @@ class TestLockCommandUniversal:
         assert "FAILED" in err
         assert "#   ResolutionError: conflict" in err
 
+    def test_failed_tuple_writes_no_pins_to_stdout(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A failed target leaves stdout empty under ``--output -``."""
+        pyproject = _universal_pyproject(tmp_path)
+        with (
+            patch(
+                "nab._resolve.resolve_for_targets",
+                return_value=_multi_tuple_failed_result(ResolutionError("conflict")),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, format="requirements-without-hashes", output=Path("-"))
+
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "# py312-linux_x86_64: FAILED" in captured.err
+
+    def test_failed_tuple_writes_no_requirements_files(self, tmp_path: Path) -> None:
+        """A failed target prevents all per-target requirements files."""
+        pyproject = _universal_pyproject(tmp_path)
+        out = tmp_path / "constraints-{python_version}.txt"
+        with (
+            patch(
+                "nab._resolve.resolve_for_targets",
+                return_value=_multi_tuple_failed_result(ResolutionError("conflict")),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, format="requirements-without-hashes", output=out)
+
+        assert list(tmp_path.glob("constraints-*")) == []
+
+    def test_failed_tuple_writes_no_pylock(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A failed target prevents pylock output and reports on stderr."""
+        pyproject = _universal_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        with (
+            patch(
+                "nab._resolve.resolve_for_targets",
+                return_value=_multi_tuple_failed_result(ResolutionError("conflict")),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, format="pylock", output=out)
+
+        assert not out.exists()
+        assert "# py312-linux_x86_64: FAILED" in capsys.readouterr().err
+
     def test_failed_tuple_multi_line_error(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:


### PR DESCRIPTION
When any matrix target fails, nab reports the results on stderr and writes no lock or requirements output. The format reference and universal-resolution guide previously showed the failure as part of the requirements output.

The diagnostics reference now explains the report for several targets, including successful pins, failed targets, and failures in a conflict's base selection.
