### PR TITLE
Lead the README with installation and explain policy overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,14 @@
 # nab
 
-nab is an experimental dependency locker for Python packages, written in Python. It reads your `pyproject.toml`, finds compatible versions of your dependencies, and writes a PEP 751 `pylock.toml` or pinned requirements. An installer such as pip then installs from that file.
+nab is an experimental dependency locker and download tool for Python
+packages, written in Python but aiming to have similar performance to
+uv on cold resolves.
+
+It reads your `pyproject.toml`, finds compatible versions of your
+dependencies, and writes a PEP 751 `pylock.toml` or pinned requirements.
+An installer such as pip then installs from that file.
 
 Documentation: <https://nab.readthedocs.io/en/stable/>
-
-## Why nab?
-
-### Keep dependency choices in a file
-
-Locking is a separate step from changing your environment. `nab lock` records exact versions, including dependencies of your dependencies, so you can review and commit the result before installing it. Installing from that lock reuses those choices; running `nab lock` again makes a fresh selection and may choose newer releases.
-
-For a single-environment lock, you can also [check the committed file in CI][check-lock].
-
-### Use standard packaging formats
-
-Keep your dependency declarations in the standard `[project]` table of `pyproject.toml`. nab reads Python packaging versions, requirements, and environment markers, and produces a [cross-tool PEP 751 lockfile][lockfiles]. You can also write hashed requirements for pip without changing the project's dependency declarations.
-
-### Choose the environments you support
-
-By default, nab resolves for the Python and platform running nab. You can [declare a different target][resolve-environment], such as the Python used in production, or a matrix of targets for several platforms. Dependency markers and wheel compatibility are evaluated for those targets, and the lock records where it applies.
-
-### Control when builds run
-
-Reading dependency metadata can require running a package's build backend. nab [reads remote sources without building them by default][build-policy]; local checkouts may build when their metadata needs it. If a remote package requires a build, you can opt in for that package. [Direct archives][archive-sources] also require a verified digest.
 
 ## Install
 
@@ -39,7 +25,92 @@ CPython 3.10 and newer.
 
 ## Quick start
 
