### PR TITLE
Distinguish candidate sources in version constraints

### DIFF
--- a/nab-provider/README.md
+++ b/nab-provider/README.md
@@ -30,4 +30,4 @@ Construct `CandidateRange(versions)` from a `VersionRange` supplied by nab-provi
 
 Leave the `prereleases` argument unset when constructing input ranges or specifier sets; explicitly configured `True` or `False` policies raise `ValueError`. Candidate ordering, source admission and prerelease selection remain host responsibilities.
 
-The module imports only the provider's vendored packaging and the standard library.
+Its runtime dependencies are the provider's vendored packaging and the standard library.

--- a/nab-provider/README.md
+++ b/nab-provider/README.md
@@ -21,3 +21,13 @@ Most users want [`nab`](https://pypi.org/project/nab/) instead.
 
 The API is currently under rapid experimentation, if you use it
 pin to an exact version.
+
+## Candidate source ranges
+
+`nab_provider.candidate_ranges` supplies `CandidateKey` and `CandidateRange` for hosts that prepare and order their own candidates. A key pairs a PEP 440 version with a host-defined source identifier, so installed and downloaded distributions can remain distinct at the same version.
+
+Construct `CandidateRange(versions)` from a `VersionRange` supplied by nab-provider's vendored packaging to admit matching versions on every source. Use `CandidateRange.singleton(key)` for one candidate or `CandidateRange.for_source(source, versions)` to restrict a source. Intersection, union, subtraction and complement operate independently on each source, including identifiers not yet encountered by the host.
+
+Leave the `prereleases` argument unset when constructing input ranges or specifier sets; explicitly configured `True` or `False` policies raise `ValueError`. Candidate ordering, source admission and prerelease selection remain host responsibilities.
+
+The module imports only the provider's vendored packaging and the standard library.

--- a/nab-provider/src/nab_provider/candidate_ranges.py
+++ b/nab-provider/src/nab_provider/candidate_ranges.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import TYPE_CHECKING, Any, cast
+from types import MemberDescriptorType
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from nab_provider._vendor.packaging.ranges import VersionRange
 
@@ -11,7 +12,6 @@ from ._compat import override
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Mapping
-    from types import MemberDescriptorType
 
     from nab_provider._vendor.packaging.version import Version
 
@@ -24,16 +24,67 @@ class _ImmutableSlots:
     """Keep fields used in candidate and range hashes unchanged."""
 
     __slots__ = ("__weakref__",)
+    _immutable_fields: ClassVar[tuple[str, ...]]
 
     @override
     def __setattr__(self, name: str, value: object) -> None:
-        message = f"cannot assign to field {name!r}"
-        raise AttributeError(message)
+        if "_immutable_fields" in type(self).__dict__ or name in self._immutable_fields:
+            message = f"cannot assign to field {name!r}"
+            raise AttributeError(message)
+        object.__setattr__(self, name, value)
 
     @override
     def __delattr__(self, name: str) -> None:
-        message = f"cannot delete field {name!r}"
-        raise AttributeError(message)
+        if "_immutable_fields" in type(self).__dict__ or name in self._immutable_fields:
+            message = f"cannot delete field {name!r}"
+            raise AttributeError(message)
+        object.__delattr__(self, name)
+
+    def __getstate__(
+        self,
+    ) -> dict[str, Any] | tuple[dict[str, Any], dict[str, Any]]:
+        """Collect fields and subclass state without copying contained values."""
+        dictionary = getattr(self, "__dict__", {}).copy()
+        slots: dict[str, Any] = {}
+        seen = set()
+        for cls in type(self).__mro__:
+            for name, descriptor in cls.__dict__.items():
+                if not isinstance(descriptor, MemberDescriptorType) or name in seen:
+                    continue
+                try:
+                    value = descriptor.__get__(self)
+                except AttributeError:
+                    continue
+                seen.add(name)
+                if name in self._immutable_fields:
+                    dictionary[name] = value
+                else:
+                    slots[name] = value
+        return (dictionary, slots) if slots else dictionary
+
+    def __setstate__(
+        self, state: dict[str, Any] | tuple[dict[str, Any], dict[str, Any]]
+    ) -> None:
+        """Restore fields and subclass state without running their constructors."""
+        dictionary, slots = state if isinstance(state, tuple) else (state, {})
+        extra = dictionary.copy()
+        for name in self._immutable_fields:
+            if name in extra and name not in slots:
+                descriptor = _attribute_slot(type(self), name)
+                if descriptor is not None:
+                    descriptor.__set__(self, extra.pop(name))
+        if extra:
+            self.__dict__.update(extra)
+        for name, value in slots.items():
+            setattr(self, name, value)
+
+
+def _attribute_slot(cls: type, name: str) -> MemberDescriptorType | None:
+    """Find the visible slot without invoking a subclass property."""
+    descriptor = next(
+        base.__dict__[name] for base in cls.__mro__ if name in base.__dict__
+    )
+    return descriptor if isinstance(descriptor, MemberDescriptorType) else None
 
 
 def _slot_writer(cls: type, name: str) -> Callable[[object, object], None]:
@@ -45,50 +96,49 @@ def _slot_writer(cls: type, name: str) -> Callable[[object, object], None]:
 class CandidateKey(_ImmutableSlots):
     """Identify a distribution by its version and installer source."""
 
-    __slots__ = __match_args__ = ("version", "source")
+    __slots__ = __match_args__ = _immutable_fields = ("version", "source")
 
     version: Version
     source: str
 
     def __init__(self, version: Version, source: str) -> None:
         """Retain the version and its host-defined source."""
-        _set_key_version(self, version)
-        _set_key_source(self, source)
+        if type(self) is CandidateKey:
+            _set_key_version(self, version)
+            _set_key_source(self, source)
+        else:
+            object.__setattr__(self, "version", version)
+            object.__setattr__(self, "source", source)
 
     @override
     def __eq__(self, other: object) -> bool:
         """Compare version and source within the exact class."""
         if other.__class__ is not self.__class__:
             return NotImplemented
-        other = cast("CandidateKey", other)
         return (self.version, self.source) == (other.version, other.source)
 
     def __lt__(self, other: object) -> bool:
         """Compare versions before source identifiers."""
         if other.__class__ is not self.__class__:
             return NotImplemented
-        other = cast("CandidateKey", other)
         return (self.version, self.source) < (other.version, other.source)
 
     def __le__(self, other: object) -> bool:
         """Compare versions before source identifiers."""
         if other.__class__ is not self.__class__:
             return NotImplemented
-        other = cast("CandidateKey", other)
         return (self.version, self.source) <= (other.version, other.source)
 
     def __gt__(self, other: object) -> bool:
         """Compare versions before source identifiers."""
         if other.__class__ is not self.__class__:
             return NotImplemented
-        other = cast("CandidateKey", other)
         return (self.version, self.source) > (other.version, other.source)
 
     def __ge__(self, other: object) -> bool:
         """Compare versions before source identifiers."""
         if other.__class__ is not self.__class__:
             return NotImplemented
-        other = cast("CandidateKey", other)
         return (self.version, self.source) >= (other.version, other.source)
 
     @override
@@ -108,15 +158,6 @@ class CandidateKey(_ImmutableSlots):
     def __str__(self) -> str:
         """Render the PEP 440 version for host diagnostics."""
         return str(self.version)
-
-    @override
-    def __reduce__(self) -> tuple[type[CandidateKey], tuple[Version, str]]:
-        """Reconstruct immutable fields through the constructor."""
-        return type(self), (self.version, self.source)
-
-    def __setstate__(self, state: dict[str, Any]) -> None:
-        """Restore a pickled field dictionary."""
-        CandidateKey.__init__(self, state["version"], state["source"])
 
 
 _set_key_version = _slot_writer(CandidateKey, "version")
@@ -143,7 +184,7 @@ class _RangeRelation(Enum):
 class CandidateRange(_ImmutableSlots):
     """An immutable default version range with finite source-specific replacements."""
 
-    __slots__ = __match_args__ = ("default", "overrides", "_hash")
+    __slots__ = __match_args__ = _immutable_fields = ("default", "overrides", "_hash")
 
     default: VersionRange
     overrides: tuple[tuple[str, VersionRange], ...]
@@ -165,9 +206,14 @@ class CandidateRange(_ImmutableSlots):
                 (source, value) for source, value in sources.items() if value != default
             )
         )
