### PR TITLE
Defer tarfile and zipfile imports in nab-index, 10M instructions off startup

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -12,7 +12,6 @@ import hashlib
 import io
 import re
 import sys
-import tarfile
 import zlib
 from collections.abc import Mapping
 from functools import lru_cache
@@ -77,7 +76,9 @@ _FileEntry = Mapping[Any, object]
 # The tar ``data`` filter (PEP 706) landed in 3.12 and was backported to
 # 3.10.12 / 3.11.4; sdist extraction requires it (see extract_sdist_archive).
 # data_filter appears with the same change, so its presence detects support.
-_SUPPORTS_DATA_FILTER = hasattr(tarfile, "data_filter")
+# ``None`` leaves that check to extract_sdist_archive, which imports tarfile;
+# a bool overrides it.
+_SUPPORTS_DATA_FILTER: bool | None = None
 
 
 # Mirrors packaging.utils._build_tag_regex: PEP 427 build numbers start with a digit.
@@ -780,6 +781,9 @@ def _extract_sdist_files_if_readable(
     answer freezes that choice of root, so changing it means bumping
     ``CACHE_VERSION_SDIST``.
     """
+    # Deferred so importing this module does not load tarfile.
+    import tarfile  # noqa: PLC0415
+
     try:
         return _read_tar_sdist_files(data)
     except (
@@ -799,6 +803,9 @@ def _extract_sdist_files_if_readable(
 
 
 def _read_tar_sdist_files(data: bytes) -> tuple[str | None, str | None]:
+    # Deferred so importing this module does not load tarfile.
+    import tarfile  # noqa: PLC0415
+
     pkg_infos: dict[str, str] = {}
     pyprojects: dict[str, str] = {}
 
@@ -879,7 +886,13 @@ def extract_sdist_archive(
     The data filter is required; a Python that lacks it (before 3.10.12 /
     3.11.4 / 3.12) is unsupported and extraction raises.
     """
-    if not _SUPPORTS_DATA_FILTER:
+    # Deferred so importing this module does not load tarfile.
+    import tarfile  # noqa: PLC0415
+
+    supports_data_filter = _SUPPORTS_DATA_FILTER
+    if supports_data_filter is None:
+        supports_data_filter = hasattr(tarfile, "data_filter")
+    if not supports_data_filter:
         msg = (
             "extracting an sdist archive requires the tar data filter;"
             " upgrade to Python 3.10.12+ / 3.11.4+ / 3.12+"

--- a/nab-index/src/nab_index/lazy_wheel.py
+++ b/nab-index/src/nab_index/lazy_wheel.py
@@ -27,7 +27,6 @@ import hashlib
 import io
 import os
 import re
-import zipfile
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
@@ -40,6 +39,8 @@ from .local_index import UnsupportedWheelError, wheel_metadata_member
 from .transport import IDENTITY_HEADERS
 
 if TYPE_CHECKING:
+    import zipfile
+
     from packaging.utils import NormalizedName
 
     from .transport import AsyncHttpTransport, HttpResponse
@@ -477,6 +478,9 @@ def _try_open(sparse: _SparseFile) -> zipfile.ZipFile | None:
     member name, offsets outside the file), so it marks the wheel unreadable
     rather than the window short.
     """
+    # Deferred so importing this module does not load zipfile.
+    import zipfile  # noqa: PLC0415
+
     try:
         return zipfile.ZipFile(sparse)
     except zipfile.BadZipFile:
@@ -590,6 +594,9 @@ def _verify_full_body(body: bytes, wheel_hash: tuple[str, str] | None) -> None:
 
 def _read_full_body(body: bytes, canonical_name: NormalizedName) -> bytes | None:
     """Read the METADATA member out of a complete in-memory wheel, or ``None``."""
+    # Deferred so importing this module does not load zipfile.
+    import zipfile  # noqa: PLC0415
+
     try:
         zip_file = zipfile.ZipFile(io.BytesIO(body))
         member = wheel_metadata_member(zip_file.namelist(), canonical_name)

--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -24,7 +24,6 @@ import errno
 import os
 import re
 import stat
-import zipfile
 from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple
 from urllib.parse import unquote, urljoin, urlparse, urlsplit
@@ -581,6 +580,9 @@ def _read_wheel_requires_python(wheel_path: Path, expected: str) -> str | None:
     one bad file does not fail the listing that carries the package's other
     versions.
     """
+    # Deferred so importing this module does not load zipfile.
+    import zipfile  # noqa: PLC0415
+
     try:
         with zipfile.ZipFile(wheel_path) as archive:
             member = wheel_metadata_member(archive.namelist(), expected)
@@ -663,6 +665,10 @@ def read_wheel_metadata(wheel_path: Path) -> str | None:
     parsed = _parse_wheel_filename(wheel_path.name)
     if parsed is None:
         return None
+
+    # Deferred so importing this module does not load zipfile.
+    import zipfile  # noqa: PLC0415
+
     try:
         with zipfile.ZipFile(wheel_path) as zf:
             member = wheel_metadata_member(zf.namelist(), parsed[0])

--- a/tests/test_cli_imports.py
+++ b/tests/test_cli_imports.py
@@ -12,7 +12,7 @@ sanctioned exemptions, and each is loaded only by a line that asked for it.
 
 The last cases ban what a command holds after it has dispatched: a line
 that only reads settings loads nothing a resolve needs, and a line that
-locks holds no part of ``email``.
+locks holds neither ``email`` nor an archive reader.
 """
 
 from __future__ import annotations
@@ -266,3 +266,18 @@ def test_a_lock_command_holds_no_email_module(tmp_path: Path) -> None:
     (tmp_path / "pyproject.toml").write_text(_PROJECT, encoding="utf-8")
 
     assert _run(_HELD_PROBE, "email", "lock", "--offline", cwd=tmp_path) == ""
+
+
+def test_a_lock_command_holds_no_archive_reader(tmp_path: Path) -> None:
+    """Probe H: locking loads neither stdlib archive reader.
+
+    :mod:`nab_index.client`, :mod:`nab_index.lazy_wheel` and
+    :mod:`nab_index.local_index` are all held by the line even under
+    ``--offline``, and each reaches :mod:`tarfile` or :mod:`zipfile` only
+    from a branch that opens an archive.
+    """
+    (tmp_path / "pyproject.toml").write_text(_PROJECT, encoding="utf-8")
+
+    held = _run(_HELD_PROBE, "tarfile,zipfile", "lock", "--offline", cwd=tmp_path)
+
+    assert held == ""


### PR DESCRIPTION
Dropping the module-scope `import tarfile` and `import zipfile` from three `nab_index` modules takes 10,045,328 instructions off `import nab._lock` (1.6% of 640,326,792) and 10,205,424 off an offline five-package `nab lock` (1.1% of 918,119,641). Both counted under callgrind with `PYTHONHASHSEED=0`.

Every `nab lock`, `nab resolve` and `nab download` was loading both readers even when it opened no archive. Eight modules go and none arrives: `tarfile`, `zipfile`, `zipfile._path`, `zipfile._path.glob`, `grp`, `pwd`, `importlib.util`, `importlib._abc`. `nab --version`, `nab cache` and `nab config` never held them and are unchanged.

The paths that do open an archive pay the import at the call site. Reading a local wheel's METADATA 1001 times through `read_wheel_metadata` still retires 4,307,005 fewer instructions (485,418,676 to 481,111,671).

Peak traced bytes on the same offline lock fall 3.0%, from 18,511,633 to 17,956,563. Timing over the 19-scenario canary set rules out a wall or CPU regression above about 6%. On one of those scenarios, `pip:google-bigquery-soda@lowest`, the counted change is 5,462,191 instructions, 0.14% of the run.

`_SUPPORTS_DATA_FILTER` now starts as `None`, and `extract_sdist_archive` probes for the tar data filter after importing `tarfile`.
