### PR TITLE
Explain root requirements behind look-ahead bans

### DIFF
--- a/nab-project/src/nab_project/_resolve/engine.py
+++ b/nab-project/src/nab_project/_resolve/engine.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
     from nab_provider.provider import ResolutionStrategy
     from nab_provider.resolver_inputs import MarkerHolds
     from nab_provider.target import ResolveTarget
-    from nab_resolver.types import Incompatibility
+    from nab_resolver.types import Incompatibility, RangeProtocol
 
     from ..fetch import FetchCoordinator
     from ..inputs import ResolveInputs
@@ -783,32 +783,21 @@ def _raise_for_source_python(
 
 
 def _augment_resolution_error(exc: ResolutionError, provider: Provider) -> None:
-    """Append per-package no-versions diagnostics to ``exc`` in-place.
+    """Attach short and verbose no-versions diagnostics to exc.
 
-    Reasons are keyed by package name and outlive the ask that recorded
-    them, so a package keeps its hint even when the tree names it over a
-    later range.
-
-    Both depths are attached: ``str(exc)`` carries the one line per package
-    a default run prints, and :attr:`~nab_resolver.errors.ResolutionError.
-    verbose_message` carries the same report with each package's clauses and
-    ``note:`` in place of its ``try:`` line.  The host picks by verbosity;
-    a host that only prints the exception gets the short one.
+    Combine repeated packages' ranges before filtering permanent bans.
     """
     if exc.incompatibility is None:
         return
 
-    packages: list[str] = []
-    seen: set[str] = set()
-    for package in _walk_no_versions_packages(exc.incompatibility):
-        if package in seen:
-            continue
-        seen.add(package)
-        packages.append(package)
+    failed: dict[str, RangeProtocol[Version]] = {}
+    for package, clause_range in _walk_no_versions_packages(exc.incompatibility):
+        earlier = failed.get(package)
+        failed[package] = clause_range if earlier is None else earlier | clause_range
 
     entries: list[tuple[str, Diagnostic]] = []
-    for package in packages:
-        diagnostic = provider.get_no_versions_reason(package)
+    for package, failed_range in failed.items():
+        diagnostic = provider.get_no_versions_reason(package, failed_range)
         if diagnostic is not None:
             entries.append((package, diagnostic))
     if not entries:
@@ -857,18 +846,12 @@ def _rules_out_candidate(node: Incompatibility[Any, Any]) -> bool:
 
 def _walk_no_versions_packages(
     incompatibility: Incompatibility[Any, Any],
-) -> list[str]:
-    """Return the packages a no-versions diagnostic may name.
+) -> list[tuple[str, RangeProtocol[Any]]]:
+    """Collect package/range pairs from clauses that exclude candidates.
 
-    NO_VERSIONS clauses name every package they carry.  A dependency clause
-    that rules its own candidate's versions out names that candidate: a union
-    widened over the whole listing conflicts during propagation, with no
-    second ``choose_version`` ask to raise a NO_VERSIONS clause.
-
-    The walk is iterative: the tree gains a level per conflict, and recursion
-    would overflow on a deeply backtracked resolve.
+    Walk iteratively because backtracking can produce a deep cause graph.
     """
-    out: list[str] = []
+    out: list[tuple[str, RangeProtocol[Any]]] = []
     seen_ids: set[int] = set()
     stack: list[Incompatibility[Any, Any]] = [incompatibility]
 
@@ -882,11 +865,12 @@ def _walk_no_versions_packages(
             for term in node.terms:
                 pkg = term.package
                 if isinstance(pkg, str):
-                    out.append(pkg)
+                    out.append((pkg, term.constraint))
         elif _rules_out_candidate(node):
-            pkg = node.terms[0].package
+            candidate = node.terms[0]
+            pkg = candidate.package
             if isinstance(pkg, str):
-                out.append(pkg)
+                out.append((pkg, candidate.constraint))
 
         # Right before left, so the left cause pops first and names keep their order.
         if node.cause_right is not None:

--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -126,9 +126,11 @@ _WINDOWS311 = ResolveTarget.for_declared(
 )
 
 
-def short_reason(provider: Provider, package: str) -> str | None:
+def short_reason(
+    provider: Provider, package: str, failed_range: VersionRange | None = None
+) -> str | None:
     """Return the one line ``package``'s diagnostic prints at default verbosity."""
-    diagnostic = provider.get_no_versions_reason(package)
+    diagnostic = provider.get_no_versions_reason(package, failed_range)
     return None if diagnostic is None else diagnostic.short
 
 
@@ -2596,6 +2598,201 @@ class TestNoVersionsReasons:
             "\nNo metadata for foo==5.0"
             "\nNo metadata for foo==3.0"
         )
