### PR TITLE
Prioritize contextual query failures in candidate providers

### DIFF
--- a/docs/how-to/embed-the-resolver.md
+++ b/docs/how-to/embed-the-resolver.md
@@ -211,6 +211,12 @@ Keep requirement fields (`package`, `constraint`, `origin`) and prepared candida
 
 Candidate queries also serve diagnostic probes, so preparing or caching a candidate must preserve answers for the same active requirements. For conditional availability, use the callback and eligibility contract above.
 
+Pass `query_feedback=True` to `CandidateProvider` to prioritize packages involved in contextual query failures. Its key is `(-parent_failures, -target_failures, host_priority)`: each failure credits the queried package and each currently decided package whose cached declarations require it. Multiple declarations from one parent count once. The default, `False`, returns the host's priority directly.
+
+Feedback changes decision order only. Candidate admission, source eligibility and absence guards still follow the host contracts above. Counts start empty for each `Resolver.solve` call and survive backjumps and restarts within that call.
+
+Providers can implement two optional notifications, supplied as no-ops by `BaseProvider`. `begin_resolution()` runs when a solve starts. `receive_contextual_failure(package)` runs before recording a guarded contextual absence and returns `True` if priority keys changed; the resolver then invalidates its cached priorities. Ordinary unguarded absences and diagnostic probes do not send this notification. Structural providers may omit both methods.
+
 ## The supported API
 
 These module paths will not move without a major version bump:

--- a/docs/how-to/embed-the-resolver.md
+++ b/docs/how-to/embed-the-resolver.md
@@ -215,7 +215,7 @@ Pass `query_feedback=True` to `CandidateProvider` to prioritize packages involve
 
 Feedback changes decision order only. Candidate admission, source eligibility and absence guards still follow the host contracts above. Counts start empty for each `Resolver.solve` call and survive backjumps and restarts within that call.
 
-Providers can implement two optional notifications, supplied as no-ops by `BaseProvider`. `begin_resolution()` runs when a solve starts. `receive_contextual_failure(package)` runs before recording a guarded contextual absence and returns `True` if priority keys changed; the resolver then invalidates its cached priorities. Ordinary unguarded absences and diagnostic probes do not send this notification. Structural providers may omit both methods.
+Providers can implement two optional notifications, supplied as no-ops by `BaseProvider`. `begin_resolution()` runs when a solve starts. `receive_contextual_failure(package)` runs before recording a guarded contextual absence and returns `True` if priority keys changed; the resolver then invalidates its cached priorities. It may change only priority state, preserving candidate availability and current decisions. Ordinary unguarded absences and diagnostic probes do not send this notification. Structural providers may omit both methods.
 
 ## The supported API
 

--- a/nab-resolver/src/nab_resolver/candidate_provider.py
+++ b/nab-resolver/src/nab_resolver/candidate_provider.py
@@ -154,6 +154,7 @@ class CandidateProvider(BaseProvider[_PackageT, _KeyT]):
         """Credit the failed query and its currently decided declaring packages."""
         if self._query_feedback is None:
             return False
+
         parents = (
             parent
             for parent, key in self._decisions.items()

--- a/nab-resolver/src/nab_resolver/candidate_provider.py
+++ b/nab-resolver/src/nab_resolver/candidate_provider.py
@@ -87,6 +87,35 @@ class CandidateHost(Protocol[_PackageT, _KeyT]):
         ...
 
 
+class _QueryFeedback(Generic[_PackageT]):
+    """Count contextual failures for one solve without changing candidate admission."""
+
+    __slots__ = ("parent_failures", "target_failures")
+
+    def __init__(self) -> None:
+        self.parent_failures: dict[_PackageT, int] = {}
+        self.target_failures: dict[_PackageT, int] = {}
+
+    def clear(self) -> None:
+        """Start a new solve with no inherited ordering feedback."""
+        self.parent_failures.clear()
+        self.target_failures.clear()
+
+    def record(self, package: _PackageT, parents: Iterable[_PackageT]) -> None:
+        """Credit the query target and each current declaring package."""
+        self.target_failures[package] = self.target_failures.get(package, 0) + 1
+        for parent in parents:
+            self.parent_failures[parent] = self.parent_failures.get(parent, 0) + 1
+
+    def priority(self, package: _PackageT, host_priority: Any) -> tuple[int, int, Any]:
+        """Prefer declaring packages, then failed targets, before the host's key."""
+        return (
+            -self.parent_failures.get(package, 0),
+            -self.target_failures.get(package, 0),
+            host_priority,
+        )
+
+
 class CandidateProvider(BaseProvider[_PackageT, _KeyT]):
     """Keep candidate identity and active requirements around a host's selection."""
 
@@ -94,10 +123,13 @@ class CandidateProvider(BaseProvider[_PackageT, _KeyT]):
         self,
         host: CandidateHost[_PackageT, _KeyT],
         roots: Sequence[CandidateRequirement[_PackageT, _KeyT]],
+        *,
+        query_feedback: bool = False,
     ) -> None:
-        """Snapshot roots and retain selected dependency provenance."""
+        """Snapshot roots and optionally prioritize contextual query failures."""
         self.host = host
         self.roots = tuple(roots)
+        self._query_feedback = _QueryFeedback[_PackageT]() if query_feedback else None
         self._decisions: Mapping[_PackageT, _KeyT] = {}
         self._selected: dict[tuple[_PackageT, _KeyT], PreparedCandidate[_KeyT]] = {}
         self._causes: dict[
@@ -110,6 +142,28 @@ class CandidateProvider(BaseProvider[_PackageT, _KeyT]):
             Mapping[_PackageT, tuple[CandidateRequirement[_PackageT, _KeyT], ...]]
             | None
         ) = None
+
+    @override
+    def begin_resolution(self) -> None:
+        """Clear ordering feedback while retaining prepared candidate metadata."""
+        if self._query_feedback is not None:
+            self._query_feedback.clear()
+
+    @override
+    def receive_contextual_failure(self, package: _PackageT) -> bool:
+        """Credit the failed query and its currently decided declaring packages."""
+        if self._query_feedback is None:
+            return False
+        parents = (
+            parent
+            for parent, key in self._decisions.items()
+            if any(
+                cause.package == package
+                for cause in self._causes.get((parent, key), ())
+            )
+        )
+        self._query_feedback.record(package, parents)
+        return True
 
     def root_requirements(self) -> list[RootRequirement[_PackageT, _KeyT]]:
         """Return solver roots with their original host provenance attached."""
@@ -211,9 +265,12 @@ class CandidateProvider(BaseProvider[_PackageT, _KeyT]):
         conflict_counts: Mapping[_PackageT, int],
         culprit_counts: Mapping[_PackageT, int] | None = None,
     ) -> Any:
-        """Use the host's package priority without listing candidates."""
+        """Combine contextual-query feedback with the host's package priority."""
         del version_range, conflict_counts, culprit_counts
-        return self.host.priority(package, self.active_requirements())
+        priority = self.host.priority(package, self.active_requirements())
+        if self._query_feedback is not None:
+            return self._query_feedback.priority(package, priority)
+        return priority
 
     def prepared(self, package: _PackageT, key: _KeyT) -> PreparedCandidate[_KeyT]:
         """Return the exact prepared candidate used by a solver decision."""

--- a/nab-resolver/src/nab_resolver/decide.py
+++ b/nab-resolver/src/nab_resolver/decide.py
@@ -254,6 +254,9 @@ def record_contextual_no_versions(resolver: Resolver[Any, Any], package: Any) ->
         resolver, package, current_range
     ):
         constraint = None
