### PR TITLE
Avoid counting snapshot entries for truthiness

### DIFF
--- a/nab-resolver/src/nab_resolver/partial_solution.py
+++ b/nab-resolver/src/nab_resolver/partial_solution.py
@@ -149,6 +149,15 @@ class _Snapshot(Mapping[PackageType, _ValueType]):
     def __len__(self) -> int:
         return sum(1 for _ in self)
 
+    def __bool__(self) -> bool:
+        """Test an untouched snapshot in constant time, otherwise stop at a key."""
+        shadow = self._shadow
+        if not shadow:
+            return bool(self._live)
+        if any(value is not _ABSENT for value in shadow.values()):
+            return True
+        return any(package not in shadow for package in self._live)
+
 
 def _take_snapshot(
     live: dict[PackageType, _ValueType],

--- a/nab-resolver/tests/test_partial_solution.py
+++ b/nab-resolver/tests/test_partial_solution.py
@@ -403,6 +403,40 @@ class TestContradictionEpoch:
 class TestSnapshots:
     """A map handed out keeps reading as it did when it was taken."""
 
+    def test_truthiness_stays_pinned_across_decisions_and_backtracking(self) -> None:
+        ps = PartialSolution()
+        empty = ps.decisions()
+        assert not empty
+
+        ps.decide("foo", 0)
+        populated = ps.decisions()
+        assert populated
+        assert not empty
+
+        ps.decide("bar", 1)
+        assert populated
+        assert not empty
+
+        ps.decide("foo", 2)
+        assert populated
+        assert populated["foo"] == 0
+
+        ps.backtrack(0)
+        assert populated
+        assert not empty
+        assert not ps.decisions()
+
+    def test_truthiness_counts_packages_with_empty_ranges(self) -> None:
+        ps = PartialSolution()
+        inc = Incompatibility([], cause=IncompatibilityCause.ROOT)
+        ps.derive("foo", Range.empty(), positive=True, cause=inc)
+        snapshot = ps.positive_ranges()
+        assert snapshot
+
+        ps.derive("foo", Range.full(), positive=True, cause=inc)
+        assert snapshot
+        assert snapshot["foo"].is_empty
+
     def test_a_snapshot_does_not_show_a_later_decision(self) -> None:
         ps = PartialSolution()
         ps.decide("foo", 3)


### PR DESCRIPTION
Testing a partial-solution snapshot for truthiness currently calls __len__, which walks every entry. Add __bool__ so an untouched or detached snapshot reads the live dictionary’s truthiness in constant time. A snapshot with frozen entries stops once it finds a package present at capture time.

Tests cover empty and populated snapshots across later decisions and backtracking, including falsey versions and empty range values.

Validation: 487 resolver tests and 3 partial-solution property tests passed; resolver branch coverage is 100%; Ruff lint and formatting checks passed. No end-to-end performance claim is made.