+
+    def test_root_ban_outranks_a_generic_reason(self) -> None:
+        """A root ban takes precedence over a generic no-match reason."""
+        coordinator = make_coordinator([], package="foo")
+        provider = Provider(coordinator)
+        provider._no_versions_reasons["foo"] = diagnosis_mod.NoVersionsReason(
+            diagnosis_mod.ReasonKind.NO_MATCH
+        )
+
+        provider.record_root_ban(
+            "foo",
+            "bar",
+            SpecifierSet("==2.0").to_range(),
+            SpecifierSet("==1.0").to_range(),
+            [V("5.0")],
+        )
+
+        assert short_reason(provider, "foo") == (
+            "5.0 needs bar in ==2.0, but your project requires bar ==1.0"
+        )
+
+    def test_root_ban_unions_the_versions_of_every_scan(self) -> None:
+        """Repeated records combine banned versions without duplicates."""
+        coordinator = make_coordinator([], package="foo")
+        provider = Provider(coordinator)
+        declared = SpecifierSet("==2.0").to_range()
+        root_range = SpecifierSet("==1.0").to_range()
+
+        provider.record_root_ban("foo", "bar", declared, root_range, [V("5.0")])
+        provider.record_root_ban(
+            "foo", "bar", declared, root_range, [V("5.0"), V("4.0")]
+        )
+
+        assert short_reason(provider, "foo") == (
+            "5.0 and 4.0 need bar in ==2.0, but your project requires bar ==1.0"
+        )
+
+    def test_two_root_bans_leave_their_ranges_to_the_detail(self) -> None:
+        """Multiple root constraints retain their ranges in Diagnostic.detail."""
+        coordinator = make_coordinator([], package="foo")
+        provider = Provider(coordinator)
+
+        provider.record_root_ban(
+            "foo",
+            "bar",
+            SpecifierSet("==2.0").to_range(),
+            SpecifierSet("==1.0").to_range(),
+            [V("5.0")],
+        )
+        provider.record_root_ban(
+            "foo",
+            "baz",
+            SpecifierSet(">=7.0").to_range(),
+            SpecifierSet("<7.0").to_range(),
+            [V("4.0")],
+        )
+
+        assert rendered_reason(provider, "foo") == (
+            "some versions are blocked by bar and baz"
+            "\n5.0 needs bar in ==2.0, but your project requires bar ==1.0"
+            "\n4.0 needs baz in >=7.0, but your project requires baz <7.0"
+        )
+
+    def test_a_root_ban_and_a_metadata_ban_are_reported_together(self) -> None:
+        """Root and metadata rejections appear in the same diagnostic."""
+        coordinator = make_coordinator([], package="foo")
+        provider = Provider(coordinator)
+
+        provider.record_root_ban(
+            "foo",
+            "bar",
+            SpecifierSet("==2.0").to_range(),
+            SpecifierSet("==1.0").to_range(),
+            [V("5.0")],
+        )
+        provider.record_metadata_ban(
+            "foo", metadata_blocks(**{"4.0": "No metadata for foo==4.0"})
+        )
+
+        assert rendered_reason(provider, "foo") == (
+            "some versions are blocked by bar or rejected on their metadata"
+            "\n5.0 needs bar in ==2.0, but your project requires bar ==1.0"
+            "\nNo metadata for foo==4.0"
+        )
+
+    def test_metadata_ban_outside_the_failed_clause_is_not_its_reason(self) -> None:
+        """Metadata failures outside the failed range are excluded."""
+        coordinator = make_coordinator([], package="foo")
+        provider = Provider(coordinator)
+        provider._no_versions_reasons["foo"] = diagnosis_mod.NoVersionsReason(
+            diagnosis_mod.ReasonKind.NO_MATCH,
+            version_range=SpecifierSet(">=2").to_range(),
+        )
+
+        provider.record_metadata_ban(
+            "foo", metadata_blocks(**{"1.0": "No metadata for foo==1.0"})
+        )
+
+        assert (
+            short_reason(provider, "foo", SpecifierSet(">=2").to_range())
+            == "no version matches the requirement"
+        )
+
+    def test_root_ban_outside_the_failed_clause_is_not_its_reason(self) -> None:
+        """Root bans are limited to versions in the failed range."""
+        coordinator = make_coordinator([], package="foo")
+        provider = Provider(coordinator)
+        provider._no_versions_reasons["foo"] = diagnosis_mod.NoVersionsReason(
+            diagnosis_mod.ReasonKind.NO_MATCH,
+            version_range=SpecifierSet(">=6.0").to_range(),
+        )
+
+        provider.record_root_ban(
+            "foo",
+            "bar",
+            SpecifierSet("==2.0").to_range(),
+            SpecifierSet("==1.0").to_range(),
+            [V("5.0")],
+        )
+
+        assert (
+            short_reason(provider, "foo", SpecifierSet(">=6.0").to_range())
+            == "no version matches the requirement"
+        )
+
+    def test_a_root_ban_names_only_the_versions_the_clause_named(self) -> None:
+        """A narrowed failure range restricts the reported banned versions."""
+        coordinator = make_coordinator([], package="foo")
+        provider = Provider(coordinator)
+
+        provider.record_root_ban(
+            "foo",
+            "bar",
+            SpecifierSet("==2.0").to_range(),
+            SpecifierSet("==1.0").to_range(),
+            [V("5.0"), V("4.0")],
+        )
+
+        assert short_reason(provider, "foo", SpecifierSet("<5.0").to_range()) == (
+            "4.0 needs bar in ==2.0, but your project requires bar ==1.0"
+        )
+
+    def test_a_ban_beside_a_filtered_sdist_keeps_the_filter_it_named(self) -> None:
+        """The metadata diagnosis retains the filter and its remedy."""
+        coordinator = make_coordinator(
+            [
+                make_wheel(
+                    "1.0", has_metadata=False, upload_time="2026-01-01T00:00:00Z"
+                ),
+                make_sdist("1.0", upload_time="2026-01-20T00:00:00Z"),
+            ]
+        )
+        provider = Provider(
+            coordinator,
+            target=_PY312,
+            uploaded_prior_to=datetime(2026, 1, 10, tzinfo=timezone.utc),
+        )
+
+        with pytest.raises(MetadataError) as excinfo:
+            provider.get_dependencies("pkg", V("1.0"))
+
+        provider.record_metadata_ban(
+            "pkg",
+            {
+                V("1.0"): diagnosis_mod.MetadataBlock(
+                    str(excinfo.value), excinfo.value.filtered_sdist_version
+                )
+            },
+        )
+        provider.record_root_ban(
+            "pkg",
+            "bar",
+            SpecifierSet("==2.0").to_range(),
+            SpecifierSet("==1.0").to_range(),
+            [V("2.0")],
+        )
+
+        diagnostic = provider.get_no_versions_reason("pkg")
+        assert diagnostic is not None
+        assert diagnostic.short == (
+            "some versions are blocked by bar or rejected on their metadata"
+        )
+        assert diagnostic.detail == (
+            "2.0 needs bar in ==2.0, but your project requires bar ==1.0",
+            "pkg 1.0 has no PEP 658 metadata on the index",
+            (
+                "the uploaded-prior-to cutoff 2026-01-10T00:00:00+00:00 excluded"
+                " pkg-1.0.tar.gz, uploaded at 2026-01-20T00:00:00Z"
+            ),
+            (
+                "note: the project-level uploaded-prior-to set that cutoff; setting"
+                ' packages."pkg".uploaded-prior-to = false lifts it for this package'
+            ),
+        )
+        assert diagnostic.remedy == 'set packages."pkg".uploaded-prior-to = false'
 
     def test_root_requirement_rejection_names_the_blocker(self) -> None:
         """When the rejection comes from the root-requirement check at

--- a/nab-project/tests/test_resolve.py
+++ b/nab-project/tests/test_resolve.py
@@ -3920,7 +3920,7 @@ class TestAugmentResolutionError:
         clause = self._no_versions_clause("missing-pkg")
         exc = ResolutionError("base message", incompatibility=clause)
         provider = MagicMock()
-        provider.get_no_versions_reason.side_effect = lambda pkg: (
+        provider.get_no_versions_reason.side_effect = lambda pkg, _range: (
             Diagnostic("package not found on any configured index")
             if pkg == "missing-pkg"
             else None
@@ -3975,7 +3975,7 @@ class TestAugmentResolutionError:
             cause_right=None,
         )
         packages = _walk_no_versions_packages(derived)
-        assert packages == ["buried-pkg"]
+        assert packages == [("buried-pkg", Range.full())]
 
     def test_walk_skips_non_string_packages(self) -> None:
         """Non-str term packages (e.g. the root sentinel) are filtered out."""
@@ -3996,7 +3996,7 @@ class TestAugmentResolutionError:
             ],
             cause=IncompatibilityCause.DEPENDENCY,
         )
-        assert _walk_no_versions_packages(clause) == ["cand"]
+        assert _walk_no_versions_packages(clause) == [("cand", Range.full())]
 
     def test_walk_names_merged_self_dependency_candidate(self) -> None:
         """A self-dependency merges to one positive term and still names it."""
@@ -4005,7 +4005,7 @@ class TestAugmentResolutionError:
             cause=IncompatibilityCause.DEPENDENCY,
             dependency_range=Range.singleton(1),
         )
-        assert _walk_no_versions_packages(clause) == ["cand"]
+        assert _walk_no_versions_packages(clause) == [("cand", Range.full())]
 
     def test_grouped_clause_hint_survives_a_later_range(self) -> None:
         """Accepted tolerance: reasons are keyed by package name, so a later
