### PR TITLE
Use explicit constructors for tag indexes and tag sets

### DIFF
--- a/nab-provider/src/nab_provider/_value.py
+++ b/nab-provider/src/nab_provider/_value.py
@@ -1,10 +1,4 @@
-"""The shared base under this package's hand-written value types.
-
-They are written out instead of declared with ``@dataclass(slots=True)``,
-because applying the decorator is import-time work every ``nab`` invocation
-pays for.  The comparison, hash and repr they share live here; each type
-declares its own fields and constructor.
-"""
+"""Equality, hashing and repr for explicit value types."""
 
 from __future__ import annotations
 
@@ -14,12 +8,10 @@ __all__ = ["SlottedValue"]
 
 
 class SlottedValue:
-    """Comparison, hashing and repr over a subclass's declared fields.
+    """Equality, hashing and repr over a subclass's declared fields.
 
-    A subclass lists its fields in ``__slots__`` and names them, in
-    declaration order, in ``__match_args__``, which is the order read here.
-    Comparison tests the exact class, so a subclass holding equal field
-    values is not equal.
+    ``__match_args__`` sets field order. Equality checks the exact class.
+    Subclasses using ``cached_property`` retain a ``__dict__``.
     """
 
     __slots__ = ()

--- a/nab-provider/src/nab_provider/tags.py
+++ b/nab-provider/src/nab_provider/tags.py
@@ -32,6 +32,8 @@ from typing import TYPE_CHECKING, Final, Literal, Protocol, TypeVar
 from nab_provider._vendor.packaging import tags as ptags
 from nab_provider._vendor.packaging.version import Version
 
+from ._value import SlottedValue
+
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
 
@@ -130,6 +132,7 @@ _X86_GLIBC2_MINOR_FLOOR = 5
 _OTHER_GLIBC2_MINOR_FLOOR = 17
 
 
+# PlatformSpec is a cache key and needs frozen fields and copy/pickle support.
 @dataclass(frozen=True)
 class PlatformSpec:
     """Concrete tag knobs for one matrix platform_id.
@@ -554,8 +557,7 @@ class _Unplaced(enum.Enum):
 _UNPLACED: Final = _Unplaced.TOKEN
 
 
-@dataclass(frozen=True)
-class _AxisIndex:
+class _AxisIndex(SlottedValue):
     """Where a tag sits in a target's expanded tag order.
 
     ``multiplied`` holds the first index of each interpreter/abi block the
@@ -565,9 +567,23 @@ class _AxisIndex:
     index :attr:`TagSet.rank` keeps for a repeated tag.
     """
 
+    __match_args__ = ("multiplied", "fixed", "platforms")
+    __slots__ = __match_args__
+
     multiplied: Mapping[tuple[str, str], int]
     fixed: Mapping[Tag, int]
     platforms: Mapping[str, int]
+
+    def __init__(
+        self,
+        multiplied: Mapping[tuple[str, str], int],
+        fixed: Mapping[Tag, int],
+        platforms: Mapping[str, int],
+    ) -> None:
+        """Record the three tables :meth:`of` reads."""
+        self.multiplied = multiplied
+        self.fixed = fixed
+        self.platforms = platforms
 
     def of(self, tag: Tag) -> int | None:
         """Return ``tag``'s index in the expanded order, or None if unaccepted.
@@ -584,8 +600,7 @@ class _AxisIndex:
         return self.fixed.get(tag)
 
 
-@dataclass(frozen=True)
-class TagSet:
+class TagSet(SlottedValue):
     """The wheel tags one target accepts, in install-preference order.
 
     A target's tags are the cross product of its interpreter/abi axis with
@@ -602,8 +617,18 @@ class TagSet:
     target's preference for the wheels carrying it.
     """
 
+    # No __slots__: the cached properties below need a __dict__.
+    __match_args__ = ("_entries", "_platforms")
+
     _entries: tuple[_AxisEntry, ...]
-    _platforms: tuple[str, ...] = ()
+    _platforms: tuple[str, ...]
+
+    def __init__(
+        self, _entries: tuple[_AxisEntry, ...], _platforms: tuple[str, ...] = ()
+    ) -> None:
+        """Record the two axes whose cross product the target accepts."""
+        self._entries = _entries
+        self._platforms = _platforms
 
     @cached_property
     def ordered(self) -> tuple[Tag, ...]:

--- a/nab-provider/tests/test_tags.py
+++ b/nab-provider/tests/test_tags.py
@@ -8,12 +8,14 @@ Pins:
   needing newer, per floor
 - the free-threaded ``cpXYt`` ABI, and ``abi3t`` in place of ``abi3``
 - ``py3-none-any`` fallback ordering
+- every knob reaching comparison, hashing and repr
 - compressed-tag-set wheels (``cp310.cp311``)
 """
 
 from __future__ import annotations
 
 from contextlib import AbstractContextManager
