### PR TITLE
Separate provider helpers from matrix and marker-set imports

### DIFF
--- a/nab-project/tests/test_requirements_file.py
+++ b/nab-project/tests/test_requirements_file.py
@@ -19,7 +19,7 @@ from nab_provider._vendor.packaging.requirements import Requirement
 from nab_provider._vendor.packaging.specifiers import SpecifierSet
 from nab_provider._vendor.packaging.utils import InvalidName
 from nab_provider.marker_holds import IntractableMarkerError, UnevaluableMarkerError
-from nab_provider.project_requirements import add_extra_marker as _add_extra_marker
+from nab_provider.project_requirements import add_extra_marker
 from nab_provider.requirements_file import (
     InvalidProjectRequirementError,
     InvalidProjectTableError,
@@ -40,24 +40,24 @@ _OVERSIZED = _AT_LIMIT + "1"
 class TestAddExtraMarker:
     def test_no_existing_marker(self) -> None:
         """A bare requirement gets a fresh ``extra ==`` marker."""
-        out = _add_extra_marker("numpy>=1.0", "foo")
+        out = add_extra_marker("numpy>=1.0", "foo")
         assert out == 'numpy>=1.0 ; extra == "foo"'
 
     def test_with_existing_marker(self) -> None:
         """An existing marker is wrapped and combined with ``and``."""
-        out = _add_extra_marker("numpy>=1.0 ; python_version >= '3.10'", "foo")
+        out = add_extra_marker("numpy>=1.0 ; python_version >= '3.10'", "foo")
         assert out == 'numpy>=1.0 ; (python_version >= "3.10") and extra == "foo"'
 
     def test_semicolon_in_direct_url_kept(self) -> None:
         """A ``;`` in a direct-URL is part of the URL, not the marker."""
-        out = _add_extra_marker("foo @ https://h/a;b/p.tar.gz", "bar")
+        out = add_extra_marker("foo @ https://h/a;b/p.tar.gz", "bar")
         req = Requirement(out)
         assert req.url == "https://h/a;b/p.tar.gz"
         assert str(req.marker) == 'extra == "bar"'
 
     def test_semicolon_in_direct_url_with_marker_kept(self) -> None:
         """The URL ``;`` survives and the existing marker is kept with extra."""
-        out = _add_extra_marker(
+        out = add_extra_marker(
             "foo @ https://h/a;b/p.tar.gz ; python_version >= '3.10'", "bar"
         )
         req = Requirement(out)
@@ -70,7 +70,7 @@ class TestAddExtraMarker:
         The dep needs ``python_version < "3.10"``, so on 3.12 it stays inactive
         only if the or group cannot leak past the and condition.
         """
-        out = _add_extra_marker(
+        out = add_extra_marker(
             'pkg ; python_version < "3.10" '
             'and ((sys_platform == "linux" or sys_platform == "darwin"))',
             "cli",
@@ -82,7 +82,7 @@ class TestAddExtraMarker:
 
     def test_non_canonical_extra_name_normalized(self) -> None:
         """A marker condition normalises a non-canonical extra name per PEP 685."""
-        out = _add_extra_marker("numpy", "My.Extra")
+        out = add_extra_marker("numpy", "My.Extra")
         assert out == 'numpy ; extra == "my-extra"'
 
     def test_extra_name_with_marker_syntax_rejected(self) -> None:
@@ -93,7 +93,7 @@ class TestAddExtraMarker:
         the dependency conditioned on a marker that is always true.
         """
         with pytest.raises(InvalidName):
-            _add_extra_marker("pkg", 'a" or os_name != "x')
+            add_extra_marker("pkg", 'a" or os_name != "x')
 
     def test_invalid_extra_name_rejected_as_project_requirement(self) -> None:
         """An invalid extra name is rejected by the synthesis path, not

--- a/nab-project/tests/test_requirements_file.py
+++ b/nab-project/tests/test_requirements_file.py
@@ -19,10 +19,10 @@ from nab_provider._vendor.packaging.requirements import Requirement
 from nab_provider._vendor.packaging.specifiers import SpecifierSet
 from nab_provider._vendor.packaging.utils import InvalidName
 from nab_provider.marker_holds import IntractableMarkerError, UnevaluableMarkerError
+from nab_provider.project_requirements import add_extra_marker as _add_extra_marker
 from nab_provider.requirements_file import (
     InvalidProjectRequirementError,
     InvalidProjectTableError,
-    _add_extra_marker,
     expand_extra_requirements,
     expand_group_includes,
     expand_self_extras,

--- a/nab-provider/src/nab_provider/_provider/metadata_resolver.py
+++ b/nab-provider/src/nab_provider/_provider/metadata_resolver.py
@@ -20,6 +20,7 @@ from nab_provider._vendor.packaging.version import InvalidVersion, Version
 from nab_provider.records import RangeOutcome, SdistFile, WheelFile
 
 from .._compat import override
+from ..environment import UnevaluableMarkerError, evaluate_prepared
 from ..errors import (
     ForeignMetadataError,
     IncompatiblePythonError,
@@ -28,7 +29,6 @@ from ..errors import (
     UnsupportedSdistError,
 )
 from ..extra_keys import join_extra
-from ..marker_holds import UnevaluableMarkerError, evaluate_prepared
 from ..metadata import (
     DEPENDENCY_FIELDS,
     WheelMetadata,
@@ -37,7 +37,7 @@ from ..metadata import (
     parse_metadata,
 )
 from ..policy import BuildPolicy
-from ..requirements_file import (
+from ..project_requirements import (
     InvalidProjectRequirementError,
     parse_project_requirement,
     parse_requirements,

--- a/nab-provider/src/nab_provider/environment.py
+++ b/nab-provider/src/nab_provider/environment.py
@@ -1,0 +1,55 @@
+"""Build and evaluate a marker environment for one resolution target."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from typing import TYPE_CHECKING
+
+from nab_provider._vendor.packaging.markers import (
+    UndefinedComparison,
+    UndefinedEnvironmentName,
+    default_environment,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Set as AbstractSet
+
+    from nab_provider._vendor.packaging.markers import Marker
+
+__all__ = [
+    "EnvironmentSource",
+    "UnevaluableMarkerError",
+    "evaluate_prepared",
+    "host_environment",
+    "marker_evaluation_error",
+]
+
+EnvironmentSource = Callable[[], Mapping[str, object]]
+
+
+class UnevaluableMarkerError(ValueError):
+    """A dependency marker parses but its environment or operator cannot decide it."""
+
+
+def marker_evaluation_error(
+    marker: Marker, exc: UndefinedComparison | UndefinedEnvironmentName
+) -> UnevaluableMarkerError:
+    """Return an evaluation error naming the complete dependency marker."""
+    return UnevaluableMarkerError(f"marker {marker} cannot be evaluated: {exc}")
+
+
+def evaluate_prepared(
+    marker: Marker, environment: dict[str, str | AbstractSet[str]]
+) -> bool:
+    """Evaluate a prepared marker environment, naming the marker if evaluation fails."""
+    try:
+        return marker.evaluate_prepared(environment)
+    except (UndefinedComparison, UndefinedEnvironmentName) as exc:
+        raise marker_evaluation_error(marker, exc) from exc
+
+
+def host_environment(
+    env_source: EnvironmentSource = default_environment,
+) -> dict[str, str]:
+    """Return the host's PEP 508 environment, keeping only string-valued entries."""
+    return {key: value for key, value in env_source().items() if isinstance(value, str)}

--- a/nab-provider/src/nab_provider/marker_holds.py
+++ b/nab-provider/src/nab_provider/marker_holds.py
@@ -16,10 +16,14 @@ from nab_markersets.errors import IntractableMarkerSet
 from nab_markersets.markersets import MarkerSet
 from nab_provider._vendor.packaging.markers import (
     UndefinedComparison,
-    UndefinedEnvironmentName,
 )
 
 from .conflict_kind import EMPTY_MEMBERSHIP_SETS
+from .environment import (
+    UnevaluableMarkerError,
+    evaluate_prepared,
+    marker_evaluation_error,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Mapping
@@ -28,17 +32,14 @@ if TYPE_CHECKING:
     from nab_provider._vendor.packaging.markers import Marker
 
 
-class UnevaluableMarkerError(ValueError):
-    """A dependency marker parses but nothing decides it.
-
-    PEP 508 accepts any operator between a variable and a literal, and PEP 440
-    gives ``~=`` a meaning only over a release with at least two components.
-    So ``python_full_version ~= "3"`` is a valid marker with nothing to
-    evaluate, and ``sys_platform ~= "linux"`` is one on a variable that holds
-    no version at all.  A marker that quotes its variable, ``"extra" == "gpu"``,
-    is a third: neither side names a variable to look up.  Any guess about one
-    of these changes what gets locked.
-    """
+__all__ = [
+    "IntractableMarkerError",
+    "UnevaluableMarkerError",
+    "dependency_marker_holds",
+    "evaluate_prepared",
+    "intractable_as_error",
+    "marker_set",
+]
 
 
 class IntractableMarkerError(ValueError):
@@ -48,16 +49,6 @@ class IntractableMarkerError(ValueError):
     the lock emitter's selection walk, so a pathological marker stops the run
     rather than iterating unbounded.
     """
-
-
-def _unevaluable(
-    marker: Marker, exc: UndefinedComparison | UndefinedEnvironmentName
-) -> UnevaluableMarkerError:
-    """Return the error for ``marker``, named in full.
-
-    The failing clause alone does not say which dependency to edit.
-    """
-    return UnevaluableMarkerError(f"marker {marker} cannot be evaluated: {exc}")
 
 
 @contextmanager
@@ -78,24 +69,7 @@ def marker_set(marker: Marker) -> MarkerSet:
     try:
         return MarkerSet.from_marker(marker)
     except UndefinedComparison as exc:
-        raise _unevaluable(marker, exc) from exc
-
-
-def evaluate_prepared(
-    marker: Marker, environment: dict[str, str | AbstractSet[str]]
-) -> bool:
-    """Evaluate ``marker`` against a ``prepare_environment`` result.
-
-    A marker packaging cannot decide raises :class:`UnevaluableMarkerError`, as
-    it does through :func:`marker_set`.  ``"extra" == "gpu"`` is one: packaging
-    reads the right-hand literal as a variable name and finds none.  So
-    ``environment`` has to carry every variable a marker may name, or a gap in
-    it is reported as an unevaluable marker.
-    """
-    try:
-        return marker.evaluate_prepared(environment)
-    except (UndefinedComparison, UndefinedEnvironmentName) as exc:
-        raise _unevaluable(marker, exc) from exc
+        raise marker_evaluation_error(marker, exc) from exc
 
 
 def dependency_marker_holds(

--- a/nab-provider/src/nab_provider/project_requirements.py
+++ b/nab-provider/src/nab_provider/project_requirements.py
@@ -1,0 +1,90 @@
+"""Validate dependency strings and arrays from project metadata."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from nab_provider._vendor.packaging.utils import canonicalize_name
+
+from .metadata import validate_specifier_versions
+from .pep508 import parse_requirement
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from nab_provider._vendor.packaging.requirements import Requirement
+
+__all__ = [
+    "InvalidProjectRequirementError",
+    "add_extra_marker",
+    "parse_project_requirement",
+    "parse_requirements",
+    "require_string_list",
+]
+
+
+class InvalidProjectRequirementError(ValueError):
+    """A pyproject.toml dependency or metadata value is invalid or unresolvable."""
+
+
+def add_extra_marker(dep_str: str, extra_name: str) -> str:
+    """Append ``extra == "name"`` to a :pep:`508` dep string.
+
+    Parses with :class:`Requirement` rather than splitting on the first
+    ``;`` so a semicolon inside a direct-reference URL is not mistaken
+    for the marker separator; an existing marker is combined with ``and``.
+
+    ``extra_name`` is a table key interpolated into the quoted marker, so
+    it is canonicalised with ``validate=True`` (PEP 685). A key that is
+    not a valid name (say one containing a quote) then raises
+    :class:`InvalidName` instead of producing a marker for the wrong
+    dependency.
+    """
+    req = parse_requirement(dep_str)
+    canonical_extra = canonicalize_name(extra_name, validate=True)
+    extra_marker = f'extra == "{canonical_extra}"'
+    if req.marker is not None:
+        marker = f"({req.marker}) and {extra_marker}"
+    else:
+        marker = extra_marker
+    req.marker = None
+    return f"{req} ; {marker}"
+
+
+def parse_project_requirement(
+    dep_str: str, source: str, *, extra: str | None = None
+) -> Requirement:
+    """Parse one PEP 508 dependency string, raising if it is malformed.
+
+    An ``extra`` name is folded in as an ``extra == "name"`` marker. A string
+    that is not valid PEP 508, or one whose specifier carries a version that
+    will not convert, raises :class:`InvalidProjectRequirementError`, so a
+    candidate declaring one malformed dependency is rejected whole rather
+    than resolved with the dependency silently dropped.
+    """
+    try:
+        text = add_extra_marker(dep_str, extra) if extra is not None else dep_str
+        req = parse_requirement(text)
+        validate_specifier_versions(req.specifier)
+    except ValueError as exc:
+        msg = f"invalid requirement in {source}: {exc}"
+        raise InvalidProjectRequirementError(msg) from exc
+    return req
+
+
+def parse_requirements(strings: Sequence[str], source: str) -> list[Requirement]:
+    """Parse PEP 508 strings, naming ``source`` if one is malformed."""
+    return [parse_project_requirement(s, source) for s in strings]
+
+
+def require_string_list(value: object, source: str) -> list[str]:
+    """Validate that a PEP 621 dependency value is an array of strings.
+
+    A bare string passes the type checker as ``Sequence[str]`` but
+    iterates character by character, so ``dependencies = "requests"``
+    would parse as eight single-character requirements rather than fail.
+    """
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        msg = f"{source} must be an array of strings"
+        raise InvalidProjectRequirementError(msg)
+    return value

--- a/nab-provider/src/nab_provider/project_requirements.py
+++ b/nab-provider/src/nab_provider/project_requirements.py
@@ -28,17 +28,9 @@ class InvalidProjectRequirementError(ValueError):
 
 
 def add_extra_marker(dep_str: str, extra_name: str) -> str:
-    """Append ``extra == "name"`` to a :pep:`508` dep string.
+    """Append an extra marker, preserving semicolons inside direct-reference URLs.
 
-    Parses with :class:`Requirement` rather than splitting on the first
-    ``;`` so a semicolon inside a direct-reference URL is not mistaken
-    for the marker separator; an existing marker is combined with ``and``.
-
-    ``extra_name`` is a table key interpolated into the quoted marker, so
-    it is canonicalised with ``validate=True`` (PEP 685). A key that is
-    not a valid name (say one containing a quote) then raises
-    :class:`InvalidName` instead of producing a marker for the wrong
-    dependency.
+    Validate and normalize the extra name according to PEP 685.
     """
     req = parse_requirement(dep_str)
     canonical_extra = canonicalize_name(extra_name, validate=True)
@@ -54,14 +46,7 @@ def add_extra_marker(dep_str: str, extra_name: str) -> str:
 def parse_project_requirement(
     dep_str: str, source: str, *, extra: str | None = None
 ) -> Requirement:
-    """Parse one PEP 508 dependency string, raising if it is malformed.
-
-    An ``extra`` name is folded in as an ``extra == "name"`` marker. A string
-    that is not valid PEP 508, or one whose specifier carries a version that
-    will not convert, raises :class:`InvalidProjectRequirementError`, so a
-    candidate declaring one malformed dependency is rejected whole rather
-    than resolved with the dependency silently dropped.
-    """
+    """Parse a dependency and its optional extra marker, rejecting invalid versions."""
     try:
         text = add_extra_marker(dep_str, extra) if extra is not None else dep_str
         req = parse_requirement(text)
@@ -78,12 +63,7 @@ def parse_requirements(strings: Sequence[str], source: str) -> list[Requirement]
 
 
 def require_string_list(value: object, source: str) -> list[str]:
-    """Validate that a PEP 621 dependency value is an array of strings.
-
-    A bare string passes the type checker as ``Sequence[str]`` but
-    iterates character by character, so ``dependencies = "requests"``
-    would parse as eight single-character requirements rather than fail.
-    """
+    """Return a list of dependency strings, rejecting scalar and non-string values."""
     if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
         msg = f"{source} must be an array of strings"
         raise InvalidProjectRequirementError(msg)

--- a/nab-provider/src/nab_provider/provider.py
+++ b/nab-provider/src/nab_provider/provider.py
@@ -28,6 +28,7 @@ from ._provider import metadata_resolver as _metadata_resolver
 from ._provider import priority as _priority
 from ._provider import sources as _sources
 from .conflict_kind import EMPTY_MEMBERSHIP_SETS
+from .environment import host_environment
 from .errors import (
     ForeignMetadataError,
     IncompatiblePythonError,
@@ -63,7 +64,6 @@ from .policy import (
     ResolveMode as ResolveMode,  # noqa: PLC0414  (re-export, importable from here)
 )
 from .records import DistFile, SdistFile, WheelFile
-from .target import host_environment
 from .vcs_admission import (
     UnsupportedVcsError,
     VcsConfig,

--- a/nab-provider/src/nab_provider/requirements_file.py
+++ b/nab-provider/src/nab_provider/requirements_file.py
@@ -11,8 +11,13 @@ from nab_provider._vendor.packaging.markers import Marker
 from nab_provider._vendor.packaging.utils import canonicalize_name
 
 from .marker_holds import dependency_marker_holds, intractable_as_error, marker_set
-from .metadata import validate_specifier_versions
 from .pep508 import NESTED_MARKER_MESSAGE, parse_requirement
+from .project_requirements import (
+    InvalidProjectRequirementError,
+    parse_project_requirement,
+    parse_requirements,
+    require_string_list,
+)
 from .resolver_inputs import (
     raise_for_unsatisfiable as raise_for_unsatisfiable,  # noqa: PLC0414  (re-export)
 )
@@ -37,10 +42,6 @@ __all__ = [
 ]
 
 
-class InvalidProjectRequirementError(ValueError):
-    """A pyproject.toml dependency or metadata value is invalid or unresolvable."""
-
-
 class InvalidProjectTableError(TypeError):
     """A pyproject.toml table such as ``[project]`` is not a table.
 
@@ -49,69 +50,6 @@ class InvalidProjectTableError(TypeError):
     specifically so an unrelated internal ``TypeError`` is not mislabelled
     as a user-file error.
     """
-
-
-def _add_extra_marker(dep_str: str, extra_name: str) -> str:
-    """Append ``extra == "name"`` to a :pep:`508` dep string.
-
-    Parses with :class:`Requirement` rather than splitting on the first
-    ``;`` so a semicolon inside a direct-reference URL is not mistaken
-    for the marker separator; an existing marker is combined with ``and``.
-
-    ``extra_name`` is a table key interpolated into the quoted marker, so
-    it is canonicalised with ``validate=True`` (PEP 685). A key that is
-    not a valid name (say one containing a quote) then raises
-    :class:`InvalidName` instead of producing a marker for the wrong
-    dependency.
-    """
-    req = parse_requirement(dep_str)
-    canonical_extra = canonicalize_name(extra_name, validate=True)
-    extra_marker = f'extra == "{canonical_extra}"'
-    if req.marker is not None:
-        marker = f"({req.marker}) and {extra_marker}"
-    else:
-        marker = extra_marker
-    req.marker = None
-    return f"{req} ; {marker}"
-
-
-def parse_project_requirement(
-    dep_str: str, source: str, *, extra: str | None = None
-) -> Requirement:
-    """Parse one PEP 508 dependency string, raising if it is malformed.
-
-    An ``extra`` name is folded in as an ``extra == "name"`` marker. A string
-    that is not valid PEP 508, or one whose specifier carries a version that
-    will not convert, raises :class:`InvalidProjectRequirementError`, so a
-    candidate declaring one malformed dependency is rejected whole rather
-    than resolved with the dependency silently dropped.
-    """
-    try:
-        text = _add_extra_marker(dep_str, extra) if extra is not None else dep_str
-        req = parse_requirement(text)
-        validate_specifier_versions(req.specifier)
-    except ValueError as exc:
-        msg = f"invalid requirement in {source}: {exc}"
-        raise InvalidProjectRequirementError(msg) from exc
-    return req
-
-
-def parse_requirements(strings: Sequence[str], source: str) -> list[Requirement]:
-    """Parse PEP 508 strings, naming ``source`` if one is malformed."""
-    return [parse_project_requirement(s, source) for s in strings]
-
-
-def require_string_list(value: object, source: str) -> list[str]:
-    """Validate that a PEP 621 dependency value is an array of strings.
-
-    A bare string passes the type checker as ``Sequence[str]`` but
-    iterates character by character, so ``dependencies = "requests"``
-    would parse as eight single-character requirements rather than fail.
-    """
-    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
-        msg = f"{source} must be an array of strings"
-        raise InvalidProjectRequirementError(msg)
-    return value
 
 
 def _canonicalize_optional_deps(

--- a/nab-provider/src/nab_provider/target.py
+++ b/nab-provider/src/nab_provider/target.py
@@ -20,7 +20,6 @@ report metadata for the target or for someone else.
 from __future__ import annotations
 
 import re
-from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from functools import lru_cache
 from typing import TYPE_CHECKING
@@ -36,6 +35,10 @@ from nab_provider._vendor.packaging.specifiers import (
 from nab_provider._vendor.packaging.version import InvalidVersion, Version
 
 from .conflict_kind import EMPTY_MEMBERSHIP_SETS, MARKER_VARIABLE_FOR_KIND
+from .environment import (
+    EnvironmentSource,
+    host_environment,
+)
 from .marker_holds import IntractableMarkerError, UnevaluableMarkerError
 from .tags import (
     FREE_THREADED_MIN_PYTHON,
@@ -45,6 +48,8 @@ from .tags import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping, Sequence
+
     from .tags import TagsSource
 
 
@@ -73,12 +78,6 @@ __all__ = [
     "slices_from_points",
     "unboundable_variables",
 ]
-
-
-# Where a host marker environment comes from.  Injected so a caller
-# (and every test) can name the interpreter it means instead of the one
-# running.
-EnvironmentSource = Callable[[], Mapping[str, object]]
 
 
 # The OS/arch PEP 508 marker values per matrix platform id.  These are
@@ -640,18 +639,6 @@ def _clause_interval_literal(
     except (InvalidVersion, InvalidSpecifier):
         raise _non_interval(parts, target) from None
     return op, specifier, version
-
-
-def host_environment(
-    env_source: EnvironmentSource = default_environment,
-) -> dict[str, str]:
-    """Return the host's PEP 508 marker environment as a plain string dict.
-
-    ``default_environment`` returns a TypedDict whose ``.items()`` view
-    widens the values to ``object``, so rebuild it as ``dict[str, str]``
-    the callers can overlay onto.
-    """
-    return {key: value for key, value in env_source().items() if isinstance(value, str)}
 
 
 def python_axis_environment(python_version: str) -> dict[str, str]:

--- a/nab-provider/tests/test_provider_imports.py
+++ b/nab-provider/tests/test_provider_imports.py
@@ -1,0 +1,55 @@
+"""A host can drive the provider without project expansion or marker algebra."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+_PROBE = """
+import sys
+
+for name in (
+    "nab_markersets",
+    "nab_provider.target",
+    "nab_provider.marker_holds",
+    "nab_provider.requirements_file",
+    "nab_provider.resolver_inputs",
+):
+    sys.modules[name] = None
+
+from nab_provider._vendor.packaging.ranges import VersionRange
+from nab_provider._vendor.packaging.specifiers import SpecifierSet
+from nab_provider._vendor.packaging.version import Version
+from nab_provider.provider import Provider
+from nab_provider.records import WheelFile
+from nab_provider.testing import make_coordinator
+from nab_resolver.resolver import Resolver
+
+wheel = WheelFile(
+    "demo-1.0-py3-none-any.whl", "https://index.test/demo.whl", "1.0",
+    None, True, None,
+)
+metadata = (
+    "Metadata-Version: 2.1\\nName: demo\\nVersion: 1.0\\n"
+    "Provides-Extra: speed\\n"
+    "Requires-Dist: absent; python_version < '2'\\n\\n"
+)
+port = make_coordinator([wheel], package="demo", metadata_text=metadata)
+roots = {
+    "demo": SpecifierSet("==1.0").to_range(),
+    "demo[speed]": VersionRange.full(),
+}
+provider = Provider(port, root_requirements=roots, root_extras={("demo", "speed")})
+resolver = Resolver(provider, range_type=VersionRange, root_version=Version("0"))
+solution = resolver.solve(roots)
+assert solution.pins == {"demo": Version("1.0"), "demo[speed]": Version("1.0")}
+assert solution.edges == (("demo[speed]", "demo"),)
+assert solution.roots == ("demo", "demo[speed]")
+"""
+
+
+def test_solve_without_project_or_marker_algebra() -> None:
+    """Resolve real metadata with extras and an environment-gated dependency."""
+    subprocess.run(  # noqa: S603 - fixed interpreter and probe
+        [sys.executable, "-c", _PROBE], check=True
+    )


### PR DESCRIPTION
When no target is supplied, `Provider` now resolves without importing `nab-markersets`, matrix construction, or dependency-group expansion.

Move marker evaluation and dependency-string parsing into `environment.py` and `project_requirements.py`, keeping existing public helper imports working. Creating `ResolveTarget` still imports matrix support.
