### PR TITLE
Use conflict feedback to order host candidates

### DIFF
--- a/docs/how-to/embed-the-resolver.md
+++ b/docs/how-to/embed-the-resolver.md
@@ -213,6 +213,8 @@ Candidate queries also serve diagnostic probes, so preparing or caching a candid
 
 Pass `query_feedback=True` to `CandidateProvider` to prioritize packages involved in contextual query failures. Its key is `(-parent_failures, -target_failures, host_priority)`: each failure credits the queried package and each currently decided package whose cached declarations require it. Multiple declarations from one parent count once. The default, `False`, returns the host's priority directly.
 
+Pass `conflict_feedback=True` to include the shared conflict tier before the host's preference. Packages involved in at least five conflicts are promoted. A culprit with at least five events is demoted only when it leads every other culprit by at least five. With both feedback options enabled, query-parent and query-target counts come first, followed by the conflict tier and the host's preference. Both options default to `False`.
+
 Feedback changes decision order only. Candidate admission, source eligibility and absence guards still follow the host contracts above. Counts start empty for each `Resolver.solve` call and survive backjumps and restarts within that call.
 
 Providers can implement two optional notifications, supplied as no-ops by `BaseProvider`. `begin_resolution()` runs when a solve starts. `receive_contextual_failure(package)` runs before recording a guarded contextual absence and returns `True` if priority keys changed; the resolver then invalidates its cached priorities. It may change only priority state, preserving candidate availability and current decisions. Ordinary unguarded absences and diagnostic probes do not send this notification. Structural providers may omit both methods.
@@ -226,6 +228,7 @@ nab_resolver.candidate_provider
                        CandidateHost, CandidateProvider,
                        CandidateRequirement, PreparedCandidate
 nab_resolver.errors     ResolutionError
+nab_resolver.priority   compute_tier, is_dominant_culprit
 nab_resolver.ranges     Range
 nab_resolver.resolver   BaseProvider, DEFAULT_MAX_ITERATIONS, Resolver,
                         ResolverObserver, ResolverProvider, Solution

--- a/docs/how-to/embed-the-resolver.md
+++ b/docs/how-to/embed-the-resolver.md
@@ -228,7 +228,9 @@ nab_resolver.candidate_provider
                        CandidateHost, CandidateProvider,
                        CandidateRequirement, PreparedCandidate
 nab_resolver.errors     ResolutionError
-nab_resolver.priority   compute_tier, is_dominant_culprit
+nab_resolver.priority   CONFLICT_THRESHOLD, CULPRIT_DEMOTE_THRESHOLD,
+                        TIER_AFFECTED, TIER_CULPRIT, TIER_NORMAL,
+                        compute_tier, is_dominant_culprit
 nab_resolver.ranges     Range
 nab_resolver.resolver   BaseProvider, DEFAULT_MAX_ITERATIONS, Resolver,
                         ResolverObserver, ResolverProvider, Solution

--- a/nab-project/tests/test_provider.py
+++ b/nab-project/tests/test_provider.py
@@ -98,6 +98,7 @@ from nab_provider.tags import PlatformSpec
 from nab_provider.target import ResolveTarget
 from nab_provider.testing import pkg_override
 from nab_resolver.errors import ResolutionError