@@ -4019,7 +4019,7 @@ class TestAugmentResolutionError:
         )
         exc = ResolutionError("base message", incompatibility=clause)
         provider = MagicMock()
-        provider.get_no_versions_reason.side_effect = lambda pkg: (
+        provider.get_no_versions_reason.side_effect = lambda pkg, _range: (
             Diagnostic("no version matches the requirement") if pkg == "cand" else None
         )
         _augment_resolution_error(exc, provider)
@@ -4070,7 +4070,7 @@ class TestAugmentResolutionError:
         )
         # Walk should record ``shared`` exactly once even though ``leaf``
         # is reachable from two branches of the derivation DAG.
-        assert _walk_no_versions_packages(top) == ["shared"]
+        assert _walk_no_versions_packages(top) == [("shared", Range.full())]
 
     def test_walks_a_chain_deeper_than_the_recursion_limit(self) -> None:
         """A derivation longer than the recursion limit is still walked."""
@@ -4083,7 +4083,7 @@ class TestAugmentResolutionError:
                 cause_right=None,
             )
 
-        assert _walk_no_versions_packages(node) == ["buried-pkg"]
+        assert _walk_no_versions_packages(node) == [("buried-pkg", Range.full())]
 
     def test_resolve_pyproject_re_raises_with_diagnostic(self, tmp_path: Path) -> None:
         """``resolve_pyproject`` re-raises the augmented ResolutionError."""
