### PR TITLE
Canonicalize a listing's equal versions once per release, not per artifact

### DIFF
--- a/nab-provider/src/nab_provider/_provider/listing.py
+++ b/nab-provider/src/nab_provider/_provider/listing.py
@@ -810,13 +810,17 @@ def _canonicalize_equal_versions(
     """
     representative: dict[Version, Version] = {}
     needs_rebuild = False
+    run_version: Version | None = None
+
     for version, _ in result:
-        chosen = representative.get(version)
-        if chosen is None:
-            representative[version] = version
-        elif chosen is not version:
-            # The listing interns its versions, so two distinct objects that
-            # compare equal are two representations of one release.
+        # ``result`` is sorted by version and the listing interns its versions,
+        # so artifacts sharing a version string arrive as a run of one object.
+        if version is run_version:
+            continue
+        run_version = version
+
+        chosen = representative.setdefault(version, version)
+        if chosen is not version:
             needs_rebuild = True
             if (len(version.release), str(version)) < (
                 len(chosen.release),


### PR DESCRIPTION
A `pip:google-bigquery-soda` resolve hands `_canonicalize_equal_versions` 35,143 (version, artifact) pairs, and the loop probed its representative map once for each, costing one `Version.__hash__` call per pair. All 35,143 of those calls go, out of about 67,000 the base resolve makes.

A release's artifacts share one interned `Version`, so consecutive pairs repeat the object the pair before them settled, and only 3,607 of the 35,143 open a new one. The loop now skips a repeat and folds the lookup and the first write into one `setdefault`.

The function costs 345 instructions per pair instead of 1,255, about 32 million fewer over those 35,143 pairs, and a whole resolve of that scenario retires between 0.80% and 0.86% fewer instructions across two runs.

Timing over the 19-scenario canary set could not resolve anything below about 2%, so it rules out a regression that large and cannot see a win this small.