-        _set_range_default(self, default)
-        _set_range_overrides(self, normalized)
-        _set_range_hash(self, hash((default, normalized)))
+        if type(self) is CandidateRange:
+            _set_range_default(self, default)
+            _set_range_overrides(self, normalized)
+            _set_range_hash(self, hash((default, normalized)))
+        else:
+            object.__setattr__(self, "default", default)
+            object.__setattr__(self, "overrides", normalized)
+            object.__setattr__(self, "_hash", hash((default, normalized)))
 
     @classmethod
     def empty(cls) -> CandidateRange:
@@ -296,16 +342,6 @@ class CandidateRange(_ImmutableSlots):
             f"{type(self).__qualname__}(default={self.default!r}, "
             f"overrides={self.overrides!r}, _hash={self._hash!r})"
         )
-
-    @override
-    def __reduce__(
-        self,
-    ) -> tuple[
-        type[CandidateRange],
-        tuple[VersionRange, tuple[tuple[str, VersionRange], ...]],
-    ]:
-        """Reconstruct a shallow copy through the constructor."""
-        return type(self), (self.default, self.overrides)
 
 
 _set_range_default = _slot_writer(CandidateRange, "default")

--- a/nab-provider/src/nab_provider/candidate_ranges.py
+++ b/nab-provider/src/nab_provider/candidate_ranges.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
 from nab_provider._vendor.packaging.ranges import VersionRange
 
@@ -12,6 +11,7 @@ from ._compat import override
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Mapping
+    from types import MemberDescriptorType
 
     from nab_provider._vendor.packaging.version import Version
 
@@ -20,17 +20,107 @@ __all__ = ["CandidateKey", "CandidateRange"]
 _CANDIDATE_VERSIONS = VersionRange.full(admit_arbitrary=False)
 
 
-@dataclass(frozen=True, order=True)
-class CandidateKey:
+class _ImmutableSlots:
+    """Keep fields used in candidate and range hashes unchanged."""
+
+    __slots__ = ("__weakref__",)
+
+    @override
+    def __setattr__(self, name: str, value: object) -> None:
+        message = f"cannot assign to field {name!r}"
+        raise AttributeError(message)
+
+    @override
+    def __delattr__(self, name: str) -> None:
+        message = f"cannot delete field {name!r}"
+        raise AttributeError(message)
+
+
+def _slot_writer(cls: type, name: str) -> Callable[[object, object], None]:
+    """Bind a slot setter for initialization without writable attributes."""
+    slot: MemberDescriptorType = cls.__dict__[name]
+    return slot.__set__
+
+
+class CandidateKey(_ImmutableSlots):
     """Identify a distribution by its version and installer source."""
+
+    __slots__ = __match_args__ = ("version", "source")
 
     version: Version
     source: str
