### PR TITLE
Store only an sdist's [project] table, ~920 kB off a langchain resolve

### DIFF
--- a/nab-project/tests/test_fetch.py
+++ b/nab-project/tests/test_fetch.py
@@ -223,6 +223,27 @@ class TestInMemoryIndex:
         assert held[2] is held[3]
         assert held[0] is not held[2]
 
+    def test_sdist_pyproject_slot_keeps_only_the_project_table(self) -> None:
+        idx = InMemoryIndex()
+        idx.store_sdist_pyproject(
+            "foo",
+            "1.0",
+            {
+                "project": {"name": "foo"},
+                "build-system": {"requires": ["setuptools"]},
+                "tool": {"mypy": {"strict": True}},
+            },
+        )
+        assert idx.get_sdist_pyproject("foo", "1.0") == {"project": {"name": "foo"}}
+
+    def test_sdist_pyproject_with_no_project_table_reads_as_fetched(self) -> None:
+        """An empty table keeps a fetched pyproject distinct from an absent one."""
+        idx = InMemoryIndex()
+        idx.store_sdist_pyproject("foo", "1.0", {"build-system": {"requires": []}})
+
+        assert idx.get_sdist_pyproject("foo", "1.0") == {}
+        assert idx.get_sdist_pyproject("bar", "1.0") is None
+
     def test_store_metadata_none(self) -> None:
         idx = InMemoryIndex()
         idx.store_metadata("foo", "1.0", None)

--- a/nab-provider/src/nab_provider/store.py
+++ b/nab-provider/src/nab_provider/store.py
@@ -47,6 +47,12 @@ def range_pending_key(package: str, version: str, wheel_url: str) -> str:
     return f"range:{package}:{version}:{wheel_url}"
 
 
+def _project_table_only(data: Mapping[str, Any]) -> dict[str, Any]:
+    """Return ``data`` cut to ``[project]``, empty unless that key holds a table."""
+    project = data.get("project")
+    return {"project": project} if isinstance(project, dict) else {}
+
+
 class InMemoryIndex:
     """Thread-safe slots for fetched data, plus the events readers wait on.
 
@@ -519,18 +525,19 @@ class InMemoryIndex:
     def store_sdist_pyproject(
         self, package: str, version: str, data: Mapping[str, Any] | None
     ) -> None:
-        """Store an sdist's parsed pyproject.toml for static-metadata fallback.
+        """Store the pyproject cut to ``[project]`` for static-metadata fallback.
 
         The host parses the TOML on the way in, so the store needs no TOML
         library.  ``None`` reads the same as never-fetched.
         """
+        stored = None if data is None else _project_table_only(data)
         with self._lock:
-            self._sdist_pyproject[(package, version)] = data
+            self._sdist_pyproject[(package, version)] = stored
 
     def get_sdist_pyproject(
         self, package: str, version: str
     ) -> Mapping[str, Any] | None:
-        """Return the parsed sdist pyproject, or ``None`` if absent or unfetched."""
+        """Return the ``[project]`` cut, or ``None`` if absent or unfetched."""
         return self._sdist_pyproject.get((package, version))
 
     def store_sdist_archive(


### PR DESCRIPTION
Peak Python allocation on `pip:langchain-ml-course --resolution lowest`, which stores 220 sdist pyprojects, falls about 920 kB, 0.61% of the run's 150 MB peak. Peak resident memory is down about 0.5% locally, between roughly 0.3% and 0.7% over 12 runs a side.

`InMemoryIndex` parked an sdist's whole parsed `pyproject.toml`. Its one reader is the dynamic-deps fallback in `metadata_resolver`, which passes the table to `static_project_from_table` and gets back `[project]` alone. `[tool]` and `[build-system]` sat in the slot until the resolve ended, read by nothing.

`store_sdist_pyproject` now keeps `{"project": ...}` and drops the rest. `None` still means absent or unfetched, and a pyproject with no `[project]` table stores `{}`. That keeps a fetched file distinct from one that was never fetched.

The narrowing costs 1,266 instructions per stored sdist, counted over those 220 tables. That is about 278,500 per resolve, against the roughly 13 billion the whole run retires. The timing runs cannot see anything below about 4%, so they only rule out a regression bigger than that.
