### PR TITLE
Reuse host candidate preparation in the resolver

### DIFF
--- a/docs/how-to/embed-the-resolver.md
+++ b/docs/how-to/embed-the-resolver.md
@@ -205,7 +205,9 @@ This mode is synchronous: availability cannot change between the final generatio
 
 The host yields `PreparedCandidate` objects in its preferred order. Each key must identify stable dependency metadata for that package, including distinctions such as source or build options. The key must be hashable and accepted by your range type. Retrieve the selected host object with `provider.prepared(package, key).origin`.
 
-Host methods receive a read-only mapping of active requirements. It contains roots and dependencies from the last decision snapshot supplied before candidate selection; `priority` can therefore see an earlier snapshot. Original host objects remain available through each requirement's `origin`. The host must keep those objects and their constraints stable while resolving.
+Host methods receive a read-only mapping of active requirements. It contains roots and dependencies from the last decision snapshot supplied before candidate selection; `priority` can therefore see an earlier snapshot. Original host objects remain available through each requirement's `origin`.
+
+Keep requirement fields (`package`, `constraint`, `origin`) and prepared candidate fields (`key`, `origin`) fixed during a resolve. Changes inside host objects may populate caches but must preserve requirement meaning and candidate metadata. Dependency collection stops when a merged restriction becomes empty; `causes_for(package, key)` returns the declarations consumed for that candidate.
 
 Candidate queries also serve diagnostic probes, so preparing or caching a candidate must preserve answers for the same active requirements. For conditional availability, use the callback and eligibility contract above.
 

--- a/docs/how-to/embed-the-resolver.md
+++ b/docs/how-to/embed-the-resolver.md
@@ -205,7 +205,7 @@ This mode is synchronous: availability cannot change between the final generatio
 
 The host yields `PreparedCandidate` objects in its preferred order. Each key must identify stable dependency metadata for that package, including distinctions such as source or build options. The key must be hashable and accepted by your range type. Retrieve the selected host object with `provider.prepared(package, key).origin`.
 
-Host methods receive a read-only mapping of active requirements. It contains roots and dependencies from the last decision snapshot supplied before candidate selection; `priority` can therefore see an earlier snapshot. Original host objects remain available through each requirement's `origin`.
+Host methods receive a read-only mapping of active requirements. It contains roots and dependencies from the last decision snapshot supplied before candidate selection; `priority` can therefore see an earlier snapshot and must tolerate its package being absent from the mapping. Original host objects remain available through each requirement's `origin`.
 
 Keep requirement fields (`package`, `constraint`, `origin`) and prepared candidate fields (`key`, `origin`) fixed during a resolve. Changes inside host objects may populate caches but must preserve requirement meaning and candidate metadata. Dependency collection stops when a merged restriction becomes empty; `causes_for(package, key)` returns the declarations consumed for that candidate.
 

--- a/docs/how-to/embed-the-resolver.md
+++ b/docs/how-to/embed-the-resolver.md
@@ -199,11 +199,24 @@ An unsuccessful query is deferred while other packages can still be decided. Aft
 
 This mode is synchronous: availability cannot change between the final generation check and recording the clause. Omit the callback for a provider with a fixed candidate universe.
 
+## Reusing a host's prepared candidates
+
+`CandidateProvider` in `nab_resolver.candidate_provider` adapts a `CandidateHost` that supplies `iter_candidates`, `get_dependencies` and `priority`. Construct it with the host and a sequence of `CandidateRequirement` roots, then pass `provider.root_requirements()` to `Resolver.solve`.
+
+The host yields `PreparedCandidate` objects in its preferred order. Each key must identify stable dependency metadata for that package, including distinctions such as source or build options. The key must be hashable and accepted by your range type. Retrieve the selected host object with `provider.prepared(package, key).origin`.
+
+Host methods receive a read-only mapping of active requirements. It contains roots and dependencies from the last decision snapshot supplied before candidate selection; `priority` can therefore see an earlier snapshot. Original host objects remain available through each requirement's `origin`. The host must keep those objects and their constraints stable while resolving.
+
+Candidate queries also serve diagnostic probes, so preparing or caching a candidate must preserve answers for the same active requirements. For conditional availability, use the callback and eligibility contract above.
+
 ## The supported API
 
 These module paths will not move without a major version bump:
 
 ```text
+nab_resolver.candidate_provider
+                       CandidateHost, CandidateProvider,
+                       CandidateRequirement, PreparedCandidate
 nab_resolver.errors     ResolutionError
 nab_resolver.ranges     Range
 nab_resolver.resolver   BaseProvider, DEFAULT_MAX_ITERATIONS, Resolver,

--- a/nab-resolver/README.md
+++ b/nab-resolver/README.md
@@ -21,6 +21,9 @@ without a major version bump.  Everything else in the package is
 internal and may be renamed or relocated in any release.
 
 ```text