@@ -4432,6 +4432,82 @@ class TestAugmentResolutionError:
             "No metadata for foo==3.0: no PEP 658 metadata and no sdist"
             " available" in diagnostics
         )
+
+    def test_root_ban_outlives_the_scan_that_accepted_an_older_version(
+        self, tmp_path: Path
+    ) -> None:
+        """A root ban remains visible after a scan accepts an older version."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "proj"\ndependencies = ["foo", "lib==9.0"]\n',
+            encoding="utf-8",
+        )
+
+        coordinator = make_coordinator(
+            listings={
+                "foo": _index_wheels("foo", "5.0", "4.0"),
+                "lib": _index_wheels("lib", "9.0", "8.0"),
+                "other": _index_wheels("other", "6.0"),
+            },
+            metadata_by_version={
+                "5.0": _metadata("foo", "5.0", "lib==8.0"),
+                "4.0": _metadata("foo", "4.0", "other==7.0"),
+                "9.0": _metadata("lib", "9.0"),
+                "8.0": _metadata("lib", "8.0"),
+                "6.0": _metadata("other", "6.0"),
+            },
+        )
+
+        with patch("nab_project.resolve.FetchCoordinator") as mock_coord_cls:
+            mock_coord_cls.return_value.__enter__ = lambda _self: coordinator
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            with pytest.raises(ResolutionError) as info:
+                _resolved(pyproject, _FAKE_TRANSPORT, python_version="3.12.0")
+
+        derivation = str(info.value).split("Diagnostics:")[0]
+        assert "lib" not in derivation
+
+        diagnostics = _diagnostics(info.value)
+        assert "<VersionRange" not in diagnostics
+        assert (
+            "foo: 5.0 needs lib in ==8.0, but your project requires lib ==9.0"
+            in diagnostics
+        )
+
+    def test_an_unsatisfiable_ask_names_no_uninvolved_requirement(
+        self, tmp_path: Path
+    ) -> None:
+        """An unrelated root constraint stays out of the failure report."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "proj"\ndependencies = ["app", "lib==9.0", "tool"]\n',
+            encoding="utf-8",
+        )
+
+        coordinator = make_coordinator(
+            listings={
+                "app": _index_wheels("app", "5.0", "4.0"),
+                "lib": _index_wheels("lib", "9.0", "8.0"),
+                "tool": _index_wheels("tool", "1.0"),
+            },
+            metadata_by_version={
+                "5.0": _metadata("app", "5.0", "lib==8.0"),
+                "4.0": _metadata("app", "4.0"),
+                "9.0": _metadata("lib", "9.0"),
+                "8.0": _metadata("lib", "8.0"),
+                "1.0": _metadata("tool", "1.0", "app>=6.0"),
+            },
+        )
+
+        with patch("nab_project.resolve.FetchCoordinator") as mock_coord_cls:
+            mock_coord_cls.return_value.__enter__ = lambda _self: coordinator
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            with pytest.raises(ResolutionError) as info:
+                _resolved(pyproject, _FAKE_TRANSPORT, python_version="3.12.0")
+
+        diagnostics = _diagnostics(info.value)
+        assert "app: no version matches the requirement" in diagnostics
+        assert "lib" not in diagnostics
 
     def test_cutoff_filtered_sdist_is_not_reported_as_never_published(
         self, tmp_path: Path

--- a/nab-provider/src/nab_provider/_provider/listing_diagnosis.py
+++ b/nab-provider/src/nab_provider/_provider/listing_diagnosis.py
@@ -305,6 +305,16 @@ class Blocker:
         self.held = held
 
 
+class RootBan:
+    """Versions permanently excluded by a root requirement."""
+
+    __slots__ = ("blocker", "versions")
+
+    def __init__(self, blocker: Blocker, versions: tuple[Version, ...]) -> None:
+        self.blocker = blocker
+        self.versions = versions
+
+
 class MetadataBlock:
     """One version whose metadata no rung of the ladder could read.
 
@@ -880,12 +890,14 @@ _CLAUSE_TEMPLATES: dict[Cause | None, str] = {
 _ALTERNATIVES = r"\[([^|\]]*)\|([^\]]*)\]"
 
 
+def _pick_forms(template: str, count: int) -> str:
+    """Take ``template``'s singular alternatives when ``count`` is 1."""
+    return re.sub(_ALTERNATIVES, r"\1" if count == 1 else r"\2", template)
+
+
 def _render(cause: Cause | None, count: int, **fields: object) -> str:
     """Fill ``cause``'s template, taking the singular form when ``count`` is 1."""
-    template = re.sub(
-        _ALTERNATIVES, r"\1" if count == 1 else r"\2", _CLAUSE_TEMPLATES[cause]
-    )
-    return template.format(n=count, **fields)
+    return _pick_forms(_CLAUSE_TEMPLATES[cause], count).format(n=count, **fields)
 
 
 # The fields a cause's template states of every file it counts, rather
@@ -1235,13 +1247,15 @@ def filtered_sdist_diagnostic(
 # behind ``-v``, so both depths say the same thing.
 _BLOCKER_CLAUSES: dict[Blocked, str] = {
     BlockerKind.DECIDED: (
-        "needs {package} in {declared}, but the resolve chose {package} {held}"
+        "[needs|need] {package} in {declared}, but the resolve chose {package} {held}"
     ),
     BlockerKind.HELD: (
-        "needs {package} in {declared}, but the resolve holds {package} in {held}"
+        "[needs|need] {package} in {declared},"
+        " but the resolve holds {package} in {held}"
     ),
     BlockerKind.ROOT: (
-        "needs {package} in {declared}, but your project requires {package} {held}"
+        "[needs|need] {package} in {declared},"
+        " but your project requires {package} {held}"
     ),
 }
 
@@ -1281,10 +1295,10 @@ def blockers_diagnostic(
     return Diagnostic(_several_blockers_short(blockers, metadata), tuple(detail))
 
 
-def _blocker_clause(provider: Provider, blocker: Blocker) -> str:
-    """Say what one rejection wanted and what stands in its way."""
+def _blocker_clause(provider: Provider, blocker: Blocker, count: int = 1) -> str:
+    """Format a blocker clause with a verb agreeing with the version count."""
     declared, held = _render_blocker(provider, blocker)
-    return _BLOCKER_CLAUSES[blocker.kind].format(
+    return _pick_forms(_BLOCKER_CLAUSES[blocker.kind], count).format(
         package=blocker.package, declared=declared, held=held
     )
 
@@ -1346,6 +1360,48 @@ def metadata_diagnostic(
             if named is not None:
                 return named
     return Diagnostic(_METADATA_REJECTED, tuple(block.message for block in blocks))
+
+
+def ban_diagnostic(
+    provider: Provider,
+    normalized: str,
+    bans: Sequence[RootBan],
+    metadata: Sequence[MetadataBlock],
+) -> Diagnostic:
+    """Explain versions rejected by root constraints or metadata failures."""
+    if not bans:
+        return metadata_diagnostic(provider, normalized, metadata)
+
+    clauses = [_root_ban_clause(provider, ban) for ban in bans]
+    if metadata:
+        rejected = metadata_diagnostic(provider, normalized, metadata)
+        return Diagnostic(
+            _several_bans_short(bans, metadata),
+            (*clauses, *rejected.detail),
+            rejected.remedy,
+        )
+    if len(clauses) == 1:
+        return Diagnostic(clauses[0])
+    return Diagnostic(_several_bans_short(bans, metadata), tuple(clauses))
+
+
+def _root_ban_clause(provider: Provider, ban: RootBan) -> str:
+    """Format the versions rejected by one root requirement."""
+    versions = [str(version) for version in ban.versions]
+    clause = _blocker_clause(provider, ban.blocker, len(versions))
+    return f"{_named_or_counted(versions, 'versions')} {clause}"
+
+
+def _several_bans_short(
+    bans: Sequence[RootBan], metadata: Sequence[MetadataBlock]
+) -> str:
+    """Summarize the blocking packages and any metadata rejections."""
+    names = _named_or_counted(
+        list(dict.fromkeys(ban.blocker.package for ban in bans)), "packages"
+    )
+    if not metadata:
+        return f"some versions are blocked by {names}"
+    return f"some versions are blocked by {names} or rejected on their metadata"
 
 
 # The bullet names the proxy, so these say "the extra" instead of

--- a/nab-provider/src/nab_provider/_provider/lookahead.py
+++ b/nab-provider/src/nab_provider/_provider/lookahead.py
@@ -336,16 +336,22 @@ def flush_pending_blocks(provider: Provider) -> None:
             )
         )
 
-    # Permanent rejections: a root requirement is fixed for the whole resolve,
-    # and a version whose metadata will not read is unusable in every state.
+    # Root and metadata rejections persist after pending state is cleared.
     unusable: defaultdict[str, RangeProtocol[Version]] = defaultdict(VersionRange.empty)
 
-    for (candidate_pkg, *_), versions in provider.pending_root_blocks.items():
+    for (
+        candidate_pkg,
+        blocker_pkg,
+        dep_range,
+        root_range,
+    ), versions in provider.pending_root_blocks.items():
         unusable[candidate_pkg] |= _candidate_union(provider, candidate_pkg, versions)
+        provider.record_root_ban(
+            candidate_pkg, blocker_pkg, dep_range, root_range, versions
+        )
 
     for candidate_pkg, blocks in provider.pending_metadata_blocks.items():
         unusable[candidate_pkg] |= _candidate_union(provider, candidate_pkg, blocks)
-        # The ban outlives this flush, so its reason has to as well.
         provider.record_metadata_ban(candidate_pkg, blocks)
 
     for candidate_pkg, rejected in unusable.items():

--- a/nab-provider/src/nab_provider/provider.py
+++ b/nab-provider/src/nab_provider/provider.py
@@ -767,6 +767,11 @@ class Provider:
             str, dict[Version, _diagnosis.MetadataBlock]
         ] = {}
 
+        # Root constraints and rejected versions retained across look-ahead scans.
+        self._root_ban_versions: dict[
+            str, dict[tuple[str, VersionRange, VersionRange], dict[Version, None]]
+        ] = {}
+
         # Blocker packages queued for force back-track by the resolver after
         # the next ``choose_version`` returns.  Populated by the look-ahead
         # abort path; drained by ``consume_force_backtrack_targets``.  uv-style
@@ -1840,6 +1845,19 @@ class Provider:
         meta = self.pending_metadata_blocks.get(normalized) or {}
         return out, tuple(meta.values())
 
+    def record_root_ban(
+        self,
+        normalized: str,
+        blocker: str,
+        declared: VersionRange,
+        root_range: VersionRange,
+        versions: Sequence[Version],
+    ) -> None:
+        """Retain a root constraint and its rejected versions across scans."""
+        recorded = self._root_ban_versions.setdefault(normalized, {})
+        banned = recorded.setdefault((blocker, declared, root_range), {})
+        banned.update(dict.fromkeys(versions))
+
     def record_metadata_ban(
         self, normalized: str, blocks: Mapping[Version, _diagnosis.MetadataBlock]
     ) -> None:
@@ -1852,31 +1870,58 @@ class Provider:
         for version, message in blocks.items():
             recorded.setdefault(version, message)
 
-    def get_no_versions_reason(self, package: str) -> Diagnostic | None:
-        """Return the recorded reason for ``package``'s NO_VERSIONS clause.
+    def _root_bans(
+        self, normalized: str, failed_range: RangeProtocol[Version] | None
+    ) -> list[_diagnosis.RootBan]:
+        """Return root bans restricted to failed_range; None includes all versions."""
+        bans: list[_diagnosis.RootBan] = []
+        recorded = self._root_ban_versions.get(normalized, {})
+        for (blocker, declared, root_range), banned in recorded.items():
+            versions = tuple(
+                version
+                for version in banned
+                if failed_range is None or version in failed_range
+            )
+            if not versions:
+                continue
+            bans.append(
+                _diagnosis.RootBan(
+                    _diagnosis.Blocker(
+                        _diagnosis.BlockerKind.ROOT, blocker, (declared,), root_range
+                    ),
+                    versions,
+                )
+            )
+        return bans
 
-        Ranked by specificity, not by which pass wrote first: a recorded
-        reason that names a cause wins, and a metadata ban beats the two
-        that say only that nothing matched.
+    def _metadata_bans(
+        self, normalized: str, failed_range: RangeProtocol[Version] | None
+    ) -> list[_diagnosis.MetadataBlock]:
+        """Return metadata bans within failed_range, or all bans when it is None."""
+        recorded = self._metadata_ban_blocks.get(normalized, {})
+        return [
+            block
+            for version, block in recorded.items()
+            if failed_range is None or version in failed_range
+        ]
 
-        This is where the sentence is built, and the only place it is built.
-        Reaching it means the resolve has already failed, so the marker is
-        rendered here rather than on the resolve path.
+    def get_no_versions_reason(
+        self, package: str, failed_range: RangeProtocol[Version] | None = None
+    ) -> Diagnostic | None:
+        """Return the recorded no-versions diagnostic for package.
 
-        Returns ``None`` if no diagnostic was captured (e.g. the
-        package was decided successfully or failed for a non-listing
-        reason such as a metadata parse error).
+        Specific recorded causes take precedence over permanent bans.
+        ``failed_range`` restricts banned versions; None includes every ban.
         """
         recorded = self._no_versions_reasons.get(package)
         if recorded is not None and not recorded.is_generic:
             return self._render_no_versions_reason(package, recorded)
 
         normalized = canonicalize_name(package)
-        blocks = self._metadata_ban_blocks.get(normalized)
-        if blocks:
-            return _diagnosis.metadata_diagnostic(
-                self, normalized, list(blocks.values())
-            )
+        bans = self._root_bans(normalized, failed_range)
+        blocks = self._metadata_bans(normalized, failed_range)
+        if bans or blocks:
+            return _diagnosis.ban_diagnostic(self, normalized, bans, blocks)
         if recorded is None:
             return None
         return self._render_no_versions_reason(package, recorded)


### PR DESCRIPTION
When look-ahead excludes `foo==5.0` because it needs `lib==8.0` but the project requires `lib==9.0`, the final failure now explains that root requirement. Previously the reason was lost if the scan accepted `foo==4.0` before resolution failed elsewhere.

Root-ban records retain the requirement and the versions it excluded across scans. The failure report filters those records to the ranges its clauses cover. Metadata bans follow the same rule, keeping unrelated rejections out of the report.
