### PR TITLE
Point the build-policy refusal at the entry that set it, not a missing table

### DIFF
--- a/nab-project/src/nab_project/build_policy.py
+++ b/nab-project/src/nab_project/build_policy.py
@@ -63,7 +63,8 @@ def enforce_build_policy_for_targets(
                 f" must be 'never'; got {', '.join(offending)}.  A PEP 517"
                 " backend runs on the host and reports the host's metadata,"
                 " not the target's.  Remove the setting (it defaults to"
-                " 'never' for a declared target) or set it to 'never'."
+                " 'never' for a declared target) or set it to 'never'.  Remove"
+                " the whole entry where build-policy is its only key."
             )
             raise ConfigError(msg)
         return BuildPolicy.NEVER
@@ -89,16 +90,26 @@ def _explicit_host_builds(
     An unset global is not offending: ``build-policy`` defaults to
     ``never`` for a target that forbids host builds rather than failing a
     project that never mentioned it.
+
+    A per-package entry is named by the surface it was declared on, so a
+    ``[[package-rules]]`` entry matching several requirements is named once.
     """
     offending: list[str] = []
     if build_policy_set and build_policy is not BuildPolicy.NEVER:
         offending.append(f"build-policy = {build_policy.value!r}")
+
     for pkg in package_overrides:
         bp = pkg.build_policy
         if bp is not None and bp is not BuildPolicy.NEVER:
-            offending.append(f"packages.{pkg.requirement} build-policy = {bp.value!r}")
+            # Only an entry parsed from a config file carries a label.
+            surface = pkg.source_label or str(pkg.requirement)
+            entry = f"{surface} build-policy = {bp.value!r}"
+            if entry not in offending:
+                offending.append(entry)
+
     for name, index_override in index_overrides.items():
         bp = index_override.build_policy
         if bp is not None and bp is not BuildPolicy.NEVER:
             offending.append(f"index.{name} build-policy = {bp.value!r}")
+
     return offending

--- a/nab-project/tests/test_build_policy.py
+++ b/nab-project/tests/test_build_policy.py
@@ -81,12 +81,56 @@ def test_the_message_names_every_offending_override() -> None:
             build_policy=BuildPolicy.NEVER,
             build_policy_set=False,
             package_overrides=(
-                pkg_override("demo", build_policy=BuildPolicy.BUILD_REMOTE),
+                pkg_override(
+                    "demo",
+                    build_policy=BuildPolicy.BUILD_REMOTE,
+                    source_label="pyproject.toml: packages.'demo'",
+                ),
             ),
             index_overrides={
                 "private": IndexOverride(build_policy=BuildPolicy.BUILD_LOCAL)
             },
         )
 
-    assert "packages.demo build-policy = 'build-remote'" in str(raised.value)
-    assert "index.private build-policy = 'build-local'" in str(raised.value)
+    message = str(raised.value)
+
+    assert "pyproject.toml: packages.'demo' build-policy = 'build-remote'" in message
+    assert "index.private build-policy = 'build-local'" in message
+
+
+def test_one_rule_entry_is_named_once_however_many_it_matches() -> None:
+    """A ``match`` list is one declaration, so it is one entry to edit."""
+    with pytest.raises(ConfigError) as raised:
+        enforce_build_policy_for_targets(
+            targets=DECLARED,
+            build_policy=BuildPolicy.NEVER,
+            build_policy_set=False,
+            package_overrides=tuple(
+                pkg_override(
+                    name,
+                    build_policy=BuildPolicy.BUILD_LOCAL,
+                    source_label="pyproject.toml: package-rules[0]",
+                )
+                for name in ("foo", "bar")
+            ),
+            index_overrides={},
+        )
+
+    message = str(raised.value)
+
+    assert "pyproject.toml: package-rules[0] build-policy = 'build-local'" in message
+    assert message.count("package-rules[0]") == 1
+
+
+def test_an_override_with_no_declared_surface_names_its_requirement() -> None:
+    """With no source label, the refusal names the override's requirement."""
+    with pytest.raises(ConfigError, match=r"got demo>=2 build-policy = 'build-local'"):
+        enforce_build_policy_for_targets(
+            targets=DECLARED,
+            build_policy=BuildPolicy.NEVER,
+            build_policy_set=False,
+            package_overrides=(
+                pkg_override("demo>=2", build_policy=BuildPolicy.BUILD_LOCAL),
+            ),
+            index_overrides={},
+        )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2067,6 +2067,8 @@ _UNIVERSAL_MATRIX = (
     '[tool.nab.matrix]\npython = ">=3.11,<3.12"\nplatforms = ["linux_x86_64"]\n'
 )
 
+_UNIVERSAL_RULE = '[[tool.nab.package-rules]]\nmatch = ["foo", "bar"]\n'
+
 
 class TestUniversalBuildPolicy:
     """Universal mode cannot build on the host: build-policy is forced never."""
@@ -2111,8 +2113,47 @@ class TestUniversalBuildPolicy:
             + _UNIVERSAL_MATRIX
             + '[tool.nab.packages.foo]\nbuild-policy = "build-remote"\n',
         )