+nab_resolver.candidate_provider
+                       CandidateHost, CandidateProvider,
+                       CandidateRequirement, PreparedCandidate
 nab_resolver.errors     ResolutionError
 nab_resolver.ranges     Range
 nab_resolver.resolver   BaseProvider, DEFAULT_MAX_ITERATIONS, Resolver,

--- a/nab-resolver/src/nab_resolver/__init__.py
+++ b/nab-resolver/src/nab_resolver/__init__.py
@@ -4,6 +4,9 @@ The supported API is the module paths below.  They will not move without a
 major version bump.  Everything else in the package is internal and may be
 renamed or relocated in any release.
 
+    nab_resolver.candidate_provider
+                           CandidateHost, CandidateProvider,
+                           CandidateRequirement, PreparedCandidate
     nab_resolver.errors     ResolutionError
     nab_resolver.ranges     Range
     nab_resolver.resolver   BaseProvider, DEFAULT_MAX_ITERATIONS, Resolver,

--- a/nab-resolver/src/nab_resolver/candidate_provider.py
+++ b/nab-resolver/src/nab_resolver/candidate_provider.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Hashable
 from dataclasses import dataclass
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar
 
 from .resolver import BaseProvider
@@ -97,6 +98,10 @@ class CandidateProvider(BaseProvider[_PackageT, _KeyT]):
         self._dependencies: dict[
             tuple[_PackageT, _KeyT], dict[_PackageT, RangeProtocol[_KeyT]]
         ] = {}
+        self._active_cache: (
+            Mapping[_PackageT, tuple[CandidateRequirement[_PackageT, _KeyT], ...]]
+            | None
+        ) = None
 
     def root_requirements(self) -> list[RootRequirement[_PackageT, _KeyT]]:
         """Return solver roots with their original host provenance attached."""
