### PR TITLE
Refuse a vcs.allowed-repos candidate with a path segment after .git

### DIFF
--- a/nab-project/tests/property_python/test_vcs_admission.py
+++ b/nab-project/tests/property_python/test_vcs_admission.py
@@ -149,7 +149,21 @@ def boundary_cases(draw: st.DrawFn) -> tuple[str, VcsConfig]:
     login = draw(st.sampled_from(["", "git@", "user:pw@"]))
     tail = draw(
         st.sampled_from(
-            ["", "\t", "\r", "\n", "?", "?x", "x", "/x", ".git", ".gitx", "#f"]
+            [
+                "",
+                "\t",
+                "\r",
+                "\n",
+                "?",
+                "?x",
+                "x",
+                "/x",
+                ".git",
+                ".git/",
+                ".git/x",
+                ".gitx",
+                "#f",
+            ]
         )
     )
     position = draw(st.sampled_from(["authority", "end"]))
@@ -225,12 +239,13 @@ def _prefix_under_repo(inner: str, prefix: str) -> bool:
     A candidate is under an allowed prefix only when the prefix ends at a
     path-segment boundary, so a sibling repo whose URL merely begins with
     the prefix (``.../airflow.git`` vs ``.../airflow.git.other``) is refused.
-    Git's optional ``.git`` suffix is stripped from the prefix and skipped
-    once on the candidate so an exact-repo prefix and the ``.git`` clone URL
-    match either way round.  A candidate whose path git would rewrite is
-    refused first: the post-authority remainder, minus the trailing ``@<ref>``
-    the clone splits off, must equal its dot-segment-normalised form both
-    whole and cut at the first ``?``.
+    Git's optional ``.git`` suffix is stripped from the prefix and skipped on
+    the candidate where the repo path ends, so an exact-repo prefix and the
+    ``.git`` clone URL match either way round.  ``<prefix>.git/<segment>`` is
+    a different repo and keeps its suffix.  A candidate whose path git would
+    rewrite is refused first: the post-authority remainder, minus the trailing
+    ``@<ref>`` the clone splits off, must equal its dot-segment-normalised form
+    both whole and cut at the first ``?``.
     """
     parts = urlsplit(inner)
     remainder = f"{parts.path}?{parts.query}" if parts.query else parts.path
@@ -242,7 +257,13 @@ def _prefix_under_repo(inner: str, prefix: str) -> bool:
     prefix = prefix.removesuffix(".git")
     if not inner.startswith(prefix):
         return False
-    rest = inner[len(prefix) :].removeprefix(".git")
+
+    rest = inner[len(prefix) :]
+    if rest.startswith(".git"):
+        after_slashes = rest[len(".git") :].lstrip("/")
+        if not after_slashes or after_slashes[0] in "@#":
+            rest = rest[len(".git") :]
+
     if not rest or not prefix or prefix[-1] in "/@#":
         return True
     return rest[0] in "/@#"

--- a/nab-provider/src/nab_provider/vcs_admission.py
+++ b/nab-provider/src/nab_provider/vcs_admission.py
@@ -167,6 +167,24 @@ def _rewritten_by_git(path: str) -> bool:
 
 
 _REPO_BOUNDARY_CHARS: frozenset[str] = frozenset({"/", "@", "#"})
+_GIT_SUFFIX = ".git"
+
+
+def _skip_optional_git_suffix(rest: str) -> str:
+    """Return ``rest`` without a leading ``.git`` that ends the repo path.
+
+    ``.git`` is optional only where a repo name ends, so it is skipped
+    when nothing but a trailing ``/``, the ref or the fragment follows
+    it.  In ``foo.git/bar`` it is part of a directory name and stays.
+    """
+    if not rest.startswith(_GIT_SUFFIX):
+        return rest
+
+    tail = rest[len(_GIT_SUFFIX) :]
+    after_slashes = tail.lstrip("/")
+    if after_slashes and after_slashes[0] not in _REPO_BOUNDARY_CHARS:
+        return rest
+    return tail
 
 
 def _repo_prefix_matches(inner_url: str, prefix: str) -> bool:
@@ -178,8 +196,9 @@ def _repo_prefix_matches(inner_url: str, prefix: str) -> bool:
     at a path-segment boundary: the candidate must equal the prefix, the
     prefix must already end in a separator, or the next candidate
     character must be ``/`` (path), ``@`` (ref) or ``#`` (fragment).
-    Git treats the ``.git`` suffix as optional, so it is stripped from the
-    prefix and skipped once on the candidate before the boundary check.
+    Git treats a trailing ``.git`` as optional, so it is stripped from the
+    prefix and skipped on the candidate by :func:`_skip_optional_git_suffix`
+    before the boundary check.
     Both URLs have their authority ``user[:pass]@`` / ``git@`` stripped
     by the caller.
 
@@ -200,10 +219,11 @@ def _repo_prefix_matches(inner_url: str, prefix: str) -> bool:
     if any(_rewritten_by_git(part) for part in (repo, repo.partition("?")[0])):
         return False
 
-    prefix = prefix.removesuffix(".git")
+    prefix = prefix.removesuffix(_GIT_SUFFIX)
     if not inner_url.startswith(prefix):
         return False
-    rest = inner_url[len(prefix) :].removeprefix(".git")
+
+    rest = _skip_optional_git_suffix(inner_url[len(prefix) :])
     if not rest or not prefix or prefix[-1] in _REPO_BOUNDARY_CHARS:
         return True
     return rest[0] in _REPO_BOUNDARY_CHARS

--- a/nab-provider/tests/test_vcs_admission.py
+++ b/nab-provider/tests/test_vcs_admission.py
@@ -402,6 +402,56 @@ class TestAdmitVcsUrlRepo:
                 config,
             )
 
+    @pytest.mark.parametrize(
+        ("allowed", "url"),
+        [
+            (
+                "https://github.com/myorg",
+                f"git+https://github.com/myorg.git/other@{_FORTY}",
+            ),
+            (
+                "https://github.com/myorg/lib",
+                f"git+https://github.com/myorg/lib.git/other@{_FORTY}",
+            ),
+            (
+                "https://github.com",
+                f"git+https://github.com.git/other@{_FORTY}",
+            ),
+            (
+                "file:///srv/git/team",
+                f"git+file:///srv/git/team.git/other@{_FORTY}",
+            ),
+        ],
+    )
+    def test_dot_git_followed_by_path_segment_refused(
+        self, allowed: str, url: str
+    ) -> None:
+        """``.git`` is optional where a repo name ends, not mid-path.
+
+        ``<prefix>.git/other`` names a different repo, and skipping the
+        suffix would put the boundary check on the ``/`` in front of it.
+        """
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+https", "git+file"}),
+            allowed_repos=(allowed,),
+        )
+        with pytest.raises(UnsupportedVcsError, match="not in vcs.allowed-repos"):
+            admit_vcs_url(url, config)
+
+    def test_dot_git_clone_url_without_ref_passes(self) -> None:
+        """An unpinned candidate ending in ``.git`` is the same repo."""
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+https"}),
+            allowed_repos=("https://github.com/myorg/myrepo",),
+            require_pin=False,
+        )
+        assert (
+            admit_vcs_url("git+https://github.com/myorg/myrepo.git", config)
+            == "git+https"
+        )
+
     def test_dot_segment_escape_above_prefix_refused(self) -> None:
         """A ``../`` path git resolves outside the prefix is refused."""
         config = VcsConfig(


### PR DESCRIPTION
`vcs.allowed-repos = ["https://github.com/myorg"]` admits and clones `git+https://github.com/myorg.git/other@<sha>`. `myorg.git` is a sibling of the entry, not a path under it. A host-only entry goes the same way: `https://github.com` admits a clone from the host `github.com.git`.

`_repo_prefix_matches` skipped a leading `.git` on the candidate wherever it fell:

    rest = inner_url[len(prefix) :].removeprefix(".git")

For `myorg.git/other@<sha>` that leaves `/other@<sha>`, so the boundary check saw a `/` and passed. Without the skip it would have seen the `.` and refused.

Git treats `.git` as optional only where a repo path ends, so it is now skipped only when nothing but a trailing `/`, the `@<ref>` or a `#` fragment follows it. `foo.git/bar` keeps the suffix and is refused. One repo still matches one entry either way round: `foo` admits `foo.git@<sha>`, and `foo.git` admits `foo@<sha>`.

The property test in `nab-project/tests/property_python/test_vcs_admission.py` carries its own copy of the rule, fixed the same way, and its boundary tails add `.git/` and `.git/x`.
