### PR TITLE
Refresh provider hints before package priority scans

### DIFF
--- a/nab-resolver/src/nab_resolver/decide.py
+++ b/nab-resolver/src/nab_resolver/decide.py
@@ -17,7 +17,7 @@ from .types import Incompatibility, IncompatibilityCause, RangeProtocol, Term
 if TYPE_CHECKING:
     from collections.abc import Set as AbstractSet
 
-    from .resolver import Resolver
+    from .resolver import Resolver, ResolverProvider
 
 __all__ = [
     "absorb_pending_clauses",
@@ -25,6 +25,7 @@ __all__ = [
     "choose_package_to_decide",
     "choose_version",
     "record_no_versions",
+    "refresh_provider_hint",
 ]
 
 
@@ -93,12 +94,18 @@ def choose_package_to_decide(
     )
 
 
-def choose_version(resolver: Resolver[Any, Any], package: Any) -> Any | None:
+def choose_version(
+    resolver: Resolver[Any, Any],
+    package: Any,
+    *,
+    hinted_provider: ResolverProvider[Any, Any] | None = None,
+) -> Any | None:
     """Ask the provider to pick a version within the allowed range.
 
     A user constraint narrows the acceptable range here rather than acting
     as an incompatibility: it restricts which version is picked but never
-    forces the package into the solution.
+    forces the package into the solution. A provider already refreshed for
+    this decision phase needs no second hint.
     """
     current_range = resolver.solution.get(package) or resolver.range_type.full()
     constraint = resolver.constraints.get(package)
@@ -106,15 +113,23 @@ def choose_version(resolver: Resolver[Any, Any], package: Any) -> Any | None:
         current_range = current_range & constraint
 
     provider = resolver.provider
-    # The hint costs two snapshots of the solution, so it is skipped for the
-    # provider whose hook is ``BaseProvider``'s discarding no-op.
+    if provider is not hinted_provider:
+        refresh_provider_hint(resolver)
+    return provider.choose_version(package, current_range)
+
+
+def refresh_provider_hint(resolver: Resolver[Any, Any]) -> ResolverProvider[Any, Any]:
+    """Return the current provider, delivering snapshots unless its hint is a no-op."""
+    provider = resolver.provider
+
+    # The inherited no-op cannot read either snapshot.
     if provider is not resolver._hint_ignoring_provider:  # noqa: SLF001
         provider.receive_partial_solution_hint(
             resolver.solution.positive_ranges(),
             resolver.solution.decisions(),
         )
 
-    return provider.choose_version(package, current_range)
+    return provider
 
 
 def _normalize_terms(

--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -241,8 +241,9 @@ class ResolverProvider(Protocol[PackageType, VersionType]):
     ) -> None:
         """Accept a snapshot of positive ranges and decisions.
 
-        Called before ``choose_version`` so providers can forward-check the
-        candidate's dependencies against accumulated constraints.
+        Delivered after propagation when undecided packages remain, before
+        availability refresh and package ordering. The following version query
+        uses the same snapshot unless the provider is replaced.
         ``decisions`` is the subset with concrete versions (not derivations);
         decision-based reasoning is safer because decisions cannot be undone
         in isolation.  Default is a no-op.
@@ -816,6 +817,12 @@ class Resolver(Generic[PackageType, VersionType]):
                 continue
 
             # Phase 3: Decision making.
+            hinted_provider = (
+                decide.refresh_provider_hint(self)
+                if self.solution.undecided_packages()
+                else None
+            )
+
             deferred = self.deferred
             if deferred is not None:
                 deferred.refresh(self.stats.derivations, self.stats.decisions)
@@ -833,7 +840,9 @@ class Resolver(Generic[PackageType, VersionType]):
                     continue
                 return self._build_result()
 
-            changed_package = self._decide_next(next_package)
+            changed_package = self._decide_next(
+                next_package, hinted_provider=hinted_provider
+            )
 
         exceeded_message = f"Resolution exceeded {self.max_iterations} iterations"
         raise ResolutionError(exceeded_message)
@@ -864,9 +873,16 @@ class Resolver(Generic[PackageType, VersionType]):
             changed_package = ROOT
         return changed_package, restart_threshold, restarts_remaining
 
-    def _decide_next(self, next_package: Any) -> Any:
+    def _decide_next(
+        self,
+        next_package: Any,
+        *,
+        hinted_provider: ResolverProvider[Any, Any] | None = None,
+    ) -> Any:
         """Run the decision phase for ``next_package``. Return next changed package."""
-        chosen_version = decide.choose_version(self, next_package)
+        chosen_version = decide.choose_version(
+            self, next_package, hinted_provider=hinted_provider
+        )
         had_pending = decide.absorb_pending_clauses(self)
 
         # Provider-driven force back-track. When the provider returns

--- a/nab-resolver/tests/test_decide.py
+++ b/nab-resolver/tests/test_decide.py
@@ -610,6 +610,21 @@ class TestThePartialSolutionHint:
 
         assert len(recorder.hints) == 1
 
+    def test_a_provider_replaced_after_the_phase_hint_receives_its_own(self) -> None:
+        first = _HintRecordingProvider()
+        replacement = _HintRecordingProvider()
+        resolver, solution = _counting_resolver(first)
+        hinted_provider = decide.refresh_provider_hint(resolver)
+        resolver.provider = replacement
+
+        assert (
+            decide.choose_version(resolver, "b", hinted_provider=hinted_provider) == 1
+        )
+
+        assert len(first.hints) == 1
+        assert replacement.hints == first.hints
+        assert solution.snapshots_taken == 4
+
     def test_a_hint_installed_between_resolves_is_honoured(self) -> None:
         """The answer is re-asked per resolve, not kept from the one before."""
         hints: list[tuple[Mapping[Any, RangeProtocol[int]], Mapping[Any, int]]] = []

--- a/nab-resolver/tests/test_deferred_availability.py
+++ b/nab-resolver/tests/test_deferred_availability.py
@@ -12,7 +12,7 @@ import pytest
 from nab_resolver._compat import override
 from nab_resolver.errors import ResolutionError
 from nab_resolver.ranges import Range
-from nab_resolver.resolver import BaseProvider, Resolver
+from nab_resolver.resolver import BaseProvider, Resolver, ResolverProvider
 from nab_resolver.types import (
     Incompatibility,
     IncompatibilityCause,
@@ -329,11 +329,16 @@ class ActionTraceResolver(Resolver[str, int]):
         self.sweeps: list[tuple[list[str], list[str]]] = []
 
     @override
-    def _decide_next(self, next_package: str) -> str:
+    def _decide_next(
+        self,
+        next_package: str,
+        *,
+        hinted_provider: ResolverProvider[str, int] | None = None,
+    ) -> str:
         assert self.deferred is not None
         before = list(self.deferred.packages)
         emitted = self.action_provider.emitted
-        result = super()._decide_next(next_package)
+        result = super()._decide_next(next_package, hinted_provider=hinted_provider)
         if self.action_provider.emitted and not emitted:
             self.sweeps.append((before, list(self.deferred.packages)))
         return result

--- a/nab-resolver/tests/test_hint_phase.py
+++ b/nab-resolver/tests/test_hint_phase.py
@@ -22,7 +22,7 @@ class PinFirstHost:
         self.parent = PreparedCandidate(1, object())
         self.child = PreparedCandidate(1, object())
         self.competitor = PreparedCandidate(1, object())
-        self.dependency = CandidateRequirement(20, Range.singleton(1), "==1")
+        self.dependency = CandidateRequirement[int, int](20, Range.singleton(1), "==1")
         self.queries: list[int] = []
 
     def iter_candidates(

--- a/nab-resolver/tests/test_hint_phase.py
+++ b/nab-resolver/tests/test_hint_phase.py
@@ -1,0 +1,131 @@
+"""Keep host requirement snapshots current before deciding package order."""
+
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any
+
+import pytest
+
+from nab_resolver.candidate_provider import (
+    CandidateProvider,
+    CandidateRequirement,
+    PreparedCandidate,
+)
+from nab_resolver.ranges import Range
+from nab_resolver.resolver import Resolver
+from nab_resolver.types import RangeProtocol
+
+
+class PinFirstHost:
+    """Prefer explicit pins, including dependencies of the latest decision."""
+
+    def __init__(self) -> None:
+        self.parent = PreparedCandidate(1, object())
+        self.child = PreparedCandidate(1, object())
+        self.competitor = PreparedCandidate(1, object())
+        self.dependency = CandidateRequirement(20, Range.singleton(1), "==1")
+        self.queries: list[int] = []
+
+    def iter_candidates(
+        self,
+        package: int,
+        allowed: RangeProtocol[int],
+        requirements: Mapping[int, Sequence[CandidateRequirement[int, int]]],
+    ) -> Iterable[PreparedCandidate[int]]:
+        self.queries.append(package)
+        yield {10: self.parent, 20: self.child, 30: self.competitor}[package]
+
+    def get_dependencies(
+        self, candidate: PreparedCandidate[int]
+    ) -> Iterable[CandidateRequirement[int, int]]:
+        if candidate is self.parent:
+            yield self.dependency
+
+    def priority(
+        self,
+        package: int,
+        requirements: Mapping[int, Sequence[CandidateRequirement[int, int]]],
+    ) -> tuple[bool, bool]:
+        active = requirements.get(package, ())
+        return (not any(item.origin == "==1" for item in active), not bool(active))
+
+
+class HintRecorder(CandidateProvider[int, int]):
+    """Retain delivered decisions to compare phase order and snapshot lifetime."""
+
+    def __init__(self, host: PinFirstHost) -> None:
+        super().__init__(
+            host,
+            [
+                CandidateRequirement(10, Range.singleton(1), "==1"),
+                CandidateRequirement(30, Range.full(), ">=1"),
+            ],
+        )
+        self.hints: list[Mapping[Any, int]] = []
+
+    def receive_partial_solution_hint(
+        self,
+        positive_ranges: Mapping[int, RangeProtocol[int]],
+        decisions: Mapping[int, int],
+    ) -> None:
+        self.hints.append(decisions)
+        super().receive_partial_solution_hint(positive_ranges, decisions)
+
+
+@pytest.mark.parametrize("dynamic", [False, True])
+def test_new_parent_pin_precedes_unpinned_competitor(*, dynamic: bool) -> None:
+    host = PinFirstHost()
+    provider = HintRecorder(host)
+    resolver = Resolver(
+        provider, availability_generation=(lambda: 0) if dynamic else None
+    )
+
+    result = resolver.solve(provider.root_requirements())
+
+    assert result.pins == {10: 1, 20: 1, 30: 1}
+    assert host.queries == [10, 20, 30]
+    assert len(provider.hints) == len(host.queries)
+    assert [set(hint) & {10, 20, 30} for hint in provider.hints] == [
+        set(),
+        {10},
+        {10, 20},
+    ]
+
+
+def test_deferred_refresh_reads_the_current_parent_requirements() -> None:
+    host = PinFirstHost()
+    provider = HintRecorder(host)
+    active_checks: list[bool] = []
+    resolvers: list[Resolver[int, int]] = []
+
+    def generation() -> int:
+        """Observe each active refresh without changing availability."""
+        if resolvers and resolvers[0].solution.undecided_packages():
+            expected = 10 in resolvers[0].solution.decisions()
+            active_checks.append((20 in provider.active_requirements()) == expected)
+        return 0
+
+    resolver = Resolver(provider, availability_generation=generation)
+    resolvers.append(resolver)
+    resolver.solve(provider.root_requirements())
+
+    assert active_checks
+    assert all(active_checks)
+
+
+def test_empty_solve_does_not_deliver_a_hint() -> None:
+    host = PinFirstHost()
+    provider = HintRecorder(host)
+    refreshes: list[int] = []
+
+    def generation() -> int:
+        refreshes.append(0)
+        return 0
+
+    resolver = Resolver(provider, availability_generation=generation)
+    before = len(refreshes)
+
+    assert resolver.solve({}).pins == {}
+
+    assert provider.hints == []
+    assert host.queries == []
+    assert len(refreshes) - before == 1


### PR DESCRIPTION
Package priorities can miss dependencies introduced by the latest decision because the provider receives its solution snapshot only when querying a version. A newly pinned dependency can therefore lose priority to an unconstrained package.

Refresh the snapshot after propagation, before availability checks and package ordering. Reuse it for the selected version query, while refreshing a replacement provider and preserving direct query calls. Providers inheriting the default no-op still avoid snapshot construction.

Stacked on #1201.