-        with pytest.raises(ConfigError, match="packages.foo"):
+        with pytest.raises(ConfigError, match=r"packages\.'foo' build-policy"):
             read_pyproject_config(path)
+
+    def test_package_rule_build_policy_names_that_surface(self, tmp_path: Path) -> None:
+        """One rule entry is one thing to edit, whatever its match list holds."""
+        path = write(
+            tmp_path,
+            '[tool.nab]\nmode = "universal"\n'
+            + _UNIVERSAL_MATRIX
+            + _UNIVERSAL_RULE
+            + 'build-policy = "build-remote"\n',
+        )
+        with pytest.raises(ConfigError) as raised:
+            read_pyproject_config(path)
+
+        message = str(raised.value)
+
+        assert f"{path}: package-rules[0] build-policy = 'build-remote'" in message
+
+        assert "packages.foo" not in message
+        assert message.count("build-remote") == 1
+
+    def test_the_prescribed_repairs_parse(self, tmp_path: Path) -> None:
+        """Every repair the refusal names leaves a config that parses."""
+        header = '[tool.nab]\nmode = "universal"\n' + _UNIVERSAL_MATRIX
+        offending = _UNIVERSAL_RULE + 'build-policy = "build-remote"\n'
+
+        with pytest.raises(ConfigError) as raised:
+            read_pyproject_config(write(tmp_path, header + offending))
+
+        assert "Remove the whole entry" in str(raised.value)
+
+        # An entry with no body sets no policy and is rejected, so removing the
+        # setting alone is a repair only where the entry keeps another key.
+        setting_removed = _UNIVERSAL_RULE + 'dist-policy = "wheel-only"\n'
+        entry_removed = ""
+        set_to_never = _UNIVERSAL_RULE + 'build-policy = "never"\n'
+
+        for repair in (setting_removed, entry_removed, set_to_never):
+            path = write(tmp_path, header + repair)
+            assert read_pyproject_config(path).build_policy is BuildPolicy.NEVER
 
     def test_package_override_without_build_policy_ok(self, tmp_path: Path) -> None:
         path = write(


### PR DESCRIPTION
A `[[tool.nab.package-rules]]` entry that sets `build-policy` under a declared target is refused by the name of a table the project never wrote, once per name in its `match` list:

```
got packages.foo build-policy = 'build-remote', packages.bar build-policy = 'build-remote'
```

There is no `[tool.nab.packages.foo]` in that project to edit. The rule expands to one override per matched requirement before the check runs, and the check named each of those after its requirement. Overrides already carry `source_label`, the surface they were declared on, so the refusal now uses that and names the entry once:

```
got /path/to/pyproject.toml: package-rules[0] build-policy = 'build-remote'
```

A `[tool.nab.packages.foo]` table is named the same way, as `packages.'foo'` prefixed by the file it came from.

The repair the message prescribed can fail: dropping `build-policy` from an entry that sets nothing else leaves an entry the parser rejects for setting no policy. Removing the whole entry is now named as a third repair.
