### PR TITLE
Take upload-cutoff verdicts once per matrix, ~1.8% off a universal resolve

### DIFF
--- a/nab-provider/src/nab_provider/_provider/listing.py
+++ b/nab-provider/src/nab_provider/_provider/listing.py
@@ -59,6 +59,15 @@ if TYPE_CHECKING:
         "invalid-version",
     ]
 
+    # A prepared listing plus the cutoff verdicts taken over it, keyed by
+    # position in the listing, or ``None`` when no cutoff is configured.
+    _SharedListing = tuple[
+        list[tuple[Version, DistFile]],
+        set[Version],
+        bool,
+        dict[int, Cause | None] | None,
+    ]
+
 
 # Matched to the provider's look-ahead abort threshold: prefetching 8 versions
 # covers the worst-case abort scan without overshooting.  Used by the
@@ -404,23 +413,14 @@ def _filter_base(
             target_drops=True,
         )
     else:
-        parsed, sdist_install_versions, sort_with_wheel_first = cache.prepared(
-            normalized,
-            provider.stats,
-            partial(
-                _prepare_listing,
-                provider,
+        parsed, sdist_install_versions, sort_with_wheel_first, time_causes = (
+            cache.prepared(
                 normalized,
-                files,
-                policy,
-                target_drops=False,
-            ),
+                provider.stats,
+                partial(_prepare_shared, provider, normalized, files, policy),
+            )
         )
-        result = [
-            pair
-            for pair in parsed
-            if not python_or_time_cause(provider, normalized, pair[0], pair[1], policy)
-        ]
+        result = _apply_target_drops(provider, normalized, policy, parsed, time_causes)
 
     result = _drop_sdist_install_wheel_only(result, sdist_install_versions)
 
@@ -443,6 +443,59 @@ def _count_files_seen(stats: ProviderStats, wheels: int, sdists: int) -> None:
     stats.distributions_seen += wheels + sdists
     stats.wheels_seen += wheels
     stats.sdists_seen += sdists
+
+
+def _prepare_shared(
+    provider: Provider,
+    normalized: str,
+    files: Sequence[WheelFile | SdistFile],
+    policy: ListingPolicy,
+) -> _SharedListing:
+    """Run the half of the pass a matrix shares, and start its cutoff table.
+
+    A cutoff verdict reads the file's stamp and its effective cutoff, and
+    neither varies with the target, so one verdict answers every Python.
+    The table starts empty: :func:`_python_or_shared_time_cause` fills it
+    as it reaches each file, so a file no target admits is never dated.
+    """
+    parsed, sdist_install_versions, sort_with_wheel_first = _prepare_listing(
+        provider, normalized, files, policy, target_drops=False
+    )
+
+    time_causes: dict[int, Cause | None] | None = None
+    if policy.time_filter_active:
+        time_causes = {}
+
+    return parsed, sdist_install_versions, sort_with_wheel_first, time_causes
+
+
+def _apply_target_drops(
+    provider: Provider,
+    normalized: str,
+    policy: ListingPolicy,
+    parsed: list[tuple[Version, DistFile]],
+    time_causes: dict[int, Cause | None] | None,
+) -> list[tuple[Version, DistFile]]:
+    """Drop the prepared files this target's Python or the cutoff refuses.
+
+    ``time_causes`` holds the matrix's cutoff verdicts by position in
+    ``parsed``, and is ``None`` when no cutoff is configured and only the
+    Requires-Python drop runs.
+    """
+    if time_causes is None:
+        return [
+            pair
+            for pair in parsed
+            if not python_or_time_cause(provider, normalized, pair[0], pair[1], policy)
+        ]
+
+    return [
+        pair
+        for index, pair in enumerate(parsed)
+        if not _python_or_shared_time_cause(
+            provider, normalized, pair[0], pair[1], policy, time_causes, index
+        )
+    ]
 
 
 def _prepare_listing(
@@ -694,6 +747,55 @@ def python_or_time_cause(
         cutoff = policy.default_cutoff
 
     cause = upload_time_cause(dist, cutoff)
+    if cause is None:
+        return None
+    if cause == DropCause.UPLOAD_TIME_NAIVE:
+        raise InvalidUploadTimeError(naive_upload_time_message(normalized, dist))
+    provider.stats.excluded_by_time += 1
+    return cause
+
+
+def _python_or_shared_time_cause(
+    provider: Provider,
+    normalized: str,
+    version: Version,
+    dist: DistFile,
+    policy: ListingPolicy,
+    time_causes: dict[int, Cause | None],
+    index: int,
+) -> Cause | None:
+    """Answer :func:`python_or_time_cause` from the matrix's shared cutoff verdicts.
+
+    The first target to get the file at ``index`` past Requires-Python
+    takes its cutoff verdict into ``time_causes``, and the rest read that
+    back.  Requires-Python is asked first, as it is per target, so a file
+    no target admits is never given a cutoff.
+
+    Written out rather than shared with :func:`python_or_time_cause`
+    through helpers: both run once per file per target, and the frames
+    that sharing adds cost more than the duplication saves.
+    """
+    if policy.overridden:
+        override_rp = provider.effective_requires_python(normalized, version)
+    else:
+        override_rp = None
+
+    if excluded_by_python(provider, dist, override_rp):
+        return DropCause.REQUIRES_PYTHON
+
+    if index in time_causes:
+        cause = time_causes[index]
+    else:
+        if policy.overridden:
+            cutoff = provider.effective_uploaded_prior_to(
+                normalized, version, policy.index_name
+            )
+        else:
+            cutoff = policy.default_cutoff
+
+        cause = upload_time_cause(dist, cutoff)
+        time_causes[index] = cause
+
     if cause is None:
         return None
     if cause == DropCause.UPLOAD_TIME_NAIVE:

--- a/nab-provider/src/nab_provider/provider.py
+++ b/nab-provider/src/nab_provider/provider.py
@@ -185,15 +185,17 @@ class ListingFilterCache:
     identical list.  Memoising it per (package, Python) leaves only the
     wheel-tag pass to run per target.
 
-    Most of that half reads no Python either: the version parse and the
-    dist-policy exclusion do the same work for every Python of a matrix,
-    and only the Requires-Python and upload-cutoff drops differ.  When the
-    resolve spans more than one Python, :attr:`shares_pythons` is set and
-    :meth:`prepared` memoises that inner pass per package, so a
+    Most of that half reads no Python either: the version parse, the
+    dist-policy exclusion and the upload cutoff reach the same answer for
+    every Python of a matrix, and only the Requires-Python drop differs.
+    When the resolve spans more than one Python, :attr:`shares_pythons` is
+    set and :meth:`prepared` memoises that inner pass per package, so a
     three-Python matrix walks each listing's files once rather than three
-    times.  A one-Python resolve has nothing to share and skips the split,
-    since materialising the intermediate list would cost it a pass it does
-    not get back.
+    times.  The memo also holds the cutoff verdicts: the first target to
+    get a file past Requires-Python takes its verdict and the rest read it
+    back, while counting the drop stays per target.  A one-Python resolve
+    has nothing to share and skips the split, since materialising the
+    intermediate list would cost it a pass it does not get back.
 
     One instance is only valid across providers that share a coordinator
     and a policy config, as the targets of one resolve do.

--- a/nab-provider/tests/test_provider_declared_target.py
+++ b/nab-provider/tests/test_provider_declared_target.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import random
 import threading
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, cast
 
@@ -23,6 +23,7 @@ from nab_provider._provider import listing as listing_mod
 from nab_provider._vendor.packaging.ranges import VersionRange
 from nab_provider._vendor.packaging.requirements import Requirement
 from nab_provider._vendor.packaging.version import Version
+from nab_provider.overrides import IndexOverride
 from nab_provider.provider import (
     BuildPolicy,
     DistPolicy,
@@ -43,6 +44,8 @@ from nab_resolver.resolver import Resolver
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from nab_provider.overrides import PackageOverride
 
 
 def _done_event() -> threading.Event:
@@ -851,6 +854,8 @@ class TestListingFilterSharedAcrossPythons:
         files: Sequence[WheelFile | SdistFile] | None = None,
         uploaded_prior_to: datetime | None = None,
         dist_policy: DistPolicy = DistPolicy.WHEEL_OR_SDIST,
+        package_overrides: Sequence[PackageOverride] = (),
+        index_overrides: Mapping[str, IndexOverride] | None = None,
     ) -> tuple[Provider, Provider]:
         """A 3.11 and a 3.12 provider over one listing, sharing ``cache``."""
         coordinator = _index_with_files(self._files() if files is None else files)
@@ -863,6 +868,8 @@ class TestListingFilterSharedAcrossPythons:
                 ),
                 uploaded_prior_to=uploaded_prior_to,
                 dist_policy=dist_policy,
+                package_overrides=package_overrides,
+                index_overrides=index_overrides,
                 listing_filter_cache=cache,
             )
 
@@ -956,6 +963,170 @@ class TestListingFilterSharedAcrossPythons:
 
         assert py311.stats.excluded_by_dist_policy == 1
         assert py312.stats.excluded_by_dist_policy == 1
+
+    @staticmethod
+    def _dated_files() -> list[WheelFile | SdistFile]:
+        """Three releases both Pythons admit, the newest of them after the cutoff."""
+        return [
+            _make_wheel("1.0", upload_time="2026-01-01T00:00:00Z"),
+            _make_wheel("2.0", upload_time="2026-02-01T00:00:00Z"),
+            _make_wheel("3.0", upload_time="2026-06-01T00:00:00Z"),
+        ]
+
+    def _cutoff_verdicts(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        cache: ListingFilterCache,
+        files: Sequence[WheelFile | SdistFile] | None = None,
+    ) -> int:
+        """Count the upload-time verdicts both Pythons take over ``cache``."""
+        verdicts = 0
+        real = listing_mod.upload_time_cause
+
+        def counting(*args: Any, **kwargs: Any) -> Any:
+            nonlocal verdicts
+            verdicts += 1
+            return real(*args, **kwargs)
+
+        monkeypatch.setattr(listing_mod, "upload_time_cause", counting)
+        for provider in self._providers(
+            cache,
+            files=self._dated_files() if files is None else files,
+            uploaded_prior_to=datetime(2026, 3, 1, tzinfo=timezone.utc),
+        ):
+            provider.fetch_versions("pkg")
+        return verdicts
+
+    def test_the_matrix_takes_each_cutoff_verdict_once(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """One verdict per file answers both Pythons: the stamp is parsed once."""
+        assert self._cutoff_verdicts(monkeypatch, ListingFilterCache(2)) == 3
+
+    def test_without_sharing_each_python_takes_the_cutoff_verdicts(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A one-Python cache keeps the cutoff in the pass, so it runs per Python."""
+        assert self._cutoff_verdicts(monkeypatch, ListingFilterCache()) == 6
+
+    def test_the_matrix_leaves_a_file_no_python_admits_undated(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """4.0 needs 3.99, so neither Python reaches the cutoff over it."""
+        files: list[WheelFile | SdistFile] = [
+            *self._dated_files(),
+            _make_wheel(
+                "4.0", requires_python=">=3.99", upload_time="2026-01-01T00:00:00Z"
+            ),
+        ]
+        assert self._cutoff_verdicts(monkeypatch, ListingFilterCache(2), files) == 3
+
+    def test_the_shared_verdict_keeps_the_cutoff_behind_requires_python(self) -> None:
+        """A naive stamp refuses only the Python that admits the file carrying it.
+
+        2.0 needs 3.12, so 3.11 drops it before the cutoff is consulted
+        and resolves; 3.12 admits it, dates it, and refuses.
+        """
+        files: list[WheelFile | SdistFile] = [
+            _make_wheel("1.0", upload_time="2026-01-01T00:00:00Z"),
+            _make_wheel(
+                "2.0", requires_python=">=3.12", upload_time="2026-01-01T00:00:00"
+            ),
+        ]
+        py311, py312 = self._providers(
+            ListingFilterCache(2),
+            files=files,
+            uploaded_prior_to=datetime(2026, 3, 1, tzinfo=timezone.utc),
+        )
+
+        assert [str(v) for v, _ in py311.fetch_versions("pkg")] == ["1.0"]
+        assert py311.stats.excluded_by_python == 1
+
+        with pytest.raises(
+            InvalidUploadTimeError, match="pkg 2.0 has a timezone-naive"
+        ):
+            py312.fetch_versions("pkg")
+
+    def test_an_override_cutoff_is_read_per_version(self) -> None:
+        """The shared verdict follows the override that dates 2.0 out.
+
+        The override cuts ``pkg<3`` off in mid-January, so 2.0's February
+        stamp goes; 3.0 falls outside it and stays under the global
+        cutoff.  Both Pythons see the same thing.
+        """
+        files: list[WheelFile | SdistFile] = [
+            _make_wheel("1.0", upload_time="2026-01-01T00:00:00Z"),
+            _make_wheel("2.0", upload_time="2026-02-01T00:00:00Z"),
+            _make_wheel("3.0", upload_time="2026-02-15T00:00:00Z"),
+        ]
+        overrides = (
+            pkg_override(
+                "pkg<3", uploaded_prior_to=datetime(2026, 1, 15, tzinfo=timezone.utc)
+            ),
+        )
+
+        def providers(cache: ListingFilterCache) -> tuple[Provider, Provider]:
+            return self._providers(
+                cache,
+                files=files,
+                uploaded_prior_to=datetime(2026, 3, 1, tzinfo=timezone.utc),
+                package_overrides=overrides,
+            )
+
+        for one, other in zip(
+            providers(ListingFilterCache(2)),
+            providers(ListingFilterCache()),
+            strict=True,
+        ):
+            assert [str(v) for v, _ in one.fetch_versions("pkg")] == ["3.0", "1.0"]
+            assert one.fetch_versions("pkg") == other.fetch_versions("pkg")
+            assert one.stats == other.stats
+            assert one.stats.excluded_by_time == 1
+
+    def test_conflicting_cutoff_overrides_are_never_consulted(self) -> None:
+        """A version every Python's Requires-Python refuses is never given a cutoff.
+
+        A package override and an index override both set
+        ``uploaded-prior-to`` for 2.0, which conflicts for anything that
+        asks its cutoff.  Nothing asks, since 2.0 needs 3.99, and the
+        index override still dates 3.0 out ahead of the global cutoff.
+        """
+        files: list[WheelFile | SdistFile] = [
+            _make_wheel("1.0", upload_time="2026-01-01T00:00:00Z"),
+            _make_wheel(
+                "2.0", requires_python=">=3.99", upload_time="2026-01-01T00:00:00Z"
+            ),
+            _make_wheel("3.0", upload_time="2026-02-15T00:00:00Z"),
+        ]
+        overrides = (
+            pkg_override(
+                "pkg==2.0", uploaded_prior_to=datetime(2026, 1, 15, tzinfo=timezone.utc)
+            ),
+        )
+
+        def providers(cache: ListingFilterCache) -> tuple[Provider, Provider]:
+            return self._providers(
+                cache,
+                files=files,
+                uploaded_prior_to=datetime(2026, 3, 1, tzinfo=timezone.utc),
+                package_overrides=overrides,
+                index_overrides={
+                    "pypi": IndexOverride(
+                        uploaded_prior_to=datetime(2026, 2, 1, tzinfo=timezone.utc)
+                    )
+                },
+            )
+
+        for one, other in zip(
+            providers(ListingFilterCache(2)),
+            providers(ListingFilterCache()),
+            strict=True,
+        ):
+            assert [str(v) for v, _ in one.fetch_versions("pkg")] == ["1.0"]
+            assert one.fetch_versions("pkg") == other.fetch_versions("pkg")
+            assert one.stats == other.stats
+            assert one.stats.excluded_by_python == 1
+            assert one.stats.excluded_by_time == 1
 
     def test_every_python_reports_the_files_it_walked(self) -> None:
         """The memo replays its counters, so the second Python still sees three."""


### PR DESCRIPTION
About 1.8% fewer instructions on `universal:scientific-python-multi`, 67 million of 3.70 billion, and 0.73% on `universal:max-25-tuples`, both under callgrind with `PYTHONHASHSEED=0`.

An upload-cutoff verdict reads a file's timestamp and the cutoff that applies to it, and neither varies with the target, but a matrix resolve took the verdict once per Python. `ListingFilterCache.prepared` now carries the verdicts next to the shared listing: the first target to get a file past Requires-Python parses its stamp, and the other Pythons read the answer back.

Requires-Python is still asked first, so a file no target admits is never dated. The `excluded_by_python` and `excluded_by_time` counts and the file that raises `InvalidUploadTimeError` are unchanged. A one-Python resolve keeps the old path, and the one-Python `universal:legacy-36-root-stress` moves 0.02%.

Locally, timing the two matrix scenarios rules out a wall or CPU slowdown above about 2.6% and puts peak memory inside about 3.5% either way.