+
+    def __init__(self, version: Version, source: str) -> None:
+        """Retain the version and its host-defined source."""
+        _set_key_version(self, version)
+        _set_key_source(self, source)
+
+    @override
+    def __eq__(self, other: object) -> bool:
+        """Compare version and source within the exact class."""
+        if other.__class__ is not self.__class__:
+            return NotImplemented
+        other = cast("CandidateKey", other)
+        return (self.version, self.source) == (other.version, other.source)
+
+    def __lt__(self, other: object) -> bool:
+        """Compare versions before source identifiers."""
+        if other.__class__ is not self.__class__:
+            return NotImplemented
+        other = cast("CandidateKey", other)
+        return (self.version, self.source) < (other.version, other.source)
+
+    def __le__(self, other: object) -> bool:
+        """Compare versions before source identifiers."""
+        if other.__class__ is not self.__class__:
+            return NotImplemented
+        other = cast("CandidateKey", other)
+        return (self.version, self.source) <= (other.version, other.source)
+
+    def __gt__(self, other: object) -> bool:
+        """Compare versions before source identifiers."""
+        if other.__class__ is not self.__class__:
+            return NotImplemented
+        other = cast("CandidateKey", other)
+        return (self.version, self.source) > (other.version, other.source)
+
+    def __ge__(self, other: object) -> bool:
+        """Compare versions before source identifiers."""
+        if other.__class__ is not self.__class__:
+            return NotImplemented
+        other = cast("CandidateKey", other)
+        return (self.version, self.source) >= (other.version, other.source)
+
+    @override
+    def __hash__(self) -> int:
+        """Hash version and source together."""
+        return hash((self.version, self.source))
+
+    @override
+    def __repr__(self) -> str:
+        """Render the class name and its identity fields."""
+        return (
+            f"{type(self).__qualname__}(version={self.version!r}, "
+            f"source={self.source!r})"
+        )
 
     @override
     def __str__(self) -> str:
         """Render the PEP 440 version for host diagnostics."""
         return str(self.version)
+
+    @override
+    def __reduce__(self) -> tuple[type[CandidateKey], tuple[Version, str]]:
+        """Reconstruct immutable fields through the constructor."""
+        return type(self), (self.version, self.source)
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        """Restore a pickled field dictionary."""
+        CandidateKey.__init__(self, state["version"], state["source"])
+
+
+_set_key_version = _slot_writer(CandidateKey, "version")
+_set_key_source = _slot_writer(CandidateKey, "source")
 
 
 class _RangeRelation(Enum):
@@ -50,9 +140,10 @@ class _RangeRelation(Enum):
         return self.value[1]
 
 
-@dataclass(frozen=True, init=False)
-class CandidateRange:
+class CandidateRange(_ImmutableSlots):
     """An immutable default version range with finite source-specific replacements."""
+
+    __slots__ = __match_args__ = ("default", "overrides", "_hash")
 
     default: VersionRange
     overrides: tuple[tuple[str, VersionRange], ...]
@@ -74,9 +165,9 @@ class CandidateRange:
                 (source, value) for source, value in sources.items() if value != default
             )
         )
-        object.__setattr__(self, "default", default)
-        object.__setattr__(self, "overrides", normalized)
-        object.__setattr__(self, "_hash", hash((default, normalized)))
+        _set_range_default(self, default)
+        _set_range_overrides(self, normalized)
+        _set_range_hash(self, hash((default, normalized)))
 
     @classmethod
     def empty(cls) -> CandidateRange:
@@ -197,3 +288,26 @@ class CandidateRange:
     def __str__(self) -> str:
         """Render the version bounds and exceptional source coordinates."""
         return f"{self.default!r}; sources={self.overrides!r}"
+
+    @override
+    def __repr__(self) -> str:
+        """Render the normalized fields and cached hash."""
+        return (
+            f"{type(self).__qualname__}(default={self.default!r}, "
+            f"overrides={self.overrides!r}, _hash={self._hash!r})"
+        )
+
+    @override
+    def __reduce__(
+        self,
+    ) -> tuple[
+        type[CandidateRange],
+        tuple[VersionRange, tuple[tuple[str, VersionRange], ...]],
+    ]:
+        """Reconstruct a shallow copy through the constructor."""
+        return type(self), (self.default, self.overrides)
+
+
+_set_range_default = _slot_writer(CandidateRange, "default")
+_set_range_overrides = _slot_writer(CandidateRange, "overrides")
+_set_range_hash = _slot_writer(CandidateRange, "_hash")

--- a/nab-provider/src/nab_provider/candidate_ranges.py
+++ b/nab-provider/src/nab_provider/candidate_ranges.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING
 
 from nab_provider._vendor.packaging.ranges import VersionRange
 
+from ._compat import override
+
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Mapping
 
@@ -25,6 +27,7 @@ class CandidateKey:
     version: Version
     source: str
 
+    @override
     def __str__(self) -> str:
         """Render the PEP 440 version for host diagnostics."""
         return str(self.version)
@@ -178,16 +181,19 @@ class CandidateRange:
         """Return the subset and disjoint range flags the resolver reads."""
         return _RangeRelation((self.is_subset(other), self.is_disjoint(other)))
 
+    @override
     def __eq__(self, other: object) -> bool:
         """Compare normalized source coordinates and admission policy."""
         if not isinstance(other, CandidateRange):
             return NotImplemented
         return self.default == other.default and self.overrides == other.overrides
 
+    @override
     def __hash__(self) -> int:
         """Return the hash fixed when the constraint was constructed."""
         return self._hash
 
+    @override
     def __str__(self) -> str:
         """Render the version bounds and exceptional source coordinates."""
         return f"{self.default!r}; sources={self.overrides!r}"

--- a/nab-provider/src/nab_provider/candidate_ranges.py
+++ b/nab-provider/src/nab_provider/candidate_ranges.py
@@ -96,7 +96,8 @@ def _slot_writer(cls: type, name: str) -> Callable[[object, object], None]:
 class CandidateKey(_ImmutableSlots):
     """Identify a distribution by its version and installer source."""
 
-    __slots__ = __match_args__ = _immutable_fields = ("version", "source")
+    __slots__ = __match_args__ = ("version", "source")
+    _immutable_fields: ClassVar[tuple[str, ...]] = __slots__
 
     version: Version
     source: str
@@ -113,31 +114,31 @@ class CandidateKey(_ImmutableSlots):
     @override
     def __eq__(self, other: object) -> bool:
         """Compare version and source within the exact class."""
-        if other.__class__ is not self.__class__:
+        if not isinstance(other, CandidateKey) or other.__class__ is not self.__class__:
             return NotImplemented
         return (self.version, self.source) == (other.version, other.source)
 
     def __lt__(self, other: object) -> bool:
         """Compare versions before source identifiers."""
-        if other.__class__ is not self.__class__:
+        if not isinstance(other, CandidateKey) or other.__class__ is not self.__class__:
             return NotImplemented
         return (self.version, self.source) < (other.version, other.source)
 
     def __le__(self, other: object) -> bool:
         """Compare versions before source identifiers."""
