### PR TITLE
Defer candidate queries while resolving dependency sources

### DIFF
--- a/docs/how-to/embed-the-resolver.md
+++ b/docs/how-to/embed-the-resolver.md
@@ -191,6 +191,14 @@ to decide the virtual root at, which `range_type.singleton()` has to
 accept, and a `format_range` unless that type's `str` already reads as a
 constraint. nab drives the resolver this way, with a PEP 440 range type.
 
+## Candidates discovered while resolving
+
+When candidate availability depends on selected packages, pass `Resolver` an `availability_generation` callback. It takes no arguments and returns an integer that increases whenever provider operations can change a candidate query's answer. Reading it must not change availability.
+
+An unsuccessful query is deferred while other packages can still be decided. After a stable pass through the remaining packages, the resolver records absence guarded by the current decisions. The provider must guarantee that absence whenever those decisions and requirements hold, even after its caches gain data. A source discovered through one parent must therefore remain eligible only while its declaring requirement is active; a growing cache alone does not satisfy this contract.
+
+This mode is synchronous: availability cannot change between the final generation check and recording the clause. Omit the callback for a provider with a fixed candidate universe.
+
 ## The supported API
 
 These module paths will not move without a major version bump:

--- a/nab-resolver/src/nab_resolver/decide.py
+++ b/nab-resolver/src/nab_resolver/decide.py
@@ -11,9 +11,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from .incompat_index import add_incompatibility
+from .root import ROOT
 from .types import Incompatibility, IncompatibilityCause, RangeProtocol, Term
 
 if TYPE_CHECKING:
+    from collections.abc import Set as AbstractSet
+
     from .resolver import Resolver
 
 __all__ = [
@@ -25,7 +28,9 @@ __all__ = [
 ]
 
 
-def choose_package_to_decide(resolver: Resolver[Any, Any]) -> Any | None:
+def choose_package_to_decide(
+    resolver: Resolver[Any, Any], excluded: AbstractSet[Any] | None = None
+) -> Any | None:
     """Choose the next undecided package, or None if all decided.
 
     Prefers ``is_ready`` packages so resolution keeps making progress while
@@ -41,7 +46,11 @@ def choose_package_to_decide(resolver: Resolver[Any, Any]) -> Any | None:
     than backjumping to level 0.
     """
     undecided = resolver.solution.undecided_packages()
+    if excluded:
+        undecided = undecided - excluded
     if not undecided:
+        if excluded is not None and resolver.solution.undecided_packages():
+            resolver.provider.begin_decision_scan()
         return None
 
     key_inputs_arrived = resolver.provider.begin_decision_scan()
@@ -70,6 +79,10 @@ def choose_package_to_decide(resolver: Resolver[Any, Any]) -> Any | None:
                 tiebreak = (1, 0, str(package))
             tiebreak_cache[package] = tiebreak
         return (ready_penalty, priority, tiebreak)
+
+    if excluded is not None:
+        resolver.solution.take_changed_packages()
+        return min(undecided, key=sort_key)
 
     return resolver.decision_queue.pick(
         undecided,
@@ -129,6 +142,8 @@ def absorb_pending_clauses(resolver: Resolver[Any, Any]) -> bool:
     the default ``NO_VERSIONS`` clause this turn.
     """
     clauses = list(resolver.provider.consume_pending_clauses())
+    if clauses and resolver.deferred is not None:
+        resolver.deferred.clear()
     for incompatibility in clauses:
         _normalize_terms(resolver, incompatibility)
         add_incompatibility(resolver, incompatibility)
@@ -178,7 +193,11 @@ def _constraint_hid_a_version(
 
 
 def record_no_versions(
-    resolver: Resolver[Any, Any], package: Any, *, had_pending: bool
+    resolver: Resolver[Any, Any],
+    package: Any,
+    *,
+    had_pending: bool,
+    deferrable: bool = True,
 ) -> None:
     """Add the default ``NO_VERSIONS`` clause for ``package``.
 
@@ -187,6 +206,9 @@ def record_no_versions(
     the supporting decisions.
     """
     if had_pending:
+        return
+    if deferrable and resolver.deferred is not None:
+        resolver.deferred.packages[package] = None
         return
 
     current_range = resolver.solution.get(package) or resolver.term_top
@@ -209,5 +231,34 @@ def record_no_versions(
             [Term(package, current_range, positive=True)],
             cause=cause,
             constraint_range=constraint_range,
+        ),
+    )
+
+
+def record_contextual_no_versions(resolver: Resolver[Any, Any], package: Any) -> None:
+    """Guard an exhausted availability query by every other current decision."""
+    decisions = resolver.solution.decisions()
+    guards = [
+        Term(name, resolver.range_type.singleton(version), positive=True)
+        for name, version in decisions.items()
+        if name is not ROOT
+    ]
+    if not guards:
+        record_no_versions(resolver, package, had_pending=False, deferrable=False)
+        return
+
+    current_range = resolver.solution.get(package) or resolver.term_top
+    resolver.observer.on_no_versions(package, current_range)
+    constraint = resolver.constraints.get(package)
+    if constraint is None or not _constraint_hid_a_version(
+        resolver, package, current_range
+    ):
+        constraint = None
+    add_incompatibility(
+        resolver,
+        Incompatibility(
+            [Term(package, current_range, positive=True), *guards],
+            cause=IncompatibilityCause.CONTEXTUAL_NO_VERSIONS,
+            constraint_range=constraint,
         ),
     )

--- a/nab-resolver/src/nab_resolver/decide.py
+++ b/nab-resolver/src/nab_resolver/decide.py
@@ -31,7 +31,7 @@ __all__ = [
 def choose_package_to_decide(
     resolver: Resolver[Any, Any], excluded: AbstractSet[Any] | None = None
 ) -> Any | None:
-    """Choose the next undecided package, or None if all decided.
+    """Choose the next undecided package outside ``excluded``, or None.
 
     Prefers ``is_ready`` packages so resolution keeps making progress while
     other listings/metadata are still in flight.  ``begin_decision_scan`` marks
@@ -199,7 +199,7 @@ def record_no_versions(
     had_pending: bool,
     deferrable: bool = True,
 ) -> None:
-    """Add the default ``NO_VERSIONS`` clause for ``package``.
+    """Defer a failed query or record its default absence clause.
 
     Skipped when the provider already supplied context-aware clauses;
     otherwise the broad clause would persist past the backjump that lifts

--- a/nab-resolver/src/nab_resolver/deferred.py
+++ b/nab-resolver/src/nab_resolver/deferred.py
@@ -1,0 +1,39 @@
+"""Track a stable sweep of queries whose candidates may be discovered later."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Generic
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+from .types import PackageType
+
+
+class DeferredChoices(Generic[PackageType]):
+    """Remember unavailable packages until resolution or availability progresses."""
+
+    def __init__(self, generation: Callable[[], int]) -> None:
+        """Start with no deferred queries at the provider's current generation."""
+        self.read_generation = generation
+        self.packages: dict[PackageType, None] = {}
+        self.generation = generation()
+        self.derivations = 0
+        self.decisions = 0
+
+    def clear(self) -> None:
+        """Start another sweep after a decision, backjump or queued clause."""
+        self.packages.clear()
+
+    def refresh(self, derivations: int, decisions: int) -> None:
+        """Invalidate failed queries when their allowed ranges or candidates change."""
+        generation = self.read_generation()
+        if (
+            generation != self.generation
+            or derivations != self.derivations
+            or decisions != self.decisions
+        ):
+            self.packages.clear()
+        self.generation = generation
+        self.derivations = derivations
+        self.decisions = decisions

--- a/nab-resolver/src/nab_resolver/report.py
+++ b/nab-resolver/src/nab_resolver/report.py
@@ -319,7 +319,7 @@ def _render_line(
 def _render_contextual_no_versions(
     incompatibility: Incompatibility[Any, Any], format_range: _FormatFn
 ) -> str:
-    """Name the unavailable package and the decisions its absence depends on."""
+    """Render an absence with its supporting decisions."""
     unavailable, *guards = incompatibility.terms
     context = " and ".join(format_term(term, format_range) for term in guards)
     if incompatibility.constraint_range is not None:

--- a/nab-resolver/src/nab_resolver/report.py
+++ b/nab-resolver/src/nab_resolver/report.py
@@ -126,7 +126,10 @@ def _shown_terms(
     The comparison runs on exactly what the reader sees, so a requirement is
     read as printed, un-narrowed, the way the line states it.
     """
-    if incompatibility.cause is IncompatibilityCause.NO_VERSIONS:
+    if incompatibility.cause in {
+        IncompatibilityCause.NO_VERSIONS,
+        IncompatibilityCause.CONTEXTUAL_NO_VERSIONS,
+    }:
         return {term.package: term for term in incompatibility.terms}
     return {
         term.package: _narrow_positive(term, narrow) for term in incompatibility.terms
@@ -273,8 +276,14 @@ def _render_line(
     terms = incompatibility.terms
     # An availability line renders its own range: narrowing it onto the listing
     # is what let it stop covering the requirement it closes against.
-    if narrow is not None and cause is not IncompatibilityCause.NO_VERSIONS:
+    if narrow is not None and cause not in {
+        IncompatibilityCause.NO_VERSIONS,
+        IncompatibilityCause.CONTEXTUAL_NO_VERSIONS,
+    }:
         terms = [_narrow_positive(term, narrow) for term in terms]
+
+    if cause is IncompatibilityCause.CONTEXTUAL_NO_VERSIONS:
+        return _render_contextual_no_versions(incompatibility, format_range)
 
     attributed = _dependency_pair(incompatibility, terms)
     if attributed is not None:
@@ -305,6 +314,21 @@ def _render_line(
         return f"because the user constrained {subject}"
 
     return _render_prefix_line(cause, terms, format_range)
+
+
+def _render_contextual_no_versions(
+    incompatibility: Incompatibility[Any, Any], format_range: _FormatFn
+) -> str:
+    """Name the unavailable package and the decisions its absence depends on."""
+    unavailable, *guards = incompatibility.terms
+    context = " and ".join(format_term(term, format_range) for term in guards)
+    if incompatibility.constraint_range is not None:
+        requirement = _with_range(
+            str(unavailable.package), format_range(incompatibility.constraint_range)
+        )
+        return f"because the user constrained {requirement} with {context} selected"
+    requirement = _format_requirement(unavailable, format_range)
+    return f"because no versions of {requirement} are available with {context} selected"
 
 
 def _render_prefix_line(

--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -611,9 +611,11 @@ class Resolver(Generic[PackageType, VersionType]):
         :class:`packaging.ranges.VersionRange` requires a parseable
         version string or :class:`~packaging.version.Version` here.
 
-        ``availability_generation`` enables synchronous candidate discovery.
+        ``availability_generation`` defers failed queries when candidate
+        availability depends on current decisions.
         Its monotonically increasing result invalidates deferred queries when
-        provider operations reveal candidates. Missing packages are retried
+        provider operations reveal candidates; reading it must not change
+        availability. Missing packages are retried
         after other decisions, and an exhausted sweep records absence guarded
         by all current decisions. The provider must ensure such an absence
         remains true whenever those decisions and requirements hold, regardless

--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING, Any, Final, Generic, Protocol
 from . import conflict, decide, incompat_index, propagate
 from ._compat import override
 from .decision_queue import DecisionQueue
+from .deferred import DeferredChoices
 from .errors import ResolutionError
 from .partial_solution import PartialSolution
 from .ranges import Range
@@ -598,6 +599,8 @@ class Resolver(Generic[PackageType, VersionType]):
         range_type: type[RangeProtocol[Any]] = Range,
         root_version: Any = 1,
         format_range: Callable[[Any], str] = str,
+        *,
+        availability_generation: Callable[[], int] | None = None,
     ) -> None:
         """Create a resolver with the given provider and optional observer.
 
@@ -608,12 +611,27 @@ class Resolver(Generic[PackageType, VersionType]):
         :class:`packaging.ranges.VersionRange` requires a parseable
         version string or :class:`~packaging.version.Version` here.
 
+        ``availability_generation`` enables synchronous candidate discovery.
+        Its monotonically increasing result invalidates deferred queries when
+        provider operations reveal candidates. Missing packages are retried
+        after other decisions, and an exhausted sweep records absence guarded
+        by all current decisions. The provider must ensure such an absence
+        remains true whenever those decisions and requirements hold, regardless
+        of later cache population. Availability must not change asynchronously
+        between the final generation check and clause recording. Omitting this
+        callback keeps the static candidate-universe contract.
+
         ``format_range`` renders a constraint in a failure report.  It travels
         with ``range_type``: the default ``str`` reads well for
         :class:`~nab_resolver.ranges.Range`, while a range type whose ``str``
         is a debug representation needs its own.
         """
         self.provider = provider
+        self.deferred = (
+            None
+            if availability_generation is None
+            else DeferredChoices[PackageType](availability_generation)
+        )
 
         # Recording the provider rather than a flag keeps the answer tied to
         # the object it was asked about, so a provider swapped into
@@ -781,10 +799,21 @@ class Resolver(Generic[PackageType, VersionType]):
                 continue
 
             # Phase 3: Decision making.
-            next_package = decide.choose_package_to_decide(self)
+            deferred = self.deferred
+            if deferred is not None:
+                deferred.refresh(self.stats.derivations, self.stats.decisions)
+            next_package = decide.choose_package_to_decide(
+                self, None if deferred is None else deferred.packages.keys()
+            )
             if next_package is None:
-                # All packages decided; the spec requires filtering out
-                # any unreachable extras before returning.
+                if deferred is not None and deferred.packages:
+                    deferred.refresh(self.stats.derivations, self.stats.decisions)
+                    if not deferred.packages:
+                        continue
+                    changed_package = next(iter(deferred.packages))
+                    decide.record_contextual_no_versions(self, changed_package)
+                    deferred.clear()
+                    continue
                 return self._build_result()
 
             changed_package = self._decide_next(next_package)
@@ -799,6 +828,8 @@ class Resolver(Generic[PackageType, VersionType]):
         restarts_remaining: int,
     ) -> tuple[Any, int, int]:
         """Run conflict resolution, targeted backtrack, and restart phases."""
+        if self.deferred is not None:
+            self.deferred.clear()
         self.stats.conflicts += 1
         self.observer.on_conflict(conflicting_incompatibility)
         learned = conflict.conflict_resolution(self, conflicting_incompatibility)
@@ -829,6 +860,8 @@ class Resolver(Generic[PackageType, VersionType]):
             self.priority_epoch += 1
             triggering = conflict.force_targeted_backtrack(self, force_targets)
             if triggering is not None:
+                if self.deferred is not None:
+                    self.deferred.clear()
                 return triggering
 
         if chosen_version is None:
@@ -899,6 +932,8 @@ class Resolver(Generic[PackageType, VersionType]):
         constraints: Mapping[PackageType, RangeProtocol[VersionType]] | None,
     ) -> None:
         """Reset solver state for a new resolution."""
+        if self.deferred is not None:
+            self.deferred.clear()
         self.incompatibilities.clear()
         self.package_to_incompatibilities.clear()
         self.clause_contradicted_at.clear()

--- a/nab-resolver/src/nab_resolver/types.py
+++ b/nab-resolver/src/nab_resolver/types.py
@@ -377,6 +377,9 @@ class IncompatibilityCause(enum.Enum):
     See: https://github.com/dart-lang/pub/blob/master/doc/solver.md#conflict-resolution
     """
 
+    CONTEXTUAL_NO_VERSIONS = enum.auto()
+    """No candidate exists while the decisions after the first term remain selected."""
+
 
 class Incompatibility(Generic[PackageType, VersionType]):
     """A set of terms that cannot all be true simultaneously.
@@ -433,6 +436,13 @@ class Incompatibility(Generic[PackageType, VersionType]):
         self.constraint_range = constraint_range
         self.origin = origin
         self.dependency_range = dependency_range
+
+    @property
+    def unavailable_package(self) -> PackageType | None:
+        """The package whose availability a contextual absence clause describes."""
+        if self.cause is IncompatibilityCause.CONTEXTUAL_NO_VERSIONS:
+            return self.terms[0].package
+        return None
 
     @override
     def __repr__(self) -> str:

--- a/nab-resolver/tests/test_deferred_availability.py
+++ b/nab-resolver/tests/test_deferred_availability.py
@@ -30,7 +30,9 @@ package.__path__ = []
 sys.modules["tests"] = package
 spec = importlib.util.spec_from_file_location("tests.test_deferred_availability", sys.argv[1])
 assert spec is not None and spec.loader is not None
-spec.loader.exec_module(importlib.util.module_from_spec(spec))
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
 """
 
 

--- a/nab-resolver/tests/test_deferred_availability.py
+++ b/nab-resolver/tests/test_deferred_availability.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import subprocess
+import sys
 from collections.abc import Mapping
+from pathlib import Path
 
 import pytest
 
@@ -17,7 +20,26 @@ from nab_resolver.types import (
     Term,
 )
 
-from .test_resolver import DictProvider
+_IMPORT_PROBE = """
+import importlib.util
+import sys
+from types import ModuleType
+
+package = ModuleType("tests")
+package.__path__ = []
+sys.modules["tests"] = package
+spec = importlib.util.spec_from_file_location("tests.test_deferred_availability", sys.argv[1])
+assert spec is not None and spec.loader is not None
+spec.loader.exec_module(importlib.util.module_from_spec(spec))
+"""
+
+
+def test_import_with_another_tests_package() -> None:
+    """Mixed-workspace collection may reserve the tests package for another suite."""
+    subprocess.run(  # noqa: S603 - the interpreter, probe and test-module path are fixed
+        [sys.executable, "-c", _IMPORT_PROBE, str(Path(__file__).resolve())],
+        check=True,
+    )
 
 
 class DiscoveringProvider(BaseProvider[str, int]):
@@ -225,25 +247,21 @@ def test_contextual_error_identifies_the_missing_package() -> None:
     assert packages == {None, "dep"}
 
 
-class ActionProvider(DictProvider):
+class ActionProvider(BaseProvider[str, int]):
     """Offer a global absence fact or request a backjump after a failed query."""
 
     def __init__(self, action: str) -> None:
-        super().__init__(
-            {
-                "app": {1: {"mid": Range.full()}},
-                "mid": {1: {"missing": Range.full()}},
-                "missing": {},
-                "trigger": {1: {}},
-            }
-        )
+        self.dependencies: dict[str, dict[str, Range[int]]] = {
+            "app": {"mid": Range.full()},
+            "mid": {"missing": Range.full()},
+            "trigger": {},
+        }
         self.action = action
         self.emitted = False
         self.decisions: Mapping[str, int] = {}
         self.targets: list[str] = []
         self.clauses: list[Incompatibility[str, int]] = []
 
-    @override
     def prioritize(
         self,
         package: str,
@@ -261,7 +279,6 @@ class ActionProvider(DictProvider):
     ) -> None:
         self.decisions = decisions
 
-    @override
     def choose_version(
         self, package: str, version_range: RangeProtocol[int]
     ) -> int | None:
@@ -277,7 +294,18 @@ class ActionProvider(DictProvider):
                     )
                 ]
             return None
-        return super().choose_version(package, version_range)
+        return 1 if self.has_satisfying_version(package, version_range) else None
+
+    def has_satisfying_version(
+        self, package: str, version_range: RangeProtocol[int]
+    ) -> bool:
+        return package in self.dependencies and 1 in version_range
+
+    def get_dependencies(self, package: str, version: int) -> dict[str, Range[int]]:
+        return self.dependencies[package]
+
+    def widen_decision(self, package: str, version: int) -> None:
+        return None
 
     @override
     def consume_force_backtrack_targets(self) -> list[str]:

--- a/nab-resolver/tests/test_deferred_availability.py
+++ b/nab-resolver/tests/test_deferred_availability.py
@@ -10,7 +10,14 @@ from nab_resolver._compat import override
 from nab_resolver.errors import ResolutionError
 from nab_resolver.ranges import Range
 from nab_resolver.resolver import BaseProvider, Resolver
-from nab_resolver.types import IncompatibilityCause, RangeProtocol
+from nab_resolver.types import (
+    Incompatibility,
+    IncompatibilityCause,
+    RangeProtocol,
+    Term,
+)
+
+from .test_resolver import DictProvider
 
 
 class DiscoveringProvider(BaseProvider[str, int]):
@@ -216,3 +223,95 @@ def test_contextual_error_identifies_the_missing_package() -> None:
         packages.add(clause.unavailable_package)
         clauses.extend([clause.cause_left, clause.cause_right])
     assert packages == {None, "dep"}
+
+
+class ActionProvider(DictProvider):
+    """Offer a global absence fact or request a backjump after a failed query."""
+
+    def __init__(self, action: str) -> None:
+        super().__init__(
+            {
+                "app": {1: {"mid": Range.full()}},
+                "mid": {1: {"missing": Range.full()}},
+                "missing": {},
+                "trigger": {1: {}},
+            }
+        )
+        self.action = action
+        self.emitted = False
+        self.decisions: Mapping[str, int] = {}
+        self.targets: list[str] = []
+        self.clauses: list[Incompatibility[str, int]] = []
+
+    @override
+    def prioritize(
+        self,
+        package: str,
+        version_range: RangeProtocol[int],
+        conflict_counts: Mapping[str, int],
+        culprit_counts: Mapping[str, int] | None = None,
+    ) -> int:
+        return {"app": 0, "mid": 1, "missing": 2, "trigger": 3}[package]
+
+    @override
+    def receive_partial_solution_hint(
+        self,
+        positive_ranges: Mapping[str, RangeProtocol[int]],
+        decisions: Mapping[str, int],
+    ) -> None:
+        self.decisions = decisions
+
+    @override
+    def choose_version(
+        self, package: str, version_range: RangeProtocol[int]
+    ) -> int | None:
+        if package == "trigger" and "mid" in self.decisions and not self.emitted:
+            self.emitted = True
+            if self.action == "backjump":
+                self.targets = ["mid"]
+            else:
+                self.clauses = [
+                    Incompatibility(
+                        [Term("missing", Range.full(), positive=True)],
+                        cause=IncompatibilityCause.NO_VERSIONS,
+                    )
+                ]
+            return None
+        return super().choose_version(package, version_range)
+
+    @override
+    def consume_force_backtrack_targets(self) -> list[str]:
+        targets, self.targets = self.targets, []
+        return targets
+
+    @override
+    def consume_pending_clauses(self) -> list[Incompatibility[str, int]]:
+        clauses, self.clauses = self.clauses, []
+        return clauses
+
+
+class ActionTraceResolver(Resolver[str, int]):
+    """Record the deferred sweep immediately around a provider action."""
+
+    def __init__(self, provider: ActionProvider) -> None:
+        super().__init__(provider, availability_generation=lambda: 0)
+        self.action_provider = provider
+        self.sweeps: list[tuple[list[str], list[str]]] = []
+
+    @override
+    def _decide_next(self, next_package: str) -> str:
+        assert self.deferred is not None
+        before = list(self.deferred.packages)
+        emitted = self.action_provider.emitted
+        result = super()._decide_next(next_package)
+        if self.action_provider.emitted and not emitted:
+            self.sweeps.append((before, list(self.deferred.packages)))
+        return result
+
+
+@pytest.mark.parametrize("action", ["backjump", "clause"])
+def test_provider_actions_start_a_fresh_deferred_sweep(action: str) -> None:
+    resolver = ActionTraceResolver(ActionProvider(action))
+    with pytest.raises(ResolutionError):
+        resolver.resolve({"app": Range.full(), "trigger": Range.full()})
+    assert resolver.sweeps == [(["missing"], [])]

--- a/nab-resolver/tests/test_deferred_availability.py
+++ b/nab-resolver/tests/test_deferred_availability.py
@@ -1,0 +1,218 @@
+"""Resolution when dependency metadata discovers additional candidate sources."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import pytest
+
+from nab_resolver._compat import override
+from nab_resolver.errors import ResolutionError
+from nab_resolver.ranges import Range
+from nab_resolver.resolver import BaseProvider, Resolver
+from nab_resolver.types import IncompatibilityCause, RangeProtocol
+
+
+class DiscoveringProvider(BaseProvider[str, int]):
+    """An in-memory candidate index extended by selected dependency metadata."""
+
+    def __init__(self, *, reveal_root: bool = False) -> None:
+        self.versions = {"app": [2, 1], "dep": [1], "reveal": [1]}
+        self.reveal_root = reveal_root
+        self.generation = 0
+        self.queries: list[tuple[str, int | None]] = []
+        self.decisions: Mapping[str, int] = {}
+
+    def availability_generation(self) -> int:
+        return self.generation
+
+    def _eligible_versions(self, package: str) -> list[int]:
+        """Offer the extra source only while its introducing parent is selected."""
+        introduced = self.decisions.get("reveal") == 1 or (
+            self.decisions.get("app") == 1 and not self.reveal_root
+        )
+        if package == "dep" and not introduced:
+            return [1]
+        return self.versions[package]
+
+    @override
+    def receive_partial_solution_hint(
+        self,
+        positive_ranges: Mapping[str, RangeProtocol[int]],
+        decisions: Mapping[str, int],
+    ) -> None:
+        self.decisions = decisions
+
+    def choose_version(
+        self, package: str, version_range: RangeProtocol[int]
+    ) -> int | None:
+        chosen = next(
+            (
+                version
+                for version in self._eligible_versions(package)
+                if version in version_range
+            ),
+            None,
+        )
+        self.queries.append((package, chosen))
+        return chosen
+
+    def has_satisfying_version(
+        self, package: str, version_range: RangeProtocol[int]
+    ) -> bool:
+        return any(
+            version in version_range for version in self._eligible_versions(package)
+        )
+
+    def get_dependencies(self, package: str, version: int) -> Mapping[str, Range[int]]:
+        if package == "app" and version == 2:
+            return {"dep": Range.at_least(2)}
+        if package == "reveal" or (
+            package == "app" and version == 1 and not self.reveal_root
+        ):
+            if 3 not in self.versions["dep"]:
+                self.versions["dep"].insert(0, 3)
+                self.generation += 1
+            return {"dep": Range.singleton(3)}
+        return {}
+
+    def prioritize(
+        self,
+        package: str,
+        version_range: RangeProtocol[int],
+        conflict_counts: Mapping[str, int],
+        culprit_counts: Mapping[str, int] | None = None,
+    ) -> int:
+        return {"app": 0, "dep": 1, "reveal": 2}[package]
+
+    def widen_decision(self, package: str, version: int) -> None:
+        return None
+
+
+@pytest.mark.parametrize("reveal_root", [False, True])
+def test_static_absence_cannot_describe_discovered_sources(reveal_root: bool) -> None:
+    provider = DiscoveringProvider(reveal_root=reveal_root)
+    roots = {"app": Range.full()}
+    if reveal_root:
+        roots["app"] = Range.singleton(2)
+        roots["reveal"] = Range.full()
+    with pytest.raises(ResolutionError):
+        Resolver(provider).resolve(roots)
+
+
+@pytest.mark.parametrize("reveal_root", [False, True])
+def test_deferred_absence_allows_later_source_discovery(reveal_root: bool) -> None:
+    provider = DiscoveringProvider(reveal_root=reveal_root)
+    roots = {"app": Range.full()}
+    if reveal_root:
+        roots["app"] = Range.singleton(2)
+        roots["reveal"] = Range.full()
+    result = Resolver(
+        provider, availability_generation=provider.availability_generation
+    ).resolve(roots)
+    expected = {"app": 1, "dep": 3}
+    if reveal_root:
+        expected.update(app=2, reveal=1)
+    assert result == expected
+    assert ("dep", None) in provider.queries
+
+
+class NeverAvailableProvider(DiscoveringProvider):
+    """Keep the dependency unavailable under every application choice."""
+
+    @override
+    def get_dependencies(self, package: str, version: int) -> Mapping[str, Range[int]]:
+        if package == "app":
+            return {"dep": Range.at_least(2)}
+        return {}
+
+
+@pytest.mark.parametrize("with_parent", [False, True])
+def test_exhausted_deferred_queries_terminate(with_parent: bool) -> None:
+    provider = NeverAvailableProvider()
+    roots = {"app": Range.full()} if with_parent else {"dep": Range.at_least(2)}
+    with pytest.raises(ResolutionError) as caught:
+        Resolver(
+            provider, availability_generation=provider.availability_generation
+        ).resolve(roots)
+    assert "dep" in str(caught.value)
+    if with_parent:
+        assert "selected" in str(caught.value)
+
+
+def test_deferred_constraint_failure_names_the_constraint() -> None:
+    provider = DiscoveringProvider()
+    with pytest.raises(ResolutionError) as caught:
+        Resolver(
+            provider, availability_generation=provider.availability_generation
+        ).resolve({"app": Range.singleton(1)}, {"dep": Range.less_than(1)})
+    assert "user constrained dep" in str(caught.value)
+
+
+def test_deferred_solver_reuse_resets_unavailable_queries() -> None:
+    provider = DiscoveringProvider()
+    resolver = Resolver(
+        provider, availability_generation=provider.availability_generation
+    )
+    with pytest.raises(ResolutionError):
+        resolver.resolve({"app": Range.singleton(2)})
+    assert resolver.resolve({"app": Range.singleton(1)}) == {"app": 1, "dep": 3}
+
+
+def test_existing_incompatibility_cause_values_remain_stable() -> None:
+    assert IncompatibilityCause.CONSTRAINT.value == 4
+    assert IncompatibilityCause.DERIVED.value == 5
+
+
+class ScanDiscoveringProvider(DiscoveringProvider):
+    """Publish metadata started by a failed query at the next scan boundary."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.pending = False
+
+    @override
+    def _eligible_versions(self, package: str) -> list[int]:
+        return self.versions[package]
+
+    @override
+    def choose_version(
+        self, package: str, version_range: RangeProtocol[int]
+    ) -> int | None:
+        version = super().choose_version(package, version_range)
+        if package == "dep" and version is None:
+            self.pending = True
+        return version
+
+    @override
+    def begin_decision_scan(self) -> None:
+        if self.pending:
+            self.pending = False
+            self.versions["dep"].insert(0, 3)
+            self.generation += 1
+
+
+def test_final_scan_observes_metadata_published_after_a_failed_query() -> None:
+    provider = ScanDiscoveringProvider()
+    result = Resolver(
+        provider, availability_generation=provider.availability_generation
+    ).resolve({"app": Range.singleton(2)})
+    assert result == {"app": 2, "dep": 3}
+    assert provider.queries == [("app", 2), ("dep", None), ("dep", 3)]
+
+
+def test_contextual_error_identifies_the_missing_package() -> None:
+    provider = NeverAvailableProvider()
+    with pytest.raises(ResolutionError) as caught:
+        Resolver(
+            provider, availability_generation=provider.availability_generation
+        ).resolve({"app": Range.full()})
+    clauses = [caught.value.incompatibility]
+    packages: set[str | None] = set()
+    while clauses:
+        clause = clauses.pop()
+        if clause is None:
+            continue
+        packages.add(clause.unavailable_package)
+        clauses.extend([clause.cause_left, clause.cause_right])
+    assert packages == {None, "dep"}


### PR DESCRIPTION
A provider that discovers a direct URL in a later dependency can now recover from an earlier query with no candidates. For example, an index containing only `dep==1` no longer prevents a later parent from requiring `dep==3` from a direct URL.

Passing `availability_generation` to `Resolver` enables retries after other decisions. Once the remaining queries are exhausted at a stable generation, the resolver records absence guarded by the current decisions. Errors identify the missing package separately from those guards.

The provider must guarantee that an absence remains true whenever those decisions and requirements hold, regardless of later cache population.