@@ -107,7 +112,15 @@ class CandidateProvider(BaseProvider[_PackageT, _KeyT]):
 
     def active_requirements(
         self,
-    ) -> dict[_PackageT, list[CandidateRequirement[_PackageT, _KeyT]]]:
+    ) -> Mapping[_PackageT, tuple[CandidateRequirement[_PackageT, _KeyT], ...]]:
+        """Return immutable requirements for the current decision snapshot."""
+        if self._active_cache is None:
+            self._active_cache = self._build_active_requirements()
+        return self._active_cache
+
+    def _build_active_requirements(
+        self,
+    ) -> Mapping[_PackageT, tuple[CandidateRequirement[_PackageT, _KeyT], ...]]:
         """Collect roots and dependencies of candidates in the current solution."""
         requirements: dict[_PackageT, list[CandidateRequirement[_PackageT, _KeyT]]] = (
             defaultdict(list)
@@ -117,7 +130,9 @@ class CandidateProvider(BaseProvider[_PackageT, _KeyT]):
         for package, key in self._decisions.items():
             for cause in self._causes.get((package, key), ()):
                 requirements[cause.package].append(cause)
-        return dict(requirements)
+        return MappingProxyType(
+            {package: tuple(causes) for package, causes in requirements.items()}
+        )
 
     def choose_version(
         self, package: _PackageT, version_range: RangeProtocol[_KeyT]
@@ -165,6 +180,7 @@ class CandidateProvider(BaseProvider[_PackageT, _KeyT]):
             )
             if dependencies[cause.package].is_empty:
                 break
+        self._active_cache = None
         self._causes[key] = tuple(causes)
         self._dependencies[key] = dependencies
         return dependencies
@@ -177,6 +193,7 @@ class CandidateProvider(BaseProvider[_PackageT, _KeyT]):
         """Retain the current decisions so rejected parents lose their requirements."""
         del positive_ranges
         self._decisions = decisions
+        self._active_cache = None
 
     def prioritize(
         self,

--- a/nab-resolver/src/nab_resolver/candidate_provider.py
+++ b/nab-resolver/src/nab_resolver/candidate_provider.py
@@ -1,0 +1,208 @@
+"""Drive the resolver with candidates prepared and ordered by a host."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Hashable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar
+
+from .resolver import BaseProvider
+from .types import RangeProtocol, RootRequirement
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping, Sequence
+
+
+_PackageT = TypeVar("_PackageT", bound=Hashable)
+_KeyT = TypeVar("_KeyT", bound=Hashable)
+
+__all__ = [
+    "CandidateHost",
+    "CandidateProvider",
+    "CandidateRequirement",
+    "PreparedCandidate",
+]
+
+
+@dataclass(frozen=True)
+class CandidateRequirement(Generic[_PackageT, _KeyT]):
+    """A solver restriction retaining the host's original requirement object."""
+
+    package: _PackageT
+    constraint: RangeProtocol[_KeyT]
+    origin: object
+
+
+@dataclass(frozen=True)
+class PreparedCandidate(Generic[_KeyT]):
+    """A usable candidate retaining the host's prepared install object."""
+
+    key: _KeyT
+    origin: object
+
+
+class CandidateHost(Protocol[_PackageT, _KeyT]):
+    """Prepare candidates using the host's current original requirements.
+
+    Eligibility for a fixed requirement set must not change because unrelated
+    metadata was cached. Source registries identify candidates; they do not
+    make every discovered source selectable.
+    """
+
+    def iter_candidates(
+        self,
+        package: _PackageT,
+        allowed: RangeProtocol[_KeyT],
+        requirements: Mapping[
+            _PackageT, Sequence[CandidateRequirement[_PackageT, _KeyT]]
+        ],
+    ) -> Iterable[PreparedCandidate[_KeyT]]:
+        """Yield usable candidates in native host order, preserving file fallbacks."""
+        ...
+
+    def get_dependencies(
+        self, candidate: PreparedCandidate[_KeyT]
+    ) -> Iterable[CandidateRequirement[_PackageT, _KeyT]]:
+        """Bind active dependencies without changing unrelated source eligibility."""
+        ...
+
+    def priority(
+        self,
+        package: _PackageT,
+        requirements: Mapping[
+            _PackageT, Sequence[CandidateRequirement[_PackageT, _KeyT]]
+        ],
+    ) -> Any:
+        """Order package decisions without preparing candidate metadata."""
+        ...
+
+
+class CandidateProvider(BaseProvider[_PackageT, _KeyT]):
+    """Keep candidate identity and active requirements around a host's selection."""
+
+    def __init__(
+        self,
+        host: CandidateHost[_PackageT, _KeyT],
+        roots: Sequence[CandidateRequirement[_PackageT, _KeyT]],
+    ) -> None:
+        """Snapshot roots and retain selected dependency provenance."""
+        self.host = host
+        self.roots = tuple(roots)
+        self._decisions: Mapping[_PackageT, _KeyT] = {}
+        self._selected: dict[tuple[_PackageT, _KeyT], PreparedCandidate[_KeyT]] = {}
+        self._causes: dict[
+            tuple[_PackageT, _KeyT], tuple[CandidateRequirement[_PackageT, _KeyT], ...]
+        ] = {}
+        self._dependencies: dict[
+            tuple[_PackageT, _KeyT], dict[_PackageT, RangeProtocol[_KeyT]]
+        ] = {}
+
+    def root_requirements(self) -> list[RootRequirement[_PackageT, _KeyT]]:
+        """Return solver roots with their original host provenance attached."""
+        return [
+            RootRequirement(root.package, root.constraint, root.origin)
+            for root in self.roots
+        ]
+
+    def active_requirements(
+        self,
+    ) -> dict[_PackageT, list[CandidateRequirement[_PackageT, _KeyT]]]:
+        """Collect roots and dependencies of candidates in the current solution."""
+        requirements: dict[_PackageT, list[CandidateRequirement[_PackageT, _KeyT]]] = (
+            defaultdict(list)
+        )
+        for root in self.roots:
+            requirements[root.package].append(root)
+        for package, key in self._decisions.items():
+            for cause in self._causes.get((package, key), ()):
+                requirements[cause.package].append(cause)
+        return dict(requirements)
+
+    def choose_version(
+        self, package: _PackageT, version_range: RangeProtocol[_KeyT]
+    ) -> _KeyT | None:
+        """Take the first prepared candidate admitted by the solver's bounds."""
+        for candidate in self.host.iter_candidates(
+            package, version_range, self.active_requirements()
+        ):
+            if candidate.key in version_range:
+                self._selected[package, candidate.key] = candidate
+                return candidate.key
+        return None
+
+    def has_satisfying_version(
+        self, package: _PackageT, version_range: RangeProtocol[_KeyT]
+    ) -> bool:
+        """Probe candidates without recording a solver selection."""
+        return any(
+            candidate.key in version_range
+            for candidate in self.host.iter_candidates(
+                package, version_range, self.active_requirements()
+            )
+        )
+
+    def widen_decision(self, package: _PackageT, version: _KeyT) -> None:
+        """Keep dependency clauses tied to one candidate identity."""
+        del package, version
+
+    def get_dependencies(
+        self, package: _PackageT, version: _KeyT
+    ) -> dict[_PackageT, RangeProtocol[_KeyT]]:
+        """Return dependencies tied to the exact selected candidate identity."""
+        key = package, version
+        cached = self._dependencies.get(key)
+        if cached is not None:
+            return cached
+        candidate = self._selected[key]
+        causes = []
+        dependencies: dict[_PackageT, RangeProtocol[_KeyT]] = {}
+        for cause in self.host.get_dependencies(candidate):
+            causes.append(cause)
+            previous = dependencies.get(cause.package)
+            dependencies[cause.package] = (
+                cause.constraint if previous is None else previous & cause.constraint
+            )
+            if dependencies[cause.package].is_empty:
+                break
+        self._causes[key] = tuple(causes)
+        self._dependencies[key] = dependencies
+        return dependencies
+
+    def receive_partial_solution_hint(
+        self,
+        positive_ranges: Mapping[_PackageT, RangeProtocol[_KeyT]],
+        decisions: Mapping[_PackageT, _KeyT],
+    ) -> None:
+        """Retain the current decisions so rejected parents lose their requirements."""
+        del positive_ranges
+        self._decisions = decisions
+
+    def prioritize(
+        self,
+        package: _PackageT,
+        version_range: RangeProtocol[_KeyT],
+        conflict_counts: Mapping[_PackageT, int],
+        culprit_counts: Mapping[_PackageT, int] | None = None,
+    ) -> Any:
+        """Use the host's package priority without listing candidates."""
+        del version_range, conflict_counts, culprit_counts
+        return self.host.priority(package, self.active_requirements())
+
+    def prepared(self, package: _PackageT, key: _KeyT) -> PreparedCandidate[_KeyT]:
+        """Return the exact prepared candidate used by a solver decision."""
+        return self._selected[package, key]
+
+    def causes_for(
+        self, package: _PackageT, key: _KeyT
+    ) -> tuple[CandidateRequirement[_PackageT, _KeyT], ...]:
+        """Return original dependency causes for one selected candidate."""
+        return self._causes.get((package, key), ())
+
+    def recorded_candidates(
+        self,
+    ) -> Iterable[tuple[_PackageT, PreparedCandidate[_KeyT]]]:
+        """Iterate prepared decisions retained for failure provenance."""
+        return (
+            (package, candidate) for (package, _), candidate in self._selected.items()
+        )

--- a/nab-resolver/src/nab_resolver/candidate_provider.py
+++ b/nab-resolver/src/nab_resolver/candidate_provider.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Hashable
-from dataclasses import dataclass
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar
 
+from ._compat import override
 from .resolver import BaseProvider
 from .types import RangeProtocol, RootRequirement
 
@@ -26,21 +26,29 @@ __all__ = [
 ]
 
 
-@dataclass(frozen=True)
 class CandidateRequirement(Generic[_PackageT, _KeyT]):
     """A solver restriction retaining the host's original requirement object."""
 
-    package: _PackageT
-    constraint: RangeProtocol[_KeyT]
-    origin: object
+    __slots__ = ("constraint", "origin", "package")
+
+    def __init__(
+        self, package: _PackageT, constraint: RangeProtocol[_KeyT], origin: object
+    ) -> None:
+        """Retain stable host inputs for the duration of a resolve."""
+        self.package = package
+        self.constraint = constraint
+        self.origin = origin
 
 
-@dataclass(frozen=True)
 class PreparedCandidate(Generic[_KeyT]):
     """A usable candidate retaining the host's prepared install object."""
 
-    key: _KeyT
-    origin: object
+    __slots__ = ("key", "origin")
+
+    def __init__(self, key: _KeyT, origin: object) -> None:
+        """Associate one stable candidate key with its host object."""
+        self.key = key
+        self.origin = origin
 
 
 class CandidateHost(Protocol[_PackageT, _KeyT]):
@@ -185,6 +193,7 @@ class CandidateProvider(BaseProvider[_PackageT, _KeyT]):
         self._dependencies[key] = dependencies
         return dependencies
 
+    @override
     def receive_partial_solution_hint(
         self,
         positive_ranges: Mapping[_PackageT, RangeProtocol[_KeyT]],

--- a/nab-resolver/src/nab_resolver/candidate_provider.py
+++ b/nab-resolver/src/nab_resolver/candidate_provider.py
@@ -121,7 +121,7 @@ class CandidateProvider(BaseProvider[_PackageT, _KeyT]):
     def active_requirements(
         self,
     ) -> Mapping[_PackageT, tuple[CandidateRequirement[_PackageT, _KeyT], ...]]:
-        """Return read-only requirement collections for the current decision snapshot."""
+        """Return read-only requirement collections for the decision snapshot."""
         if self._active_cache is None:
             self._active_cache = self._build_active_requirements()
         return self._active_cache

--- a/nab-resolver/src/nab_resolver/candidate_provider.py
+++ b/nab-resolver/src/nab_resolver/candidate_provider.py
@@ -121,7 +121,7 @@ class CandidateProvider(BaseProvider[_PackageT, _KeyT]):
     def active_requirements(
         self,
     ) -> Mapping[_PackageT, tuple[CandidateRequirement[_PackageT, _KeyT], ...]]:
-        """Return immutable requirements for the current decision snapshot."""
+        """Return read-only requirement collections for the current decision snapshot."""
         if self._active_cache is None:
             self._active_cache = self._build_active_requirements()
         return self._active_cache
@@ -172,7 +172,7 @@ class CandidateProvider(BaseProvider[_PackageT, _KeyT]):
     def get_dependencies(
         self, package: _PackageT, version: _KeyT
     ) -> dict[_PackageT, RangeProtocol[_KeyT]]:
-        """Return dependencies tied to the exact selected candidate identity."""
+        """Return dependency restrictions, stopping at the first empty result."""
         key = package, version
         cached = self._dependencies.get(key)
         if cached is not None:
@@ -222,7 +222,7 @@ class CandidateProvider(BaseProvider[_PackageT, _KeyT]):
     def causes_for(
         self, package: _PackageT, key: _KeyT
     ) -> tuple[CandidateRequirement[_PackageT, _KeyT], ...]:
-        """Return original dependency causes for one selected candidate."""
+        """Return the host dependency declarations consumed for this candidate."""
         return self._causes.get((package, key), ())
 
     def recorded_candidates(

--- a/nab-resolver/tests/test_candidate_provider.py
+++ b/nab-resolver/tests/test_candidate_provider.py
@@ -1,0 +1,104 @@
+"""Exercise host adaptation without packaging types or package-name strings."""
+
+from collections.abc import Iterable, Mapping, Sequence
+
+from nab_resolver.candidate_provider import (
+    CandidateProvider,
+    CandidateRequirement,
+    PreparedCandidate,
+)
+from nab_resolver.ranges import Range
+from nab_resolver.resolver import Resolver
+from nab_resolver.types import RangeProtocol
+
+
+class MemoryHost:
+    """Serve integer package identifiers and opaque string candidate keys."""
+
+    def __init__(self) -> None:
+        self.app = PreparedCandidate("app-one", object())
+        self.dep = PreparedCandidate("dep-one", object())
+        self.request = CandidateRequirement(20, Range.singleton("dep-one"), object())
+
+    def iter_candidates(
+        self,
+        package: int,
+        allowed: RangeProtocol[str],
+        requirements: Mapping[int, Sequence[CandidateRequirement[int, str]]],
+    ) -> Iterable[PreparedCandidate[str]]:
+        if package == 10:
+            yield self.app
+        elif package == 20:
+            yield self.dep
+
+    def get_dependencies(
+        self, candidate: PreparedCandidate[str]
+    ) -> Iterable[CandidateRequirement[int, str]]:
+        if candidate is self.app:
+            yield self.request
+
+    def priority(
+        self,
+        package: int,
+        requirements: Mapping[int, Sequence[CandidateRequirement[int, str]]],
+    ) -> int:
+        return package
+
+
+def test_host_selection_retains_original_provenance() -> None:
+    host = MemoryHost()
+    origin = object()
+    provider = CandidateProvider(host, [CandidateRequirement(10, Range.full(), origin)])
+    resolver = Resolver(provider, root_version="root")
+    solution = resolver.solve(provider.root_requirements())
+    assert solution.pins == {10: "app-one", 20: "dep-one"}
+    assert provider.root_requirements()[0].origin is origin
+    assert provider.prepared(10, "app-one") is host.app
+    assert provider.causes_for(10, "app-one") == (host.request,)
+    assert provider.causes_for(0, "missing") == ()
+    assert dict(provider.recorded_candidates()) == {10: host.app, 20: host.dep}
+
+
+def test_probe_does_not_record_selection() -> None:
+    provider = CandidateProvider(
+        MemoryHost(), [CandidateRequirement(20, Range.full(), object())]
+    )
+    assert provider.has_satisfying_version(20, Range.singleton("dep-one"))
+    assert not provider.has_satisfying_version(20, Range.singleton("dep-two"))
+    assert list(provider.recorded_candidates()) == []
+    assert provider.choose_version(20, Range.singleton("dep-two")) is None
+
+
+def test_cached_dependencies_do_not_survive_their_selected_parent() -> None:
+    host = MemoryHost()
+    provider = CandidateProvider(
+        host, [CandidateRequirement(10, Range.full(), object())]
+    )
+    provider.choose_version(10, Range.full())
+    provider.get_dependencies(10, "app-one")
+    assert 20 not in provider.active_requirements()
+    provider.receive_partial_solution_hint({}, {10: "app-one"})
+    assert provider.active_requirements()[20] == [host.request]
+    provider.receive_partial_solution_hint({}, {})
+    assert 20 not in provider.active_requirements()
+    assert provider.causes_for(10, "app-one") == (host.request,)
+
+
+def test_contradictory_dependencies_stop_further_host_work() -> None:
+    class ContradictoryHost(MemoryHost):
+        """Refuse work after contradictory declarations invalidate a candidate."""
+
+        def get_dependencies(
+            self, candidate: PreparedCandidate[str]
+        ) -> Iterable[CandidateRequirement[int, str]]:
+            yield self.request
+            yield CandidateRequirement(20, Range.singleton("dep-two"), object())
+            raise AssertionError("unreachable dependency was materialized")
+
+    host = ContradictoryHost()
+    provider = CandidateProvider(
+        host, [CandidateRequirement(10, Range.full(), object())]
+    )
+    provider.choose_version(10, Range.full())
+    assert provider.get_dependencies(10, "app-one") == {20: Range.empty()}
+    assert len(provider.causes_for(10, "app-one")) == 2

--- a/nab-resolver/tests/test_candidate_provider.py
+++ b/nab-resolver/tests/test_candidate_provider.py
@@ -2,6 +2,8 @@
 
 from collections.abc import Iterable, Mapping, Sequence
 
+import pytest
+
 from nab_resolver.candidate_provider import (
     CandidateProvider,
     CandidateRequirement,
@@ -78,7 +80,7 @@ def test_cached_dependencies_do_not_survive_their_selected_parent() -> None:
     provider.get_dependencies(10, "app-one")
     assert 20 not in provider.active_requirements()
     provider.receive_partial_solution_hint({}, {10: "app-one"})
-    assert provider.active_requirements()[20] == [host.request]
+    assert provider.active_requirements()[20] == (host.request,)
     provider.receive_partial_solution_hint({}, {})
     assert 20 not in provider.active_requirements()
     assert provider.causes_for(10, "app-one") == (host.request,)
@@ -102,3 +104,26 @@ def test_contradictory_dependencies_stop_further_host_work() -> None:
     provider.choose_version(10, Range.full())
     assert provider.get_dependencies(10, "app-one") == {20: Range.empty()}
     assert len(provider.causes_for(10, "app-one")) == 2
+
+
+def test_cached_requirement_view_is_immutable_and_tracks_new_dependencies() -> None:
+    host = MemoryHost()
+    provider = CandidateProvider(
+        host, [CandidateRequirement(10, Range.full(), object())]
+    )
+    provider.choose_version(10, Range.full())
+    provider.receive_partial_solution_hint({}, {10: "app-one"})
+    before = provider.active_requirements()
+    assert 20 not in before
+    with pytest.raises(TypeError):
+        before[20] = (host.request,)
+
+    provider.get_dependencies(10, "app-one")
+    after = provider.active_requirements()
+    assert after[20] == (host.request,)
+    assert 20 not in before
+    assert provider.active_requirements() is after
+
+    provider.receive_partial_solution_hint({}, {})
+    assert 20 not in provider.active_requirements()
+    assert after[20] == (host.request,)

--- a/nab-resolver/tests/test_candidate_provider.py
+++ b/nab-resolver/tests/test_candidate_provider.py
@@ -1,6 +1,7 @@
 """Exercise host adaptation without packaging types or package-name strings."""
 
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Iterable, Mapping, MutableMapping, Sequence
+from typing import cast
 
 import pytest
 
@@ -20,7 +21,9 @@ class MemoryHost:
     def __init__(self) -> None:
         self.app = PreparedCandidate("app-one", object())
         self.dep = PreparedCandidate("dep-one", object())
-        self.request = CandidateRequirement(20, Range.singleton("dep-one"), object())
+        self.request = CandidateRequirement[int, str](
+            20, Range.singleton("dep-one"), object()
+        )
 
     def iter_candidates(
         self,
@@ -142,7 +145,9 @@ def test_cached_requirement_view_is_immutable_and_tracks_new_dependencies() -> N
     before = provider.active_requirements()
     assert 20 not in before
     with pytest.raises(TypeError):
-        before[20] = (host.request,)
+        cast("MutableMapping[int, tuple[CandidateRequirement[int, str], ...]]", before)[
+            20
+        ] = (host.request,)
 
     provider.get_dependencies(10, "app-one")
     after = provider.active_requirements()

--- a/nab-resolver/tests/test_candidate_provider.py
+++ b/nab-resolver/tests/test_candidate_provider.py
@@ -86,6 +86,32 @@ def test_cached_dependencies_do_not_survive_their_selected_parent() -> None:
     assert provider.causes_for(10, "app-one") == (host.request,)
 
 
+def test_duplicate_dependencies_intersect_and_reuse_host_metadata() -> None:
+    class RepeatedHost(MemoryHost):
+        """Count metadata reads while yielding two compatible restrictions."""
+
+        reads = 0
+
+        def get_dependencies(
+            self, candidate: PreparedCandidate[str]
+        ) -> Iterable[CandidateRequirement[int, str]]:
+            self.reads += 1
+            yield self.request
+            yield CandidateRequirement(20, Range.full(), object())
+
+    host = RepeatedHost()
+    provider = CandidateProvider(
+        host, [CandidateRequirement(10, Range.full(), object())]
+    )
+    provider.choose_version(10, Range.full())
+    first = provider.get_dependencies(10, "app-one")
+    assert first == {20: Range.singleton("dep-one")}
+    assert len(provider.causes_for(10, "app-one")) == 2
+
+    assert provider.get_dependencies(10, "app-one") is first
+    assert host.reads == 1
+
+
 def test_contradictory_dependencies_stop_further_host_work() -> None:
     class ContradictoryHost(MemoryHost):
         """Refuse work after contradictory declarations invalidate a candidate."""


### PR DESCRIPTION
`CandidateProvider` lets a host reuse its own candidate preparation and ordering while preserving original candidate and requirement objects.

The optional `nab_resolver.candidate_provider` module exposes `CandidateHost`, `CandidateRequirement` and `PreparedCandidate`. Package identifiers and candidate keys are generic hashable values.

- Duplicate dependency restrictions are intersected while the consumed declarations remain available for diagnostics.
- Read-only requirement collections are cached between decision hints and new metadata.

Fields on `CandidateRequirement` and `PreparedCandidate` must stay fixed during a resolve. Priority callbacks must tolerate the preceding snapshot, where the package being ranked may be absent. `docs/how-to/embed-the-resolver.md` documents this contract.