+from dataclasses import FrozenInstanceError
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -261,6 +263,83 @@ class TestPlatformSpec:
         """Pins the escaped label shape for a realistic kernel release."""
         spec = PlatformSpec("linux_x86_64", platform_release="5.15.0-generic")
         assert spec.label == "linux_x86_64-rel5.15.0_2d_generic"
+
+
+class TestPlatformSpecFields:
+    """Check platform fields and frozen cache-key behavior."""
+
+    @pytest.mark.parametrize(
+        ("platform_id", "knob", "value"),
+        [
+            ("linux_x86_64", "libc", "musl"),
+            ("linux_x86_64", "runs_on_libc", (2, 28)),
+            ("macos_arm64", "runs_on_macos", (14, 0)),
+            ("linux_x86_64", "platform_release", "5.15.0"),
+            ("linux_x86_64", "platform_version", "#1 SMP"),
+            ("linux_x86_64", "free_threaded", True),
+        ],
+    )
+    def test_a_declared_knob_separates_the_spec_from_the_default(
+        self, platform_id: str, knob: str, value: object
+    ) -> None:
+        """A spec with one knob off the default is unequal, and its repr names it."""
+        declared = PlatformSpec(platform_id, **{knob: value})  # type: ignore[arg-type]
+
+        assert declared != PlatformSpec(platform_id)
+        assert f"{knob}={value!r}" in repr(declared)
+
+    def test_the_platform_id_separates_two_otherwise_equal_specs(self) -> None:
+        """``platform_id`` is a compared field, and the repr names it."""
+        assert PlatformSpec("linux_x86_64") != PlatformSpec("linux_aarch64")
+        assert "platform_id='linux_aarch64'" in repr(PlatformSpec("linux_aarch64"))
+
+    def test_two_specs_declaring_the_same_knobs_agree(self) -> None:
+        """Equal specs hash alike, so a set holds one of the pair."""
+        spec = PlatformSpec("linux_x86_64", libc="musl", runs_on_libc=(1, 2))
+        twin = PlatformSpec("linux_x86_64", libc="musl", runs_on_libc=(1, 2))
+
+        assert spec == twin
+        assert hash(spec) == hash(twin)
+        assert len({spec, twin}) == 1
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "platform_id",
+            "libc",
+            "runs_on_libc",
+            "runs_on_macos",
+            "platform_release",
+            "platform_version",
+            "free_threaded",
+        ],
+    )
+    def test_cache_key_fields_are_immutable(self, field: str) -> None:
+        spec = PlatformSpec("linux_x86_64")
+        cache = {spec: "cached"}
+
+        with pytest.raises(FrozenInstanceError):
+            setattr(spec, field, getattr(spec, field))
+        with pytest.raises(FrozenInstanceError):
+            delattr(spec, field)
+
+        assert cache[spec] == "cached"
+
+    def test_subclass_can_change_its_own_fields(self) -> None:
+        class ExtendedSpec(PlatformSpec):
+            """A platform spec with mutable ancillary data."""
+
+            note: str
+
+        spec = ExtendedSpec("linux_x86_64")
+        spec.note = "extra"
+        assert spec.note == "extra"
+        del spec.note
+
+        with pytest.raises(FrozenInstanceError):
+            spec.libc = "musl"
+        with pytest.raises(FrozenInstanceError):
+            del spec.libc
 
 
 class TestLibcFamilyExclusivity:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,23 +27,13 @@ if TYPE_CHECKING:
 
 @pytest.fixture(autouse=True)
 def _reset_nab_output(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
-    """Pin nab's output state so the CLI suite is deterministic.
+    """Isolate CLI colour settings and reset the per-run printer.
 
-    Two hazards this guards against:
-
-    * CI sets ``FORCE_COLOR=1`` so its tool logs are coloured, which would
-      otherwise make nab wrap its message tokens in ANSI and break the plain
-      output the assertions expect.  Both variables are cleared rather than
-      relying on ``NO_COLOR`` winning: a case that wants the isatty decision
-      clears ``NO_COLOR``, and an ambient ``FORCE_COLOR`` left behind would
-      paint whatever it looked at.
-    * ``nab.output.begin`` sets a module-level printer (bound to the run's
-      streams) and installs a logging handler on the nab loggers; without the
-      reset a test that runs ``main`` would leak the printer (whose captured
-      stream is closed once the test ends) and the handler into later tests.
+    Printers hold captured streams that close when their test finishes.
     """
     monkeypatch.setenv("NO_COLOR", "1")
     monkeypatch.delenv("FORCE_COLOR", raising=False)
+    monkeypatch.delenv("TERM", raising=False)
     yield
     reset_run()
 


### PR DESCRIPTION
Locally, `nab cache dir` retires 5,831,053 fewer instructions: 304,714,709 to 298,883,656 (about 1.9%).

Replace the dataclass decorators on `_AxisIndex` and `TagSet` with explicit constructors and shared value operations. `TagSet` retains a dictionary for its cached properties. `PlatformSpec` remains a frozen dataclass because it is used as a cache key and must preserve copying and pickling.

The CLI output fixture also clears ambient `TERM` to isolate terminal-colour tests.