-        if other.__class__ is not self.__class__:
+        if not isinstance(other, CandidateKey) or other.__class__ is not self.__class__:
             return NotImplemented
         return (self.version, self.source) <= (other.version, other.source)
 
     def __gt__(self, other: object) -> bool:
         """Compare versions before source identifiers."""
-        if other.__class__ is not self.__class__:
+        if not isinstance(other, CandidateKey) or other.__class__ is not self.__class__:
             return NotImplemented
         return (self.version, self.source) > (other.version, other.source)
 
     def __ge__(self, other: object) -> bool:
         """Compare versions before source identifiers."""
-        if other.__class__ is not self.__class__:
+        if not isinstance(other, CandidateKey) or other.__class__ is not self.__class__:
             return NotImplemented
         return (self.version, self.source) >= (other.version, other.source)
 
@@ -184,7 +185,8 @@ class _RangeRelation(Enum):
 class CandidateRange(_ImmutableSlots):
     """An immutable default version range with finite source-specific replacements."""
 
-    __slots__ = __match_args__ = _immutable_fields = ("default", "overrides", "_hash")
+    __slots__ = __match_args__ = ("default", "overrides", "_hash")
+    _immutable_fields: ClassVar[tuple[str, ...]] = __slots__
 
     default: VersionRange
     overrides: tuple[tuple[str, VersionRange], ...]

--- a/nab-provider/src/nab_provider/candidate_ranges.py
+++ b/nab-provider/src/nab_provider/candidate_ranges.py
@@ -1,0 +1,193 @@
+"""Resolve version constraints independently for each candidate source."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from nab_provider._vendor.packaging.ranges import VersionRange
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Mapping
+
+    from nab_provider._vendor.packaging.version import Version
+
+__all__ = ["CandidateKey", "CandidateRange"]
+
+_CANDIDATE_VERSIONS = VersionRange.full(admit_arbitrary=False)
+
+
+@dataclass(frozen=True, order=True)
+class CandidateKey:
+    """Identify a distribution by its version and installer source."""
+
+    version: Version
+    source: str
+
+    def __str__(self) -> str:
+        """Render the PEP 440 version for host diagnostics."""
+        return str(self.version)
+
+
+class _RangeRelation(Enum):
+    EMPTY = (True, True)
+    SUBSET = (True, False)
+    DISJOINT = (False, True)
+    OVERLAPPING = (False, False)
+
+    @property
+    def is_subset(self) -> bool:
+        """Whether every admitted candidate is also in the other constraint."""
+        return self.value[0]
+
+    @property
+    def is_disjoint(self) -> bool:
+        """Whether the constraints admit no shared candidate."""
+        return self.value[1]
+
+
+@dataclass(frozen=True, init=False)
+class CandidateRange:
+    """An immutable default version range with finite source-specific replacements."""
+
+    default: VersionRange
+    overrides: tuple[tuple[str, VersionRange], ...]
+    _hash: int
+
+    def __init__(
+        self,
+        default: VersionRange,
+        overrides: Mapping[str, VersionRange] | Iterable[tuple[str, VersionRange]] = (),
+    ) -> None:
+        """Snapshot source bounds with the default prerelease configuration."""
+        default = default & _CANDIDATE_VERSIONS
+        sources = {
+            source: value & _CANDIDATE_VERSIONS
+            for source, value in dict(overrides).items()
+        }
+        normalized = tuple(
+            sorted(
+                (source, value) for source, value in sources.items() if value != default
+            )
+        )
+        object.__setattr__(self, "default", default)
+        object.__setattr__(self, "overrides", normalized)
+        object.__setattr__(self, "_hash", hash((default, normalized)))
+
+    @classmethod
+    def empty(cls) -> CandidateRange:
+        """Return a constraint admitting no candidate."""
+        return cls(VersionRange.empty())
+
+    @classmethod
+    def full(cls) -> CandidateRange:
+        """Return every PEP 440 version on every source."""
+        return cls(_CANDIDATE_VERSIONS)
+
+    @classmethod
+    def singleton(cls, candidate: CandidateKey) -> CandidateRange:
+        """Return a constraint admitting this candidate identity alone."""
+        return cls.for_source(
+            candidate.source, VersionRange.singleton(candidate.version)
+        )
+
+    @classmethod
+    def for_source(
+        cls, source: str, versions: VersionRange | None = None
+    ) -> CandidateRange:
+        """Restrict the given source and exclude every other source."""
+        if versions is None:
+            versions = _CANDIDATE_VERSIONS
+        return cls(VersionRange.empty(), [(source, versions)])
+
+    def for_versions(self, source: str) -> VersionRange:
+        """Return the version constraint applying to one source."""
+        for key, value in self.overrides:
+            if key == source:
+                return value
+        return self.default
+
+    @property
+    def is_empty(self) -> bool:
+        """Whether no version is admitted on any source."""
+        return self.default.is_empty and all(
+            versions.is_empty for _, versions in self.overrides
+        )
+
+    def __contains__(self, candidate: CandidateKey) -> bool:
+        """Check the version bounds on the candidate's source."""
+        return candidate.version in self.for_versions(candidate.source)
+
+    def _combine(
+        self,
+        other: CandidateRange,
+        operation: Callable[[VersionRange, VersionRange], VersionRange],
+    ) -> CandidateRange:
+        """Apply one range operation to every affected source coordinate."""
+        default = operation(self.default, other.default)
+        sources = {source for source, _ in self.overrides + other.overrides}
+        return CandidateRange(
+            default,
+            (
+                (
+                    source,
+                    operation(self.for_versions(source), other.for_versions(source)),
+                )
+                for source in sources
+            ),
+        )
+
+    def __and__(self, other: object) -> CandidateRange:
+        """Intersect each source coordinate."""
+        if not isinstance(other, CandidateRange):
+            return NotImplemented
+        return self._combine(other, VersionRange.__and__)
+
+    def __or__(self, other: object) -> CandidateRange:
+        """Union each source coordinate."""
+        if not isinstance(other, CandidateRange):
+            return NotImplemented
+        return self._combine(other, VersionRange.__or__)
+
+    def __sub__(self, other: object) -> CandidateRange:
+        """Remove the other constraint on each source coordinate."""
+        if not isinstance(other, CandidateRange):
+            return NotImplemented
+        return self._combine(other, VersionRange.__sub__)
+
+    def __invert__(self) -> CandidateRange:
+        """Complement the bounds independently on each source."""
+        return CandidateRange(
+            ~self.default, ((source, ~value) for source, value in self.overrides)
+        )
+
+    def is_subset(self, other: CandidateRange) -> bool:
+        """Whether every admitted candidate is also in the other constraint."""
+        return (self - other).is_empty
+
+    def is_superset(self, other: CandidateRange) -> bool:
+        """Whether every candidate in the other constraint is admitted here."""
+        return other.is_subset(self)
+
+    def is_disjoint(self, other: CandidateRange) -> bool:
+        """Whether the constraints admit no shared candidate."""
+        return (self & other).is_empty
+
+    def relation(self, other: CandidateRange) -> _RangeRelation:
+        """Return the subset and disjoint range flags the resolver reads."""
+        return _RangeRelation((self.is_subset(other), self.is_disjoint(other)))
+
+    def __eq__(self, other: object) -> bool:
+        """Compare normalized source coordinates and admission policy."""
+        if not isinstance(other, CandidateRange):
+            return NotImplemented
+        return self.default == other.default and self.overrides == other.overrides
+
+    def __hash__(self) -> int:
+        """Return the hash fixed when the constraint was constructed."""
+        return self._hash
+
+    def __str__(self) -> str:
+        """Render the version bounds and exceptional source coordinates."""
+        return f"{self.default!r}; sources={self.overrides!r}"