+from nab_resolver.priority import TIER_CULPRIT, compute_tier
 from nab_resolver.resolver import Resolver
 from nab_resolver.types import (
     Incompatibility,
@@ -12077,11 +12078,6 @@ class TestComputeTier:
     """Cover the tier-decision branches."""
 
     def test_force_backtracked_returns_culprit(self) -> None:
-        from nab_provider._provider.priority import (
-            TIER_CULPRIT,
-            compute_tier,
-        )
-
         tier = compute_tier(
             "foo",
             affected_count=0,

--- a/nab-provider/src/nab_provider/_provider/priority.py
+++ b/nab-provider/src/nab_provider/_provider/priority.py
@@ -12,14 +12,7 @@ from operator import itemgetter
 from typing import TYPE_CHECKING
 
 from nab_provider._vendor.packaging.ranges import VersionRange
-from nab_resolver.priority import (
-    CONFLICT_THRESHOLD as CONFLICT_THRESHOLD,
-    CULPRIT_DEMOTE_THRESHOLD as CULPRIT_DEMOTE_THRESHOLD,
-    TIER_AFFECTED as TIER_AFFECTED,
-    TIER_CULPRIT as TIER_CULPRIT,
-    TIER_NORMAL as TIER_NORMAL,
-    compute_tier,
-)
+from nab_resolver.priority import CULPRIT_DEMOTE_THRESHOLD, compute_tier
 
 if TYPE_CHECKING:
     from collections.abc import Mapping

--- a/nab-provider/src/nab_provider/_provider/priority.py
+++ b/nab-provider/src/nab_provider/_provider/priority.py
@@ -12,6 +12,14 @@ from operator import itemgetter
 from typing import TYPE_CHECKING
 
 from nab_provider._vendor.packaging.ranges import VersionRange
+from nab_resolver.priority import (
+    CONFLICT_THRESHOLD as CONFLICT_THRESHOLD,
+    CULPRIT_DEMOTE_THRESHOLD as CULPRIT_DEMOTE_THRESHOLD,
+    TIER_AFFECTED as TIER_AFFECTED,
+    TIER_CULPRIT as TIER_CULPRIT,
+    TIER_NORMAL as TIER_NORMAL,
+    compute_tier,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -22,42 +30,9 @@ if TYPE_CHECKING:
     from ..provider import Provider
 
 
-CONFLICT_THRESHOLD = 5
-
-# Demotion requires a runaway gap to the second-highest culprit, so
-# co-dominant culprits keep standard ordering.
-CULPRIT_DEMOTE_THRESHOLD = 5
-
-# Lower number = higher priority.
-TIER_AFFECTED = 0
-TIER_NORMAL = 1
-TIER_CULPRIT = 2
-
 # Matching count used while a listing is in flight, so not-yet-fetched
 # packages sort behind ready ones.
 _NO_LISTING_PRIOR = 1000
-
-
-def compute_tier(
-    normalized: str,
-    affected_count: int,
-    culprit_count: int,
-    culprit_counts: Mapping[str, int] | None,
-    *,
-    force_backtracked: bool = False,
-) -> int:
-    """Decide the priority tier from conflict and culprit counts.
-
-    ``force_backtracked`` short-circuits the gap rule: the look-ahead
-    abort is a precise enough culprit signal on its own.
-    """
-    if affected_count >= CONFLICT_THRESHOLD:
-        return TIER_AFFECTED
-    if force_backtracked:
-        return TIER_CULPRIT
-    if is_dominant_culprit(normalized, culprit_count, culprit_counts):
-        return TIER_CULPRIT
-    return TIER_NORMAL
 
 
 def compute_matching(
@@ -128,26 +103,6 @@ def compute_matching(
         per_pkg = provider.matching_cache[normalized] = {}
     per_pkg[version_range] = matching
     return matching
-
-
-def is_dominant_culprit(
-    package: str,
-    package_count: int,
-    culprit_counts: Mapping[str, int] | None,
-) -> bool:
-    """Return True when ``package`` is the runaway top culprit.
-
-    Demote only when the gap to the next culprit is >= CULPRIT_DEMOTE_THRESHOLD;
-    co-dominant culprits stay within ~1 of each other so the standard ordering
-    wins.
-    """
-    if culprit_counts is None or package_count < CULPRIT_DEMOTE_THRESHOLD:
-        return False
-    second_highest = max(
-        (count for other, count in culprit_counts.items() if other != package),
-        default=0,
-    )
-    return package_count - second_highest >= CULPRIT_DEMOTE_THRESHOLD
 
 
 def prioritize(

--- a/nab-provider/src/nab_provider/provider.py
+++ b/nab-provider/src/nab_provider/provider.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, fields
 from itertools import chain
 from typing import TYPE_CHECKING, TypeVar, cast
 
+import nab_resolver.priority as _conflict_priority
 from nab_provider._vendor.packaging.markers import prepare_environment
 from nab_provider._vendor.packaging.ranges import VersionRange
 from nab_provider._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
@@ -482,11 +483,11 @@ class Provider:
     # blockers that are also the right pin.
     _MAX_FORCE_BACKTRACKS_PER_PKG = 3
 
-    TIER_AFFECTED = _priority.TIER_AFFECTED
-    TIER_NORMAL = _priority.TIER_NORMAL
-    TIER_CULPRIT = _priority.TIER_CULPRIT
-    CONFLICT_THRESHOLD = _priority.CONFLICT_THRESHOLD
-    CULPRIT_DEMOTE_THRESHOLD = _priority.CULPRIT_DEMOTE_THRESHOLD
+    TIER_AFFECTED = _conflict_priority.TIER_AFFECTED
+    TIER_NORMAL = _conflict_priority.TIER_NORMAL
+    TIER_CULPRIT = _conflict_priority.TIER_CULPRIT
+    CONFLICT_THRESHOLD = _conflict_priority.CONFLICT_THRESHOLD
+    CULPRIT_DEMOTE_THRESHOLD = _conflict_priority.CULPRIT_DEMOTE_THRESHOLD
 
     def __init__(  # noqa: PLR0913, PLR0915, PLR0917 - resolver config is wide; bundling all flags into one bag is worse for callers
         self,

--- a/nab-provider/tests/test_decision_scan.py
+++ b/nab-provider/tests/test_decision_scan.py
@@ -27,11 +27,7 @@ from __future__ import annotations
 import threading
 from typing import TYPE_CHECKING
 
-from nab_provider._provider.priority import (
-    _NO_LISTING_PRIOR,
-    CONFLICT_THRESHOLD,
-    CULPRIT_DEMOTE_THRESHOLD,
-)
+from nab_provider._provider.priority import _NO_LISTING_PRIOR
 from nab_provider._vendor.packaging.ranges import VersionRange
 from nab_provider._vendor.packaging.version import Version
 from nab_provider.provider import DecisionOrder, Provider
@@ -39,6 +35,10 @@ from nab_provider.records import DEFAULT_INDEX_NAME, WheelFile
 from nab_provider.store import InMemoryIndex
 from nab_provider.testing import FakeFetchPort, make_coordinator
 from nab_resolver import decide
+from nab_resolver.priority import (
+    CONFLICT_THRESHOLD,
+    CULPRIT_DEMOTE_THRESHOLD,
+)
 from nab_resolver.resolver import Resolver
 from nab_resolver.types import Incompatibility, IncompatibilityCause, Term
 

--- a/nab-resolver/README.md
+++ b/nab-resolver/README.md
@@ -25,7 +25,9 @@ nab_resolver.candidate_provider
                        CandidateHost, CandidateProvider,
                        CandidateRequirement, PreparedCandidate
 nab_resolver.errors     ResolutionError
-nab_resolver.priority   compute_tier, is_dominant_culprit
+nab_resolver.priority   CONFLICT_THRESHOLD, CULPRIT_DEMOTE_THRESHOLD,
+                        TIER_AFFECTED, TIER_CULPRIT, TIER_NORMAL,
+                        compute_tier, is_dominant_culprit
 nab_resolver.ranges     Range
 nab_resolver.resolver   BaseProvider, DEFAULT_MAX_ITERATIONS, Resolver,
                         ResolverObserver, ResolverProvider, Solution

--- a/nab-resolver/README.md
+++ b/nab-resolver/README.md
@@ -25,6 +25,7 @@ nab_resolver.candidate_provider
                        CandidateHost, CandidateProvider,
                        CandidateRequirement, PreparedCandidate
 nab_resolver.errors     ResolutionError
+nab_resolver.priority   compute_tier, is_dominant_culprit
 nab_resolver.ranges     Range
 nab_resolver.resolver   BaseProvider, DEFAULT_MAX_ITERATIONS, Resolver,
                         ResolverObserver, ResolverProvider, Solution

--- a/nab-resolver/src/nab_resolver/__init__.py
+++ b/nab-resolver/src/nab_resolver/__init__.py
@@ -8,6 +8,7 @@ renamed or relocated in any release.
                            CandidateHost, CandidateProvider,
                            CandidateRequirement, PreparedCandidate
     nab_resolver.errors     ResolutionError
+    nab_resolver.priority   compute_tier, is_dominant_culprit
     nab_resolver.ranges     Range
     nab_resolver.resolver   BaseProvider, DEFAULT_MAX_ITERATIONS, Resolver,
                             ResolverObserver, ResolverProvider, Solution

--- a/nab-resolver/src/nab_resolver/__init__.py
+++ b/nab-resolver/src/nab_resolver/__init__.py
@@ -8,7 +8,9 @@ renamed or relocated in any release.
                            CandidateHost, CandidateProvider,
                            CandidateRequirement, PreparedCandidate
     nab_resolver.errors     ResolutionError
-    nab_resolver.priority   compute_tier, is_dominant_culprit
+    nab_resolver.priority   CONFLICT_THRESHOLD, CULPRIT_DEMOTE_THRESHOLD,
+                            TIER_AFFECTED, TIER_CULPRIT, TIER_NORMAL,
+                            compute_tier, is_dominant_culprit
     nab_resolver.ranges     Range
     nab_resolver.resolver   BaseProvider, DEFAULT_MAX_ITERATIONS, Resolver,
                             ResolverObserver, ResolverProvider, Solution

--- a/nab-resolver/src/nab_resolver/candidate_provider.py
+++ b/nab-resolver/src/nab_resolver/candidate_provider.py
@@ -269,13 +269,16 @@ class CandidateProvider(BaseProvider[_PackageT, _KeyT]):
         conflict_counts: Mapping[_PackageT, int],
         culprit_counts: Mapping[_PackageT, int] | None = None,
     ) -> Any:
-        """Order by query parent/target feedback, conflict tier, then host preference."""
+        """Order query feedback (parent, target), conflict tier, and host preference."""
         del version_range
         priority = self.host.priority(package, self.active_requirements())
         if self._conflict_feedback:
             affected = conflict_counts.get(package, 0)
             culprit = 0 if culprit_counts is None else culprit_counts.get(package, 0)
-            priority = (compute_tier(package, affected, culprit, culprit_counts), priority)
+            priority = (
+                compute_tier(package, affected, culprit, culprit_counts),
+                priority,
+            )
         if self._query_feedback is not None:
             return self._query_feedback.priority(package, priority)
         return priority

--- a/nab-resolver/src/nab_resolver/candidate_provider.py
+++ b/nab-resolver/src/nab_resolver/candidate_provider.py
@@ -8,6 +8,7 @@ from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar
 
 from ._compat import override
+from .priority import compute_tier
 from .resolver import BaseProvider
 from .types import RangeProtocol, RootRequirement
 
@@ -125,11 +126,13 @@ class CandidateProvider(BaseProvider[_PackageT, _KeyT]):
         roots: Sequence[CandidateRequirement[_PackageT, _KeyT]],
         *,
         query_feedback: bool = False,
+        conflict_feedback: bool = False,
     ) -> None:
-        """Snapshot roots and optionally prioritize contextual query failures."""
+        """Snapshot roots and enable optional query or conflict ordering feedback."""
         self.host = host
         self.roots = tuple(roots)
         self._query_feedback = _QueryFeedback[_PackageT]() if query_feedback else None
+        self._conflict_feedback = conflict_feedback
         self._decisions: Mapping[_PackageT, _KeyT] = {}
         self._selected: dict[tuple[_PackageT, _KeyT], PreparedCandidate[_KeyT]] = {}
         self._causes: dict[
@@ -266,9 +269,13 @@ class CandidateProvider(BaseProvider[_PackageT, _KeyT]):
         conflict_counts: Mapping[_PackageT, int],
         culprit_counts: Mapping[_PackageT, int] | None = None,
     ) -> Any:
-        """Combine contextual-query feedback with the host's package priority."""
-        del version_range, conflict_counts, culprit_counts
+        """Order by query parent/target feedback, conflict tier, then host preference."""
+        del version_range
         priority = self.host.priority(package, self.active_requirements())
+        if self._conflict_feedback:
+            affected = conflict_counts.get(package, 0)
+            culprit = 0 if culprit_counts is None else culprit_counts.get(package, 0)
+            priority = (compute_tier(package, affected, culprit, culprit_counts), priority)
         if self._query_feedback is not None:
             return self._query_feedback.priority(package, priority)
         return priority

--- a/nab-resolver/src/nab_resolver/priority.py
+++ b/nab-resolver/src/nab_resolver/priority.py
@@ -1,4 +1,4 @@
-"""Order affected packages before ordinary choices and dominant culprits after them."""
+"""Promote affected packages before applying culprit demotion."""
 
 from __future__ import annotations
 
@@ -22,14 +22,14 @@ __all__ = [
 
 CONFLICT_THRESHOLD = 5
 
-# Demotion requires a runaway gap to the second-highest culprit, so
-# co-dominant culprits keep standard ordering.
+# Minimum culprit count and lead required for count-based demotion.
 CULPRIT_DEMOTE_THRESHOLD = 5
 
 # Lower number = higher priority.
 TIER_AFFECTED = 0
 TIER_NORMAL = 1
 TIER_CULPRIT = 2
+
 
 def compute_tier(
     package: PackageType,

--- a/nab-resolver/src/nab_resolver/priority.py
+++ b/nab-resolver/src/nab_resolver/priority.py
@@ -1,0 +1,64 @@
+"""Order affected packages before ordinary choices and dominant culprits after them."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from .types import PackageType
+
+__all__ = [
+    "CONFLICT_THRESHOLD",
+    "CULPRIT_DEMOTE_THRESHOLD",
+    "TIER_AFFECTED",
+    "TIER_CULPRIT",
+    "TIER_NORMAL",
+    "compute_tier",
+    "is_dominant_culprit",
+]
+
+
+CONFLICT_THRESHOLD = 5
+
+# Demotion requires a runaway gap to the second-highest culprit, so
+# co-dominant culprits keep standard ordering.
+CULPRIT_DEMOTE_THRESHOLD = 5
+
+# Lower number = higher priority.
+TIER_AFFECTED = 0
+TIER_NORMAL = 1
+TIER_CULPRIT = 2
+
+def compute_tier(
+    package: PackageType,
+    affected_count: int,
+    culprit_count: int,
+    culprit_counts: Mapping[PackageType, int] | None,
+    *,
+    force_backtracked: bool = False,
+) -> int:
+    """Apply conflict promotion and culprit or forced-backtrack demotion."""
+    if affected_count >= CONFLICT_THRESHOLD:
+        return TIER_AFFECTED
+    if force_backtracked:
+        return TIER_CULPRIT
+    if is_dominant_culprit(package, culprit_count, culprit_counts):
+        return TIER_CULPRIT
+    return TIER_NORMAL
+
+
+def is_dominant_culprit(
+    package: PackageType,
+    package_count: int,
+    culprit_counts: Mapping[PackageType, int] | None,
+) -> bool:
+    """Identify the leading culprit when its gap reaches the demotion threshold."""
+    if culprit_counts is None or package_count < CULPRIT_DEMOTE_THRESHOLD:
+        return False
+    second_highest = max(
+        (count for other, count in culprit_counts.items() if other != package),
+        default=0,
+    )
+    return package_count - second_highest >= CULPRIT_DEMOTE_THRESHOLD

--- a/nab-resolver/tests/test_candidate_conflict_feedback.py
+++ b/nab-resolver/tests/test_candidate_conflict_feedback.py
@@ -1,0 +1,133 @@
+"""Use ordinary conflict feedback without changing native candidate admission."""
+
+from collections.abc import Iterable, Mapping, Sequence
+
+import pytest
+
+from nab_resolver.candidate_provider import (
+    CandidateProvider,
+    CandidateRequirement,
+    PreparedCandidate,
+)
+from nab_resolver.priority import compute_tier
+from nab_resolver.ranges import Range
+from nab_resolver.resolver import Resolver
+from nab_resolver.types import RangeProtocol
+
+
+class UpperBoundHost:
+    """Offer consumers whose metadata rejects the newest earlier hub choice."""
+
+    def __init__(self) -> None:
+        self.hubs = [PreparedCandidate(version, (10, version)) for version in (2, 1)]
+        self.consumers = [
+            PreparedCandidate(version, (20, version)) for version in range(12, 0, -1)
+        ]
+        self.reads: list[PreparedCandidate[int]] = []
+
+    def iter_candidates(
+        self,
+        package: int,
+        allowed: RangeProtocol[int],
+        requirements: Mapping[int, Sequence[CandidateRequirement[int, int]]],
+    ) -> Iterable[PreparedCandidate[int]]:
+        yield from self.hubs if package == 10 else self.consumers
+
+    def get_dependencies(
+        self, candidate: PreparedCandidate[int]
+    ) -> Iterable[CandidateRequirement[int, int]]:
+        self.reads.append(candidate)
+        if candidate in self.consumers:
+            yield CandidateRequirement(10, Range.less_than(2), object())
+
+    def priority(
+        self,
+        package: int,
+        requirements: Mapping[int, Sequence[CandidateRequirement[int, int]]],
+    ) -> int:
+        return package
+
+
+def make_provider(
+    host: UpperBoundHost, *, query: bool = False, conflict: bool = False
+) -> CandidateProvider[int, int]:
+    """Keep both root preferences and candidate catalogs identical across policies."""
+    return CandidateProvider(
+        host,
+        [CandidateRequirement(package, Range.full(), object()) for package in (10, 20)],
+        query_feedback=query,
+        conflict_feedback=conflict,
+    )
+
+
+@pytest.mark.parametrize(
+    "affected,culprit,others,forced,expected",
+    [
+        (0, 0, None, False, 1),
+        (4, 4, {2: 0}, False, 1),
+        (5, 20, {2: 1}, True, 0),
+        (0, 5, {}, False, 2),
+        (0, 8, {2: 4}, False, 1),
+        (0, 9, {2: 4}, False, 2),
+        (0, 5, None, False, 1),
+        (0, 0, None, True, 2),
+    ],
+)
+def test_shared_conflict_tier_boundaries(
+    affected: int,
+    culprit: int,
+    others: Mapping[int, int] | None,
+    forced: bool,
+    expected: int,
+) -> None:
+    assert compute_tier(1, affected, culprit, others, force_backtracked=forced) == expected
+
+
+def test_feedback_defaults_keep_the_host_preference() -> None:
+    provider = make_provider(UpperBoundHost())
+    assert provider.prioritize(10, Range.full(), {10: 20}, {10: 50}) == 10
+    assert provider.prioritize(20, Range.full(), {10: 20}, {10: 50}) == 20
+
+
+def test_conflict_feedback_reorders_without_changing_candidates() -> None:
+    host = UpperBoundHost()
+    provider = make_provider(host, conflict=True)
+    counts = {20: 5}
+    culprits = {10: 8, 20: 2}
+    assert provider.prioritize(20, Range.full(), counts, culprits) < provider.prioritize(
+        10, Range.full(), counts, culprits
+    )
+    assert provider.choose_version(10, Range.full()) == 2
+    assert provider.prepared(10, 2) is host.hubs[0]
+    assert provider.prioritize(10, Range.full(), {}, None) == (1, 10)
+
+
+def test_query_parent_and_target_feedback_precede_conflict_tiers() -> None:
+    host = UpperBoundHost()
+    provider = make_provider(host, query=True, conflict=True)
+    assert provider.choose_version(20, Range.full()) == 12
+    provider.get_dependencies(20, 12)
+    provider.receive_partial_solution_hint({}, {20: 12})
+    assert provider.receive_contextual_failure(10)
+
+    # The declaring consumer still precedes its failed hub, even if it is a culprit.
+    assert provider.prioritize(20, Range.full(), {10: 5}, {20: 20}) < provider.prioritize(
+        10, Range.full(), {10: 5}, {20: 20}
+    )
+    # The failed hub still precedes an unmentioned package with an affected tier.
+    assert provider.prioritize(10, Range.full(), {30: 5}, {10: 20}) < provider.prioritize(
+        30, Range.full(), {30: 5}, {10: 20}
+    )
+
+
+def test_repeated_upper_bound_conflicts_preserve_pins() -> None:
+    rows = []
+    for enabled in (False, True):
+        host = UpperBoundHost()
+        provider = make_provider(host, conflict=enabled)
+        resolver = Resolver(provider, availability_generation=lambda: 0)
+        solution = resolver.solve(provider.root_requirements())
+        rows.append((solution.pins, resolver.stats.decisions, resolver.stats.conflicts))
+    assert rows[0][0] == rows[1][0] == {10: 1, 20: 12}
+    assert rows[1][1] <= rows[0][1]
+    assert rows[1][2] <= rows[0][2]

--- a/nab-resolver/tests/test_candidate_conflict_feedback.py
+++ b/nab-resolver/tests/test_candidate_conflict_feedback.py
@@ -23,7 +23,6 @@ class UpperBoundHost:
         self.consumers = [
             PreparedCandidate(version, (20, version)) for version in range(12, 0, -1)
         ]
-        self.reads: list[PreparedCandidate[int]] = []
 
     def iter_candidates(
         self,
@@ -36,7 +35,6 @@ class UpperBoundHost:
     def get_dependencies(
         self, candidate: PreparedCandidate[int]
     ) -> Iterable[CandidateRequirement[int, int]]:
-        self.reads.append(candidate)
         if candidate in self.consumers:
             yield CandidateRequirement(10, Range.less_than(2), object())
 
@@ -61,7 +59,7 @@ def make_provider(
 
 
 @pytest.mark.parametrize(
-    "affected,culprit,others,forced,expected",
+    ("affected", "culprit", "others", "forced", "expected"),
     [
         (0, 0, None, False, 1),
         (4, 4, {2: 0}, False, 1),
@@ -80,7 +78,9 @@ def test_shared_conflict_tier_boundaries(
     forced: bool,
     expected: int,
 ) -> None:
-    assert compute_tier(1, affected, culprit, others, force_backtracked=forced) == expected
+    assert (
+        compute_tier(1, affected, culprit, others, force_backtracked=forced) == expected
+    )
 
 
 def test_feedback_defaults_keep_the_host_preference() -> None:
@@ -94,9 +94,9 @@ def test_conflict_feedback_reorders_without_changing_candidates() -> None:
     provider = make_provider(host, conflict=True)
     counts = {20: 5}
     culprits = {10: 8, 20: 2}
-    assert provider.prioritize(20, Range.full(), counts, culprits) < provider.prioritize(
-        10, Range.full(), counts, culprits
-    )
+    assert provider.prioritize(
+        20, Range.full(), counts, culprits
+    ) < provider.prioritize(10, Range.full(), counts, culprits)
     assert provider.choose_version(10, Range.full()) == 2
     assert provider.prepared(10, 2) is host.hubs[0]
     assert provider.prioritize(10, Range.full(), {}, None) == (1, 10)
@@ -111,13 +111,13 @@ def test_query_parent_and_target_feedback_precede_conflict_tiers() -> None:
     assert provider.receive_contextual_failure(10)
 
     # The declaring consumer still precedes its failed hub, even if it is a culprit.
-    assert provider.prioritize(20, Range.full(), {10: 5}, {20: 20}) < provider.prioritize(
-        10, Range.full(), {10: 5}, {20: 20}
-    )
+    assert provider.prioritize(
+        20, Range.full(), {10: 5}, {20: 20}
+    ) < provider.prioritize(10, Range.full(), {10: 5}, {20: 20})
     # The failed hub still precedes an unmentioned package with an affected tier.
-    assert provider.prioritize(10, Range.full(), {30: 5}, {10: 20}) < provider.prioritize(
-        30, Range.full(), {30: 5}, {10: 20}
-    )
+    assert provider.prioritize(
+        10, Range.full(), {30: 5}, {10: 20}
+    ) < provider.prioritize(30, Range.full(), {30: 5}, {10: 20})
 
 
 def test_repeated_upper_bound_conflicts_preserve_pins() -> None:
@@ -129,5 +129,5 @@ def test_repeated_upper_bound_conflicts_preserve_pins() -> None:
         solution = resolver.solve(provider.root_requirements())
         rows.append((solution.pins, resolver.stats.decisions, resolver.stats.conflicts))
     assert rows[0][0] == rows[1][0] == {10: 1, 20: 12}
-    assert rows[1][1] <= rows[0][1]
-    assert rows[1][2] <= rows[0][2]
+    assert rows[1][1] < rows[0][1]
+    assert rows[1][2] < rows[0][2]


### PR DESCRIPTION
The accompanying pip update shortened a warm local `trustllm` resolve by about 14% to 34% compared with the preceding prototype, with a middle estimate near 30%, and reduced peak resident memory by about 25%. That comparison includes this policy and current resolver snapshot handling; it does not isolate the policy. All 124 selected distribution records matched, but the update still took about 30% longer than pip main.

`CandidateProvider(..., conflict_feedback=True)` applies the existing provider policy before the host's preference:

- Promote packages repeatedly affected by conflicts.
- Delay a dominant culprit unless affected-package promotion takes precedence.

The policy comes from a shared pure helper, preserving the regular provider's ordering. The option defaults to `False` and composes after query parent/target feedback.

These measurements used CPython 3.12.3 on Ubuntu/WSL and PyPI uploads before `2025-11-16T23:48:07Z`. The broader pip comparison still has unresolved cases, including an Airflow provider resolve reaching an older, unbuildable `zope.event` sdist.