-Use your existing `pyproject.toml`, or save this small example in a new directory:
+From a directory containing your `pyproject.toml` (or the [example
+below](#example-project)), resolve and write the lock:
+
+```bash
+nab lock pyproject.toml
+```
+
+Open `pylock.toml` to see the selected versions and distribution hashes.
+
+In a virtual environment matching the lock's Python and platform,
+install with pip 26.1 or newer:
+
+```bash
+python -m pip install -r pylock.toml
+```
+
+pip's `pylock.toml` support is experimental. This installs the locked
+dependencies; installing your own project is a separate step. The
+[getting-started tutorial][getting-started] includes environment setup,
+and [Use a lock][use-lock] explains pip's selection limits.
+
+## Why nab?
+
+### Keep dependency choices in a file
+
+Locking is a separate step from changing your environment. `nab lock`
+records exact dependency versions for the environments you resolve,
+so you can review and commit the result before installing it.
+
+For a single-environment lock, you can also [check the committed file in
+CI][check-lock].
+
+### Use standard packaging formats
+
+Keep your dependency declarations in the standard `[project]` table of
+`pyproject.toml`. nab reads Python packaging versions, requirements, and
+environment markers, and produces a [cross-tool PEP 751
+lockfile][lockfiles]. You can also write hashed requirements for pip.
+
+### Choose your target environments explicitly
+
+By default, nab resolves for the Python and platform running nab. You
+can [declare a different target][resolve-environment], such as the
+Python used in production, or a matrix of targets for several platforms.
+Dependency markers and wheel compatibility are evaluated for those
+targets, and the lock records where it applies. If any declared target
+cannot be resolved, nab fails without writing a lock.
+
+### Security via build and VCS policies
+
+Reading dependency metadata can require running a package's build
+backend. nab [reads remote sources without building them by
+default][build-policy]; local checkouts may build when their metadata
+needs it. If a remote package requires a build, you can opt in for that
+package. [Direct archives][archive-sources] also require a verified
+digest.
+
+nab blocks [VCS dependencies][vcs] by default and supports only Git. To
+allow them, set `policy = "allow"` under `[tool.nab.vcs]` and list both
+the permitted URL schemes and repository prefixes in `allowed-schemes`
+and `allowed-repos`. By default, `require-pin = true` requires a full
+40-character commit SHA; branch and tag references are rejected. Declare
+dependencies in `[[tool.nab.vcs-sources]]`. Allowing a repository
+permits cloning and reading static metadata; running its build backend
+still requires opting in to remote builds.
+
+### Override global policies for specific packages and indexes
+
+To keep global policies strict and secure while allowing exceptions for
+specific needs, you can [override global policies][policy-overrides] for
+a package, a version range such as `numpy > 2`, or every package served
+by a named index.
+
+For example, allow remote builds for one package, require wheels for
+selected versions, or set a different upload cutoff for an internal
+index. Use `[tool.nab.packages."numpy > 2"]` for one selector,
+`[[tool.nab.package-rules]]` to share a policy across several, or
+`[tool.nab.index.<name>]` for an index.
+
+Requirement selectors accept package names and version specifiers.
+Fields without an override retain their global defaults.
+
+## Example project
+
+If you do not have a project yet, save this small example as
+`pyproject.toml` in a new directory:
 
 ```toml
 # pyproject.toml
@@ -52,23 +123,14 @@ dependencies = [
 ]
 ```
 
-From that directory, resolve and write the lock:
+Run `nab lock pyproject.toml` from that directory. The constraints above
+must hold together: nab may choose an older FastAPI release to satisfy
+the Starlette limit.
 
-```bash
-nab lock pyproject.toml
-```
+## Write hashed requirements
 
-Open `pylock.toml` to see the selected versions and distribution hashes. The constraints above must hold together: nab may choose an older FastAPI release to satisfy the Starlette limit.
-
-In the virtual environment where you want to use those dependencies, install with pip 26.1 or newer:
-
-```bash
-python -m pip install -r pylock.toml
-```
-
-pip's `pylock.toml` support is experimental. This installs the locked dependencies; installing your own project is a separate step. The [getting-started tutorial][getting-started] includes environment setup, and [Use a lock][use-lock] explains pip's selection limits.
-
-For a project using only index packages, the hashed-requirements alternative is:
+For a single-environment project using only index packages, the
+hashed-requirements alternative is:
 
 ```bash
 nab lock --format requirements pyproject.toml
@@ -77,19 +139,25 @@ python -m pip install --require-hashes -r requirements.txt
 
 This performs a fresh resolve and writes `requirements.txt`.
 
-`--format requirements-without-hashes` omits separate hash lines from index pins; archive URLs keep their digest. See [Output formats][output-formats] before using local, VCS, archive, or multi-target inputs.
+`--format requirements-without-hashes` omits separate hash lines from
+index pins; archive URLs keep their digest. See [Output
+formats][output-formats] before using local, VCS, archive, or
+multi-target inputs.
 
 ## Lock for your deployment targets
 
-If your application uses Python 3.12 on the same platform as nab, select it explicitly:
+If your application uses Python 3.12 on the same platform as nab, select
+it explicitly:
 
 ```bash
 nab lock --python 3.12 pyproject.toml
 ```
 
-`--python` changes the resolve target; it does not install or switch interpreters. Use an environment matching the lock when installing.
+`--python` changes the resolve target; it does not install or switch
+interpreters. Use an environment matching the lock when installing.
 
-To cover Python 3.11 and 3.12 on Linux and macOS, add these tables to your project:
+To cover Python 3.11 and 3.12 on Linux x86-64 and macOS ARM64, add these
+tables to your project:
 
 ```toml
 [tool.nab]
@@ -100,7 +168,11 @@ python = ">=3.11,<3.13"
 platforms = ["linux_x86_64", "macos_arm64"]
 ```
 
-Run `nab lock pyproject.toml` again to write one lock covering those four targets. Versions can differ between targets when compatibility requires it. The multi-target lock format is experimental; [Universal resolution][universal] explains the matrix and how to set minimum operating-system versions.
+Run `nab lock pyproject.toml` again to write one lock covering those
+four targets. Versions can differ between targets when compatibility
+requires it. The multi-target lock format is experimental; [Universal
+resolution][universal] explains the matrix and how to set minimum
+operating-system versions.
 
 ## Libraries
 
@@ -128,7 +200,9 @@ supported inputs and experimental features.
 [lockfiles]: https://nab.readthedocs.io/en/stable/reference/lockfile.html
 [output-formats]: https://nab.readthedocs.io/en/stable/reference/formats.html
 [packages]: https://nab.readthedocs.io/en/stable/explanation/packages.html
+[policy-overrides]: https://nab.readthedocs.io/en/stable/reference/configuration.html#overrides
 [resolve-environment]: https://nab.readthedocs.io/en/stable/reference/configuration.html#the-resolve-environment
 [status]: https://nab.readthedocs.io/en/stable/#status
 [universal]: https://nab.readthedocs.io/en/stable/explanation/universal.html
 [use-lock]: https://nab.readthedocs.io/en/stable/how-to/use-the-lock.html
+[vcs]: https://nab.readthedocs.io/en/stable/how-to/vcs.html

--- a/tests/test_readme_docs.py
+++ b/tests/test_readme_docs.py
@@ -77,6 +77,8 @@ _STABLE_DOCS_LINK = re.compile(rf"{re.escape(_STABLE_DOCS_ROOT)}[^)\s>]*")
 _WHY_DOCS_TARGETS = {
     f"{_STABLE_DOCS_ROOT}reference/build-policy.html",
     f"{_STABLE_DOCS_ROOT}how-to/archive-sources.html",
+    f"{_STABLE_DOCS_ROOT}how-to/vcs.html",
+    f"{_STABLE_DOCS_ROOT}reference/configuration.html#overrides",
     f"{_STABLE_DOCS_ROOT}reference/configuration.html#the-resolve-environment",
     f"{_STABLE_DOCS_ROOT}reference/lockfile.html",
     f"{_STABLE_DOCS_ROOT}reference/lockfile.html#checking-the-lock-in-ci",
@@ -353,8 +355,8 @@ def test_only_the_level_that_builds_index_sdists_names_them(
 
 
 def test_readme_project_is_valid_toml() -> None:
-    """The quick-start project is a minimal PEP 621 project."""
-    blocks = _fenced_blocks(_section(README, "Quick start"), "toml")
+    """The example project is a minimal PEP 621 project."""
+    blocks = _fenced_blocks(_section(README, "Example project"), "toml")
     assert len(blocks) == 1
 
     project = tomli.loads(blocks[0])["project"]


### PR DESCRIPTION
Put installation and a short lock-and-install quick start before the feature overview. Move the sample project and hashed-requirements workflow into their own sections.

Explain VCS admission and per-package, version-range, and per-index policy overrides. Clarify target coverage and examples, and wrap prose at roughly 72 characters.