--- a/nab-provider/tests/test_candidate_range_imports.py
+++ b/nab-provider/tests/test_candidate_range_imports.py
@@ -1,0 +1,60 @@
+"""Source ranges work without the provider's candidate and target policies."""
+
+import subprocess
+import sys
+
+_PROBE = """
+import sys
+
+for name in (
+    "nab_markersets",
+    "nab_provider.provider",
+    "nab_provider.fetch_port",
+    "nab_provider.target",
+    "nab_provider.marker_holds",
+    "nab_provider.resolver_inputs",
+):
+    sys.modules[name] = None
+
+from nab_provider._vendor.packaging.version import Version
+from nab_provider.candidate_ranges import CandidateKey, CandidateRange
+from nab_resolver.resolver import BaseProvider, Resolver
+
+installed = CandidateKey(Version("1"), "installed")
+direct = CandidateKey(Version("1"), "direct")
+child = CandidateKey(Version("2"), "index")
+catalog = {"demo": (installed, direct), "child": (child,)}
+
+class SourceProvider(BaseProvider):
+    def choose_version(self, package, allowed):
+        return next((key for key in catalog[package] if key in allowed), None)
+
+    def has_satisfying_version(self, package, allowed):
+        return self.choose_version(package, allowed) is not None
+
+    def get_dependencies(self, package, key):
+        if package == "demo" and key == direct:
+            return {"child": CandidateRange.singleton(child)}
+        return {}
+
+    def prioritize(self, package, allowed, conflicts, culprits=None):
+        return package
+
+    def widen_decision(self, package, key):
+        return None
+
+resolver = Resolver(
+    SourceProvider(), range_type=CandidateRange,
+    root_version=CandidateKey(Version("0"), "root"),
+)
+solution = resolver.solve({"demo": CandidateRange.singleton(direct)})
+assert solution.pins == {"demo": direct, "child": child}
+assert solution.edges == (("demo", "child"),)
+"""
+
+
+def test_solve_with_only_source_ranges() -> None:
+    """Select distinct metadata for a direct source at an installed version."""
+    subprocess.run(  # noqa: S603 - fixed interpreter and probe
+        [sys.executable, "-c", _PROBE], check=True
+    )