+    receive_failure = getattr(resolver.provider, "receive_contextual_failure", None)
+    if receive_failure is not None and receive_failure(package):
+        resolver.priority_epoch += 1
     add_incompatibility(
         resolver,
         Incompatibility(

--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -335,7 +335,10 @@ class BaseProvider(Generic[PackageType, VersionType]):
         return
 
     def receive_contextual_failure(self, package: PackageType) -> bool:
-        """Report whether a contextual absence changed the provider's priorities."""
+        """Report whether a contextual absence changed priorities.
+
+        Change priority state only, preserving availability and current decisions.
+        """
         del package
         return False
 

--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -312,7 +312,7 @@ class ResolverProvider(Protocol[PackageType, VersionType]):
 
 
 class BaseProvider(Generic[PackageType, VersionType]):
-    """Defaults for the six provider methods a synchronous provider does not need.
+    """Defaults for optional provider behavior.
 
     Supplies ``begin_decision_scan``, ``is_ready``,
     ``receive_partial_solution_hint``, ``consume_pending_clauses``,
@@ -322,10 +322,22 @@ class BaseProvider(Generic[PackageType, VersionType]):
     ``choose_version``, ``has_satisfying_version``, ``get_dependencies``,
     ``prioritize`` and ``widen_decision``.
 
+    ``begin_resolution`` and ``receive_contextual_failure`` are optional lifecycle
+    and priority notifications. Structural providers may omit both.
+
     Subclassing is optional; the resolver accepts anything that satisfies the
     protocol.  Nothing re-exports this, so import it as
     ``from nab_resolver.resolver import BaseProvider``.
     """
+
+    def begin_resolution(self) -> None:
+        """Receive notification that a new solve is beginning."""
+        return
+
+    def receive_contextual_failure(self, package: PackageType) -> bool:
+        """Report whether a contextual absence changed the provider's priorities."""
+        del package
+        return False
 
     def begin_decision_scan(self) -> Callable[[PackageType], bool] | None:
         """Freeze nothing and offer no probe: no state moves between scans."""
@@ -961,6 +973,9 @@ class Resolver(Generic[PackageType, VersionType]):
 
         # Re-asked here, so a hook installed since the last resolve is honoured.
         self._hint_ignoring_provider = _provider_with_inherited_hint(self.provider)
+        begin_resolution = getattr(self.provider, "begin_resolution", None)
+        if begin_resolution is not None:
+            begin_resolution()
 
     def _add_root_requirements(
         self, requirements: Sequence[RootRequirement[PackageType, VersionType]]

--- a/nab-resolver/tests/test_base_provider.py
+++ b/nab-resolver/tests/test_base_provider.py
@@ -43,6 +43,8 @@ OWED = frozenset(
     }
 )
 
+OPTIONAL = frozenset({"begin_resolution", "receive_contextual_failure"})
+
 Graph = dict[str, dict[int, dict[str, Range[int]]]]
 
 
@@ -85,7 +87,7 @@ class NewestFirstProvider(BaseProvider[str, int]):
 class TestTheSplit:
     def test_supplies_exactly_the_documented_defaults(self) -> None:
         defined = {name for name in vars(BaseProvider) if not name.startswith("_")}
-        assert defined == SUPPLIED
+        assert defined == SUPPLIED | OPTIONAL
 
     def test_leaves_the_owed_methods_to_the_subclass(self) -> None:
         assert OWED.isdisjoint(dir(BaseProvider))
@@ -98,9 +100,16 @@ class TestTheSplit:
             if not name.startswith("_") and callable(value)
         }
         assert declared == SUPPLIED | OWED
+        assert declared.isdisjoint(OPTIONAL)
 
 
 class TestDefaults:
+    def test_beginning_a_resolution_retains_no_state(self) -> None:
+        assert BaseProvider[str, int]().begin_resolution() is None
+
+    def test_contextual_failure_does_not_change_priority(self) -> None:
+        assert BaseProvider[str, int]().receive_contextual_failure("foo") is False
+
     def test_beginning_a_scan_freezes_nothing(self) -> None:
         assert BaseProvider[str, int]().begin_decision_scan() is None
 

--- a/nab-resolver/tests/test_candidate_provider.py
+++ b/nab-resolver/tests/test_candidate_provider.py
@@ -1,7 +1,7 @@
 """Exercise host adaptation without packaging types or package-name strings."""
 
 from collections.abc import Iterable, Mapping, MutableMapping, Sequence
-from typing import cast
+from typing import Any, cast
 
 import pytest
 
@@ -10,8 +10,12 @@ from nab_resolver.candidate_provider import (
     CandidateRequirement,
     PreparedCandidate,
 )
+from nab_resolver.decide import choose_package_to_decide
+from nab_resolver.errors import ResolutionError
+from nab_resolver.propagate import unit_propagation
 from nab_resolver.ranges import Range
 from nab_resolver.resolver import Resolver
+from nab_resolver.root import ROOT
 from nab_resolver.types import RangeProtocol
 
 
@@ -158,3 +162,127 @@ def test_cached_requirement_view_is_immutable_and_tracks_new_dependencies() -> N
     provider.receive_partial_solution_hint({}, {})
     assert 20 not in provider.active_requirements()
     assert after[20] == (host.request,)
+
+
+def test_query_feedback_prioritizes_current_generic_parents_then_targets() -> None:
+    host = MemoryHost()
+    provider = CandidateProvider(
+        host, [CandidateRequirement(10, Range.full(), object())], query_feedback=True
+    )
+    provider.choose_version(10, Range.full())
+    provider.get_dependencies(10, "app-one")
+    provider.receive_partial_solution_hint({}, {10: "app-one"})
+
+    assert provider.receive_contextual_failure(20)
+    assert provider.prioritize(10, Range.full(), {}) == (-1, 0, 10)
+    assert provider.prioritize(20, Range.full(), {}) == (0, -1, 20)
+
+    provider.receive_partial_solution_hint({}, {})
+    assert provider.receive_contextual_failure(20)
+    assert provider.prioritize(10, Range.full(), {}) == (-1, 0, 10)
+    assert provider.prioritize(20, Range.full(), {}) == (0, -2, 20)
+
+    provider.begin_resolution()
+    assert provider.prioritize(10, Range.full(), {}) == (0, 0, 10)
+    assert provider.prioritize(20, Range.full(), {}) == (0, 0, 20)
+
+
+def test_query_feedback_is_disabled_by_default() -> None:
+    provider = CandidateProvider(MemoryHost(), [])
+    provider.begin_resolution()
+    assert provider.receive_contextual_failure(20) is False
+    assert provider.prioritize(20, Range.full(), {}) == 20
+
+
+def test_duplicate_declarations_credit_one_current_parent() -> None:
+    class RepeatedHost(MemoryHost):
+        """Retain two declarations of the same dependency from one candidate."""
+
+        def get_dependencies(
+            self, candidate: PreparedCandidate[str]
+        ) -> Iterable[CandidateRequirement[int, str]]:
+            yield self.request
+            yield CandidateRequirement(20, Range.full(), object())
+
+    provider = CandidateProvider(RepeatedHost(), [], query_feedback=True)
+    provider.choose_version(10, Range.full())
+    provider.get_dependencies(10, "app-one")
+    provider.receive_partial_solution_hint({}, {10: "app-one"})
+    provider.receive_contextual_failure(20)
+    assert provider.prioritize(10, Range.full(), {}) == (-1, 0, 10)
+
+    provider.receive_partial_solution_hint({}, {10: "another-key"})
+    provider.receive_contextual_failure(20)
+    assert provider.prioritize(10, Range.full(), {}) == (-1, 0, 10)
+    assert provider.prioritize(20, Range.full(), {}) == (0, -2, 20)
+
+
+def test_failed_solve_feedback_is_cleared_before_reuse() -> None:
+    host = MemoryHost()
+    host.dep = PreparedCandidate("dep-two", object())
+    provider = CandidateProvider(
+        host, [CandidateRequirement(10, Range.full(), object())], query_feedback=True
+    )
+    resolver = Resolver(
+        provider, root_version="root", availability_generation=lambda: 0
+    )
+    with pytest.raises(ResolutionError):
+        resolver.solve(provider.root_requirements())
+    assert provider.prioritize(10, Range.full(), {})[:2] == (-1, 0)
+    assert provider.prioritize(20, Range.full(), {})[:2] == (0, -1)
+
+    host.dep = PreparedCandidate("dep-one", object())
+    assert resolver.solve(provider.root_requirements()).pins == {
+        10: "app-one",
+        20: "dep-one",
+    }
+    assert provider.prioritize(10, Range.full(), {})[:2] == (0, 0)
+    assert provider.prioritize(20, Range.full(), {})[:2] == (0, 0)
+
+
+def test_disabled_feedback_preserves_an_opaque_host_key() -> None:
+    priority = object()
+
+    class OpaquePriorityHost(MemoryHost):
+        """Return one opaque ordering key without preparing candidates."""
+
+        def priority(
+            self,
+            package: int,
+            requirements: Mapping[int, Sequence[CandidateRequirement[int, str]]],
+        ) -> Any:
+            return priority
+
+    provider = CandidateProvider(OpaquePriorityHost(), [])
+    assert provider.prioritize(10, Range.full(), {}) is priority
+    assert provider.receive_contextual_failure(10) is False
+    assert provider.prioritize(10, Range.full(), {}) is priority
+
+
+def test_feedback_prefers_a_declaring_parent_after_backtrack() -> None:
+    provider = CandidateProvider(
+        MemoryHost(),
+        [
+            CandidateRequirement(10, Range.full(), object()),
+            CandidateRequirement(20, Range.full(), object()),
+        ],
+        query_feedback=True,
+    )
+    resolver = Resolver(provider, root_version="root")
+    resolver._reset(None)
+    resolver._add_root_requirements(provider.root_requirements())
+    assert unit_propagation(resolver, ROOT) is None
+    assert provider.choose_version(10, Range.full()) == "app-one"
+    provider.get_dependencies(10, "app-one")
+    resolver.solution.decide(10, "app-one")
+    provider.receive_partial_solution_hint(
+        resolver.solution.positive_ranges(), resolver.solution.decisions()
+    )
+    assert provider.receive_contextual_failure(20)
+
+    resolver.solution.backtrack(1)
+    provider.receive_partial_solution_hint(
+        resolver.solution.positive_ranges(), resolver.solution.decisions()
+    )
+
+    assert choose_package_to_decide(resolver) == 10

--- a/nab-resolver/tests/test_candidate_query_feedback.py
+++ b/nab-resolver/tests/test_candidate_query_feedback.py
@@ -1,0 +1,162 @@
+"""Exercise contextual feedback on a finite dependency conflict with unrelated leaves."""
+
+from collections.abc import Iterable, Mapping, Sequence
+from enum import Enum
+from typing import cast
+
+import pytest
+
+from nab_resolver.candidate_provider import (
+    CandidateProvider,
+    CandidateRequirement,
+    PreparedCandidate,
+)
+from nab_resolver.ranges import Range
+from nab_resolver.resolver import Resolver
+from nab_resolver.types import RangeProtocol
+
+
+class Package(Enum):
+    APP = "app"
+    PARQUET = "fastparquet"
+    FILES = "fsspec"
+    API = "opentelemetry-api"
+    COMMON = "opentelemetry-exporter-otlp-proto-common"
+    GRPC = "opentelemetry-exporter-otlp-proto-grpc"
+    HTTP = "opentelemetry-exporter-otlp-proto-http"
+    SDK = "opentelemetry-sdk"
+    PACKAGING = "packaging"
+    SODA = "soda-core"
+    DUCK = "soda-core-duckdb"
+
+
+class Dependency:
+    """Retain a dependency's constraint and its host ordering category."""
+
+    __slots__ = ("constraint", "package", "priority")
+
+    def __init__(
+        self, package: Package, constraint: Range[int], *, priority: int
+    ) -> None:
+        self.package = package
+        self.constraint = constraint
+        self.priority = priority
+
+    def bind(self) -> CandidateRequirement[Package, int]:
+        """Keep the host's ordering category beside the solver restriction."""
+        return CandidateRequirement(self.package, self.constraint, self)
+
+
+def pin(package: Package, version: int) -> Dependency:
+    """Give exact requirements the first host priority category."""
+    return Dependency(package, Range.singleton(version), priority=0)
+
+
+def bounded(package: Package, low: int, high: int) -> Dependency:
+    """Represent an upper-bounded requirement without making it an exact pin."""
+    return Dependency(package, Range.at_least(low) & Range.less_than(high), priority=1)
+
+
+def free(package: Package) -> Dependency:
+    """Leave a leaf's versions unconstrained and last in host order."""
+    return Dependency(package, Range.full(), priority=2)
+
+
+class GraphHost:
+    """Prepare newest candidates from active requests while retaining real dependency records."""
+
+    def __init__(self, *, shared_dependency: bool) -> None:
+        app = [pin(Package.PARQUET, 1), bounded(Package.DUCK, 1, 2)]
+        if shared_dependency:
+            app.append(bounded(Package.GRPC, 116, 200))
+        app.append(bounded(Package.HTTP, 116, 200))
+        self.graph = {
+            Package.APP: {1: app},
+            Package.PARQUET: {1: [free(Package.FILES), free(Package.PACKAGING)]},
+            Package.FILES: {version: [] for version in (1, 2, 3)},
+            Package.PACKAGING: {version: [] for version in (1, 2, 3)},
+            Package.DUCK: {1: [pin(Package.SODA, 1)]},
+            Package.SODA: {
+                1: [bounded(Package.API, 116, 123), bounded(Package.HTTP, 116, 123)]
+            },
+            Package.API: {version: [] for version in (122, 134)},
+            Package.SDK: {
+                version: [pin(Package.API, version)] for version in (122, 134)
+            },
+        }
+        for package in (
+            (Package.HTTP, Package.GRPC) if shared_dependency else (Package.HTTP,)
+        ):
+            self.graph[package] = {}
+            for version in (122, 134):
+                dependencies = [bounded(Package.API, 115, 200)]
+                if shared_dependency:
+                    dependencies.append(pin(Package.COMMON, version))
+                dependencies.append(bounded(Package.SDK, version, version + 1))
+                self.graph[package][version] = dependencies
+        if shared_dependency:
+            self.graph[Package.COMMON] = {version: [] for version in (122, 134)}
+
+    def iter_candidates(
+        self,
+        package: Package,
+        allowed: RangeProtocol[int],
+        requirements: Mapping[Package, Sequence[CandidateRequirement[Package, int]]],
+    ) -> Iterable[PreparedCandidate[int]]:
+        """Yield catalog candidates admitted by the active original requests."""
+        if package not in requirements:
+            return
+        for version in sorted(self.graph[package], reverse=True):
+            if all(
+                version in requirement.constraint
+                for requirement in requirements[package]
+            ):
+                yield PreparedCandidate(version, (package, version))
+
+    def get_dependencies(
+        self, candidate: PreparedCandidate[int]
+    ) -> Iterable[CandidateRequirement[Package, int]]:
+        """Bind the selected catalog entry's dependency declarations."""
+        package, version = cast("tuple[Package, int]", candidate.origin)
+        return (dependency.bind() for dependency in self.graph[package][version])
+
+    def priority(
+        self,
+        package: Package,
+        requirements: Mapping[Package, Sequence[CandidateRequirement[Package, int]]],
+    ) -> tuple[int, str]:
+        """Prefer pins and upper bounds, then use the package's stable label."""
+        priorities = (
+            cast("Dependency", requirement.origin).priority
+            for requirement in requirements.get(package, ())
+        )
+        return min(priorities, default=2), package.value
+
+
+@pytest.mark.parametrize("shared_dependency", [False, True])
+def test_feedback_limits_unrelated_version_enumeration(shared_dependency: bool) -> None:
+    host = GraphHost(shared_dependency=shared_dependency)
+    roots = [pin(Package.APP, 1).bind()]
+    ordinary = CandidateProvider(host, roots)
+    guided = CandidateProvider(host, roots, query_feedback=True)
+    baseline = Resolver(ordinary, availability_generation=lambda: 0)
+    resolver = Resolver(guided, availability_generation=lambda: 0)
+
+    expected = {package: max(versions) for package, versions in host.graph.items()}
+    for package in (
+        Package.API,
+        Package.SDK,
+        Package.HTTP,
+        Package.COMMON,
+        Package.GRPC,
+    ):
+        if package in expected:
+            expected[package] = 122
+    assert baseline.solve(ordinary.root_requirements()).pins == expected
+    assert resolver.solve(guided.root_requirements()).pins == expected
+    assert resolver.stats.decisions <= 128
+    assert resolver.stats.decisions < baseline.stats.decisions
+
+    first_decisions = resolver.stats.decisions
+    assert resolver.solve(guided.root_requirements()).pins == expected
+    assert resolver.stats.decisions == first_decisions

--- a/nab-resolver/tests/test_contextual_failure_hooks.py
+++ b/nab-resolver/tests/test_contextual_failure_hooks.py
@@ -1,0 +1,135 @@
+"""Check optional failure notifications against the real decision queue and solve lifecycle."""
+
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+
+from nab_resolver.decide import choose_package_to_decide, record_contextual_no_versions
+from nab_resolver.errors import ResolutionError
+from nab_resolver.propagate import unit_propagation
+from nab_resolver.ranges import Range
+from nab_resolver.resolver import BaseProvider, Resolver
+from nab_resolver.root import ROOT
+from nab_resolver.types import RangeProtocol, RootRequirement
+
+
+class OrderingProvider(BaseProvider[str, int]):
+    """Change package order only when a failure notification requests it."""
+
+    def __init__(self, *, change_priority: bool = True) -> None:
+        self.change_priority = change_priority
+        self.failures: list[str] = []
+        self.beginnings = 0
+
+    def begin_resolution(self) -> None:
+        self.beginnings += 1
+        self.failures.clear()
+
+    def receive_contextual_failure(self, package: str) -> bool:
+        self.failures.append(package)
+        return self.change_priority
+
+    def choose_version(self, package: str, version_range: RangeProtocol[int]) -> int | None:
+        return 1 if package != "missing" and 1 in version_range else None
+
+    def has_satisfying_version(self, package: str, version_range: RangeProtocol[int]) -> bool:
+        return package != "missing" and 1 in version_range
+
+    def get_dependencies(self, package: str, version: int) -> Mapping[str, Range[int]]:
+        return {"missing": Range.full()} if package == "app" else {}
+
+    def prioritize(
+        self,
+        package: str,
+        version_range: RangeProtocol[int],
+        conflict_counts: Mapping[str, int],
+        culprit_counts: Mapping[str, int] | None = None,
+    ) -> int:
+        prefer_second = self.change_priority and bool(self.failures)
+        return int(package != ("second" if prefer_second else "first"))
+
+    def widen_decision(self, package: str, version: int) -> None:
+        return None
+
+
+@pytest.mark.parametrize("change_priority", [False, True])
+def test_notification_invalidates_cached_order_only_when_requested(
+    change_priority: bool,
+) -> None:
+    provider = OrderingProvider(change_priority=change_priority)
+    resolver = Resolver(provider)
+    resolver._reset(None)
+    resolver._add_root_requirements(
+        [RootRequirement(name, Range.full()) for name in ("guard", "first", "second")]
+    )
+    assert unit_propagation(resolver, ROOT) is None
+    resolver.solution.decide("guard", 1)
+    assert choose_package_to_decide(resolver) == "first"
+    before = resolver.priority_epoch
+
+    record_contextual_no_versions(resolver, "missing")
+
+    assert provider.failures == ["missing"]
+    assert resolver.priority_epoch == before + int(change_priority)
+    assert choose_package_to_decide(resolver) == (
+        "second" if change_priority else "first"
+    )
+
+
+def test_notifications_use_the_replacement_provider() -> None:
+    original = OrderingProvider()
+    replacement = OrderingProvider()
+    resolver = Resolver(original)
+    resolver.provider = replacement
+    resolver._reset(None)
+    resolver._add_root_requirements([RootRequirement("guard", Range.full())])
+    resolver.solution.decide("guard", 1)
+
+    record_contextual_no_versions(resolver, "missing")
+
+    assert original.beginnings == 0
+    assert original.failures == []
+    assert replacement.beginnings == 1
+    assert replacement.failures == ["missing"]
+
+
+class LegacyProvider:
+    """Expose the original provider protocol without either optional notification."""
+
+    def __init__(self) -> None:
+        self.inner = OrderingProvider()
+
+    def __getattr__(self, name: str) -> Any:
+        if name in {"begin_resolution", "receive_contextual_failure"}:
+            raise AttributeError(name)
+        return getattr(self.inner, name)
+
+
+def test_structural_provider_can_omit_notifications() -> None:
+    provider = LegacyProvider()
+    resolver = Resolver(provider, availability_generation=lambda: 0)
+    with pytest.raises(ResolutionError):
+        resolver.solve({"app": Range.full()})
+    assert provider.inner.beginnings == 0
+    assert provider.inner.failures == []
+
+
+def test_unguarded_absence_sends_no_contextual_notification() -> None:
+    provider = OrderingProvider()
+    resolver = Resolver(provider, availability_generation=lambda: 0)
+    with pytest.raises(ResolutionError):
+        resolver.solve({"missing": Range.full()})
+    assert provider.beginnings == 1
+    assert provider.failures == []
+
+
+def test_backjump_does_not_begin_another_resolution() -> None:
+    provider = OrderingProvider()
+    resolver = Resolver(provider, availability_generation=lambda: 0)
+    for count in (1, 2):
+        with pytest.raises(ResolutionError):
+            resolver.solve({"app": Range.full()})
+        assert resolver.stats.conflicts > 0
+        assert provider.beginnings == count
+        assert provider.failures == ["missing"]

--- a/nab-resolver/tests/test_contextual_failure_hooks.py
+++ b/nab-resolver/tests/test_contextual_failure_hooks.py
@@ -1,7 +1,7 @@
 """Check optional failure notifications against the real decision queue and solve lifecycle."""
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -9,7 +9,7 @@ from nab_resolver.decide import choose_package_to_decide, record_contextual_no_v
 from nab_resolver.errors import ResolutionError
 from nab_resolver.propagate import unit_propagation
 from nab_resolver.ranges import Range
-from nab_resolver.resolver import BaseProvider, Resolver
+from nab_resolver.resolver import BaseProvider, Resolver, ResolverProvider
 from nab_resolver.root import ROOT
 from nab_resolver.types import RangeProtocol, RootRequirement
 
@@ -30,10 +30,14 @@ class OrderingProvider(BaseProvider[str, int]):
         self.failures.append(package)
         return self.change_priority
 
-    def choose_version(self, package: str, version_range: RangeProtocol[int]) -> int | None:
+    def choose_version(
+        self, package: str, version_range: RangeProtocol[int]
+    ) -> int | None:
         return 1 if package != "missing" and 1 in version_range else None
 
-    def has_satisfying_version(self, package: str, version_range: RangeProtocol[int]) -> bool:
+    def has_satisfying_version(
+        self, package: str, version_range: RangeProtocol[int]
+    ) -> bool:
         return package != "missing" and 1 in version_range
 
     def get_dependencies(self, package: str, version: int) -> Mapping[str, Range[int]]:
@@ -77,30 +81,34 @@ def test_notification_invalidates_cached_order_only_when_requested(
     )
 
 
-def test_notifications_use_the_replacement_provider() -> None:
+@pytest.mark.parametrize("replace_before_start", [False, True])
+def test_notifications_use_the_replacement_provider(replace_before_start: bool) -> None:
     original = OrderingProvider()
     replacement = OrderingProvider()
     resolver = Resolver(original)
-    resolver.provider = replacement
+    if replace_before_start:
+        resolver.provider = replacement
     resolver._reset(None)
     resolver._add_root_requirements([RootRequirement("guard", Range.full())])
     resolver.solution.decide("guard", 1)
+    resolver.provider = replacement
 
     record_contextual_no_versions(resolver, "missing")
 
-    assert original.beginnings == 0
+    assert original.beginnings == int(not replace_before_start)
     assert original.failures == []
-    assert replacement.beginnings == 1
+    assert replacement.beginnings == int(replace_before_start)
     assert replacement.failures == ["missing"]
 
 
 class LegacyProvider:
-    """Expose the original provider protocol without either optional notification."""
+    """Delegate provider operations while omitting optional notifications."""
 
     def __init__(self) -> None:
         self.inner = OrderingProvider()
 
     def __getattr__(self, name: str) -> Any:
+        """Delegate required operations while leaving notifications absent."""
         if name in {"begin_resolution", "receive_contextual_failure"}:
             raise AttributeError(name)
         return getattr(self.inner, name)
@@ -108,7 +116,9 @@ class LegacyProvider:
 
 def test_structural_provider_can_omit_notifications() -> None:
     provider = LegacyProvider()
-    resolver = Resolver(provider, availability_generation=lambda: 0)
+    resolver = Resolver(
+        cast("ResolverProvider[str, int]", provider), availability_generation=lambda: 0
+    )
     with pytest.raises(ResolutionError):
         resolver.solve({"app": Range.full()})
     assert provider.inner.beginnings == 0


### PR DESCRIPTION
With contextual-query feedback enabled, both pip prototypes resolve `datacontract-cli==0.10.10` in about eight to nine seconds; their revisions before feedback hit the two-minute limit. Pip main completes in about thirteen seconds. All successful plans select the same 84 distributions. These are single runs with initially empty private pip caches on Debian 12.10 / CPython 3.11.2, with upload cutoff `2025-06-08T17:23:33Z`.

`CandidateProvider(..., query_feedback=True)` credits a guarded absence to the queried package and each currently decided package whose cached declarations require it. Ordering compares parent failure counts, target failure counts, then the host priority. The default returns the host priority directly.

- Feedback resets for each solve and survives its backtracks and restarts.
- Optional `begin_resolution()` and `receive_contextual_failure(package)` hooks handle initialization and priority-cache invalidation. Structural providers may omit both hooks.

Stacked on #1198.
