### PR TITLE
Release 0.0.17

### DIFF
--- a/nab-index/pyproject.toml
+++ b/nab-index/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nab-index"
-version = "0.0.17"
+version = "0.0.18.dev0"
 description = "PyPI Simple-API client and on-disk cache for nab"
 readme = "README.md"
 license = "MIT"
@@ -20,7 +20,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "nab-provider==0.0.17",
+    "nab-provider==0.0.18.dev0",
     "packaging>=24.0",
     "truststore>=0.10",
     "typing_extensions>=4.6",

--- a/nab-index/pyproject.toml
+++ b/nab-index/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nab-index"
-version = "0.0.17.dev0"
+version = "0.0.17"
 description = "PyPI Simple-API client and on-disk cache for nab"
 readme = "README.md"
 license = "MIT"
@@ -20,7 +20,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "nab-provider==0.0.17.dev0",
+    "nab-provider==0.0.17",
     "packaging>=24.0",
     "truststore>=0.10",
     "typing_extensions>=4.6",

--- a/nab-index/src/nab_index/_version.py
+++ b/nab-index/src/nab_index/_version.py
@@ -1,3 +1,3 @@
 """The lockstep workspace version, written by ``tasks/release.py``."""
 
-__version__ = "0.0.17"
+__version__ = "0.0.18.dev0"

--- a/nab-index/src/nab_index/_version.py
+++ b/nab-index/src/nab_index/_version.py
@@ -1,3 +1,3 @@
 """The lockstep workspace version, written by ``tasks/release.py``."""
 
-__version__ = "0.0.17.dev0"
+__version__ = "0.0.17"

--- a/nab-markersets/pyproject.toml
+++ b/nab-markersets/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nab-markersets"
-version = "0.0.17.dev0"
+version = "0.0.17"
 description = "PEP 508 marker algebra: markers as sets of environments"
 readme = "README.md"
 license = "MIT"