--- a/nab-provider/tests/test_candidate_range_imports.py
+++ b/nab-provider/tests/test_candidate_range_imports.py
@@ -7,6 +7,7 @@ _PROBE = """
 import sys
 
 for name in (
+    "dataclasses",
     "nab_markersets",
     "nab_provider.provider",
     "nab_provider.fetch_port",

--- a/nab-provider/tests/test_candidate_range_values.py
+++ b/nab-provider/tests/test_candidate_range_values.py
@@ -1,0 +1,21 @@
+"""Restore a key serialized with its field-dictionary layout."""
+
+import base64
+import pickle
+
+from nab_provider._vendor.packaging.version import Version
+from nab_provider.candidate_ranges import CandidateKey
+
+# Protocol 4 field-dictionary pickles written with PYTHONHASHSEED=0.
+_LEGACY_KEY = (
+    "gASVnAAAAAAAAACMHW5hYl9wcm92aWRlci5jYW5kaWRhdGVfcmFuZ2VzlIwMQ2FuZGlkYXRlS2V5"
+    "lJOUKYGUfZQojAd2ZXJzaW9ulIwmbmFiX3Byb3ZpZGVyLl92ZW5kb3IucGFja2FnaW5nLnZlcnNp"
+    "b26UjAdWZXJzaW9ulJOUKYGUKEsASwGFlE5OTk50lGKMBnNvdXJjZZSMBmRpcmVjdJR1Yi4="
+)
+
+
+def test_read_legacy_key_field_dictionary_pickle() -> None:
+    expected = CandidateKey(Version("1"), "direct")
+    restored = pickle.loads(base64.b64decode(_LEGACY_KEY))  # noqa: S301 - fixed trusted fixture
+    assert restored == expected
+    assert hash(restored) == hash(expected)

--- a/nab-provider/tests/test_candidate_range_values.py
+++ b/nab-provider/tests/test_candidate_range_values.py
@@ -1,10 +1,14 @@
 """Restore a key serialized with its field-dictionary layout."""
 
 import base64
+import copy
 import pickle
 
+import pytest
+
+from nab_provider._vendor.packaging.ranges import VersionRange
 from nab_provider._vendor.packaging.version import Version
-from nab_provider.candidate_ranges import CandidateKey
+from nab_provider.candidate_ranges import CandidateKey, CandidateRange
 
 # Protocol 4 field-dictionary pickles written with PYTHONHASHSEED=0.
 _LEGACY_KEY = (
@@ -19,3 +23,145 @@ def test_read_legacy_key_field_dictionary_pickle() -> None:
     restored = pickle.loads(base64.b64decode(_LEGACY_KEY))  # noqa: S301 - fixed trusted fixture
     assert restored == expected
     assert hash(restored) == hash(expected)
+
+
+class DictKey(CandidateKey):
+    """Require mutable metadata that is not part of key identity."""
+
+    initializations = 0
+
+    def __init__(self, version: Version, source: str, extra: list[str]) -> None:
+        super().__init__(version, source)
+        self.extra = extra
+        type(self).initializations += 1
+
+
+class SlotKey(CandidateKey):
+    """Keep subclass metadata in slots, including an unset optional slot."""
+
+    __slots__ = ("extra", "unused")
+    initializations = 0
+
+    def __init__(self, version: Version, source: str, extra: list[str]) -> None:
+        super().__init__(version, source)
+        self.extra = extra
+        type(self).initializations += 1
+
+
+@pytest.mark.parametrize("cls", [DictKey, SlotKey])
+def test_key_subclass_state_survives_copies_without_constructor_calls(
+    cls: type,
+) -> None:
+    cls.initializations = 0
+    key = cls(Version("1"), "direct", ["metadata"])
+    for restored in (copy.copy(key), copy.deepcopy(key)):
+        assert restored == key
+        assert restored.extra == key.extra
+        assert cls.initializations == 1
+    for protocol in range(pickle.HIGHEST_PROTOCOL + 1):
+        restored = pickle.loads(pickle.dumps(key, protocol))  # noqa: S301 - local value roundtrip
+        assert restored == key
+        assert restored.extra == key.extra
+        assert cls.initializations == 1
+    del key.extra
+    key.extra = ["replacement"]
+    for name in ("version", "source"):
+        with pytest.raises(AttributeError):
+            setattr(key, name, None)
+        with pytest.raises(AttributeError):
+            delattr(key, name)
+
+
+class MetadataRange(CandidateRange):
+    """Require subclass state that a shallow copy must retain unchanged."""
+
+    __slots__ = ("extra",)
+    initializations = 0
+
+    def __init__(self, default: VersionRange, extra: list[str]) -> None:
+        super().__init__(default)
+        self.extra = extra
+        type(self).initializations += 1
+
+
+def test_range_subclass_shallow_copy_retains_state_and_field_identity() -> None:
+    MetadataRange.initializations = 0
+    original = MetadataRange(VersionRange.full(admit_arbitrary=False), ["metadata"])
+    restored = copy.copy(original)
+    assert restored == original
+    assert restored.default is original.default
+    assert restored.overrides is original.overrides
+    assert restored.extra is original.extra
+    assert MetadataRange.initializations == 1
+    del restored.extra
+    restored.extra = ["replacement"]
+    for name in ("default", "overrides", "_hash"):
+        with pytest.raises(AttributeError):
+            setattr(restored, name, None)
+        with pytest.raises(AttributeError):
+            delattr(restored, name)
+
+
+class ShadowKey(CandidateKey):
+    """Replace an inherited field with a visible subclass slot."""
+
+    __slots__ = ("version",)
+
+
+class ShadowRange(CandidateRange):
+    """Replace inherited bounds with visible subclass slots."""
+
+    __slots__ = ("default", "overrides")
+
+
+def test_constructor_respects_subclass_slots_shadowing_base_fields() -> None:
+    key = ShadowKey(Version("1"), "direct")
+    assert key.version == Version("1")
+    assert key.source == "direct"
+    copied = copy.copy(key)
+    assert copied.version == key.version
+    default = VersionRange.full(admit_arbitrary=False)
+    constraint = ShadowRange(default, {"direct": VersionRange.singleton(key.version)})
+    assert constraint.default == default
+    assert key in constraint
+
+
+class PropertyKey(CandidateKey):
+    """Keep a visible field in dictionary state behind a property."""
+
+    writes = 0
+    storage_name = "version"
+
+    @property
+    def version(self) -> Version:
+        return self.__dict__[self.storage_name]
+
+    @version.setter
+    def version(self, value: Version) -> None:
+        self.__dict__[self.storage_name] = value
+        type(self).writes += 1
+
+
+class PrivatePropertyKey(PropertyKey):
+    """Store a property under a distinct backing attribute name."""
+
+    storage_name = "_version"
+
+
+@pytest.mark.parametrize("cls", [PropertyKey, PrivatePropertyKey])
+def test_copy_preserves_property_state_without_replaying_its_setter(cls: type) -> None:
+    cls.writes = 0
+    key = cls(Version("1"), "direct")
+    assert cls.writes == 1
+    for restored in (copy.copy(key), copy.deepcopy(key)):
+        assert restored == key
+        assert restored.version == Version("1")
+        assert cls.writes == 1
+
+
+def test_base_key_supports_all_pickle_protocols() -> None:
+    key = CandidateKey(Version("1"), "direct")
+    for protocol in range(pickle.HIGHEST_PROTOCOL + 1):
+        restored = pickle.loads(pickle.dumps(key, protocol))  # noqa: S301 - local value roundtrip
+        assert restored == key
+        assert hash(restored) == hash(key)

--- a/nab-provider/tests/test_candidate_ranges.py
+++ b/nab-provider/tests/test_candidate_ranges.py
@@ -1,0 +1,110 @@
+"""Check source-specific constraints against their product-set semantics."""
+
+from dataclasses import FrozenInstanceError
+from itertools import product
+
+import pytest
+
+from nab_provider._vendor.packaging.specifiers import SpecifierSet
+from nab_provider._vendor.packaging.version import Version
+from nab_provider.candidate_ranges import CandidateKey, CandidateRange
+
+
+@pytest.mark.parametrize(
+    "specifier", ["", "<2", ">=1rc1", "!=1.5", "==1.*", "===invalid"]
+)
+def test_source_constraints_obey_set_laws(specifier: str) -> None:
+    versions = SpecifierSet(specifier).to_range()
+    ranges = [
+        CandidateRange.empty(),
+        CandidateRange.full(),
+        CandidateRange(versions),
+        CandidateRange.for_source("direct", versions),
+        CandidateRange(versions, {"installed": SpecifierSet("==1").to_range()}),
+    ]
+    keys = [
+        CandidateKey(Version(version), source)
+        for version, source in product(
+            ["0", "1rc1", "1", "1.5", "2", "2+local"],
+            ["index", "installed", "direct", "undiscovered"],
+        )
+    ]
+    for left, right in product(ranges, repeat=2):
+        assert left.is_subset((left - right) | right)
+        assert (left - right).is_disjoint(right)
+        assert left | right == right | left
+        assert left & right == right & left
+        assert left.is_superset(~~left)
+        assert (~~left).is_superset(left)
+        assert left & CandidateRange.full() == left
+        assert left | CandidateRange.empty() == left
+        for key in keys:
+            assert (key in (left & right)) == (key in left and key in right)
+            assert (key in (left | right)) == (key in left or key in right)
+            assert (key in (left - right)) == (key in left and key not in right)
+            assert (key in ~left) == (key not in left)
+
+
+def test_singleton_keeps_the_source_at_the_same_version() -> None:
+    installed = CandidateKey(Version("1"), "installed")
+    direct = CandidateKey(Version("1"), "direct")
+    selected = CandidateRange.singleton(installed)
+    assert installed in selected
+    assert direct not in selected
+    assert selected.is_disjoint(CandidateRange.singleton(direct))
+    assert str(installed) == "1"
+    assert "installed" in str(selected)
+
+
+def test_overrides_are_snapshotted_and_redundant_coordinates_are_removed() -> None:
+    full = CandidateRange.full().default
+    overrides = {"direct": SpecifierSet("==1").to_range()}
+    constraint = CandidateRange(full, overrides)
+    overrides["direct"] = SpecifierSet("<0").to_range()
+    assert CandidateKey(Version("1"), "direct") in constraint
+
+    restored = CandidateRange(full, [("direct", overrides["direct"]), ("direct", full)])
+    assert restored == CandidateRange.full()
+    assert hash(restored) == hash(CandidateRange.full())
+    with pytest.raises(FrozenInstanceError):
+        constraint.default = full
+
+
+def test_relation_reports_each_subset_and_disjoint_combination() -> None:
+    one = CandidateRange.singleton(CandidateKey(Version("1"), "index"))
+    two = CandidateRange.singleton(CandidateKey(Version("2"), "index"))
+    for left, right, subset, disjoint in (
+        (CandidateRange.empty(), one, True, True),
+        (one, one | two, True, False),
+        (one, two, False, True),
+        (one | two, one, False, False),
+    ):
+        relation = left.relation(right)
+        assert relation.is_subset is subset
+        assert relation.is_disjoint is disjoint
+
+
+def test_unknown_operand_protocol() -> None:
+    constraint = CandidateRange.full()
+    assert constraint.__eq__(object()) is NotImplemented
+    assert constraint.__and__(object()) is NotImplemented
+    assert constraint.__or__(object()) is NotImplemented
+    assert constraint.__sub__(object()) is NotImplemented
+
+
+def test_source_complement_includes_sources_not_known_to_the_host() -> None:
+    direct = CandidateRange.for_source("direct")
+    unknown = CandidateKey(Version("1"), "not-discovered-yet")
+    assert unknown not in direct
+    assert unknown in ~direct
+    assert ~CandidateRange.empty() == CandidateRange.full()
+
+
+@pytest.mark.parametrize("prereleases", [True, False])
+def test_configured_prerelease_policies_are_rejected(prereleases: bool) -> None:
+    versions = SpecifierSet(">=1", prereleases=prereleases).to_range()
+    with pytest.raises(ValueError, match="different pre-release policies"):
+        CandidateRange(versions)
+
+    with pytest.raises(ValueError, match="different pre-release policies"):
+        CandidateRange(CandidateRange.full().default, {"direct": versions})

--- a/nab-provider/tests/test_candidate_ranges.py
+++ b/nab-provider/tests/test_candidate_ranges.py
@@ -1,6 +1,9 @@
 """Check source-specific constraints against their product-set semantics."""
 
-from dataclasses import FrozenInstanceError
+import copy
+import operator
+import pickle
+import weakref
 from itertools import product
 
 import pytest
@@ -66,7 +69,7 @@ def test_overrides_are_snapshotted_and_redundant_coordinates_are_removed() -> No
     restored = CandidateRange(full, [("direct", overrides["direct"]), ("direct", full)])
     assert restored == CandidateRange.full()
     assert hash(restored) == hash(CandidateRange.full())
-    with pytest.raises(FrozenInstanceError):
+    with pytest.raises(AttributeError, match="cannot assign to field"):
         constraint.default = full
 
 
@@ -108,3 +111,96 @@ def test_configured_prerelease_policies_are_rejected(prereleases: bool) -> None:
 
     with pytest.raises(ValueError, match="different pre-release policies"):
         CandidateRange(CandidateRange.full().default, {"direct": versions})
+
+
+class DerivedKey(CandidateKey):
+    """Exercise inherited comparisons without changing the key fields."""
+
+
+def test_key_preserves_value_operations_and_exact_class_comparisons() -> None:
+    low = CandidateKey(Version("1"), "z")
+    high = CandidateKey(version=Version("2"), source="a")
+    assert low == CandidateKey(Version("1"), "z")
+    assert low != high
+    assert hash(low) == hash((low.version, low.source))
+    assert repr(low) == "CandidateKey(version=<Version('1')>, source='z')"
+    assert sorted([high, low, CandidateKey(Version("1"), "a")]) == [
+        CandidateKey(Version("1"), "a"),
+        low,
+        high,
+    ]
+
+    for operation in (operator.lt, operator.le, operator.gt, operator.ge):
+        assert operation(low, high) == operation(
+            (low.version, low.source), (high.version, high.source)
+        )
+        assert operation(low, low) == operation(
+            (low.version, low.source), (low.version, low.source)
+        )
+    for name in ("__eq__", "__lt__", "__le__", "__gt__", "__ge__"):
+        assert getattr(low, name)(object()) is NotImplemented
+        assert getattr(low, name)(DerivedKey(low.version, low.source)) is NotImplemented
+        assert getattr(DerivedKey(low.version, low.source), name)(low) is NotImplemented
+    assert DerivedKey(low.version, low.source) == DerivedKey(low.version, low.source)
+    assert DerivedKey(low.version, low.source) < DerivedKey(high.version, high.source)
+    assert low != DerivedKey(low.version, low.source)
+
+
+def test_values_keep_their_pattern_fields_and_range_representation() -> None:
+    key = CandidateKey(Version("1"), "direct")
+    constraint = CandidateRange.singleton(key)
+    assert CandidateKey.__match_args__ == ("version", "source")
+    assert CandidateRange.__match_args__ == ("default", "overrides", "_hash")
+    match key:
+        case CandidateKey(version, source):
+            assert (version, source) == (Version("1"), "direct")
+    match constraint:
+        case CandidateRange(default, overrides, cached_hash):
+            assert (default, overrides, cached_hash) == (
+                constraint.default,
+                constraint.overrides,
+                hash(constraint),
+            )
+    assert repr(constraint) == (
+        f"CandidateRange(default={constraint.default!r}, overrides={constraint.overrides!r}, "
+        f"_hash={hash(constraint)!r})"
+    )
+
+
+def test_slotted_values_refuse_replacement_and_deletion() -> None:
+    key = CandidateKey(Version("1"), "direct")
+    constraint = CandidateRange.singleton(key)
+    for value, fields in (
+        (key, ("version", "source")),
+        (constraint, ("default", "overrides", "_hash")),
+    ):
+        saved_hash = hash(value)
+        assert not hasattr(value, "__dict__")
+        assert weakref.ref(value)() is value
+        for name in (*fields, "extra"):
+            with pytest.raises(AttributeError, match="cannot assign to field"):
+                setattr(value, name, None)
+            with pytest.raises(AttributeError, match="cannot delete field"):
+                delattr(value, name)
+        assert hash(value) == saved_hash
+
+
+def test_copy_and_pickle_preserve_keys_and_shallow_range_copies() -> None:
+    key = CandidateKey(Version("1"), "direct")
+    restored_keys = (
+        copy.copy(key),
+        copy.deepcopy(key),
+        pickle.loads(pickle.dumps(key)),  # noqa: S301 - roundtrip of a local value
+    )
+    for restored in restored_keys:
+        assert restored is not key
+        assert restored == key
+        assert hash(restored) == hash(key)
+        assert repr(restored) == repr(key)
+
+    constraint = CandidateRange.singleton(key)
+    restored_range = copy.copy(constraint)
+    assert restored_range is not constraint
+    assert restored_range == constraint
+    assert hash(restored_range) == hash(constraint)
+    assert repr(restored_range) == repr(constraint)

--- a/nab-provider/tests/test_candidate_ranges.py
+++ b/nab-provider/tests/test_candidate_ranges.py
@@ -130,13 +130,11 @@ def test_key_preserves_value_operations_and_exact_class_comparisons() -> None:
         high,
     ]
 
-    for operation in (operator.lt, operator.le, operator.gt, operator.ge):
-        assert operation(low, high) == operation(
-            (low.version, low.source), (high.version, high.source)
-        )
-        assert operation(low, low) == operation(
-            (low.version, low.source), (low.version, low.source)
-        )
+    for operation in (operator.eq, operator.lt, operator.le, operator.gt, operator.ge):
+        for other in (high, low, CandidateKey(low.version, "a")):
+            assert operation(low, other) == operation(
+                (low.version, low.source), (other.version, other.source)
+            )
     for name in ("__eq__", "__lt__", "__le__", "__gt__", "__ge__"):
         assert getattr(low, name)(object()) is NotImplemented
         assert getattr(low, name)(DerivedKey(low.version, low.source)) is NotImplemented
@@ -154,6 +152,8 @@ def test_values_keep_their_pattern_fields_and_range_representation() -> None:
     match key:
         case CandidateKey(version, source):
             assert (version, source) == (Version("1"), "direct")
+        case _:
+            pytest.fail("CandidateKey did not match its declared fields")
     match constraint:
         case CandidateRange(default, overrides, cached_hash):
             assert (default, overrides, cached_hash) == (
@@ -161,6 +161,8 @@ def test_values_keep_their_pattern_fields_and_range_representation() -> None:
                 constraint.overrides,
                 hash(constraint),
             )
+        case _:
+            pytest.fail("CandidateRange did not match its declared fields")
     assert repr(constraint) == (
         f"CandidateRange(default={constraint.default!r}, overrides={constraint.overrides!r}, "
         f"_hash={hash(constraint)!r})"
@@ -201,6 +203,8 @@ def test_copy_and_pickle_preserve_keys_and_shallow_range_copies() -> None:
     constraint = CandidateRange.singleton(key)
     restored_range = copy.copy(constraint)
     assert restored_range is not constraint
+    assert restored_range.default is constraint.default
+    assert restored_range.overrides is constraint.overrides
     assert restored_range == constraint
     assert hash(restored_range) == hash(constraint)
     assert repr(restored_range) == repr(constraint)


### PR DESCRIPTION
`CandidateKey` distinguishes installed and downloaded distributions at the same version. `CandidateRange` combines version constraints with source identifiers, including sources discovered later.

The optional `nab_provider.candidate_ranges` module provides per-source restrictions and range algebra. Its runtime dependencies are vendored packaging and the standard library. Hosts control ordering, source admission and prerelease selection; input ranges must use the provider's vendored `VersionRange` with explicit prerelease policy unset.
