### PR TITLE
Precheck candidate dependencies before making decisions

### DIFF
--- a/docs/how-to/embed-the-resolver.md
+++ b/docs/how-to/embed-the-resolver.md
@@ -222,7 +222,7 @@ Providers can implement two optional notifications, supplied as no-ops by `BaseP
 
 ## Checking dependencies before a decision
 
-`CandidateProvider(..., dependency_precheck=True)` reads a candidate's complete dependency mapping before deciding it. If a dependency contradicts both an already selected key and its positive range, the provider queues that ordinary dependency clause. The candidate stays undecided, and its declarations do not enter the active requirement map. Self-dependency candidates follow the normal decision path. Metadata errors and the existing stop at an intrinsically empty restriction are preserved; `has_satisfying_version` does not precheck or queue clauses.
+`CandidateProvider(..., dependency_precheck=True)` reads a candidate's complete dependency mapping before deciding it. If a dependency contradicts both an already selected key and its positive range, the provider queues that ordinary dependency clause. The candidate stays undecided, and its declarations do not enter the active requirement map. Mappings that include the candidate’s own package follow the normal decision path. Metadata errors and the existing stop at an intrinsically empty restriction are preserved; `has_satisfying_version` does not precheck or queue clauses.
 
 `precheck_feedback=True` additionally requests a retreat after four distinct candidates from one package share the same selected blocker key. It permits at most three requests per blocker package in a solve, retains the dependency clauses, and demotes requested blockers before the host preference. This option requires `dependency_precheck=True`; both default to `False`. Ordinary `conflict_feedback` remains independent. Rejection history survives backtracks and restarts but resets for a new solve.
 

--- a/docs/how-to/embed-the-resolver.md
+++ b/docs/how-to/embed-the-resolver.md
@@ -219,6 +219,13 @@ Feedback changes decision order only. Candidate admission, source eligibility an
 
 Providers can implement two optional notifications, supplied as no-ops by `BaseProvider`. `begin_resolution()` runs when a solve starts. `receive_contextual_failure(package)` runs before recording a guarded contextual absence and returns `True` if priority keys changed; the resolver then invalidates its cached priorities. It may change only priority state, preserving candidate availability and current decisions. Ordinary unguarded absences and diagnostic probes do not send this notification. Structural providers may omit both methods.
 
+
+## Checking dependencies before a decision
+
+`CandidateProvider(..., dependency_precheck=True)` reads a candidate's complete dependency mapping before deciding it. If a dependency contradicts both an already selected key and its positive range, the provider queues that ordinary dependency clause. The candidate stays undecided, and its declarations do not enter the active requirement map. Self-dependency candidates follow the normal decision path. Metadata errors and the existing stop at an intrinsically empty restriction are preserved; `has_satisfying_version` does not precheck or queue clauses.
+
+`precheck_feedback=True` additionally requests a retreat after four distinct candidates from one package share the same selected blocker key. It permits at most three requests per blocker package in a solve, retains the dependency clauses, and demotes requested blockers before the host preference. This option requires `dependency_precheck=True`; both default to `False`. Ordinary `conflict_feedback` remains independent. Rejection history survives backtracks and restarts but resets for a new solve.
+
 ## The supported API
 
 These module paths will not move without a major version bump:
@@ -229,6 +236,7 @@ nab_resolver.candidate_provider
                        CandidateRequirement, PreparedCandidate
 nab_resolver.errors     ResolutionError
 nab_resolver.priority   CONFLICT_THRESHOLD, CULPRIT_DEMOTE_THRESHOLD,
+                        MAX_PRECHECK_BACKTRACKS, PRECHECK_REJECTION_THRESHOLD,
                         TIER_AFFECTED, TIER_CULPRIT, TIER_NORMAL,
                         compute_tier, is_dominant_culprit
 nab_resolver.ranges     Range

--- a/nab-provider/src/nab_provider/provider.py
+++ b/nab-provider/src/nab_provider/provider.py
@@ -476,12 +476,12 @@ class Provider:
     # Set low because the trigger is conservative: a unique
     # ``(blocker_pkg, blocker_version)`` repeating across every rejection
     # is already a strong signal.
-    _LOOKAHEAD_ABORT_THRESHOLD = 4
+    _LOOKAHEAD_ABORT_THRESHOLD = _conflict_priority.PRECHECK_REJECTION_THRESHOLD
 
     # Max force-backtracks one blocker can drive per resolution.
     # One-shot misses sustained culprits; unlimited oscillates on
     # blockers that are also the right pin.
-    _MAX_FORCE_BACKTRACKS_PER_PKG = 3
+    _MAX_FORCE_BACKTRACKS_PER_PKG = _conflict_priority.MAX_PRECHECK_BACKTRACKS
 
     TIER_AFFECTED = _conflict_priority.TIER_AFFECTED
     TIER_NORMAL = _conflict_priority.TIER_NORMAL

--- a/nab-resolver/README.md
+++ b/nab-resolver/README.md
@@ -26,6 +26,7 @@ nab_resolver.candidate_provider
                        CandidateRequirement, PreparedCandidate
 nab_resolver.errors     ResolutionError
 nab_resolver.priority   CONFLICT_THRESHOLD, CULPRIT_DEMOTE_THRESHOLD,
+                        MAX_PRECHECK_BACKTRACKS, PRECHECK_REJECTION_THRESHOLD,
                         TIER_AFFECTED, TIER_CULPRIT, TIER_NORMAL,
                         compute_tier, is_dominant_culprit
 nab_resolver.ranges     Range

--- a/nab-resolver/src/nab_resolver/__init__.py
+++ b/nab-resolver/src/nab_resolver/__init__.py
@@ -9,6 +9,7 @@ renamed or relocated in any release.
                            CandidateRequirement, PreparedCandidate
     nab_resolver.errors     ResolutionError
     nab_resolver.priority   CONFLICT_THRESHOLD, CULPRIT_DEMOTE_THRESHOLD,
+                            MAX_PRECHECK_BACKTRACKS, PRECHECK_REJECTION_THRESHOLD,
                             TIER_AFFECTED, TIER_CULPRIT, TIER_NORMAL,
                             compute_tier, is_dominant_culprit
     nab_resolver.ranges     Range

--- a/nab-resolver/src/nab_resolver/candidate_provider.py
+++ b/nab-resolver/src/nab_resolver/candidate_provider.py
@@ -147,12 +147,13 @@ class _PrecheckFeedback(Generic[_PackageT, _KeyT]):
         self, package: _PackageT, key: _KeyT, blocker: _PackageT, blocked_key: _KeyT
     ) -> None:
         """Record a distinct candidate and request a retreat at the shared threshold."""
+        requests = self.counts.get(blocker, 0)
+        if requests >= MAX_PRECHECK_BACKTRACKS:
+            return
         rejected = self.rejected.setdefault((package, blocker, blocked_key), set())
         rejected.add(key)
-        requests = self.counts.get(blocker, 0)
         if (
             len(rejected) >= PRECHECK_REJECTION_THRESHOLD
-            and requests < MAX_PRECHECK_BACKTRACKS
             and blocker not in self.targets
         ):
             self.targets.append(blocker)
@@ -292,7 +293,7 @@ class CandidateProvider(BaseProvider[_PackageT, _KeyT]):
         key: _KeyT,
         allowed: RangeProtocol[_KeyT],
     ) -> bool:
-        """Queue a dependency conflict while leaving the rejected candidate undecided."""
+        """Queue a dependency conflict without deciding the rejected candidate."""
         dependencies = self.get_dependencies(package, key)
         if package in dependencies:
             return False
@@ -406,7 +407,9 @@ class CandidateProvider(BaseProvider[_PackageT, _KeyT]):
                 and self._precheck_feedback.requested(package)
             )
             priority = (
-                compute_tier(package, affected, culprit, counts, force_backtracked=forced),
+                compute_tier(
+                    package, affected, culprit, counts, force_backtracked=forced
+                ),
                 priority,
             )
         if self._query_feedback is not None:

--- a/nab-resolver/src/nab_resolver/candidate_provider.py
+++ b/nab-resolver/src/nab_resolver/candidate_provider.py
@@ -304,14 +304,14 @@ class CandidateProvider(BaseProvider[_PackageT, _KeyT]):
             assignment = self._positive_ranges.get(dependency)
             if assignment is None or not assignment.is_disjoint(required):
                 continue
-            selected = type(required).singleton(self._decisions[dependency])
+            selected = required.singleton(self._decisions[dependency])
             if not selected.is_disjoint(required):
                 continue
 
             self._pending.append(
                 Incompatibility(
                     [
-                        Term(package, type(allowed).singleton(key), positive=True),
+                        Term(package, allowed.singleton(key), positive=True),
                         Term(dependency, required, positive=False),
                     ],
                     cause=IncompatibilityCause.DEPENDENCY,

--- a/nab-resolver/src/nab_resolver/candidate_provider.py
+++ b/nab-resolver/src/nab_resolver/candidate_provider.py
@@ -8,9 +8,19 @@ from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar
 
 from ._compat import override
-from .priority import compute_tier
+from .priority import (
+    MAX_PRECHECK_BACKTRACKS,
+    PRECHECK_REJECTION_THRESHOLD,
+    compute_tier,
+)
 from .resolver import BaseProvider
-from .types import RangeProtocol, RootRequirement
+from .types import (
+    Incompatibility,
+    IncompatibilityCause,
+    RangeProtocol,
+    RootRequirement,
+    Term,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping, Sequence
@@ -117,6 +127,48 @@ class _QueryFeedback(Generic[_PackageT]):
         )
 
 
+class _PrecheckFeedback(Generic[_PackageT, _KeyT]):
+    """Bound retreat requests from distinct candidates sharing a selected blocker."""
+
+    __slots__ = ("counts", "rejected", "targets")
+
+    def __init__(self) -> None:
+        self.rejected: dict[tuple[_PackageT, _PackageT, _KeyT], set[_KeyT]] = {}
+        self.counts: dict[_PackageT, int] = {}
+        self.targets: list[_PackageT] = []
+
+    def clear(self) -> None:
+        """Forget rejection history at the start of a new solve."""
+        self.rejected.clear()
+        self.counts.clear()
+        self.targets.clear()
+
+    def record(
+        self, package: _PackageT, key: _KeyT, blocker: _PackageT, blocked_key: _KeyT
+    ) -> None:
+        """Record a distinct candidate and request a retreat at the shared threshold."""
+        rejected = self.rejected.setdefault((package, blocker, blocked_key), set())
+        rejected.add(key)
+        requests = self.counts.get(blocker, 0)
+        if (
+            len(rejected) >= PRECHECK_REJECTION_THRESHOLD
+            and requests < MAX_PRECHECK_BACKTRACKS
+            and blocker not in self.targets
+        ):
+            self.targets.append(blocker)
+            self.counts[blocker] = requests + 1
+            rejected.clear()
+
+    def consume_targets(self) -> list[_PackageT]:
+        """Drain requested blockers without clearing their per-solve counts."""
+        targets, self.targets = self.targets, []
+        return targets
+
+    def requested(self, package: _PackageT) -> bool:
+        """Whether the package has been named in a retreat request this solve."""
+        return package in self.counts
+
+
 class CandidateProvider(BaseProvider[_PackageT, _KeyT]):
     """Keep candidate identity and active requirements around a host's selection."""
 
@@ -127,12 +179,23 @@ class CandidateProvider(BaseProvider[_PackageT, _KeyT]):
         *,
         query_feedback: bool = False,
         conflict_feedback: bool = False,
+        dependency_precheck: bool = False,
+        precheck_feedback: bool = False,
     ) -> None:
-        """Snapshot roots and enable optional query or conflict ordering feedback."""
+        """Snapshot roots and configure optional ordering and dependency prechecks."""
+        if precheck_feedback and not dependency_precheck:
+            message = "precheck_feedback requires dependency_precheck"
+            raise ValueError(message)
         self.host = host
         self.roots = tuple(roots)
         self._query_feedback = _QueryFeedback[_PackageT]() if query_feedback else None
         self._conflict_feedback = conflict_feedback
+        self._dependency_precheck = dependency_precheck
+        self._precheck_feedback = (
+            _PrecheckFeedback[_PackageT, _KeyT]() if precheck_feedback else None
+        )
+        self._positive_ranges: Mapping[_PackageT, RangeProtocol[_KeyT]] = {}
+        self._pending: list[Incompatibility[_PackageT, _KeyT]] = []
         self._decisions: Mapping[_PackageT, _KeyT] = {}
         self._selected: dict[tuple[_PackageT, _KeyT], PreparedCandidate[_KeyT]] = {}
         self._causes: dict[
@@ -151,6 +214,13 @@ class CandidateProvider(BaseProvider[_PackageT, _KeyT]):
         """Clear ordering feedback while retaining prepared candidate metadata."""
         if self._query_feedback is not None:
             self._query_feedback.clear()
+        self._pending.clear()
+        if self._precheck_feedback is not None:
+            self._precheck_feedback.clear()
+        if self._dependency_precheck:
+            self._positive_ranges = {}
+            self._decisions = {}
+            self._active_cache = None
 
     @override
     def receive_contextual_failure(self, package: _PackageT) -> bool:
@@ -203,14 +273,68 @@ class CandidateProvider(BaseProvider[_PackageT, _KeyT]):
     def choose_version(
         self, package: _PackageT, version_range: RangeProtocol[_KeyT]
     ) -> _KeyT | None:
-        """Take the first prepared candidate admitted by the solver's bounds."""
+        """Prepare a candidate or queue its conflicting dependency before selection."""
         for candidate in self.host.iter_candidates(
             package, version_range, self.active_requirements()
         ):
             if candidate.key in version_range:
                 self._selected[package, candidate.key] = candidate
+                if self._dependency_precheck and self._precheck_dependencies(
+                    package, candidate.key, version_range
+                ):
+                    return None
                 return candidate.key
         return None
+
+    def _precheck_dependencies(
+        self,
+        package: _PackageT,
+        key: _KeyT,
+        allowed: RangeProtocol[_KeyT],
+    ) -> bool:
+        """Queue a dependency conflict while leaving the rejected candidate undecided."""
+        dependencies = self.get_dependencies(package, key)
+        if package in dependencies:
+            return False
+
+        for dependency, required in dependencies.items():
+            if dependency not in self._decisions:
+                continue
+            assignment = self._positive_ranges.get(dependency)
+            if assignment is None or not assignment.is_disjoint(required):
+                continue
+            selected = type(required).singleton(self._decisions[dependency])
+            if not selected.is_disjoint(required):
+                continue
+
+            self._pending.append(
+                Incompatibility(
+                    [
+                        Term(package, type(allowed).singleton(key), positive=True),
+                        Term(dependency, required, positive=False),
+                    ],
+                    cause=IncompatibilityCause.DEPENDENCY,
+                )
+            )
+            if self._precheck_feedback is not None:
+                self._precheck_feedback.record(
+                    package, key, dependency, self._decisions[dependency]
+                )
+            return True
+        return False
+
+    @override
+    def consume_pending_clauses(self) -> list[Incompatibility[_PackageT, _KeyT]]:
+        """Drain prechecked dependencies before an ordinary absence is recorded."""
+        pending, self._pending = self._pending, []
+        return pending
+
+    @override
+    def consume_force_backtrack_targets(self) -> list[_PackageT]:
+        """Request bounded retreats after repeated proven precheck blockers."""
+        if self._precheck_feedback is None:
+            return []
+        return self._precheck_feedback.consume_targets()
 
     def has_satisfying_version(
         self, package: _PackageT, version_range: RangeProtocol[_KeyT]
@@ -258,7 +382,8 @@ class CandidateProvider(BaseProvider[_PackageT, _KeyT]):
         decisions: Mapping[_PackageT, _KeyT],
     ) -> None:
         """Retain the current decisions so rejected parents lose their requirements."""
-        del positive_ranges
+        if self._dependency_precheck:
+            self._positive_ranges = positive_ranges
         self._decisions = decisions
         self._active_cache = None
 
@@ -272,11 +397,16 @@ class CandidateProvider(BaseProvider[_PackageT, _KeyT]):
         """Order query feedback (parent, target), conflict tier, and host preference."""
         del version_range
         priority = self.host.priority(package, self.active_requirements())
-        if self._conflict_feedback:
-            affected = conflict_counts.get(package, 0)
-            culprit = 0 if culprit_counts is None else culprit_counts.get(package, 0)
+        if self._conflict_feedback or self._precheck_feedback is not None:
+            affected = conflict_counts.get(package, 0) if self._conflict_feedback else 0
+            counts = culprit_counts if self._conflict_feedback else None
+            culprit = 0 if counts is None else counts.get(package, 0)
+            forced = (
+                self._precheck_feedback is not None
+                and self._precheck_feedback.requested(package)
+            )
             priority = (
-                compute_tier(package, affected, culprit, culprit_counts),
+                compute_tier(package, affected, culprit, counts, force_backtracked=forced),
                 priority,
             )
         if self._query_feedback is not None:

--- a/nab-resolver/src/nab_resolver/priority.py
+++ b/nab-resolver/src/nab_resolver/priority.py
@@ -1,4 +1,4 @@
-"""Promote affected packages before applying culprit demotion."""
+"""Shared conflict ordering and bounded dependency-precheck feedback."""
 
 from __future__ import annotations
 
@@ -12,6 +12,8 @@ if TYPE_CHECKING:
 __all__ = [
     "CONFLICT_THRESHOLD",
     "CULPRIT_DEMOTE_THRESHOLD",
+    "MAX_PRECHECK_BACKTRACKS",
+    "PRECHECK_REJECTION_THRESHOLD",
     "TIER_AFFECTED",
     "TIER_CULPRIT",
     "TIER_NORMAL",
@@ -21,6 +23,8 @@ __all__ = [
 
 
 CONFLICT_THRESHOLD = 5
+PRECHECK_REJECTION_THRESHOLD = 4
+MAX_PRECHECK_BACKTRACKS = 3
 
 # Minimum culprit count and lead required for count-based demotion.
 CULPRIT_DEMOTE_THRESHOLD = 5

--- a/nab-resolver/tests/test_candidate_dependency_precheck.py
+++ b/nab-resolver/tests/test_candidate_dependency_precheck.py
@@ -5,7 +5,12 @@ from typing import cast
 
 import pytest
 
-from nab_resolver.candidate_provider import CandidateProvider, CandidateRequirement, PreparedCandidate
+from nab_resolver import conflict
+from nab_resolver.candidate_provider import (
+    CandidateProvider,
+    CandidateRequirement,
+    PreparedCandidate,
+)
 from nab_resolver.ranges import Range
 from nab_resolver.resolver import Resolver
 from nab_resolver.types import IncompatibilityCause, RangeProtocol
@@ -17,8 +22,14 @@ class Host:
     def __init__(self) -> None:
         self.catalog = {
             10: [PreparedCandidate(version, (10, version)) for version in (2, 1)],
-            20: [PreparedCandidate(version, (20, version)) for version in range(16, 0, -1)],
-            30: [PreparedCandidate(version, (30, version)) for version in range(16, 0, -1)],
+            20: [
+                PreparedCandidate(version, (20, version))
+                for version in range(16, 0, -1)
+            ],
+            30: [
+                PreparedCandidate(version, (30, version))
+                for version in range(16, 0, -1)
+            ],
         }
         self.events: list[str] = []
         self.self_requirement: Range[int] | None = None
@@ -26,12 +37,16 @@ class Host:
         self.required = Range.less_than(2)
 
     def iter_candidates(
-        self, package: int, allowed: RangeProtocol[int],
+        self,
+        package: int,
+        allowed: RangeProtocol[int],
         requirements: Mapping[int, Sequence[CandidateRequirement[int, int]]],
     ) -> Iterable[PreparedCandidate[int]]:
         yield from self.catalog.get(package, ())
 
-    def get_dependencies(self, candidate: PreparedCandidate[int]) -> Iterable[CandidateRequirement[int, int]]:
+    def get_dependencies(
+        self, candidate: PreparedCandidate[int]
+    ) -> Iterable[CandidateRequirement[int, int]]:
         package, _ = cast("tuple[int, int]", candidate.origin)
         self.events.append(f"metadata:{package}")
         if package in (20, 30):
@@ -39,26 +54,38 @@ class Host:
             yield CandidateRequirement(10, self.required, "child origin")
             if self.self_requirement is not None:
                 self.events.append("self")
-                yield CandidateRequirement(package, self.self_requirement, "self origin")
+                yield CandidateRequirement(
+                    package, self.self_requirement, "self origin"
+                )
             if self.fail_after_dependency:
                 self.events.append("error")
                 raise OSError("late metadata error")
 
-    def priority(self, package: int, requirements: Mapping[int, Sequence[CandidateRequirement[int, int]]]) -> int:
+    def priority(
+        self,
+        package: int,
+        requirements: Mapping[int, Sequence[CandidateRequirement[int, int]]],
+    ) -> int:
         return package
 
 
-def prepared_provider(host: Host, *, feedback: bool = False) -> CandidateProvider[int, int]:
+def prepared_provider(
+    host: Host, *, feedback: bool = False
+) -> CandidateProvider[int, int]:
     """Supply the real hint snapshots a selected hub would leave behind."""
     provider = CandidateProvider(
-        host, [CandidateRequirement(20, Range.full(), "root")],
-        dependency_precheck=True, precheck_feedback=feedback,
+        host,
+        [CandidateRequirement(20, Range.full(), "root")],
+        dependency_precheck=True,
+        precheck_feedback=feedback,
     )
     provider.receive_partial_solution_hint({10: Range.singleton(2)}, {10: 2})
     return provider
 
 
-def reject(provider: CandidateProvider[int, int], key: int, *, package: int = 20) -> list[int]:
+def reject(
+    provider: CandidateProvider[int, int], key: int, *, package: int = 20
+) -> list[int]:
     """Reject one candidate, preserving its exact clause before consuming feedback."""
     before = dict(provider.active_requirements())
     assert provider.choose_version(package, Range.singleton(key)) is None
@@ -89,7 +116,9 @@ def test_precheck_clause_and_probe_do_not_activate_rejected_metadata() -> None:
 
 def test_disabled_precheck_leaves_dependency_reading_to_the_core() -> None:
     host = Host()
-    provider = CandidateProvider(host, [CandidateRequirement(20, Range.full(), object())])
+    provider = CandidateProvider(
+        host, [CandidateRequirement(20, Range.full(), object())]
+    )
     provider.receive_partial_solution_hint({10: Range.singleton(2)}, {10: 2})
     assert provider.choose_version(20, Range.full()) == 16
     assert host.events == []
@@ -97,7 +126,9 @@ def test_disabled_precheck_leaves_dependency_reading_to_the_core() -> None:
 
 
 @pytest.mark.parametrize("self_bounds", [Range.full(), Range.singleton(99)])
-def test_later_self_declaration_delegates_the_complete_candidate(self_bounds: Range[int]) -> None:
+def test_later_self_declaration_delegates_the_complete_candidate(
+    self_bounds: Range[int],
+) -> None:
     host = Host()
     host.self_requirement = self_bounds
     provider = prepared_provider(host)
@@ -133,7 +164,9 @@ def test_selected_singleton_must_also_be_disjoint() -> None:
     assert provider.consume_pending_clauses() == []
 
 
-def test_feedback_requires_distinct_candidates_in_one_parent_and_blocker_group() -> None:
+def test_feedback_requires_distinct_candidates_in_one_parent_and_blocker_group() -> (
+    None
+):
     provider = prepared_provider(Host(), feedback=True)
     for _ in range(5):
         assert reject(provider, 16) == []
@@ -163,16 +196,24 @@ def test_feedback_cap_survives_blocker_changes_and_resets_for_a_new_solve() -> N
     provider.receive_partial_solution_hint({10: Range.singleton(3)}, {10: 3})
     for key in (16, 15, 14, 13):
         assert reject(provider, key) == []
-    assert provider.prioritize(10, Range.full(), {}, None) > provider.prioritize(20, Range.full(), {}, None)
+    assert provider.prioritize(10, Range.full(), {}, None) > provider.prioritize(
+        20, Range.full(), {}, None
+    )
 
     provider.begin_resolution()
-    assert provider.prioritize(10, Range.full(), {}, None) < provider.prioritize(20, Range.full(), {}, None)
+    assert provider.prioritize(10, Range.full(), {}, None) < provider.prioritize(
+        20, Range.full(), {}, None
+    )
     provider.receive_partial_solution_hint({10: Range.singleton(2)}, {10: 2})
-    assert [target for key in (16, 15, 14, 13) for target in reject(provider, key)] == [10]
+    assert [target for key in (16, 15, 14, 13) for target in reject(provider, key)] == [
+        10
+    ]
 
 
 def test_feedback_is_not_available_without_prechecking() -> None:
-    with pytest.raises(ValueError, match="precheck_feedback requires dependency_precheck"):
+    with pytest.raises(
+        ValueError, match="precheck_feedback requires dependency_precheck"
+    ):
         CandidateProvider(Host(), [], precheck_feedback=True)
 
 
@@ -181,14 +222,76 @@ def test_prechecks_and_bounded_feedback_preserve_the_real_solution() -> None:
     for enabled, feedback in ((False, False), (True, False), (True, True)):
         host = Host()
         provider = CandidateProvider(
-            host, [CandidateRequirement(package, Range.full(), object()) for package in (10, 20)],
-            dependency_precheck=enabled, precheck_feedback=feedback,
+            host,
+            [
+                CandidateRequirement(package, Range.full(), object())
+                for package in (10, 20)
+            ],
+            dependency_precheck=enabled,
+            precheck_feedback=feedback,
         )
         resolver = Resolver(provider, availability_generation=lambda: 0)
         solution = resolver.solve(provider.root_requirements())
-        rows.append((solution.pins, resolver.stats.decisions, resolver.stats.conflicts, host.events.count("metadata:20")))
+        rows.append(
+            (
+                solution.pins,
+                resolver.stats.decisions,
+                resolver.stats.conflicts,
+                host.events.count("metadata:20"),
+            )
+        )
     assert rows[0][0] == rows[1][0] == rows[2][0] == {10: 1, 20: 16}
     assert rows[1][1] < rows[0][1]
     assert rows[2][1] <= rows[1][1]
     assert rows[2][2] < rows[1][2]
     assert rows[2][3] < rows[1][3]
+
+
+def test_intrinsically_empty_dependencies_stop_metadata_consumption() -> None:
+    class EmptyHost(Host):
+        def get_dependencies(
+            self, candidate: PreparedCandidate[int]
+        ) -> Iterable[CandidateRequirement[int, int]]:
+            yield CandidateRequirement(10, Range.singleton(1), object())
+            yield CandidateRequirement(10, Range.singleton(2), object())
+            raise AssertionError("metadata after an empty intersection was read")
+
+    provider = prepared_provider(EmptyHost())
+    assert provider.choose_version(20, Range.singleton(16)) is None
+    clauses = provider.consume_pending_clauses()
+    assert len(clauses) == 1
+    assert clauses[0].terms[1].constraint.is_empty
+
+
+def test_capped_blockers_do_not_accumulate_more_candidate_history() -> None:
+    provider = prepared_provider(Host(), feedback=True)
+    for key in range(16, 4, -1):
+        reject(provider, key)
+    feedback = provider._precheck_feedback
+    assert feedback is not None
+    before = {group: set(keys) for group, keys in feedback.rejected.items()}
+    for key in range(4, 0, -1):
+        assert reject(provider, key) == []
+    assert feedback.rejected == before
+
+
+def test_an_ordinary_restart_preserves_precheck_feedback() -> None:
+    host = Host()
+    provider = prepared_provider(host, feedback=True)
+    resolver = Resolver(provider)
+    resolver._reset(None)
+    resolver._add_root_requirements(provider.root_requirements())
+    provider.receive_partial_solution_hint({10: Range.singleton(2)}, {10: 2})
+    assert [target for key in (16, 15, 14, 13) for target in reject(provider, key)] == [
+        10
+    ]
+    resolver.stats.package_conflict_counts[20] = 5
+    _, _, restarted = conflict.maybe_restart(resolver, 5, 1)
+    assert restarted
+    assert provider.prioritize(10, Range.full(), {}, None) > provider.prioritize(
+        20, Range.full(), {}, None
+    )
+    provider.receive_partial_solution_hint({10: Range.singleton(2)}, {10: 2})
+    assert [target for key in (12, 11, 10, 9) for target in reject(provider, key)] == [
+        10
+    ]

--- a/nab-resolver/tests/test_candidate_dependency_precheck.py
+++ b/nab-resolver/tests/test_candidate_dependency_precheck.py
@@ -1,0 +1,194 @@
+"""Precheck real host declarations without deciding or activating rejected candidates."""
+
+from collections.abc import Iterable, Mapping, Sequence
+from typing import cast
+
+import pytest
+
+from nab_resolver.candidate_provider import CandidateProvider, CandidateRequirement, PreparedCandidate
+from nab_resolver.ranges import Range
+from nab_resolver.resolver import Resolver
+from nab_resolver.types import IncompatibilityCause, RangeProtocol
+
+
+class Host:
+    """Keep metadata fixed while an earlier hub choice blocks newer parents."""
+
+    def __init__(self) -> None:
+        self.catalog = {
+            10: [PreparedCandidate(version, (10, version)) for version in (2, 1)],
+            20: [PreparedCandidate(version, (20, version)) for version in range(16, 0, -1)],
+            30: [PreparedCandidate(version, (30, version)) for version in range(16, 0, -1)],
+        }
+        self.events: list[str] = []
+        self.self_requirement: Range[int] | None = None
+        self.fail_after_dependency = False
+        self.required = Range.less_than(2)
+
+    def iter_candidates(
+        self, package: int, allowed: RangeProtocol[int],
+        requirements: Mapping[int, Sequence[CandidateRequirement[int, int]]],
+    ) -> Iterable[PreparedCandidate[int]]:
+        yield from self.catalog.get(package, ())
+
+    def get_dependencies(self, candidate: PreparedCandidate[int]) -> Iterable[CandidateRequirement[int, int]]:
+        package, _ = cast("tuple[int, int]", candidate.origin)
+        self.events.append(f"metadata:{package}")
+        if package in (20, 30):
+            self.events.append("child")
+            yield CandidateRequirement(10, self.required, "child origin")
+            if self.self_requirement is not None:
+                self.events.append("self")
+                yield CandidateRequirement(package, self.self_requirement, "self origin")
+            if self.fail_after_dependency:
+                self.events.append("error")
+                raise OSError("late metadata error")
+
+    def priority(self, package: int, requirements: Mapping[int, Sequence[CandidateRequirement[int, int]]]) -> int:
+        return package
+
+
+def prepared_provider(host: Host, *, feedback: bool = False) -> CandidateProvider[int, int]:
+    """Supply the real hint snapshots a selected hub would leave behind."""
+    provider = CandidateProvider(
+        host, [CandidateRequirement(20, Range.full(), "root")],
+        dependency_precheck=True, precheck_feedback=feedback,
+    )
+    provider.receive_partial_solution_hint({10: Range.singleton(2)}, {10: 2})
+    return provider
+
+
+def reject(provider: CandidateProvider[int, int], key: int, *, package: int = 20) -> list[int]:
+    """Reject one candidate, preserving its exact clause before consuming feedback."""
+    before = dict(provider.active_requirements())
+    assert provider.choose_version(package, Range.singleton(key)) is None
+    assert dict(provider.active_requirements()) == before
+    clauses = provider.consume_pending_clauses()
+    assert len(clauses) == 1
+    assert clauses[0].cause is IncompatibilityCause.DEPENDENCY
+    assert clauses[0].terms[0].package == package
+    assert clauses[0].terms[0].constraint == Range.singleton(key)
+    assert clauses[0].terms[1].package == 10
+    assert not clauses[0].terms[1].is_positive()
+    assert provider.consume_pending_clauses() == []
+    return provider.consume_force_backtrack_targets()
+
+
+def test_precheck_clause_and_probe_do_not_activate_rejected_metadata() -> None:
+    host = Host()
+    provider = prepared_provider(host)
+    assert provider.choose_version(20, Range.singleton(16)) is None
+    before = list(host.events)
+    assert provider.has_satisfying_version(20, Range.singleton(16))
+    assert host.events == before
+    assert 10 not in provider.active_requirements()
+    assert len(provider.consume_pending_clauses()) == 1
+    assert provider.consume_pending_clauses() == []
+    assert provider.consume_force_backtrack_targets() == []
+
+
+def test_disabled_precheck_leaves_dependency_reading_to_the_core() -> None:
+    host = Host()
+    provider = CandidateProvider(host, [CandidateRequirement(20, Range.full(), object())])
+    provider.receive_partial_solution_hint({10: Range.singleton(2)}, {10: 2})
+    assert provider.choose_version(20, Range.full()) == 16
+    assert host.events == []
+    assert provider.consume_pending_clauses() == []
+
+
+@pytest.mark.parametrize("self_bounds", [Range.full(), Range.singleton(99)])
+def test_later_self_declaration_delegates_the_complete_candidate(self_bounds: Range[int]) -> None:
+    host = Host()
+    host.self_requirement = self_bounds
+    provider = prepared_provider(host)
+    assert provider.choose_version(20, Range.singleton(16)) == 16
+    assert host.events == ["metadata:20", "child", "self"]
+    assert provider.consume_pending_clauses() == []
+
+
+def test_late_metadata_error_is_not_hidden_by_an_earlier_blocker() -> None:
+    host = Host()
+    host.fail_after_dependency = True
+    provider = prepared_provider(host)
+    with pytest.raises(OSError, match="late metadata error"):
+        provider.choose_version(20, Range.singleton(16))
+    assert host.events == ["metadata:20", "child", "error"]
+    assert provider.consume_pending_clauses() == []
+
+
+def test_precheck_needs_both_a_decision_and_disjoint_positive_bounds() -> None:
+    host = Host()
+    provider = prepared_provider(host)
+    for positive, decisions in [({}, {}), ({}, {10: 2}), ({10: Range.full()}, {10: 2})]:
+        provider.receive_partial_solution_hint(positive, decisions)
+        assert provider.choose_version(20, Range.singleton(16)) == 16
+        assert provider.consume_pending_clauses() == []
+
+
+def test_selected_singleton_must_also_be_disjoint() -> None:
+    host = Host()
+    provider = prepared_provider(host)
+    provider.receive_partial_solution_hint({10: Range.singleton(2)}, {10: 1})
+    assert provider.choose_version(20, Range.singleton(16)) == 16
+    assert provider.consume_pending_clauses() == []
+
+
+def test_feedback_requires_distinct_candidates_in_one_parent_and_blocker_group() -> None:
+    provider = prepared_provider(Host(), feedback=True)
+    for _ in range(5):
+        assert reject(provider, 16) == []
+    for key in (16, 15, 14):
+        assert reject(provider, key, package=30) == []
+    for key in (15, 14):
+        assert reject(provider, key) == []
+    assert reject(provider, 13) == [10]
+    assert provider.consume_force_backtrack_targets() == []
+
+
+def test_blocker_versions_have_separate_rejection_groups() -> None:
+    provider = prepared_provider(Host(), feedback=True)
+    for key in (16, 15, 14):
+        assert reject(provider, key) == []
+    provider.receive_partial_solution_hint({10: Range.singleton(3)}, {10: 3})
+    for key in (16, 15, 14):
+        assert reject(provider, key) == []
+    provider.receive_partial_solution_hint({10: Range.singleton(2)}, {10: 2})
+    assert reject(provider, 13) == [10]
+
+
+def test_feedback_cap_survives_blocker_changes_and_resets_for_a_new_solve() -> None:
+    provider = prepared_provider(Host(), feedback=True)
+    requests = [target for key in range(16, 0, -1) for target in reject(provider, key)]
+    assert requests == [10, 10, 10]
+    provider.receive_partial_solution_hint({10: Range.singleton(3)}, {10: 3})
+    for key in (16, 15, 14, 13):
+        assert reject(provider, key) == []
+    assert provider.prioritize(10, Range.full(), {}, None) > provider.prioritize(20, Range.full(), {}, None)
+
+    provider.begin_resolution()
+    assert provider.prioritize(10, Range.full(), {}, None) < provider.prioritize(20, Range.full(), {}, None)
+    provider.receive_partial_solution_hint({10: Range.singleton(2)}, {10: 2})
+    assert [target for key in (16, 15, 14, 13) for target in reject(provider, key)] == [10]
+
+
+def test_feedback_is_not_available_without_prechecking() -> None:
+    with pytest.raises(ValueError, match="precheck_feedback requires dependency_precheck"):
+        CandidateProvider(Host(), [], precheck_feedback=True)
+
+
+def test_prechecks_and_bounded_feedback_preserve_the_real_solution() -> None:
+    rows = []
+    for enabled, feedback in ((False, False), (True, False), (True, True)):
+        host = Host()
+        provider = CandidateProvider(
+            host, [CandidateRequirement(package, Range.full(), object()) for package in (10, 20)],
+            dependency_precheck=enabled, precheck_feedback=feedback,
+        )
+        resolver = Resolver(provider, availability_generation=lambda: 0)
+        solution = resolver.solve(provider.root_requirements())
+        rows.append((solution.pins, resolver.stats.decisions, resolver.stats.conflicts, host.events.count("metadata:20")))
+    assert rows[0][0] == rows[1][0] == rows[2][0] == {10: 1, 20: 16}
+    assert rows[1][1] < rows[0][1]
+    assert rows[2][1] <= rows[1][1]
+    assert rows[2][2] < rows[1][2]
+    assert rows[2][3] < rows[1][3]

--- a/nab-resolver/tests/test_candidate_dependency_precheck.py
+++ b/nab-resolver/tests/test_candidate_dependency_precheck.py
@@ -295,3 +295,25 @@ def test_an_ordinary_restart_preserves_precheck_feedback() -> None:
     assert [target for key in (12, 11, 10, 9) for target in reject(provider, key)] == [
         10
     ]
+
+
+@pytest.mark.parametrize("blocker_present", [False, True])
+def test_unusable_retreat_requests_keep_clauses_and_remain_bounded(
+    blocker_present: bool,
+) -> None:
+    provider = prepared_provider(Host(), feedback=True)
+    resolver = Resolver(provider)
+    if blocker_present:
+        resolver.solution.decide(10, 2)
+    resolver.solution.decide(30, 1)
+    before = dict(resolver.solution.decisions())
+    requests = []
+    for key in range(16, 0, -1):
+        targets = reject(provider, key)
+        requests.extend(targets)
+        assert conflict.force_targeted_backtrack(resolver, targets) is None
+
+    assert requests == [10, 10, 10]
+    assert resolver.stats.targeted_backtracks == 0
+    assert dict(resolver.solution.decisions()) == before
+    assert provider.consume_pending_clauses() == []


### PR DESCRIPTION
A host candidate can now be excluded before it becomes a decision when its dependency contradicts an already selected package. `CandidateProvider(..., dependency_precheck=True)` queues the ordinary dependency clause and leaves the rejected candidate's declarations inactive.

An additional `precheck_feedback=True` option requests a retreat after four distinct candidate keys from one parent package encounter the same selected blocker key. Requests are capped at three per blocker package per solve. Requested blockers receive the culprit tier before the host's preference; ordinary affected-package promotion takes precedence when enabled. This feedback is independent of the ordinary conflict-count policy.

Both options default to `False`. Prechecking preserves metadata error order and delegates candidates with self-dependencies to the normal decision path. Diagnostic candidate probes queue neither dependency clauses nor feedback. Rejection history survives ordinary backtracks and restarts, and resets for a new solve.