@@ -29,7 +29,7 @@ classifiers = [
 # says whether one did.
 [project.optional-dependencies]
 packaging = ["packaging>=26.3"]
-nab-vendored-packaging = ["nab-provider==0.0.17.dev0"]
+nab-vendored-packaging = ["nab-provider==0.0.17"]
 
 [project.urls]
 Homepage = "https://github.com/notatallshaw/nab"

--- a/nab-markersets/pyproject.toml
+++ b/nab-markersets/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nab-markersets"
-version = "0.0.17"
+version = "0.0.18.dev0"
 description = "PEP 508 marker algebra: markers as sets of environments"
 readme = "README.md"
 license = "MIT"
@@ -29,7 +29,7 @@ classifiers = [
 # says whether one did.
 [project.optional-dependencies]
 packaging = ["packaging>=26.3"]
-nab-vendored-packaging = ["nab-provider==0.0.17"]
+nab-vendored-packaging = ["nab-provider==0.0.18.dev0"]
 
 [project.urls]
 Homepage = "https://github.com/notatallshaw/nab"

--- a/nab-project/pyproject.toml
+++ b/nab-project/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nab-project"
-version = "0.0.17"
+version = "0.0.18.dev0"
 description = "Index-backed provider, lockfile emitter, and downloader for nab"
 readme = "README.md"
 license = "MIT"
@@ -20,10 +20,10 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "nab-markersets==0.0.17",
-    "nab-provider==0.0.17",
-    "nab-resolver==0.0.17",
-    "nab-index==0.0.17",
+    "nab-markersets==0.0.18.dev0",
+    "nab-provider==0.0.18.dev0",
+    "nab-resolver==0.0.18.dev0",
+    "nab-index==0.0.18.dev0",
     # fetch.py normalises a name for nab-index's API, which is typed in
     # released packaging's NormalizedName.
     "packaging>=24.0",

--- a/nab-project/pyproject.toml
+++ b/nab-project/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nab-project"
-version = "0.0.17.dev0"
+version = "0.0.17"
 description = "Index-backed provider, lockfile emitter, and downloader for nab"
 readme = "README.md"
 license = "MIT"
@@ -20,10 +20,10 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "nab-markersets==0.0.17.dev0",
-    "nab-provider==0.0.17.dev0",
-    "nab-resolver==0.0.17.dev0",
-    "nab-index==0.0.17.dev0",
+    "nab-markersets==0.0.17",
+    "nab-provider==0.0.17",
+    "nab-resolver==0.0.17",
+    "nab-index==0.0.17",
     # fetch.py normalises a name for nab-index's API, which is typed in
     # released packaging's NormalizedName.
     "packaging>=24.0",

--- a/nab-provider/pyproject.toml
+++ b/nab-provider/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nab-provider"
-version = "0.0.17.dev0"
+version = "0.0.17"
 description = "IO-free resolution core for nab"
 readme = "README.md"
 license = "MIT"
@@ -23,8 +23,8 @@ classifiers = [
 # a config file. A host that supplies its own IO takes this, the solver and the
 # marker algebra, and none of nab's HTTP client, cache, or build machinery.
 dependencies = [
-    "nab-markersets==0.0.17.dev0",
-    "nab-resolver==0.0.17.dev0",
+    "nab-markersets==0.0.17",
+    "nab-resolver==0.0.17",
     "typing_extensions>=4.6",
 ]
 

--- a/nab-provider/pyproject.toml
+++ b/nab-provider/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nab-provider"
-version = "0.0.17"
+version = "0.0.18.dev0"
 description = "IO-free resolution core for nab"
 readme = "README.md"
 license = "MIT"
@@ -23,8 +23,8 @@ classifiers = [
 # a config file. A host that supplies its own IO takes this, the solver and the
 # marker algebra, and none of nab's HTTP client, cache, or build machinery.
 dependencies = [
-    "nab-markersets==0.0.17",
-    "nab-resolver==0.0.17",
+    "nab-markersets==0.0.18.dev0",
+    "nab-resolver==0.0.18.dev0",
     "typing_extensions>=4.6",
 ]
 

--- a/nab-resolver/pyproject.toml
+++ b/nab-resolver/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nab-resolver"
-version = "0.0.17"
+version = "0.0.18.dev0"
 description = "Generic PubGrub dependency-resolver core"
 readme = "README.md"
 license = "MIT"

--- a/nab-resolver/pyproject.toml
+++ b/nab-resolver/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nab-resolver"
-version = "0.0.17.dev0"
+version = "0.0.17"
 description = "Generic PubGrub dependency-resolver core"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nab"
-version = "0.0.17.dev0"
+version = "0.0.17"
 description = "PubGrub-based dependency resolver for Python packages"
 readme = "README.md"
 license = "MIT"
@@ -20,17 +20,17 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "nab-resolver==0.0.17.dev0",
-    "nab-markersets==0.0.17.dev0",
-    "nab-provider==0.0.17.dev0",
-    "nab-project==0.0.17.dev0",
-    "nab-index==0.0.17.dev0",
+    "nab-resolver==0.0.17",
+    "nab-markersets==0.0.17",
+    "nab-provider==0.0.17",
+    "nab-project==0.0.17",
+    "nab-index==0.0.17",
     "tomli>=2.2",
     "typing_extensions>=4.6",
 ]
 
 [project.optional-dependencies]
-httpx = ["nab-index[httpx]==0.0.17.dev0"]
+httpx = ["nab-index[httpx]==0.0.17"]
 
 [project.urls]
 Homepage = "https://github.com/notatallshaw/nab"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nab"
-version = "0.0.17"
+version = "0.0.18.dev0"
 description = "PubGrub-based dependency resolver for Python packages"
 readme = "README.md"
 license = "MIT"
@@ -20,17 +20,17 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "nab-resolver==0.0.17",
-    "nab-markersets==0.0.17",
-    "nab-provider==0.0.17",
-    "nab-project==0.0.17",
-    "nab-index==0.0.17",
+    "nab-resolver==0.0.18.dev0",
+    "nab-markersets==0.0.18.dev0",
+    "nab-provider==0.0.18.dev0",
+    "nab-project==0.0.18.dev0",
+    "nab-index==0.0.18.dev0",
     "tomli>=2.2",
     "typing_extensions>=4.6",
 ]
 
 [project.optional-dependencies]
-httpx = ["nab-index[httpx]==0.0.17"]
+httpx = ["nab-index[httpx]==0.0.18.dev0"]
 
 [project.urls]
 Homepage = "https://github.com/notatallshaw/nab"

--- a/src/nab/_version.py
+++ b/src/nab/_version.py
@@ -1,3 +1,3 @@
 """The lockstep workspace version, written by ``tasks/release.py``."""
 
-__version__ = "0.0.17"
+__version__ = "0.0.18.dev0"

--- a/src/nab/_version.py
+++ b/src/nab/_version.py
@@ -1,3 +1,3 @@
 """The lockstep workspace version, written by ``tasks/release.py``."""
 
-__version__ = "0.0.17.dev0"
+__version__ = "0.0.17"


### PR DESCRIPTION
Release all six packages at 0.0.17, then return development to 0.0.18.dev0.

Merge with a merge commit to keep the release commit and `v0.0.17` tag in history. Publishing the tag's GitHub release triggers the PyPI uploads.
