### PR TITLE
Avoid rescanning snapshot entries for truthiness

### DIFF
--- a/nab-resolver/src/nab_resolver/partial_solution.py
+++ b/nab-resolver/src/nab_resolver/partial_solution.py
@@ -150,11 +150,11 @@ class _Snapshot(Mapping[PackageType, _ValueType]):
         return sum(1 for _ in self)
 
     def __bool__(self) -> bool:
-        """Test an untouched snapshot in constant time, otherwise stop at a key."""
+        """Return whether the snapshot contains any packages."""
         shadow = self._shadow
         if not shadow:
             return bool(self._live)
-        for package in self._live:  # noqa: SIM110 - avoid yielding a boolean for every absent key
+        for package in self._live:
             if shadow.get(package, _UNSET) is not _ABSENT:
                 return True
         return False

--- a/nab-resolver/src/nab_resolver/partial_solution.py
+++ b/nab-resolver/src/nab_resolver/partial_solution.py
@@ -154,9 +154,10 @@ class _Snapshot(Mapping[PackageType, _ValueType]):
         shadow = self._shadow
         if not shadow:
             return bool(self._live)
-        if any(value is not _ABSENT for value in shadow.values()):
-            return True
-        return any(package not in shadow for package in self._live)
+        for package in self._live:  # noqa: SIM110 - avoid yielding a boolean for every absent key
+            if shadow.get(package, _UNSET) is not _ABSENT:
+                return True
+        return False
 
 
 def _take_snapshot(

--- a/nab-resolver/tests/test_partial_solution.py
+++ b/nab-resolver/tests/test_partial_solution.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import gc
+from collections import UserDict
+from collections.abc import Iterator
 from typing import Any
 
 import pytest
@@ -17,6 +19,20 @@ from nab_resolver.types import Incompatibility, IncompatibilityCause, Term
 _CAUSE: Incompatibility[str, int] = Incompatibility(
     [Term("foo", Range.at_least(2))], cause=IncompatibilityCause.NO_VERSIONS
 )
+
+
+class CountingSnapshotMap(UserDict[str, Any]):
+    """Count entries visited through key or value iteration in a snapshot map."""
+
+    def __init__(self, entries: dict[str, Any]) -> None:
+        super().__init__(entries)
+        self.visits = 0
+
+    def __iter__(self) -> Iterator[str]:
+        """Yield keys and count each visit."""
+        for key in super().__iter__():
+            self.visits += 1
+            yield key
 
 
 class TestAssignments:
@@ -402,6 +418,47 @@ class TestContradictionEpoch:
 
 class TestSnapshots:
     """A map handed out keeps reading as it did when it was taken."""
+
+    def test_empty_snapshot_truthiness_scans_at_most_one_map(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        ps = PartialSolution()
+        snapshot = ps.decisions()
+        assert isinstance(snapshot, partial_solution._Snapshot)
+        for index in range(8):
+            ps.decide(str(index), 0)
+
+        live = CountingSnapshotMap(snapshot._live)
+        shadow = CountingSnapshotMap(snapshot._shadow)
+        monkeypatch.setattr(snapshot, "_live", live)
+        monkeypatch.setattr(snapshot, "_shadow", shadow)
+
+        assert not snapshot
+        assert live.visits + shadow.visits <= 8
+
+    @pytest.mark.parametrize("initial_count", [0, 1, 32])
+    def test_truthiness_after_many_later_decisions(self, initial_count: int) -> None:
+        ps = PartialSolution()
+        for index in range(initial_count):
+            ps.decide(str(index), 0)
+        decisions = ps.decisions()
+        ranges = ps.positive_ranges()
+
+        for index in range(initial_count, initial_count + 32):
+            ps.decide(str(index), 1)
+        for index in range(initial_count):
+            ps.decide(str(index), 2)
+
+        assert bool(decisions) == bool(initial_count)
+        assert bool(ranges) == bool(initial_count)
+        assert dict(decisions) == dict.fromkeys(map(str, range(initial_count)), 0)
+
+        ps.backtrack(0)
+
+        assert bool(decisions) == bool(initial_count)
+        assert bool(ranges) == bool(initial_count)
+        assert not ps.decisions()
+        assert not ps.positive_ranges()
 
     def test_truthiness_stays_pinned_across_decisions_and_backtracking(self) -> None:
         ps = PartialSolution()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -389,6 +389,7 @@ ignore = [
     "ANN401",  # Disallows Any (needed for generic library)
     "CPY001",  # Copyright notice per file; the licence sits at the repo root.
     "S101",    # Assert usage (needed for type narrowing and tests)
+    "SIM110",  # Allow explicit loops in place of any/all.
     "TID252",  # Bans relative imports; the project prefers them.
 ]
 


### PR DESCRIPTION
Walk live keys once and stop at the first package present when the snapshot was taken. Removing the generators also avoids a closure allocation on the untouched-snapshot path.